### PR TITLE
added video editor

### DIFF
--- a/src/components/AtomTypes/Video/VideoEditor.jsx
+++ b/src/components/AtomTypes/Video/VideoEditor.jsx
@@ -1,0 +1,110 @@
+import React, {PropTypes} from 'react';
+import Radium from 'radium';
+import {safeGetInToJS} from 'utils/safeParse';
+import {s3Upload} from 'utils/uploadFile';
+import {Loader, CustomizableForm} from 'components';
+
+let styles = {};
+
+export const VideoEditor = React.createClass({
+	propTypes: {
+		atomEditData: PropTypes.object
+	},
+	
+	getInitialState() {
+		return {
+			url: '',
+			metadata: {},
+			isUploading: false,
+			width: 600
+		};
+	},
+	setVideoSize(container) {
+		if (container)	this.setState({width: container.offsetWidth});
+	},
+	componentWillMount() {
+		const metadata = safeGetInToJS(this.props.atomEditData, ['currentVersionData', 'content', 'metadata']) || {};
+		const defaultMetadata = {
+			location: {
+				title: 'Location',
+				value: ''
+			},
+			originData: {
+				title: 'Date of origin',
+				value: '',
+			},
+		};
+		this.setState({metadata: {
+			...defaultMetadata,
+			...metadata
+		}});
+	},
+
+	getSaveVersionContent: function() {
+		const cleanMetadata = {};
+		Object.keys(this.state.metadata).map((key, index)=>{
+			// Clear all the metadata entries that don't have a value
+			if (this.state.metadata[key].value) {
+				cleanMetadata[key] = this.state.metadata[key];
+			}
+		});
+		return {
+			url: this.state.url || safeGetInToJS(this.props.atomEditData, ['currentVersionData', 'content', 'url']),
+			metadata: cleanMetadata,
+		};
+	},
+
+	handleFileSelect: function(evt) {
+		if (evt.target.files.length) {
+			this.setState({isUploading: true});
+			s3Upload(evt.target.files[0], ()=>{}, this.onFileFinish, 0);
+		}
+	},
+
+	onFileFinish: function(evt, index, type, filename) {
+		this.setState({
+			url: 'https://assets.pubpub.org/' + filename,
+			isUploading: false,
+		});
+	},
+
+	metadataUpdate: function(newMetadata) {
+		this.setState({metadata: newMetadata});
+	},
+
+	render: function() {
+		const title = safeGetInToJS(this.props.atomEditData, ['atomData', 'title']);
+		const videoSource = safeGetInToJS(this.props.atomEditData, ['currentVersionData', 'content', 'url']);
+		return (
+			<div ref={this.setVideoSize}>
+				<h3>Preview</h3>
+				<video src={videoSource} width={this.state.width} controls/>
+				<div style={styles.loaderWrapper}>
+					<Loader loading={this.state.isUploading} showCompletion={true}/>
+				</div>
+				<a href={videoSource} target="_blank" className={'underlineOnHover'} style={styles.originalLink}>View Original</a>
+
+				<h3>Choose new file</h3>
+				<input id={'videoFile'} name={'video file'} type="file" accept="video/*" onChange={this.handleFileSelect} />
+
+				<h3>Metadata</h3>
+				<CustomizableForm formData={this.state.metadata} onUpdate={this.metadataUpdate}/>
+				
+			</div>
+		);
+	}
+});
+
+export default Radium(VideoEditor)
+
+styles = {
+	loaderWrapper: {
+		display: 'inline-block',
+	},
+	originalLink: {
+		display: 'table-cell',
+		color: 'inherit',
+		textDecoration: 'none',
+		fontSize: '0.9em',
+	},
+};

--- a/src/components/AtomTypes/Video/VideoEditor.test.js
+++ b/src/components/AtomTypes/Video/VideoEditor.test.js
@@ -1,0 +1,18 @@
+import {expect} from 'chai';
+import {shallowRender} from 'tests/helpersClient';
+import {VideoEditor} from './VideoEditor.jsx'
+
+describe('Components', () => {
+	describe('VideoEditor.jsx', () => {
+
+		it('should render with empty props', () => {
+			const props = {};
+			const {renderOutput, error} = shallowRender(VideoEditor, props) ;
+
+			expect(error).to.not.exist; // Did not render an error
+			expect(renderOutput).to.exist; // Successfully rendered
+			
+		});
+
+	});
+});

--- a/src/components/AtomTypes/Video/VideoViewer.jsx
+++ b/src/components/AtomTypes/Video/VideoViewer.jsx
@@ -1,0 +1,64 @@
+import React, {PropTypes} from 'react';
+import Radium from 'radium';
+import {safeGetInToJS} from 'utils/safeParse';
+
+let styles;
+
+export const VideoViewer = React.createClass({
+	propTypes: {
+		atomData: PropTypes.object,
+		renderType: PropTypes.oneOf(['full', 'embed', 'static-full', 'static-embed'])
+	},
+	getInitialState() {
+		return {width: 600}
+	},
+	setVideoSize(container) {
+		if (container) this.setState({width: container.offsetWidth});
+	},
+	render: function() {
+
+		const title = safeGetInToJS(this.props.atomData, ['atomData', 'title']);
+		const videoSource = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'url']);
+		const metadata = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'metadata']) || {};
+		
+		switch (this.props.renderType) {
+		case 'embed':
+		case 'static-embed':
+			return <video src={videoSource} width={this.state.width} controls/>;
+		case 'full':
+		case 'static-full':
+		default:
+			return (
+				<div ref={this.setVideoSize}>
+					<video src={videoSource} width={this.state.width} controls />
+					
+					{Object.keys(metadata).length > 0 &&
+						<h2>Metadata</h2>	
+					}
+					
+					{Object.keys(metadata).map((key, index)=>{
+						return (
+							<div key={'metadata-' + index}>
+								<div style={styles.key}>{metadata[key].title}:</div>
+								<div style={styles.value}>{metadata[key].value}</div>
+							</div>
+						);
+					})}
+
+				</div>
+			);
+		}
+
+	}
+});
+
+export default Radium(VideoViewer)
+
+styles = {
+	key: {
+		fontSize: '1.2em',
+	},
+	value: {
+		marginBottom: '1.25em',
+	},
+};

--- a/src/components/AtomTypes/Video/VideoViewer.test.js
+++ b/src/components/AtomTypes/Video/VideoViewer.test.js
@@ -1,0 +1,18 @@
+import {expect} from 'chai';
+import {shallowRender} from 'tests/helpersClient';
+import {VideoViewer} from './VideoViewer.jsx'
+
+describe('Components', () => {
+	describe('VideoViewer.jsx', () => {
+
+		it('should render with empty props', () => {
+			const props = {};
+			const {renderOutput, error} = shallowRender(VideoViewer, props) ;
+
+			expect(error).to.not.exist; // Did not render an error
+			expect(renderOutput).to.exist; // Successfully rendered
+			
+		});
+
+	});
+});

--- a/src/components/AtomTypes/index.js
+++ b/src/components/AtomTypes/index.js
@@ -1,8 +1,42 @@
-export ImageEditor from './Image/ImageEditor';
-export ImageViewer from './Image/ImageViewer';
+// export ImageEditor from './Image/ImageEditor';
+// export ImageViewer from './Image/ImageViewer';
+//
+// export MarkdownEditor from './Markdown/MarkdownEditor';
+// export MarkdownViewer from './Markdown/MarkdownViewer';
+//
+// export JupyterEditor from './Jupyter/JupyterEditor';
+// export JupyterViewer from './Jupyter/JupyterViewer';
+//
+// export VideoEditor from './Video/VideoEditor';
+// export VideoViewer from './Video/VideoViewer';
 
-export MarkdownEditor from './Markdown/MarkdownEditor';
-export MarkdownViewer from './Markdown/MarkdownViewer';
+import ImageEditor from './Image/ImageEditor';
+import ImageViewer from './Image/ImageViewer';
 
-export JupyterEditor from './Jupyter/JupyterEditor';
-export JupyterViewer from './Jupyter/JupyterViewer';
+import MarkdownEditor from './Markdown/MarkdownEditor';
+import MarkdownViewer from './Markdown/MarkdownViewer';
+
+import JupyterEditor from './Jupyter/JupyterEditor';
+import JupyterViewer from './Jupyter/JupyterViewer';
+
+import VideoEditor from './Video/VideoEditor';
+import VideoViewer from './Video/VideoViewer';
+
+export default {
+	image: {
+		editor: ImageEditor,
+		viewer: ImageViewer
+	},
+	markdown: {
+		editor: MarkdownEditor,
+		viewer: MarkdownViewer
+	},
+	jupyter: {
+		editor: JupyterEditor,
+		viewer: JupyterViewer
+	},
+	video: {
+		editor: VideoEditor,
+		viewer: VideoViewer
+	}
+}

--- a/src/containers/AtomEditor/AtomEditorPane.jsx
+++ b/src/containers/AtomEditor/AtomEditorPane.jsx
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react';
 import Radium from 'radium';
-import {MarkdownEditor, ImageEditor, JupyterEditor} from 'components/AtomTypes' ;
+// import {MarkdownEditor, ImageEditor, JupyterEditor} from 'components/AtomTypes' ;
+import AtomTypes from 'components/AtomTypes';
 import {safeGetInToJS} from 'utils/safeParse';
 
 export const AtomEditorPane = React.createClass({
@@ -16,16 +17,21 @@ export const AtomEditorPane = React.createClass({
 		};
 
 		const type = safeGetInToJS(this.props.atomEditData, ['atomData', 'type']);
-		switch (type) {
-		case 'markdown':
-			return <MarkdownEditor {...props} loginData={this.props.loginData} />;
-		case 'image':
-			return <ImageEditor {...props} />;
-		case 'jupyter':
-			return <JupyterEditor {...props} />;
-		default:
+		if (AtomTypes.hasOwnProperty(type)) {
+			return React.createElement(AtomTypes[type].editor, {...props, loginData: this.props.loginData});
+		} else {
 			return <div>Unknown Type</div>;
 		}
+		// switch (type) {
+		// case 'markdown':
+		// 	return <MarkdownEditor {...props} loginData={this.props.loginData} />;
+		// case 'image':
+		// 	return <ImageEditor {...props} />;
+		// case 'jupyter':
+		// 	return <JupyterEditor {...props} />;
+		// default:
+		// 	return <div>Unknown Type</div>;
+		// }
 	}
 });
 

--- a/src/containers/AtomReader/AtomViewerPane.jsx
+++ b/src/containers/AtomReader/AtomViewerPane.jsx
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react';
 import Radium from 'radium';
-import {MarkdownViewer, ImageViewer, JupyterViewer} from 'components/AtomTypes' ;
+// import {MarkdownViewer, ImageViewer, JupyterViewer} from 'components/AtomTypes' ;
+import AtomTypes from 'components/AtomTypes';
 import {safeGetInToJS} from 'utils/safeParse';
 
 export const AtomViewerPane = React.createClass({
@@ -10,16 +11,21 @@ export const AtomViewerPane = React.createClass({
 
 	render: function() {
 		const type = safeGetInToJS(this.props.atomData, ['atomData', 'type']);
-		switch (type) {
-		case 'markdown':
-			return <MarkdownViewer atomData={this.props.atomData} />;
-		case 'image':
-			return <ImageViewer atomData={this.props.atomData} />;
-		case 'jupyter':
-			return <JupyterViewer atomData={this.props.atomData} />;
-		default:
+		if (AtomTypes.hasOwnProperty(type)) {
+			return React.createElement(AtomTypes[type].viewer, {atomData: this.props.atomData});
+		} else {
 			return <div>Unknown Type</div>;
 		}
+		// switch (type) {
+		// case 'markdown':
+		// 	return <MarkdownViewer atomData={this.props.atomData} />;
+		// case 'image':
+		// 	return <ImageViewer atomData={this.props.atomData} />;
+		// case 'jupyter':
+		// 	return <JupyterViewer atomData={this.props.atomData} />;
+		// default:
+		// 	return <div>Unknown Type</div>;
+		// }
 	}
 });
 

--- a/src/containers/Landing/Landing.jsx
+++ b/src/containers/Landing/Landing.jsx
@@ -44,6 +44,10 @@ const Landing = React.createClass({
 			atomType = 'pdf'; break;
 		case 'ipynb':
 			atomType = 'jupyter'; break;
+		case 'mp4':
+		case 'ogg':
+		case 'webm':
+			atomType = 'video'; break;
 		default:
 			break;
 		}


### PR DESCRIPTION
yay look videos

This is currently only using the default HTML5 video player, which only handles MP4, OGG, and webm filetypes. We probably eventually want a more rich, inclusive video player, but those are a pain because they're big and styling them is a pain. I'll update this branch with a better one once I get code splitting working on atom viewer types, which doesn't happen yet.