### PR TITLE
Added LaTeX atom and updated IFrame atom

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "immutable": "^3.7.5",
     "intl": "^1.1.0",
     "invariant": "^2.2.1",
+    "katex": "^0.6.0",
     "kerberos": "^0.0.21",
     "less": "^2.6.0",
     "lodash": "^4.12.0",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "firepad": "^1.3.0",
     "fuzzy": "^0.1.1",
     "googleapis": "^8.2.0",
+    "happypack": "^2.1.1",
     "history": "^2.0.0",
     "html-pdf": "^2.0.1",
     "http-proxy": "^1.13.2",

--- a/src/components/AtomTypes/IFrame/IFrameEditor.jsx
+++ b/src/components/AtomTypes/IFrame/IFrameEditor.jsx
@@ -2,9 +2,10 @@ import React, {PropTypes} from 'react';
 import Radium from 'radium';
 import {safeGetInToJS} from 'utils/safeParse';
 import {Loader, CustomizableForm} from 'components';
-import {isWebUri} from 'valid-url';
 
 let styles = {};
+const defaultHeight = '300';
+const defaultWidth = '100%';
 
 export const IFrameEditor = React.createClass({
 	propTypes: {
@@ -13,69 +14,44 @@ export const IFrameEditor = React.createClass({
 
 	getInitialState() {
 		return {
-			url: false,
-			metadata: {},
-			isUploading: false,
+			source: '',
+			height: defaultHeight,
+			width: defaultWidth
 		};
 	},
 
 	componentWillMount() {
-		const metadata = safeGetInToJS(this.props.atomEditData, ['currentVersionData', 'content', 'metadata']) || {};
-		const defaultMetadata = {
-			location: {
-				title: 'Location',
-				value: ''
-			},
-			originData: {
-				title: 'Date of origin',
-				value: '',
-			},
-		};
-		this.setState({metadata: {
-			...defaultMetadata,
-			...metadata
-		}});
+		const height = safeGetInToJS(this.props.atomEditData, ['currentVersionData', 'content', 'height']) || defaultHeight;
+		const width = safeGetInToJS(this.props.atomEditData, ['currentVersionData', 'content', 'width']) || defaultWidth;
+		const source = safeGetInToJS(this.props.atomEditData, ['currentVersionData', 'content', 'source']) || '';
+		this.setState({source, width, height});
 	},
-
-	getSaveVersionContent: function() {
-		const cleanMetadata = {};
-		Object.keys(this.state.metadata).map((key, index)=>{
-			// Clear all the metadata entries that don't have a value
-			if (this.state.metadata[key].value) {
-				cleanMetadata[key] = this.state.metadata[key];
-			}
-		});
-		return {
-			url: this.state.url || safeGetInToJS(this.props.atomEditData, ['currentVersionData', 'content', 'url']),
-			metadata: cleanMetadata,
-		};
+	getSaveVersionContent() {
+		const {source, height, width} = this.state;
+		return {source, height, width};
 	},
-
-	handleSourceChange: function(evt) {
-		if (evt.target.value && isWebUri(evt.target.value)) {
-			this.setState({url: evt.target.value});
-		}
+	updateData(prop) {
+		return evt => this.setState({[prop]: evt.target.value});
 	},
-	
-	metadataUpdate: function(newMetadata) {
-		this.setState({metadata: newMetadata});
-	},
-
-	render: function() {
-		const title = safeGetInToJS(this.props.atomEditData, ['atomData', 'title']);
-		const iframeSource = this.state.url || safeGetInToJS(this.props.atomEditData, ['currentVersionData', 'content', 'url']);
+	render() {
+		const {height, width, source} = this.state;
 		return (
 			<div>
+				<div>
+					<h3>Source</h3>
+					<input type="text" value={source} onChange={this.updateData('source')}/>
+				</div>
+				<div>
+					<h3>Height</h3>
+					<input type="text" value={height} onChange={this.updateData('height')}/>
+				</div>
+				<div>
+					<h3>Width</h3>
+					<input type="text" value={width} onChange={this.updateData('width')}/>
+				</div>
 				<h3>Preview</h3>
-				<iframe src={iframeSource} style={styles.iframe}></iframe>
-				<a href={iframeSource} alt={'Source Link: ' + title} target="_blank" className={'underlineOnHover'} style={styles.sourceLink}>View Source</a>
-
-				<h3>Choose a difference source</h3>
-				<input id={'imageFile'} name={'image file'} type="text" onChange={this.handleSourceChange} />
-
-				<h3>Metadata</h3>
-				<CustomizableForm formData={this.state.metadata} onUpdate={this.metadataUpdate}/>
-
+				<iframe src={source} style={styles.iframe(height, width)}></iframe>
+				<a href={source} alt={'View Source'} target="_blank" className={'underlineOnHover'} style={styles.sourceLink}>View Source</a>
 			</div>
 		);
 	}
@@ -84,17 +60,11 @@ export const IFrameEditor = React.createClass({
 export default Radium(IFrameEditor);
 
 styles = {
-	loaderWrapper: {
-		display: 'inline-block',
-	},
 	sourceLink: {
 		display: 'table-cell',
 		color: 'inherit',
 		textDecoration: 'none',
 		fontSize: '0.9em',
 	},
-	iframe: {
-		width: '100%',
-		minHeight: '400px',
-	}
+	iframe: (height, width) => ({height, width})
 };

--- a/src/components/AtomTypes/IFrame/IFrameViewer.jsx
+++ b/src/components/AtomTypes/IFrame/IFrameViewer.jsx
@@ -2,7 +2,9 @@ import React, {PropTypes} from 'react';
 import Radium from 'radium';
 import {safeGetInToJS} from 'utils/safeParse';
 
-let styles;
+let styles = {};
+const defaultHeight = '300';
+const defaultWidth = '100%';
 
 export const IFrameViewer = React.createClass({
 	propTypes: {
@@ -10,54 +12,26 @@ export const IFrameViewer = React.createClass({
 		renderType: PropTypes.string, // full, embed, static-full, static-embed
 	},
 
-	render: function() {
+	render() {
 
 		const title = safeGetInToJS(this.props.atomData, ['atomData', 'title']);
-		const iframeSource = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'url']);
-		const metadata = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'metadata']) || {};
+		const source = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'source']) || '';
+		const height = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'height']) || defaultHeight;
+		const width = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'width']) || defaultWidth;
 
 		switch (this.props.renderType) {
 			case 'embed':
 			case 'static-embed':
-				return <iframe src={iframeSource} style={styles.iframe}></iframe>
 			case 'full':
 			case 'static-full':
 			default:
-				return (
-					<div>
-						<iframe src={iframeSource} style={styles.iframe}></iframe>
-
-						{Object.keys(metadata).length > 0 &&
-						<h2>Metadata</h2>
-						}
-
-						{Object.keys(metadata).map((key, index)=>{
-							return (
-								<div key={'metadata-' + index}>
-									<div style={styles.key}>{metadata[key].title}:</div>
-									<div style={styles.value}>{metadata[key].value}</div>
-								</div>
-							);
-						})}
-
-					</div>
-				);
+				return <iframe src={source} style={styles.iframe(height, width)}></iframe>;
 		}
-
 	}
 });
 
 export default Radium(IFrameViewer);
 
 styles = {
-	key: {
-		fontSize: '1.2em',
-	},
-	value: {
-		marginBottom: '1.25em',
-	},
-	iframe: {
-		width: '100%',
-		minHeight: '400px',
-	}
+	iframe: (height, width) => ({height, width})
 };

--- a/src/components/AtomTypes/LaTeX/LaTeXEditor.jsx
+++ b/src/components/AtomTypes/LaTeX/LaTeXEditor.jsx
@@ -1,0 +1,71 @@
+import React, {PropTypes} from 'react';
+import Radium from 'radium';
+import {safeGetInToJS} from 'utils/safeParse';
+import {Loader, CustomizableForm} from 'components';
+
+import katex from 'katex';
+
+let styles = {};
+
+export const LaTeXEditor = React.createClass({
+	propTypes: {
+		atomEditData: PropTypes.object,
+	},
+
+	getInitialState() {
+		return {
+			text: '',
+			inlineHTML: '',
+			displayHTML: ''
+		};
+	},
+
+	componentWillMount() {
+		const text = safeGetInToJS(this.props.atomEditData, ['currentVersionData', 'content', 'text']) || '';
+		const html = this.generateHTML(text);
+		this.setState({text, ...html});
+	},
+
+	getSaveVersionContent: function() {
+		const {text, inlineHTML, displayHTML} = this.state;
+		return {text, inlineHTML, displayHTML};
+	},
+	
+	generateHTML(text) {
+		const inlineHTML = katex.renderToString(text, {displayMode: false, throwOnError: false});
+		const displayHTML = katex.renderToString(text, {displayMode: true, throwOnError: false});
+		return {inlineHTML, displayHTML}
+	},
+	
+	updateText: function(evt) {
+		const text = evt.target.value;
+		const html = this.generateHTML(text);
+		this.setState({text, ...html});
+	},
+
+	render: function() {
+		const {text, inlineHTML, displayHTML} = this.state;
+		return (
+			<div style={styles.container}>
+				<h3>Preview</h3>
+				<div dangerouslySetInnerHTML={{__html: displayHTML}} style={styles.output}></div>
+				<textarea value={text} onChange={this.updateText} style={styles.input}/>
+			</div>
+		);
+	}
+});
+
+export default Radium(LaTeXEditor);
+
+styles = {
+	container: {
+		width: '100%'
+	},
+	input: {
+		width: '100%',
+		minHeight: '100px',
+	},
+	output: {
+		width: '100%'
+	}
+};

--- a/src/components/AtomTypes/LaTeX/LaTeXEditor.test.js
+++ b/src/components/AtomTypes/LaTeX/LaTeXEditor.test.js
@@ -1,0 +1,18 @@
+import {expect} from 'chai';
+import {shallowRender} from 'tests/helpersClient';
+import {LaTeXEditor} from './LaTeXEditor.jsx'
+
+describe('Components', () => {
+	describe('LaTeXEditor.jsx', () => {
+
+		it('should render with empty props', () => {
+			const props = {};
+			const {renderOutput, error} = shallowRender(LaTeXEditor, props) ;
+
+			expect(error).to.not.exist; // Did not render an error
+			expect(renderOutput).to.exist; // Successfully rendered
+			
+		});
+
+	});
+});

--- a/src/components/AtomTypes/LaTeX/LaTeXViewer.jsx
+++ b/src/components/AtomTypes/LaTeX/LaTeXViewer.jsx
@@ -2,6 +2,8 @@ import React, {PropTypes} from 'react';
 import Radium from 'radium';
 import {safeGetInToJS} from 'utils/safeParse';
 
+import katex from 'katex';
+
 let styles;
 
 export const LaTeXViewer = React.createClass({
@@ -10,10 +12,27 @@ export const LaTeXViewer = React.createClass({
 		renderType: PropTypes.string, // full, embed, static-full, static-embed
 	},
 
-	render: function() {
-		const inlineHTML = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'inlineHTML']) || '';
-		const displayHTML = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'displayHTML']) || '';
+	generateHTML(text) {
+		const inlineHTML = katex.renderToString(text, {displayMode: false, throwOnError: false});
+		const displayHTML = katex.renderToString(text, {displayMode: true, throwOnError: false});
+		return {inlineHTML, displayHTML}
+	},
+	
+	getData() {
+		const text = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'text']);
+		const inlineHTML = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'inlineHTML']);
+		const displayHTML = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'displayHTML']);
 		
+		if (inlineHTML && displayHTML) {
+			return {text, inlineHTML, displayHTML};
+		}
+		else	{
+			return {text, ...this.generateHTML(text)};
+		}
+	},
+
+	render: function() {
+		const {displayHTML, inlineHTML} = this.getData();
 		switch (this.props.renderType) {
 			case 'embed':
 			case 'static-embed':

--- a/src/components/AtomTypes/LaTeX/LaTeXViewer.jsx
+++ b/src/components/AtomTypes/LaTeX/LaTeXViewer.jsx
@@ -1,0 +1,33 @@
+import React, {PropTypes} from 'react';
+import Radium from 'radium';
+import {safeGetInToJS} from 'utils/safeParse';
+
+let styles;
+
+export const LaTeXViewer = React.createClass({
+	propTypes: {
+		atomData: PropTypes.object,
+		renderType: PropTypes.string, // full, embed, static-full, static-embed
+	},
+
+	render: function() {
+		const inlineHTML = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'inlineHTML']) || '';
+		const displayHTML = safeGetInToJS(this.props.atomData, ['currentVersionData', 'content', 'displayHTML']) || '';
+		
+		switch (this.props.renderType) {
+			case 'embed':
+			case 'static-embed':
+				return <div dangerouslySetInnerHTML={{__html: displayHTML}}></div>
+			case 'full':
+			case 'static-full':
+			default:
+				return <div dangerouslySetInnerHTML={{__html: inlineHTML}}></div>
+		}
+	}
+});
+
+export default Radium(LaTeXViewer);
+
+styles = {
+	
+};

--- a/src/components/AtomTypes/LaTeX/LaTeXViewer.test.js
+++ b/src/components/AtomTypes/LaTeX/LaTeXViewer.test.js
@@ -1,0 +1,18 @@
+import {expect} from 'chai';
+import {shallowRender} from 'tests/helpersClient';
+import {LaTeXViewer} from './LaTeXViewer.jsx'
+
+describe('Components', () => {
+	describe('LaTeXViewer.jsx', () => {
+
+		it('should render with empty props', () => {
+			const props = {};
+			const {renderOutput, error} = shallowRender(LaTeXViewer, props) ;
+
+			expect(error).to.not.exist; // Did not render an error
+			expect(renderOutput).to.exist; // Successfully rendered
+			
+		});
+
+	});
+});

--- a/src/components/AtomTypes/index.js
+++ b/src/components/AtomTypes/index.js
@@ -13,6 +13,9 @@ import VideoViewer from './Video/VideoViewer';
 import IFrameEditor from './IFrame/IFrameEditor';
 import IFrameViewer from './IFrame/IFrameViewer';
 
+import LaTeXEditor from './LaTeX/LaTeXEditor';
+import LaTeXViewer from './LaTeX/LaTeXViewer';
+
 export default {
 	image: {
 		editor: ImageEditor,
@@ -33,5 +36,9 @@ export default {
 	iframe: {
 		editor: IFrameEditor,
 		viewer: IFrameViewer
+	},
+	latex: {
+		editor: LaTeXEditor,
+		viewer: LaTeXViewer
 	}
 };

--- a/src/containers/Landing/Landing.jsx
+++ b/src/containers/Landing/Landing.jsx
@@ -41,8 +41,10 @@ const Landing = React.createClass({
 		let props = {};
 		if (source && isWebUri(source)) {
 			atomType = 'iframe';
-			props = {url: source};
+			props = {source};
 		} else {
+			atomType = 'latex';
+			props = {text: source};
 			// add more text atom types here
 		}
 		this.props.dispatch(createAtom(atomType, props));

--- a/src/server.js
+++ b/src/server.js
@@ -180,6 +180,8 @@ app.use((req, res) => {
 							<script src="/js/typo.js"></script>
 							<script src="/js/spellcheck.js"></script>
 							<script src="https://cdn.ravenjs.com/2.1.0/raven.min.js"></script>
+							
+							<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css">
 
 							<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
 


### PR DESCRIPTION
- LaTeX atom using KHan Academy's KaTeX package. It's fast and light and outputs pure HTML. Downside is that there's an extra stylesheet link in server.js now.
- Added width and height props to IFrame, and cleaned up the code a bit
- Updated package.json with happypack (for dev rebuilds) and katex (for the LaTeX atom)