### PR TITLE
fix: update all broken Storybook entries

### DIFF
--- a/client/components/PubDraftHeader/PubDraftHeader.js
+++ b/client/components/PubDraftHeader/PubDraftHeader.js
@@ -32,7 +32,7 @@ class PubDraftHeader extends Component {
 	}
 
 	componentWillUnmount() {
-		this.stickyInstance.cleanUp();
+		this.stickyInstance.cleanup();
 	}
 
 	render() {

--- a/client/components/PubHeader/PubHeader.js
+++ b/client/components/PubHeader/PubHeader.js
@@ -57,7 +57,7 @@ class PubHeader extends Component {
 	}
 
 	componentWillUnmount() {
-		this.cleanupSticky();
+		this.stickyInstance.cleanup();
 		window.removeEventListener('resize', this.handleResize);
 	}
 
@@ -65,14 +65,8 @@ class PubHeader extends Component {
 		const nextOffsetHeight = this.headerRef.current.offsetHeight;
 		if (nextOffsetHeight !== this.offsetHeight) {
 			this.offsetHeight = nextOffsetHeight;
-			this.cleanupSticky();
-			this.stickyInstance = stickybits('.pub-header-component', { stickyBitStickyOffset: 35 - this.offsetHeight, useStickyClasses: true });
-		}
-	}
-
-	cleanupSticky() {
-		if (this.stickyInstance && typeof this.stickyInstance.cleanup === "function") {
 			this.stickyInstance.cleanup();
+			this.stickyInstance = stickybits('.pub-header-component', { stickyBitStickyOffset: 35 - this.offsetHeight, useStickyClasses: true });
 		}
 	}
 

--- a/searchSync/init.js
+++ b/searchSync/init.js
@@ -1,3 +1,3 @@
-require('babel-register');
+require('@babel/register');
 // require('./migrate-v5.js');
 require('./searchSync.js');

--- a/stories/components/footerStories.js
+++ b/stories/components/footerStories.js
@@ -10,9 +10,9 @@ import { accentDataDark, accentDataLight, communityData } from '../data';
 const wrapperStyle = { margin: '1em 0em' };
 
 const customSocialItems = [
-	{ id: 'si-0', icon: <Icon icon="vimeo" />, title: "Website", value: "custom", url: "https://vimeo.com/custom" },
-	{ id: 'si-1', icon: <Icon icon="soundcloud" />, title: "Check out my SoundCloud", value: "custom", url: "https://twitter.com/custom" },
-	{ id: 'si-2', icon: <Icon icon="spotify" />, title: "Facebook", value: "custom" , url: "https://facebook.com/}" },
+	{ id: 'si-0', icon: <Icon icon="vimeo" />, title: 'Website', value: 'custom', url: 'https://vimeo.com/custom' },
+	{ id: 'si-1', icon: <Icon icon="soundcloud" />, title: 'Check out my SoundCloud', value: 'custom', url: 'https://twitter.com/custom' },
+	{ id: 'si-2', icon: <Icon icon="spotify" />, title: 'Facebook', value: 'custom', url: 'https://facebook.com/}' },
 ];
 
 storiesOf('Components/Footer', module)

--- a/stories/components/headerStories.js
+++ b/stories/components/headerStories.js
@@ -29,7 +29,7 @@ const headerBars = function(isBasePubPub) {
 			<h4 style={titleStyle}>Logged Out</h4>
 			<div style={wrapperStyle}>
 				<Header
-					loginData={{isAdmin: false}}
+					loginData={{ isAdmin: false }}
 					communityData={communityData}
 					locationData={locationData}
 					smallHeaderLogo={data.smallHeaderLogo}

--- a/stories/components/pubDraftHeaderStories.js
+++ b/stories/components/pubDraftHeaderStories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import PubDraftHeader from 'components/PubDraftHeader/PubDraftHeader';
-import { pubData, locationData, loginData} from '../data';
+import { pubData, locationData, loginData } from '../data';
 
 storiesOf('Components/PubDraftHeader', module)
 .add('default', () => (

--- a/stories/data.js
+++ b/stories/data.js
@@ -15,9 +15,9 @@ export const accentDataLight = {
 };
 
 import initialData from './dataInitial.js';
-export const {locationData, loginData} = initialData;
+export const { locationData, loginData } = initialData;
 
-export {default as communityData} from './dataCommunity.js';
-export {default as collectionData} from './dataCollection.js';
-export {default as pubData} from './dataPub.js';
-export {plainDoc, imageDoc, fullDoc} from './dataDocs.js';
+export { default as communityData } from './dataCommunity.js';
+export { default as collectionData } from './dataCollection.js';
+export { default as pubData } from './dataPub.js';
+export { plainDoc, imageDoc, fullDoc } from './dataDocs.js';


### PR DESCRIPTION
This PR fixes various React Storybook entries that were previously failing due mostly to missing props. I've added the props where appropriate and I'm looking into a way to automatically test that all fixtures mount and render, either as a pre-push hook or a CI step, to make sure this doesn't happen again.

_Test plan:_

Run `npm run storybook` and visit `localhost:9001`. Check that every story renders as expected.