### PR TITLE
dev: eliminate remaining lint errors

### DIFF
--- a/client/containers/Pub/Pub.js
+++ b/client/containers/Pub/Pub.js
@@ -67,6 +67,11 @@ class Pub extends Component {
 			// sectionsData: [{ id: '', order: 0, title: 'Introduction' }],
 			menuWrapperRefNode: undefined,
 			editorChangeObject: {},
+			// TODO(ian): I'm pretty sure this state is being propagated into
+			// the UI, but indirectly by way of a setState callback that
+			// uses this value to compute another state value. Refactor this
+			// code so it's not confusing to static analysis toools.
+			// eslint-disable-next-line react/no-unused-state
 			clickedMarks: [],
 			linkPopupIsOpen: false,
 		};
@@ -421,12 +426,14 @@ class Pub extends Component {
 				...changeObject,
 				currentScroll: window.scrollY,
 			},
+			// eslint-disable-next-line react/no-unused-state
 			clickedMarks: [],
 		}, this.calculateLinkPopupState);
 	}
 
 	handleEditorSingleClick(view) {
 		this.setState({
+			// eslint-disable-next-line react/no-unused-state
 			clickedMarks: marksAtSelection(view)
 		}, this.calculateLinkPopupState);
 	}

--- a/searchSync/init.js
+++ b/searchSync/init.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 require('babel-register');
 // require('./migrate-v5.js');
 require('./searchSync.js');

--- a/server/Html.js
+++ b/server/Html.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 let manifest;
 try {
+	// eslint-disable-next-line import/no-unresolved
 	manifest = require('../dist/manifest.json');
 } catch (err) {
 	// No Manifest file. Must be dev mode.


### PR DESCRIPTION
I want to get to the point where linting happens as a pre-push hook, so I'm getting rid of remaining lint errors that I see by means of `eslint-disable` comments. If anything that I'm trying to disable looks suspicious, let me know!

_Test plan:_
Run `npm run lint` and verify a lack of errors.