### PR TITLE
fix: FormattingBar image caption field updates when image selection is changed

### DIFF
--- a/client/components/PubBody/PubBody.js
+++ b/client/components/PubBody/PubBody.js
@@ -22,6 +22,7 @@ const propTypes = {
 
 	clientData: PropTypes.object.isRequired,
 	editorKey: PropTypes.string.isRequired,
+	editorCustomPlugins: PropTypes.shape({}),
 	onClientChange: PropTypes.func.isRequired,
 	// onHighlightClick: PropTypes.func.isRequired,
 	isReadOnly: PropTypes.bool.isRequired,
@@ -34,6 +35,7 @@ const propTypes = {
 const defaultProps = {
 	// sectionId: undefined,
 	content: undefined,
+	editorCustomPlugins: {},
 	highlights: [],
 	// threads: [],
 	slug: '',
@@ -105,6 +107,7 @@ class PubBody extends Component {
 				)}
 
 				<Editor
+					customPlugins={this.props.editorCustomPlugins}
 					customNodes={{
 						...discussionSchema,
 					}}

--- a/client/components/PubDraftHeader/PubDraftHeader.js
+++ b/client/components/PubDraftHeader/PubDraftHeader.js
@@ -10,6 +10,7 @@ require('./pubDraftHeader.scss');
 const propTypes = {
 	pubData: PropTypes.object.isRequired,
 	loginData: PropTypes.object.isRequired,
+	formattingBarKey: PropTypes.string,
 	editorChangeObject: PropTypes.object.isRequired,
 	setOptionsMode: PropTypes.func.isRequired,
 	collabStatus: PropTypes.string.isRequired,
@@ -19,6 +20,7 @@ const propTypes = {
 
 const defaultProps = {
 	threads: [],
+	formattingBarKey: '',
 };
 
 class PubDraftHeader extends Component {
@@ -73,6 +75,7 @@ class PubDraftHeader extends Component {
 					<FormattingBar
 						editorChangeObject={this.props.editorChangeObject}
 						threads={this.props.threads}
+						key={this.props.formattingBarKey}
 					/>
 				)}
 				{/* <div className="spacer" /> */}

--- a/client/components/PubEditorUserInputCapture/PubEditorUserInputCapture.js
+++ b/client/components/PubEditorUserInputCapture/PubEditorUserInputCapture.js
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { Plugin } from 'prosemirror-state';
+
+const createCaptureInputPlugin = (onCapture) => () =>
+	new Plugin({
+		props: {
+			handleDOMEvents: {
+				mouseup: onCapture,
+				keydown: onCapture,
+			},
+		},
+	});
+
+const propTypes = {
+	children: PropTypes.func.isRequired,
+};
+
+export default class PubEditorUserInputCapture extends React.Component {
+	constructor(props) {
+		super(props);
+		this.captureInputPlugin = createCaptureInputPlugin(this.updateCapture.bind(this));
+		this.state = {
+			lastInputCapture: Date.now(),
+		};
+	}
+
+	updateCapture() {
+		setTimeout(() => this.setState({ lastInputCapture: Date.now() }));
+	}
+
+	render() {
+		return this.props.children({
+			captureInputPlugin: this.captureInputPlugin,
+			lastInputCapture: this.state.lastInputCapture,
+		});
+	}
+}
+
+PubEditorUserInputCapture.propTypes = propTypes;

--- a/client/containers/Pub/Pub.js
+++ b/client/containers/Pub/Pub.js
@@ -33,6 +33,7 @@ import {
 	getRandomColor,
 	generateHash,
 } from 'utilities';
+import PubEditorUserInputCapture from '../../components/PubEditorUserInputCapture/PubEditorUserInputCapture';
 
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 require('@firebase/auth');
@@ -635,173 +636,200 @@ class Pub extends Component {
 						setDiscussionChannel={this.setDiscussionChannel}
 					/>
 
-					<div>
-						{pubData.isDraft && (
-							<PubDraftHeader
-								pubData={pubData}
-								loginData={loginData}
-								editorChangeObject={this.state.editorChangeObject}
-								setOptionsMode={this.setOptionsMode}
-								bottomCutoffId="discussions"
-								onRef={this.handleMenuWrapperRef}
-								collabStatus={this.state.collabStatus}
-								activeCollaborators={this.state.activeCollaborators}
-								threads={threads}
-							/>
-						)}
+					<PubEditorUserInputCapture>
+						{({ captureInputPlugin, lastInputCapture }) => (
+							<React.Fragment>
+								{pubData.isDraft && (
+									<PubDraftHeader
+										pubData={pubData}
+										loginData={loginData}
+										editorChangeObject={this.state.editorChangeObject}
+										setOptionsMode={this.setOptionsMode}
+										bottomCutoffId="discussions"
+										onRef={this.handleMenuWrapperRef}
+										collabStatus={this.state.collabStatus}
+										activeCollaborators={this.state.activeCollaborators}
+										threads={threads}
+										formattingBarKey={lastInputCapture.toString()}
+									/>
+								)}
 
-						<div className="container pub">
-							<div className="row">
-								<div className="col-12 pub-columns">
-									<div className="main-content">
-										{isCollabLoading && <PubLoadingBars />}
+								<div className="container pub">
+									<div className="row">
+										<div className="col-12 pub-columns">
+											<div className="main-content">
+												{isCollabLoading && <PubLoadingBars />}
 
-										{/* Prev/Content/Next Buttons */}
-										{!isCollabLoading && hasSections && (
-											<PubSectionNav
-												pubData={pubData}
-												queryObject={queryObject}
-												hasSections={hasSections}
-												sectionId={sectionId}
-												setOptionsMode={this.setOptionsMode}
-											/>
-										)}
+												{/* Prev/Content/Next Buttons */}
+												{!isCollabLoading && hasSections && (
+													<PubSectionNav
+														pubData={pubData}
+														queryObject={queryObject}
+														hasSections={hasSections}
+														sectionId={sectionId}
+														setOptionsMode={this.setOptionsMode}
+													/>
+												)}
 
-										<div style={isCollabLoading ? { opacity: 0 } : {}}>
-											<PubBody
-												showWorkingDraftButton={
-													!pubData.isDraft &&
-													(pubData.isEditor || pubData.isManager)
-												}
-												isDraft={pubData.isDraft}
-												versionId={activeVersion && activeVersion.id}
-												sectionId={sectionId}
-												content={activeContent}
-												threads={threads}
-												slug={pubData.slug}
-												highlights={highlights}
-												hoverBackgroundColor={
-													this.props.communityData.accentMinimalColor
-												}
-												setActiveThread={this.setActiveThread}
-												onChange={this.handleEditorChange}
-												onSingleClick={this.handleEditorSingleClick}
-												// Props from CollabEditor
-												editorKey={`${this.props.pubData.editorKey}${
-													sectionId ? '/' : ''
-												}${sectionId || ''}`}
-												isReadOnly={
-													!pubData.isDraft ||
-													(!pubData.isManager && !pubData.isDraftEditor)
-												}
-												clientData={this.state.activeCollaborators[0]}
-												onClientChange={this.handleClientChange}
-												onStatusChange={this.handleStatusChange}
-												discussionNodeOptions={{
-													// getThreads: this.getThreads,
-													getThreads: () => {
-														return this.getThreads();
-													},
-													// getThreads: ()=> { return ()=>{ return threads; }; },
-													// getThreads: function() { return threads; },
-													getPubData: () => {
-														return pubData;
-													},
-													getLocationData: () => {
-														return this.props.locationData;
-													},
-													getLoginData: () => {
-														return loginData;
-													},
-													getOnPostDiscussion: () => {
-														return this.handlePostDiscussion;
-													},
-													getOnPutDiscussion: () => {
-														return this.handlePutDiscussion;
-													},
-													getGetHighlightContent: () => {
-														return this.getHighlightContent;
-													},
-													getHandleQuotePermalink: () => {
-														return this.handleQuotePermalink;
-													},
-												}}
-												// menuWrapperRefNode={this.state.menuWrapperRefNode}
-											/>
-										</div>
+												<div style={isCollabLoading ? { opacity: 0 } : {}}>
+													<PubBody
+														showWorkingDraftButton={
+															!pubData.isDraft &&
+															(pubData.isEditor || pubData.isManager)
+														}
+														isDraft={pubData.isDraft}
+														versionId={
+															activeVersion && activeVersion.id
+														}
+														sectionId={sectionId}
+														content={activeContent}
+														threads={threads}
+														slug={pubData.slug}
+														highlights={highlights}
+														hoverBackgroundColor={
+															this.props.communityData
+																.accentMinimalColor
+														}
+														setActiveThread={this.setActiveThread}
+														onChange={this.handleEditorChange}
+														onSingleClick={this.handleEditorSingleClick}
+														// Props from CollabEditor
+														editorKey={`${
+															this.props.pubData.editorKey
+														}${sectionId ? '/' : ''}${sectionId || ''}`}
+														editorCustomPlugins={{
+															captureInputPlugin: captureInputPlugin,
+														}}
+														isReadOnly={
+															!pubData.isDraft ||
+															(!pubData.isManager &&
+																!pubData.isDraftEditor)
+														}
+														clientData={
+															this.state.activeCollaborators[0]
+														}
+														onClientChange={this.handleClientChange}
+														onStatusChange={this.handleStatusChange}
+														discussionNodeOptions={{
+															// getThreads: this.getThreads,
+															getThreads: () => {
+																return this.getThreads();
+															},
+															// getThreads: ()=> { return ()=>{ return threads; }; },
+															// getThreads: function() { return threads; },
+															getPubData: () => {
+																return pubData;
+															},
+															getLocationData: () => {
+																return this.props.locationData;
+															},
+															getLoginData: () => {
+																return loginData;
+															},
+															getOnPostDiscussion: () => {
+																return this.handlePostDiscussion;
+															},
+															getOnPutDiscussion: () => {
+																return this.handlePutDiscussion;
+															},
+															getGetHighlightContent: () => {
+																return this.getHighlightContent;
+															},
+															getHandleQuotePermalink: () => {
+																return this.handleQuotePermalink;
+															},
+														}}
+													/>
+												</div>
 
-										{!isCollabLoading &&
-											isEmptyDoc &&
-											pubData.isDraft &&
-											(pubData.isEditor || pubData.isManager) && (
-												<PubInlineImport
-													editorView={this.state.editorChangeObject.view}
+												{!isCollabLoading &&
+													isEmptyDoc &&
+													pubData.isDraft &&
+													(pubData.isEditor || pubData.isManager) && (
+														<PubInlineImport
+															editorView={
+																this.state.editorChangeObject.view
+															}
+														/>
+													)}
+
+												{/* Prev/Content/Next Buttons */}
+												{!isCollabLoading && hasSections && (
+													<PubSectionNav
+														pubData={pubData}
+														queryObject={queryObject}
+														hasSections={hasSections}
+														sectionId={sectionId}
+														setOptionsMode={this.setOptionsMode}
+													/>
+												)}
+
+												{/* License */}
+												{!pubData.isDraft && <PubLicense />}
+											</div>
+											<div className="side-content" ref={this.sideMarginRef}>
+												{/* Table of Contents */}
+												<PubSideToc
+													pubData={pubData}
+													activeContent={activeContent}
+													editorChangeObject={
+														this.state.editorChangeObject
+													}
 												/>
-											)}
 
-										{/* Prev/Content/Next Buttons */}
-										{!isCollabLoading && hasSections && (
-											<PubSectionNav
-												pubData={pubData}
-												queryObject={queryObject}
-												hasSections={hasSections}
-												sectionId={sectionId}
-												setOptionsMode={this.setOptionsMode}
-											/>
-										)}
+												{/* Collaborators */}
+												<PubSideCollaborators
+													pubData={pubData}
+													setOptionsMode={this.setOptionsMode}
+												/>
 
-										{/* License */}
-										{!pubData.isDraft && <PubLicense />}
-									</div>
-									<div className="side-content" ref={this.sideMarginRef}>
-										{/* Table of Contents */}
-										<PubSideToc
-											pubData={pubData}
-											activeContent={activeContent}
-											editorChangeObject={this.state.editorChangeObject}
-										/>
-
-										{/* Collaborators */}
-										<PubSideCollaborators
-											pubData={pubData}
-											setOptionsMode={this.setOptionsMode}
-										/>
-
-										{/* Quick Options */}
-										{/* <PubSideOptions
+												{/* Quick Options */}
+												{/* <PubSideOptions
 											pubData={pubData}
 											communityData={this.props.communityData}
 											setOptionsMode={this.setOptionsMode}
 											activeDiscussionChannel={activeDiscussionChannel}
 											setDiscussionChannel={this.setDiscussionChannel}
 										/> */}
-										{pubData.publicDiscussions && (
-											<PubSideDiscussions
-												key={
-													activeDiscussionChannel
-														? activeDiscussionChannel.id
-														: 'public-channel'
-												}
-												threads={threads}
-												pubData={pubData}
-												locationData={this.state.locationData}
-												editorChangeObject={this.state.editorChangeObject}
-												loginData={this.props.loginData}
-												onPostDiscussion={this.handlePostDiscussion}
-												onPutDiscussion={this.handlePutDiscussion}
-												getHighlightContent={this.getHighlightContent}
-												activeThread={this.state.activeThreadNumber}
-												setActiveThread={this.setActiveThread}
-												activeDiscussionChannel={activeDiscussionChannel}
-												initialContent={this.state.initialDiscussionContent}
-												getAbsolutePosition={this.getAbsolutePosition}
-											/>
-										)}
+												{pubData.publicDiscussions && (
+													<PubSideDiscussions
+														key={
+															activeDiscussionChannel
+																? activeDiscussionChannel.id
+																: 'public-channel'
+														}
+														threads={threads}
+														pubData={pubData}
+														locationData={this.state.locationData}
+														editorChangeObject={
+															this.state.editorChangeObject
+														}
+														loginData={this.props.loginData}
+														onPostDiscussion={this.handlePostDiscussion}
+														onPutDiscussion={this.handlePutDiscussion}
+														getHighlightContent={
+															this.getHighlightContent
+														}
+														activeThread={this.state.activeThreadNumber}
+														setActiveThread={this.setActiveThread}
+														activeDiscussionChannel={
+															activeDiscussionChannel
+														}
+														initialContent={
+															this.state.initialDiscussionContent
+														}
+														getAbsolutePosition={
+															this.getAbsolutePosition
+														}
+													/>
+												)}
+											</div>
+										</div>
 									</div>
 								</div>
-							</div>
-						</div>
-					</div>
+							</React.Fragment>
+						)}
+					</PubEditorUserInputCapture>
 					{pubData.publicDiscussions && (
 						<div id="discussions" className="discussions">
 							<div className="container pub">

--- a/package-lock.json
+++ b/package-lock.json
@@ -14886,7 +14886,7 @@
 			"dependencies": {
 				"semver": {
 					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+					"resolved": "http://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
 					"integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
 		"pg": "^7.8.1",
 		"postcss-loader": "^3.0.0",
 		"prop-types": "^15.7.2",
+		"prosemirror-state": "^1.2.2",
 		"query-string": "^6.2.0",
 		"raven-js": "^3.27.0",
 		"react": "^16.8.3",


### PR DESCRIPTION
The use of an `Editor` component as an uncontrolled text editor presents problems for a React-based UI, since only its initial contents are controlled by a prop. When the same editor needs to be shown consecutively for two different pieces of information — in this case, the captions of two images in a Pub — React does not naively destroy the first instance and create a new one to pass initial contents into as we'd hope. I've done this by adding a `key` prop for the image based on its document position. During collaborative editing, this could cause issues when other users are changing the document position of an image as someone is trying to update its caption, but short of a new system of stable identifiers for pub entities, I think this is the best I can do for now.

_Test plan:_
Create a new pub and add two images, each with its own caption. Observe that when you move your selection from one image to the other, the caption textbox in the image formatting bar updates to match.