### PR TITLE
update: Move cursor to end of selection after creating a link

### DIFF
--- a/client/containers/Pub/Pub.js
+++ b/client/containers/Pub/Pub.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 /* eslint-disable-next-line import/no-extraneous-dependencies */
 import firebase from '@firebase/app';
 import checkIfMobile from 'is-mobile';
+import { TextSelection } from 'prosemirror-state';
 // import applyDevTools from 'prosemirror-dev-tools';
 import PageWrapper from 'components/PageWrapper/PageWrapper';
 import PubHeader from 'components/PubHeader/PubHeader';
@@ -271,7 +272,11 @@ class Pub extends Component {
 		if (this.state.linkPopupIsOpen && (evt.key === 'Escape' || evt.key === 'Enter')) {
 			evt.preventDefault();
 			this.setState({ linkPopupIsOpen: false }, () => {
-				this.state.editorChangeObject.view.focus();
+				const { view } = this.state.editorChangeObject;
+				view.dispatch(
+					view.state.tr.setSelection(new TextSelection(view.state.selection.$to)),
+				);
+				view.focus();
 			});
 		}
 		if (evt.key === 'k' && evt.metaKey) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14886,7 +14886,7 @@
 			"dependencies": {
 				"semver": {
 					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+					"resolved": "http://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
 					"integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
 		"pg": "^7.8.1",
 		"postcss-loader": "^3.0.0",
 		"prop-types": "^15.7.2",
+		"prosemirror-state": "^1.2.2",
 		"query-string": "^6.2.0",
 		"raven-js": "^3.27.0",
 		"react": "^16.8.3",


### PR DESCRIPTION
This PR modifies the way the link creation flow works in the pub editor: after selecting a block of text, adding a link to it, and hitting enter, your cursor will be moved to the end of the new link. Previously, the link would remain highlighted, necessitating an extra key press.

I'd like all of this link manipulation logic to be moved out of `Pub.js` and into something a little more specific. But I'm going to wait until after our impending refactor of that area to tackle this.

_Test plan:_
Add some text to a pub. Highlight part of it, add a link, and verify that after dismissing the link popup, your cursor is at the end of the new link.