### PR TITLE
fix: Improve handling of userId in discussions code

### DIFF
--- a/server/apiRoutes/discussions.js
+++ b/server/apiRoutes/discussions.js
@@ -2,6 +2,10 @@ import app from '../server';
 import { Pub, User, Discussion, CommunityAdmin, PubManager } from '../models';
 
 app.post('/api/discussions', (req, res) => {
+	if (req.body.userId !== (req.user || {}).id) {
+		res.status(500).json('Not authorized to add to discussions as this user');
+	}
+
 	Discussion.findAll({
 		where: {
 			pubId: req.body.pubId,


### PR DESCRIPTION
We now validate the `userId` passed in though an `/api/discussions` request before posting a comment.

_Test plan:_
- Verify that adding discussions still works.
- As a logged-out visitor to a pub, try spoofing a `userId` of another user and verify that you get a 500 error.