### PR TITLE
fix: Correctly position remove button on tags

### DIFF
--- a/client/components/LayoutEditorPubs/LayoutEditorPubs.js
+++ b/client/components/LayoutEditorPubs/LayoutEditorPubs.js
@@ -209,25 +209,23 @@ class LayoutEditorPubs extends Component {
 						onChange={this.changeTitle}
 					/>
 					<InputField label="Filter by Tag">
-						<div className="bp3-button-group bp3-select">
-							<TagMultiSelect
-								allTags={this.props.communityData.tags}
-								selectedTagIds={this.props.content.tagIds || []}
-								onItemSelect={(newTagId) => {
-									const existingTagIds = this.props.content.tagIds || [];
-									const newTagIds = [...existingTagIds, newTagId];
-									this.setTagIds(newTagIds);
-								}}
-								onRemove={(evt, tagIndex) => {
-									const existingTagIds = this.props.content.tagIds || [];
-									const newTagIds = existingTagIds.filter((item, filterIndex) => {
-										return filterIndex !== tagIndex;
-									});
-									this.setTagIds(newTagIds);
-								}}
-								placeholder="Add tags..."
-							/>
-						</div>
+						<TagMultiSelect
+							allTags={this.props.communityData.tags}
+							selectedTagIds={this.props.content.tagIds || []}
+							onItemSelect={(newTagId) => {
+								const existingTagIds = this.props.content.tagIds || [];
+								const newTagIds = [...existingTagIds, newTagId];
+								this.setTagIds(newTagIds);
+							}}
+							onRemove={(evt, tagIndex) => {
+								const existingTagIds = this.props.content.tagIds || [];
+								const newTagIds = existingTagIds.filter((item, filterIndex) => {
+									return filterIndex !== tagIndex;
+								});
+								this.setTagIds(newTagIds);
+							}}
+							placeholder="Add tags..."
+						/>
 					</InputField>
 					<InputField label="Limit">
 						<div className="bp3-button-group bp3-select">


### PR DESCRIPTION
This PR fixes an issue where the remove/"x" button on tags was not being correctly positioned due to what looks like an extraneous `.bp3-` Blueprint CSS class that was being applied to one of its parents. AFAIK the parent element with that class is safe to remove entirely, and I think the general takeaway is that we should leave the use of Blueprint CSS classes to the Blueprint React API wherever possible.

_Before:_
<img width="281" alt="image" src="https://user-images.githubusercontent.com/2208769/53758891-dbb8e700-3e73-11e9-8d65-3eaa8dcf1eaf.png">
_After:_
<img width="314" alt="image" src="https://user-images.githubusercontent.com/2208769/53758895-e07d9b00-3e73-11e9-8d4f-8e36ccdbcd5f.png">

_Test plan:_
Find a place where we use a `TagMultiSelect` component — the "Filter by tags" entry in the layout editor at `/dashboard/pages/` is as good as any — and verify that added tags have their close button positioned correctly.