### PR TITLE
feature: Attribution "affiliation" field

### DIFF
--- a/client/components/AttributionEditor/AttributionRow.js
+++ b/client/components/AttributionEditor/AttributionRow.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { Checkbox, Icon, Position } from '@blueprintjs/core';
+import { Checkbox, Icon, InputGroup, Position } from '@blueprintjs/core';
 import { MultiSelect } from '@blueprintjs/select';
 
 import Avatar from 'components/Avatar/Avatar';
@@ -24,15 +24,114 @@ const defaultProps = {
 	isDragging: false,
 };
 
+const AttributionDetailControls = (props) => {
+	const { attribution, onAttributionUpdate, roles } = props;
+	const { affiliation, id, isAuthor } = attribution;
+	return (
+		<div className="detail-controls">
+			<Checkbox
+				checked={isAuthor}
+				onChange={(evt) =>
+					onAttributionUpdate({
+						id: id,
+						isAuthor: evt.target.checked,
+					})
+				}
+			>
+				List on byline
+			</Checkbox>
+			<MultiSelect
+				className="roles"
+				items={roles}
+				itemListPredicate={getFilteredRoles}
+				itemRenderer={(item, { handleClick, modifiers }) => {
+					return (
+						<li key={item}>
+							<button
+								type="button"
+								tabIndex={-1}
+								onClick={handleClick}
+								className={
+									modifiers.active ? 'bp3-menu-item bp3-active' : 'bp3-menu-item'
+								}
+							>
+								{item}
+							</button>
+						</li>
+					);
+				}}
+				selectedItems={roles}
+				tagRenderer={(item) => {
+					return <span>{item}</span>;
+				}}
+				tagInputProps={{
+					onRemove: (evt, roleIndex) => {
+						const newRoles = roles.filter((_, filterIndex) => {
+							return filterIndex !== roleIndex;
+						});
+						onAttributionUpdate({
+							id: id,
+							roles: newRoles,
+						});
+					},
+					placeholder: 'Add roles...',
+					tagProps: {
+						className: 'bp3-minimal bp3-intent-primary',
+					},
+					inputProps: {
+						placeholder: 'Add roles...',
+					},
+				}}
+				resetOnSelect={true}
+				onItemSelect={(newRole) => {
+					const existingRoles = roles;
+					const newRoles = [...existingRoles, newRole];
+					onAttributionUpdate({
+						id: id,
+						roles: newRoles,
+					});
+				}}
+				noResults={<div className="bp3-menu-item">No Matching Roles</div>}
+				popoverProps={{
+					popoverClassName: 'bp3-minimal',
+					position: Position.BOTTOM_LEFT,
+					modifiers: {
+						preventOverflow: {
+							enabled: false,
+						},
+						hide: {
+							enabled: false,
+						},
+						flip: {
+							enabled: false,
+						},
+					},
+				}}
+			/>
+			<InputGroup
+				className="affiliation"
+				placeholder="Affiliation"
+				defaultValue={affiliation}
+				onKeyDown={(evt) => {
+					if (evt.key === 'Enter') {
+						evt.currentTarget.blur();
+					}
+				}}
+				onBlur={(evt) =>
+					onAttributionUpdate({
+						id: id,
+						affiliation: evt.target.value.trim(),
+					})
+				}
+			/>
+		</div>
+	);
+};
+
+AttributionDetailControls.propTypes = { ...propTypes, roles: PropTypes.array.isRequired };
+
 const AttributionRow = (props) => {
-	const {
-		attribution,
-		canEdit,
-		dragHandleProps,
-		isDragging,
-		onAttributionDelete,
-		onAttributionUpdate,
-	} = props;
+	const { attribution, canEdit, dragHandleProps, isDragging, onAttributionDelete } = props;
 	const { user, id, isAuthor } = attribution;
 	const roles = attribution.roles || [];
 	return (
@@ -84,91 +183,7 @@ const AttributionRow = (props) => {
 								</span>
 							);
 						})}
-					{canEdit && (
-						<Checkbox
-							checked={isAuthor}
-							onChange={(evt) =>
-								onAttributionUpdate({
-									id: id,
-									isAuthor: evt.target.checked,
-								})
-							}
-						>
-							List on byline
-						</Checkbox>
-					)}
-					{canEdit && (
-						<MultiSelect
-							items={roles || []}
-							itemListPredicate={getFilteredRoles}
-							itemRenderer={(item, { handleClick, modifiers }) => {
-								return (
-									<li key={item}>
-										<button
-											type="button"
-											tabIndex={-1}
-											onClick={handleClick}
-											className={
-												modifiers.active
-													? 'bp3-menu-item bp3-active'
-													: 'bp3-menu-item'
-											}
-										>
-											{item}
-										</button>
-									</li>
-								);
-							}}
-							selectedItems={roles || []}
-							tagRenderer={(item) => {
-								return <span>{item}</span>;
-							}}
-							tagInputProps={{
-								onRemove: (evt, roleIndex) => {
-									const newRoles = roles.filter((_, filterIndex) => {
-										return filterIndex !== roleIndex;
-									});
-									onAttributionUpdate({
-										id: id,
-										roles: newRoles,
-									});
-								},
-								placeholder: 'Add roles...',
-								tagProps: {
-									className: 'bp3-minimal bp3-intent-primary',
-								},
-								inputProps: {
-									placeholder: 'Add roles...',
-								},
-							}}
-							resetOnSelect={true}
-							onItemSelect={(newRole) => {
-								const existingRoles = roles || [];
-								const newRoles = [...existingRoles, newRole];
-								onAttributionUpdate({
-									id: id,
-									roles: newRoles,
-								});
-							}}
-							noResults={<div className="bp3-menu-item">No Matching Roles</div>}
-							popoverProps={{
-								popoverClassName: 'bp3-minimal',
-								position: Position.BOTTOM_LEFT,
-								usePortal: false,
-								modifiers: {
-									preventOverflow: {
-										enabled: false,
-									},
-									hide: {
-										enabled: false,
-									},
-									flip: {
-										enabled: false,
-									},
-								},
-							}}
-						/>
-					)}
+					{canEdit && <AttributionDetailControls {...props} roles={roles} />}
 				</div>
 			</div>
 		</div>

--- a/client/components/AttributionEditor/attributionEditor.scss
+++ b/client/components/AttributionEditor/attributionEditor.scss
@@ -8,9 +8,9 @@
 			box-shadow: 0px 1px 4px 2px rgba(0, 0, 0, 0.25);
 		}
 		.drag-handle {
-            width: 20px;
+			width: 20px;
+			padding-top: 18px; /* Hand-aligned to center of avatar bubble */
             display: flex;
-            align-items: center;
             justify-content: center;
         }
 		display: flex;
@@ -40,6 +40,25 @@
 				margin-right: 2em;
 				margin-top: 7px;
 				white-space: nowrap;
+			}
+		}
+		.detail-controls {
+			width: 100%;
+			display: flex;
+			margin-top: 2px;
+			& > *:not(:last-child) {
+				margin-right: 20px;
+			}
+			.affiliation {
+				min-width: 100px;
+				width: 35%;
+			}
+			.roles {
+				width: 45%;
+			}
+			/* Address the InputGroup created by MultiSelect */
+			.roles > :first-child {
+				width: 100%;
 			}
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3675,7 +3675,7 @@
 		},
 		"@types/concat-stream": {
 			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+			"resolved": "http://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
 			"integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
 			"requires": {
 				"@types/node": "*"
@@ -3688,7 +3688,7 @@
 		},
 		"@types/form-data": {
 			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+			"resolved": "http://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
 			"integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
 			"requires": {
 				"@types/node": "*"
@@ -4027,7 +4027,7 @@
 		},
 		"agentkeepalive": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
 			"integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8="
 		},
 		"airbnb-js-shims": {
@@ -4356,7 +4356,7 @@
 		},
 		"array-flatten": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
 		"array-includes": {
@@ -4484,7 +4484,7 @@
 				},
 				"util": {
 					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+					"resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
 					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
 					"requires": {
 						"inherits": "2.0.1"
@@ -4664,7 +4664,7 @@
 		},
 		"babel-helper-is-nodes-equiv": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
 			"integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
 			"dev": true
 		},
@@ -5685,7 +5685,7 @@
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"requires": {
 				"buffer-xor": "^1.0.3",
@@ -5719,7 +5719,7 @@
 		},
 		"browserify-rsa": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -5774,7 +5774,7 @@
 		},
 		"buffer": {
 			"version": "4.9.1",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+			"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"requires": {
 				"base64-js": "^1.0.2",
@@ -5836,7 +5836,7 @@
 				},
 				"readable-stream": {
 					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"optional": true,
 					"requires": {
@@ -5931,7 +5931,7 @@
 		},
 		"callsites": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
 			"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
 			"dev": true
 		},
@@ -5952,7 +5952,7 @@
 		},
 		"camelcase-keys": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"requires": {
 				"camelcase": "^2.0.0",
@@ -7047,7 +7047,7 @@
 		},
 		"create-hash": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"requires": {
 				"cipher-base": "^1.0.1",
@@ -7059,7 +7059,7 @@
 		},
 		"create-hmac": {
 			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"requires": {
 				"cipher-base": "^1.0.3",
@@ -7182,7 +7182,7 @@
 		},
 		"css-select": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
 			"requires": {
 				"boolbase": "~1.0.0",
@@ -7633,7 +7633,7 @@
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -7837,7 +7837,7 @@
 		},
 		"duplexer": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 			"dev": true
 		},
@@ -8249,7 +8249,7 @@
 		},
 		"es6-promisify": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
 			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 			"requires": {
 				"es6-promise": "^4.0.3"
@@ -9450,7 +9450,7 @@
 			"dependencies": {
 				"core-js": {
 					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
 					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
 				}
 			}
@@ -9574,7 +9574,7 @@
 		},
 		"finalhandler": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
 			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
 			"requires": {
 				"debug": "2.6.9",
@@ -10469,7 +10469,7 @@
 		},
 		"get-stream": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 		},
 		"get-value": {
@@ -10798,7 +10798,7 @@
 		},
 		"got": {
 			"version": "6.7.1",
-			"resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+			"resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"requires": {
 				"create-error-class": "^3.0.0",
@@ -11720,7 +11720,7 @@
 		},
 		"http-errors": {
 			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"requires": {
 				"depd": "~1.1.2",
@@ -12307,7 +12307,7 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
 		},
 		"is-path-inside": {
@@ -14955,7 +14955,7 @@
 		},
 		"mailgun.js": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/mailgun.js/-/mailgun.js-2.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/mailgun.js/-/mailgun.js-2.0.1.tgz",
 			"integrity": "sha1-E9cD4MJehdopgYoD8dQkpZkddAI=",
 			"requires": {
 				"btoa": "^1.1.2",
@@ -14973,7 +14973,7 @@
 			"dependencies": {
 				"es6-promise": {
 					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+					"resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
 					"integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
 				},
 				"lodash.isplainobject": {
@@ -15105,7 +15105,7 @@
 		},
 		"media-typer": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
 		"mem": {
@@ -15173,7 +15173,7 @@
 		},
 		"meow": {
 			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+			"resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"requires": {
 				"camelcase-keys": "^2.0.0",
@@ -15414,7 +15414,7 @@
 		},
 		"minimist": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"mississippi": {
@@ -15518,7 +15518,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
@@ -15526,7 +15526,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 				}
 			}
@@ -15758,7 +15758,7 @@
 			"dependencies": {
 				"semver": {
 					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+					"resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
 					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
 				}
 			}
@@ -16342,7 +16342,7 @@
 		},
 		"os-homedir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-locale": {
@@ -16355,7 +16355,7 @@
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"osenv": {
@@ -16656,7 +16656,7 @@
 		},
 		"path-browserify": {
 			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
 			"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
 		},
 		"path-dirname": {
@@ -16671,7 +16671,7 @@
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-is-inside": {
@@ -16899,7 +16899,7 @@
 		},
 		"popsicle": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/popsicle/-/popsicle-1.4.0.tgz",
+			"resolved": "http://registry.npmjs.org/popsicle/-/popsicle-1.4.0.tgz",
 			"integrity": "sha1-wuOKlnpvjEllzNwwwEKQwfLFW+0=",
 			"requires": {
 				"arrify": "^1.0.0",
@@ -16914,12 +16914,12 @@
 			"dependencies": {
 				"async": {
 					"version": "0.9.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+					"resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
 					"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
 				},
 				"combined-stream": {
 					"version": "0.0.7",
-					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+					"resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
 					"integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
 					"requires": {
 						"delayed-stream": "0.0.5"
@@ -16932,7 +16932,7 @@
 				},
 				"form-data": {
 					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
 					"integrity": "sha1-Jvi8JtpkQOKZy9z7aQNcT3em5GY=",
 					"requires": {
 						"async": "~0.9.0",
@@ -16942,12 +16942,12 @@
 				},
 				"mime-db": {
 					"version": "1.12.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+					"resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
 					"integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
 				},
 				"mime-types": {
 					"version": "2.0.14",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+					"resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
 					"integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
 					"requires": {
 						"mime-db": "~1.12.0"
@@ -17598,7 +17598,7 @@
 		},
 		"ramda": {
 			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
+			"resolved": "http://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
 			"integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=",
 			"dev": true
 		},
@@ -18247,7 +18247,7 @@
 		},
 		"react-resize-detector": {
 			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-2.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/react-resize-detector/-/react-resize-detector-2.3.0.tgz",
 			"integrity": "sha512-oCAddEWWeFWYH5FAcHdBYcZjAw9fMzRUK9sWSx6WvSSOPVRxcHd5zTIGy/mOus+AhN/u6T4TMiWxvq79PywnJQ==",
 			"requires": {
 				"lodash.debounce": "^4.0.8",
@@ -18619,7 +18619,7 @@
 		},
 		"reduce-css-calc": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+			"resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
 			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
 			"requires": {
 				"balanced-match": "^0.4.2",
@@ -18784,7 +18784,7 @@
 			"dependencies": {
 				"jsesc": {
 					"version": "0.5.0",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
 				}
 			}
@@ -19159,12 +19159,12 @@
 			"dependencies": {
 				"mime-db": {
 					"version": "1.25.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
+					"resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
 					"integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
 				},
 				"mime-types": {
 					"version": "2.1.13",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
+					"resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
 					"integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
 					"requires": {
 						"mime-db": "~1.25.0"
@@ -19235,7 +19235,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
 				"ret": "~0.1.10"
@@ -19427,7 +19427,7 @@
 			"dependencies": {
 				"source-map": {
 					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"requires": {
 						"amdefine": ">=0.0.4"
@@ -19600,7 +19600,7 @@
 		},
 		"sha.js": {
 			"version": "2.4.11",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"requires": {
 				"inherits": "^2.0.1",
@@ -20005,7 +20005,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"srcset": {
@@ -20369,7 +20369,7 @@
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
 				"ansi-regex": "^2.0.0"
@@ -20385,7 +20385,7 @@
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-indent": {
@@ -20452,7 +20452,7 @@
 				},
 				"file-loader": {
 					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
+					"resolved": "http://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
 					"integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
 					"dev": true,
 					"requires": {
@@ -20636,7 +20636,7 @@
 		},
 		"tar": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+			"resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 			"requires": {
 				"block-stream": "*",
@@ -20869,7 +20869,7 @@
 		},
 		"through": {
 			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
@@ -21132,7 +21132,7 @@
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+			"resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
 			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
 		},
 		"tunnel-agent": {
@@ -21721,7 +21721,7 @@
 		},
 		"vm-browserify": {
 			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+			"resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
 			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
 			"requires": {
 				"indexof": "0.0.1"
@@ -22255,7 +22255,7 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
 				"string-width": "^1.0.1",
@@ -22328,7 +22328,7 @@
 			"dependencies": {
 				"xmlbuilder": {
 					"version": "9.0.7",
-					"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+					"resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
 					"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -161,7 +161,8 @@
 	"jest": {
 		"moduleDirectories": [
 			"node_modules",
-			"<rootDir>/client"
+			"<rootDir>/client",
+			"<rootDir>"
 		],
 		"moduleNameMapper": {
 			"\\.[s]?css$": "<rootDir>/stories/styleMock.js"

--- a/server/apiRoutes/handlers/attributions.js
+++ b/server/apiRoutes/handlers/attributions.js
@@ -5,7 +5,15 @@
 import { User } from '../../models';
 import withPermissions from '../permissions/withPermissions';
 
-const CAN_UPDATE_ATTRIBUTES = ['name', 'avatar', 'title', 'order', 'isAuthor', 'roles'];
+const CAN_UPDATE_ATTRIBUTES = [
+	'name',
+	'avatar',
+	'title',
+	'order',
+	'isAuthor',
+	'roles',
+	'affiliation',
+];
 
 const INCLUDE_USER_ATTRIBUTES = {
 	model: User,

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -541,6 +541,13 @@ new Promise((resolve) => {
 	// 		return Promise.all(pageUpdates);
 	// 	});
 	// })
+	.then(() => {
+		console.log("Syncing attributions models");
+		return Promise.all([
+			sequelize.queryInterface.addColumn('CollectionAttributions', 'affiliation', { type: Sequelize.TEXT }),
+			sequelize.queryInterface.addColumn('PubAttributions', 'affiliation', { type: Sequelize.TEXT }),
+		]);
+	})
 	.catch((err) => {
 		console.log('Error with Migration', err);
 	})

--- a/server/models/collectionAttribution.js
+++ b/server/models/collectionAttribution.js
@@ -11,7 +11,7 @@ export default (sequelize) => {
 			order: { type: Sequelize.DOUBLE },
 			isAuthor: { type: Sequelize.BOOLEAN },
 			roles: { type: Sequelize.JSONB },
-
+			affiliation: { type: Sequelize.TEXT },
 			/* Set by Associations */
 			userId: { type: Sequelize.UUID },
 			collectionId: { type: Sequelize.UUID, allowNull: false },

--- a/server/models/pubAttribution.js
+++ b/server/models/pubAttribution.js
@@ -11,6 +11,7 @@ export default (sequelize) => {
 			order: { type: Sequelize.DOUBLE },
 			isAuthor: { type: Sequelize.BOOLEAN },
 			roles: { type: Sequelize.JSONB },
+			affiliation: { type: Sequelize.TEXT },
 
 			/* Set by Associations */
 			userId: { type: Sequelize.UUID },

--- a/shared/crossref/__tests__/__snapshots__/createDeposit.test.js.snap
+++ b/shared/crossref/__tests__/__snapshots__/createDeposit.test.js.snap
@@ -17,6 +17,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "first",
+                  "affiliation": "Massachusetts Institute of Technology",
                   "given_name": "Travis",
                   "surname": "Rich",
                 },
@@ -35,6 +36,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "additional",
+                  "affiliation": "Springfield A&M",
                   "given_name": "Ian",
                   "surname": "Reynolds",
                 },
@@ -100,6 +102,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "first",
+                  "affiliation": "Massachusetts Institute of Technology",
                   "given_name": "Travis",
                   "surname": "Rich",
                 },
@@ -118,6 +121,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "additional",
+                  "affiliation": "Springfield A&M",
                   "given_name": "Ian",
                   "surname": "Reynolds",
                 },
@@ -181,6 +185,7 @@ Object {
               Object {
                 "@contributor_role": "author",
                 "@sequence": "first",
+                "affiliation": "Massachusetts Institute of Technology",
                 "given_name": "Travis",
                 "surname": "Rich",
               },
@@ -199,6 +204,7 @@ Object {
               Object {
                 "@contributor_role": "author",
                 "@sequence": "additional",
+                "affiliation": "Springfield A&M",
                 "given_name": "Ian",
                 "surname": "Reynolds",
               },
@@ -271,6 +277,7 @@ Object {
               Object {
                 "@contributor_role": "author",
                 "@sequence": "first",
+                "affiliation": "Massachusetts Institute of Technology",
                 "given_name": "Travis",
                 "surname": "Rich",
               },
@@ -289,6 +296,7 @@ Object {
               Object {
                 "@contributor_role": "author",
                 "@sequence": "additional",
+                "affiliation": "Springfield A&M",
                 "given_name": "Ian",
                 "surname": "Reynolds",
               },
@@ -381,6 +389,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "first",
+                  "affiliation": "Springfield A&M",
                   "given_name": "Ian",
                   "surname": "Reynolds",
                 },
@@ -457,6 +466,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "first",
+                  "affiliation": "Massachusetts Institute of Technology",
                   "given_name": "Travis",
                   "surname": "Rich",
                 },
@@ -475,6 +485,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "additional",
+                  "affiliation": "Springfield A&M",
                   "given_name": "Ian",
                   "surname": "Reynolds",
                 },
@@ -525,6 +536,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "first",
+                  "affiliation": "Springfield A&M",
                   "given_name": "Ian",
                   "surname": "Reynolds",
                 },
@@ -591,6 +603,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "first",
+                  "affiliation": "Massachusetts Institute of Technology",
                   "given_name": "Travis",
                   "surname": "Rich",
                 },
@@ -609,6 +622,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "additional",
+                  "affiliation": "Springfield A&M",
                   "given_name": "Ian",
                   "surname": "Reynolds",
                 },
@@ -659,6 +673,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "first",
+                  "affiliation": "Springfield A&M",
                   "given_name": "Ian",
                   "surname": "Reynolds",
                 },
@@ -725,6 +740,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "first",
+                  "affiliation": "Massachusetts Institute of Technology",
                   "given_name": "Travis",
                   "surname": "Rich",
                 },
@@ -743,6 +759,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "additional",
+                  "affiliation": "Springfield A&M",
                   "given_name": "Ian",
                   "surname": "Reynolds",
                 },
@@ -793,6 +810,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "first",
+                  "affiliation": "Springfield A&M",
                   "given_name": "Ian",
                   "surname": "Reynolds",
                 },
@@ -858,6 +876,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "first",
+                  "affiliation": "Massachusetts Institute of Technology",
                   "given_name": "Travis",
                   "surname": "Rich",
                 },
@@ -876,6 +895,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "additional",
+                  "affiliation": "Springfield A&M",
                   "given_name": "Ian",
                   "surname": "Reynolds",
                 },
@@ -949,6 +969,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "first",
+                  "affiliation": "Massachusetts Institute of Technology",
                   "given_name": "Travis",
                   "surname": "Rich",
                 },
@@ -967,6 +988,7 @@ Object {
                 Object {
                   "@contributor_role": "author",
                   "@sequence": "additional",
+                  "affiliation": "Springfield A&M",
                   "given_name": "Ian",
                   "surname": "Reynolds",
                 },

--- a/shared/crossref/__tests__/createDeposit.test.js
+++ b/shared/crossref/__tests__/createDeposit.test.js
@@ -1,6 +1,6 @@
 /* global describe, it, expect */
-import { mapMetadataFields } from 'shared/collections/metadata';
-import { getSchemaForKind } from 'shared/collections/schemas';
+import { mapMetadataFields } from '../../collections/metadata';
+import { getSchemaForKind } from '../../collections/schemas';
 
 import createDepositPartial from '../createDeposit';
 

--- a/shared/crossref/__tests__/data/attributions.js
+++ b/shared/crossref/__tests__/data/attributions.js
@@ -10,6 +10,7 @@ export default [
 		userId: '237fe275-0618-4a8f-bd40-ea9065836e67',
 		collectionId: 'e281f63f-02df-4153-9b7d-e5fe1386b0e3',
 		createdAt: '2019-04-11T18:06:51.222Z',
+		affiliation: 'Massachusetts Institute of Technology',
 		user: {
 			id: '237fe275-0618-4a8f-bd40-ea9065836e67',
 			firstName: 'Travis',
@@ -73,6 +74,7 @@ export default [
 		order: 0.03125,
 		isAuthor: true,
 		roles: null,
+		affiliation: 'Springfield A&M',
 		userId: '6ddd7a7b-c542-4127-b403-33a67eb40ff3',
 		collectionId: 'e281f63f-02df-4153-9b7d-e5fe1386b0e3',
 		createdAt: '2019-04-11T18:06:47.699Z',

--- a/shared/crossref/__tests__/data/pub.js
+++ b/shared/crossref/__tests__/data/pub.js
@@ -57,6 +57,7 @@ export default {
 			order: 0.5,
 			isAuthor: true,
 			roles: null,
+			affiliation: 'Springfield A&M',
 			userId: '6ddd7a7b-c542-4127-b403-33a67eb40ff3',
 			pubId: '1519656b-cc26-43ad-83f2-dbf5b828a8c7',
 			createdAt: '2019-04-11T18:39:11.942Z',

--- a/shared/crossref/schema/contributors.js
+++ b/shared/crossref/schema/contributors.js
@@ -15,7 +15,11 @@ export default (attributions) => {
 					surname: attribution.user.lastName
 						? attribution.user.lastName
 						: attribution.user.firstName,
+					affiliation: attribution.affiliation,
 				};
+				if (!personNameOutput.affiliation) {
+					delete personNameOutput.affiliation;
+				}
 				if (!personNameOutput.given_name) {
 					delete personNameOutput.given_name;
 				}

--- a/stories/containers/Pub/PubManage/attributionStories.js
+++ b/stories/containers/Pub/PubManage/attributionStories.js
@@ -5,8 +5,14 @@ import { pubData, communityData } from 'data';
 
 require('containers/Pub/PubManage/pubManage.scss');
 
-storiesOf('containers/Pub/PubManage/Attribution', module).add('default', () => (
-	<div className="pub-manage-component" style={{ margin: '20px' }}>
-		<Attribution pubData={pubData} communityData={communityData} />
-	</div>
-));
+storiesOf('containers/Pub/PubManage/Attribution', module)
+	.add('editable', () => (
+		<div className="pub-manage-component" style={{ margin: '20px' }}>
+			<Attribution pubData={{ ...pubData, canManage: true }} communityData={communityData} />
+		</div>
+	))
+	.add('read-only', () => (
+		<div className="pub-manage-component" style={{ margin: '20px' }}>
+			<Attribution pubData={pubData} communityData={communityData} />
+		</div>
+	));


### PR DESCRIPTION
This pull request adds the `affiliation` field to the `PubAttribution` and `CollectionAttribution` models, allowing us to set an affiliation for contributors to pubs and collections, and submit that information to Crossref. To users, we expose a field like this:

![image](https://user-images.githubusercontent.com/2208769/58357375-8c69cd80-7e48-11e9-97d4-53f319e2dc86.png)

Right now it's just a freeform string — so you could affiliate yourself with the Chattanooga School of Clowning Arts if you want. Eventually we'll want to start collecting affiliations at the `User` level, linking to ORCID, etc. — but it's a start.

_Test plan:_
After running `npm migrate && npm start` I observed the following:
- Both the collection and pub-level attribution editors let you see and update affiliation for each author
- Submitting DOI information for both a collection and a pub causes the affiliation to appear for each author in the deposit generated at `test.crossref.org`.

(In theory we could update our CitationJS code to use this as well, but from a quick skim of the documentation I'm not sure if they support this/this is something we'd include here — @isTravis feel free to weigh in)