### PR TITLE
update: Restore collab avatars in v6

### DIFF
--- a/client/containers/Pub/Pub.js
+++ b/client/containers/Pub/Pub.js
@@ -28,7 +28,11 @@ const Pub = (props) => {
 				communityData={props.communityData}
 				loginData={props.loginData}
 			>
-				<PubSyncManager pubData={props.pubData} locationData={props.locationData}>
+				<PubSyncManager
+					pubData={props.pubData}
+					locationData={props.locationData}
+					loginData={props.loginData}
+				>
 					{({ pubData, collabData, firebaseBranchRef, updateLocalData, historyData }) => {
 						const mode = pubData.mode;
 						const modeProps = {

--- a/client/containers/Pub/PubDocument/PubBody.js
+++ b/client/containers/Pub/PubDocument/PubBody.js
@@ -1,7 +1,6 @@
-import React, { useContext, useRef } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import Editor from '@pubpub/editor';
-import { PageContext } from 'components/PageWrapper/PageWrapper';
 import { getResizedUrl } from 'utils';
 import discussionSchema from './DiscussionAddon/discussionSchema';
 
@@ -22,7 +21,6 @@ let setSavingTimeout;
 
 const PubBody = (props) => {
 	const { pubData, collabData, firebaseBranchRef, updateLocalData, historyData } = props;
-	const { loginData } = useContext(PageContext);
 	const prevStatusRef = useRef(null);
 	prevStatusRef.current = collabData.status;
 
@@ -87,9 +85,8 @@ const PubBody = (props) => {
 					useCollaborativeOptions
 						? {
 								firebaseRef: firebaseBranchRef,
-								clientData: { id: loginData.id },
+								clientData: props.collabData.localCollabUser,
 								initialDocKey: pubData.initialDocKey,
-								onClientChange: () => {},
 								onStatusChange: (status) => {
 									getNextStatus(status, (nextStatus) => {
 										props.updateLocalData('collab', nextStatus);

--- a/client/containers/Pub/PubDocument/PubHeaderCollaborators.js
+++ b/client/containers/Pub/PubDocument/PubHeaderCollaborators.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip } from '@blueprintjs/core';
+
+import { Avatar } from 'components';
+
+const propTypes = {
+	collaborators: PropTypes.arrayOf(
+		PropTypes.shape({
+			cursorColor: PropTypes.string,
+			id: PropTypes.string,
+			image: PropTypes.string,
+			initials: PropTypes.string,
+			name: PropTypes.string,
+		}),
+	).isRequired,
+};
+
+const getUniqueCollaborators = (collaborators) => {
+	const uniqueCollaborators = {};
+	collaborators.forEach((item) => {
+		if (item.initials !== '?') {
+			uniqueCollaborators[item.id] = item;
+		}
+	});
+	const numAnonymous = collaborators.reduce(
+		(sum, collaborator) => (collaborator.initials === '?' ? sum + 1 : sum),
+		0,
+	);
+	if (numAnonymous) {
+		uniqueCollaborators.anon = {
+			backgroundColor: 'rgba(96,96,96, 0.2)',
+			cursorColor: 'rgba(96,96,96, 1.0)',
+			id: 'anon',
+			initials: numAnonymous,
+			name: `${numAnonymous} anonymous user${numAnonymous === 1 ? '' : 's'}`,
+		};
+	}
+	return uniqueCollaborators;
+};
+
+const PubHeaderCollaborators = (props) => {
+	const uniqueCollaborators = getUniqueCollaborators(props.collaborators);
+	return (
+		<div>
+			{Object.keys(uniqueCollaborators)
+				.map((key) => uniqueCollaborators[key])
+				.filter((x) => x)
+				.map((collaborator) => {
+					return (
+						<div className="avatar-wrapper" key={`present-avatar-${collaborator.id}`}>
+							<Tooltip content={collaborator.name} tooltipClassName="bp3-dark">
+								<Avatar
+									/* Cast userInitials to string since
+									the anonymous Avatar is a int count */
+									userInitials={String(collaborator.initials)}
+									userAvatar={collaborator.image}
+									borderColor={collaborator.cursorColor}
+									borderWidth="2px"
+									width={24}
+								/>
+							</Tooltip>
+						</div>
+					);
+				})}
+		</div>
+	);
+};
+PubHeaderCollaborators.propTypes = propTypes;
+export default PubHeaderCollaborators;

--- a/client/containers/Pub/PubDocument/PubHeaderFormatting.js
+++ b/client/containers/Pub/PubDocument/PubHeaderFormatting.js
@@ -1,9 +1,10 @@
-import React, { useContext, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { PageContext } from 'components/PageWrapper/PageWrapper';
-import { Tooltip } from '@blueprintjs/core';
 import stickybits from 'stickybits';
-import { Avatar, FormattingBar } from 'components';
+
+import { FormattingBar } from 'components';
+
+import PubHeaderCollaborators from './PubHeaderCollaborators';
 
 require('./pubHeaderFormatting.scss');
 
@@ -15,19 +16,16 @@ const propTypes = {
 	// editorChangeObject: PropTypes.object,
 	// setOptionsMode: PropTypes.func.isRequired,
 	// collabStatus: PropTypes.string,
-	activeCollaborators: PropTypes.array,
 	threads: PropTypes.array,
 };
 
 const defaultProps = {
 	// collabStatus: 'connecting',
 	threads: [],
-	activeCollaborators: [],
 	// formattingBarKey: '',
 };
 
 const PubHeaderFormatting = (props) => {
-	const { loginData } = useContext(PageContext);
 	const stickyInstanceRef = useRef(undefined);
 	useEffect(() => {
 		stickyInstanceRef.current = stickybits('.pub-draft-header-component', {
@@ -41,27 +39,6 @@ const PubHeaderFormatting = (props) => {
 	}, []);
 
 	const { pubData, collabData } = props;
-	const uniqueActiveCollaborators = {};
-	props.activeCollaborators.forEach((item) => {
-		if (item.initials !== '?') {
-			uniqueActiveCollaborators[item.id] = item;
-		}
-	});
-	const numAnonymous = props.activeCollaborators.reduce((prev, curr) => {
-		if (curr.initials === '?') {
-			return prev + 1;
-		}
-		return prev;
-	}, 0);
-	if (numAnonymous) {
-		uniqueActiveCollaborators.anon = {
-			backgroundColor: 'rgba(96,96,96, 0.2)',
-			cursorColor: 'rgba(96,96,96, 1.0)',
-			id: 'anon',
-			initials: numAnonymous,
-			name: `${numAnonymous} anonymous user${numAnonymous === 1 ? '' : 's'}`,
-		};
-	}
 	// const viewOnly = !pubData.canEditBranch;
 	if (!pubData.canEditBranch) {
 		return null;
@@ -76,34 +53,7 @@ const PubHeaderFormatting = (props) => {
 
 			{/* <div className="spacer" /> */}
 			<div className="right-content">
-				{Object.keys(uniqueActiveCollaborators)
-					.map((key) => {
-						return uniqueActiveCollaborators[key];
-					})
-					.filter((item) => {
-						return item && item.id !== loginData.id;
-					})
-					.map((collaborator) => {
-						return (
-							<div
-								className="avatar-wrapper"
-								key={`present-avatar-${collaborator.id}`}
-							>
-								<Tooltip content={collaborator.name} tooltipClassName="bp3-dark">
-									<Avatar
-										/* Cast userInitials to string since
-									the anonymous Avatar is a int count */
-										userInitials={String(collaborator.initials)}
-										userAvatar={collaborator.image}
-										borderColor={collaborator.cursorColor}
-										borderWidth="2px"
-										width={24}
-									/>
-								</Tooltip>
-							</div>
-						);
-					})}
-
+				<PubHeaderCollaborators collaborators={props.collabData.remoteCollabUsers} />
 				<span className={`collab-status ${collabData.status}`}>
 					<span className="status-prefix">Working Draft </span>
 					{collabData.status}

--- a/client/utils/firebaseClient.js
+++ b/client/utils/firebaseClient.js
@@ -26,5 +26,3 @@ export const initFirebase = (rootKey, authToken) => {
 			console.error('Error authenticating firebase', err);
 		});
 };
-
-export const y = 6;


### PR DESCRIPTION
As in v5 we would like to show the avatars of other collaborators currently editing the same pub branch. Most of the code is in place to do this is already left over from v5 — I've just had to make some tweaks to make it understand branches, and do a bit of cleanup along the way. Here it is in action:
<img width="1440" alt="Screen Shot 2019-05-30 at 5 35 49 PM" src="https://user-images.githubusercontent.com/2208769/58666550-a4869480-8301-11e9-8c2f-83d7b2c81c23.png">

_Test plan:_
Log in as two different PubPub users and open the same pub. Then verify that:
- Users do not see themselves among the collaborators
- Collaborator avatars appear in the draft editing bar as expected
- Cursor colors in the editor match the color rings around the avatars
- Custom profile images are shown for users that have them
- Closing a user's editor causes their bubble to disappear