### PR TITLE
update: Port pub export to v6

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -50,6 +50,7 @@
         "react/jsx-one-expression-per-line": 0,
         "react/jsx-wrap-multilines": 0,
         "react/no-danger": 0,
+        "react/no-unescaped-entities": ["error", {"forbid": [">", "}"]}],
         "space-before-function-paren": 0
     }
 }

--- a/client/containers/Pub/PubMeta/Download.js
+++ b/client/containers/Pub/PubMeta/Download.js
@@ -1,270 +1,235 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { Button, Intent } from '@blueprintjs/core';
-import { getCollabJSONs } from '@pubpub/editor';
 import dateFormat from 'dateformat';
+import { Button, ButtonGroup, Menu, MenuItem, Popover, Tooltip } from '@blueprintjs/core';
+
 import { FileUploadButton } from 'components';
 import { PageContext } from 'components/PageWrapper/PageWrapper';
 import { apiFetch } from 'utils';
+import { pingTask } from 'utils/pingTask';
 
 require('./download.scss');
 
 const propTypes = {
 	pubData: PropTypes.object.isRequired,
-	editorView: PropTypes.object.isRequired,
-	// loginData: PropTypes.object.isRequired,
-	setPubData: PropTypes.func.isRequired,
-	// TODO: we should pass in content in the case that we are in the working draft
-	// or maybe just a reference to the function to get draft content.
+	updateLocalData: PropTypes.func.isRequired,
 };
 
-const Download = (props) => {
-	const [isLoading, setIsLoading] = useState(false);
-	const [selectedType, setSelectedType] = useState({ format: 'pdf', title: 'PDF' });
-	const [taskId, setTaskId] = useState(undefined);
-	const { communityData } = useContext(PageContext);
+const formatTypes = [
+	{ format: 'pdf', title: 'PDF' },
+	{ format: 'docx', title: 'Word' },
+	{ format: 'markdown', title: 'Markdown' },
+	{ format: 'epub', title: 'EPUB' },
+	{ format: 'html', title: 'HTML' },
+	{ format: 'odt', title: 'OpenDocument' },
+	{ format: 'plain', title: 'Plain Text' },
+	{ format: 'jats', title: 'JATS XML' },
+	{ format: 'tex', title: 'LaTeX' },
+];
 
-	// class Download extends Component {
-	// constructor(props) {
-	// 	super(props);
-	// 	this.state = {
-	// 		isLoading: false,
-	// 		type: { format: 'pdf', title: 'PDF' },
-	// 		taskId: undefined,
-	// 	};
-	// 	this.getDraftContent = this.getDraftContent.bind(this);
-	// 	this.handleExport = this.handleExport.bind(this);
-	// 	this.updateDownloads = this.updateDownloads.bind(this);
-	// 	this.checkTask = this.checkTask.bind(this);
-	// 	this.getExistingDownload = this.getExistingDownload.bind(this);
-	// 	this.getFormattedDownload = this.getFormattedDownload.bind(this);
-	// }
-
-	const updateDownloads = (type, fileUrl) => {
-		if (type !== 'formatted' && !props.pubData.activeVersion.id) {
-			return null;
+// The "formatted download" is the file that the pub manager can upload themselves to represent the
+// pub. It's stored in pub.downloads, but it's treated as a kind of special case.
+const getFormattedDownload = (downloads) => {
+	return downloads.reduce((prev, curr) => {
+		const currIsNewer = !prev || !prev.createdAt || curr.createdAt > prev.createdAt;
+		if (curr.type === 'formatted' && currIsNewer) {
+			return curr;
 		}
-		const downloadItem = {
-			type: type,
-			url: fileUrl,
-			versionId: type === 'formatted' ? undefined : props.pubData.activeVersion.id,
-			createdAt: new Date(),
-		};
-		const prevDownloads = props.pubData.downloads || [];
-		const newDownloads = [...prevDownloads, downloadItem];
-		return apiFetch('/api/pubs', {
-			method: 'PUT',
-			body: JSON.stringify({
+		return prev;
+	}, null);
+};
+
+// Finds a download for the given branchId and formatType
+const getExistingDownload = (downloads, branchId, formatType) => {
+	return downloads.find((download) => {
+		const sameBranch = download.branchId === branchId;
+		const sameType = download.type === formatType.format;
+		return sameType && sameBranch;
+	});
+};
+
+// Updates the pub's downloads list, both locally and on the server
+const updateDownloads = (type, fileUrl, pubData, communityData, updateLocalData) => {
+	if (type !== 'formatted' && !pubData.activeBranch.id) {
+		return null;
+	}
+	const downloadItem = {
+		type: type,
+		url: fileUrl,
+		branchId: type === 'formatted' ? null : pubData.activeBranch.id,
+		createdAt: new Date(),
+	};
+	const prevDownloads = pubData.downloads || [];
+	const newDownloads = [...prevDownloads, downloadItem];
+	return apiFetch('/api/pubs', {
+		method: 'PUT',
+		body: JSON.stringify({
+			downloads: newDownloads,
+			pubId: pubData.id,
+			communityId: communityData.id,
+		}),
+	})
+		.then(() => {
+			updateLocalData('pub', {
 				downloads: newDownloads,
-				pubId: props.pubData.id,
-				communityId: communityData.id,
-			}),
+			});
 		})
-			.then(() => {
-				props.setPubData({
-					...props.pubData,
-					downloads: newDownloads,
-				});
-			})
-			.catch((err) => {
-				console.error('Error Saving Pub Downloads: ', err);
-			});
-	};
-
-	const checkTask = () => {
-		return apiFetch(`/api/workerTasks?workerTaskId=${taskId}`)
-			.then((taskData) => {
-				if (taskData.isProcessing) {
-					setTimeout(() => {
-						checkTask();
-					}, 1500);
-				} else {
-					setIsLoading(false);
-					setTaskId(undefined);
-					// this.setState({
-					// 	isLoading: false,
-					// 	taskId: undefined,
-					// });
-					window.open(taskData.output.url);
-					updateDownloads(selectedType.format, taskData.output.url);
-				}
-			})
-			.catch(() => {
-				setIsLoading(false);
-				// this.setState({ isLoading: false });
-			});
-	};
-
-	const getDraftContent = () => {
-		if (!props.pubData.isDraft) {
-			return new Promise((resolve) => {
-				resolve(undefined);
-			});
-		}
-
-		const sectionsData = props.pubData.sectionsData;
-		const editorRefs = sectionsData.map((item) => {
-			return `${props.pubData.editorKey}/${item.id}`;
+		.catch((err) => {
+			console.error('Error Saving Pub Downloads: ', err);
 		});
+};
 
-		return getCollabJSONs(props.editorView, editorRefs)
-			.then((content) => {
-				const newContent =
-					content.length === 1
-						? content[0]
-						: content.map((item, index) => {
-								return {
-									title: sectionsData[index].title,
-									id: sectionsData[index].id,
-									content: item,
-								};
-						  });
-				return newContent;
-			})
-			.catch((err) => {
-				console.error('Error getting draft content', err);
-			});
-	};
+// Kicks off an export task on the backend
+const startExportTask = (pubId, branchId, format) =>
+	apiFetch('/api/export', {
+		method: 'POST',
+		body: JSON.stringify({
+			pubId: pubId,
+			branchId: branchId,
+			format: format,
+		}),
+	});
 
-	const getFormattedDownload = () => {
-		const downloads = props.pubData.downloads || [];
-		const formattedDownload = downloads.reduce((prev, curr) => {
-			const currIsNewer = !prev.createdAt || curr.createdAt > prev.createdAt;
-			if (curr.type === 'formatted' && currIsNewer) {
-				return curr;
-			}
-			return prev;
-		}, {});
-		return formattedDownload;
-	};
-
-	const getExistingDownload = () => {
-		const downloads = props.pubData.downloads || [];
-		return downloads.reduce((prev, curr) => {
-			const sameVersion = curr.versionId === props.pubData.activeVersion.id;
-			const sameType = curr.type === selectedType.format;
-			if (sameType && sameVersion) {
-				return curr.url;
-			}
-			return prev;
-		}, undefined);
-	};
-
-	const handleExport = () => {
-		const existingDownload = getExistingDownload();
-		if (existingDownload) {
-			return window.open(existingDownload);
-		}
-		// Check if that format is available for download, if not send off event.
-		setIsLoading(true);
-		// this.setState({ isLoading: true });
-		return getDraftContent()
-			.then((draftContent) => {
-				return apiFetch('/api/export', {
-					method: 'POST',
-					body: JSON.stringify({
-						pubId: props.pubData.id,
-						versionId: props.pubData.isDraft ? 'draft' : props.pubData.activeVersion.id,
-						content: draftContent,
-						format: selectedType.format,
-					}),
-				});
-			})
-			.then((newTaskId) => {
-				setTaskId(newTaskId);
-				// this.setState({ taskId: taskId });
-				setTimeout(() => {
-					checkTask();
-				}, 1500);
-			})
-			.catch(() => {
-				setIsLoading(false);
-				// this.setState({ isLoading: false });
-			});
-	};
-
-	const formattedDownload = getFormattedDownload();
-	const formattedDownloadUrl = formattedDownload.url || '';
-	const formattedDownloadExtenstion = formattedDownloadUrl
+const FormattedDownloadView = (props) => {
+	const { formattedDownload, onUpdateDownloads, shouldShowUploadForm } = props;
+	const { url = '', date } = formattedDownload || {};
+	const extension = url
 		.split('.')
 		.pop()
 		.toLowerCase();
-	const formattedDownloadDate = formattedDownload.date;
-	const types = [
-		{ format: 'pdf', title: 'PDF' },
-		{ format: 'docx', title: 'Word' },
-		{ format: 'markdown', title: 'Markdown' },
-		{ format: 'epub', title: 'EPUB' },
-		{ format: 'html', title: 'HTML' },
-		{ format: 'odt', title: 'OpenDocument' },
-		{ format: 'plain', title: 'Plain Text' },
-		{ format: 'jats', title: 'JATS XML' },
-		{ format: 'tex', title: 'LaTeX' },
-	];
+	return (
+		<div>
+			<h5>Custom download</h5>
+			{shouldShowUploadForm ? (
+				<p>
+					You can upload a file, like a PDF with custom styling, to associate with this
+					pub. It will be provided to readers as the pub's default download, but they'll
+					still be able to use the automatic export tools.
+				</p>
+			) : (
+				<p>
+					The Pub manager has provided a custom version of this pub that you can download.
+				</p>
+			)}
+			<div className="buttons-wrapper">
+				{formattedDownload && (
+					<div>
+						<Button
+							text={`Download ${extension.toUpperCase()}`}
+							onClick={() => window.open(url)}
+						/>
+						<div className="subtext">Uploaded {dateFormat(date, 'mmm dd, yyyy')}</div>
+					</div>
+				)}
+				{shouldShowUploadForm && (
+					<FileUploadButton
+						onUploadFinish={onUpdateDownloads}
+						className="typset-button"
+						text="Upload new file"
+					/>
+				)}
+			</div>
+		</div>
+	);
+};
+
+FormattedDownloadView.propTypes = {
+	formattedDownload: PropTypes.oneOf([
+		null,
+		PropTypes.shape({
+			date: PropTypes.string,
+			extension: PropTypes.string,
+			url: PropTypes.string,
+		}),
+	]).isRequired,
+	onUpdateDownloads: PropTypes.func.isRequired,
+	shouldShowUploadForm: PropTypes.bool.isRequired,
+};
+
+const Download = (props) => {
+	const { pubData, updateLocalData } = props;
+	const {
+		canManage,
+		downloads: maybeDownloads,
+		activeBranch: { id: branchId },
+		id: pubId,
+	} = pubData;
+	const downloads = maybeDownloads || [];
+	const [isLoading, setIsLoading] = useState(false);
+	const [isError, setIsError] = useState(false);
+	const [selectedType, setSelectedType] = useState(formatTypes[0]);
+	const { communityData } = useContext(PageContext);
+	const formattedDownload = getFormattedDownload(downloads);
+
+	const updateDownloadsHere = useCallback(
+		(format, url) => updateDownloads(format, url, pubData, communityData, updateLocalData),
+		[pubData, communityData, updateLocalData],
+	);
+
+	useEffect(() => {
+		if (!isLoading) {
+			return;
+		}
+		setIsError(false);
+		// Check if that format is available for download -- if not, request it from the server.
+		const existingDownload = getExistingDownload(downloads, branchId, selectedType);
+		if (existingDownload) {
+			setIsLoading(false);
+			window.open(existingDownload.url);
+			return;
+		}
+		startExportTask(pubId, branchId, selectedType.format)
+			.then((newTaskId) => pingTask(newTaskId, 1500))
+			.then((taskOutput) => {
+				setIsLoading(false);
+				window.open(taskOutput.url);
+			})
+			.catch(() => {
+				setIsError(true);
+				setIsLoading(false);
+			});
+	}, [branchId, downloads, isLoading, pubId, selectedType, updateDownloadsHere]);
+
 	return (
 		<div className="pub-meta_download-component">
-			{(props.pubData.canManage || !!formattedDownloadUrl) && (
-				<div>
-					<h2>Download</h2>
-					<p>Default file provided by Pub manager</p>
-					<div className="buttons-wrapper">
-						{!!formattedDownloadUrl && (
-							<div>
-								<Button
-									text={`Download ${formattedDownloadExtenstion.toUpperCase()}`}
-									large={true}
-									intent={Intent.PRIMARY}
-									className="typset-button"
-									onClick={() => {
-										window.open(formattedDownloadUrl);
-									}}
-								/>
-								<div className="subtext">
-									Uploaded {dateFormat(formattedDownloadDate, 'mmm dd, yyyy')}
-								</div>
-							</div>
-						)}
-						{props.pubData.canManage && (
-							<FileUploadButton
-								onUploadFinish={(fileUrl) => {
-									updateDownloads('formatted', fileUrl);
-								}}
-								className="typset-button"
-								text="Upload new default file"
-							/>
-						)}
-					</div>
+			{(canManage || formattedDownload) && (
+				<div className="formatted-download-option">
+					<FormattedDownloadView
+						formattedDownload={formattedDownload}
+						shouldShowUploadForm={canManage}
+						onUpdateDownloads={(fileUrl) => updateDownloadsHere('formatted', fileUrl)}
+					/>
 				</div>
 			)}
-
-			<h2>Download Generated File</h2>
-			<p>Auto-generated files based on article content.</p>
-			<div className="bp3-button-group">
-				{types.map((type) => {
-					return (
-						<Button
-							key={type.format}
-							active={selectedType.format === type.format}
-							disabled={isLoading}
-							onClick={() => {
-								setSelectedType(type);
-								// this.setState({ type: type });
-							}}
-							text={type.title}
-						/>
-					);
-				})}
-			</div>
-
-			<div className="buttons-wrapper">
-				<Button
-					type="button"
-					large={true}
-					intent={Intent.PRIMARY}
-					text={`Download Generated ${selectedType.title}`}
-					loading={isLoading}
-					onClick={handleExport}
-				/>
+			<div className="export-option">
+				<h5>Download Generated File</h5>
+				<p>Auto-generated files based on pub content.</p>
+				<ButtonGroup>
+					<Tooltip isOpen={isError} content="There was a problem generating the file.">
+						<Button loading={isLoading} onClick={() => setIsLoading(true)}>
+							Download as {selectedType.title}
+						</Button>
+					</Tooltip>
+					<Popover
+						content={
+							<Menu>
+								{formatTypes.map((type) => (
+									<MenuItem
+										key={type.format}
+										active={selectedType.format === type.format}
+										onClick={() => {
+											setSelectedType(type);
+											setIsError(false);
+										}}
+										text={type.title}
+									/>
+								))}
+							</Menu>
+						}
+					>
+						<Button disabled={isLoading} icon="chevron-down" />
+					</Popover>
+				</ButtonGroup>
 			</div>
 		</div>
 	);

--- a/client/containers/Pub/PubMeta/PubMeta.js
+++ b/client/containers/Pub/PubMeta/PubMeta.js
@@ -24,7 +24,7 @@ const shouldUseSticky = (metaMode) => metaMode === 'history';
 
 const metaHeaderText = (metaMode) => {
 	if (metaMode === 'details') {
-		return 'Article details';
+		return 'Pub details';
 	}
 	return metaMode.charAt(0).toUpperCase() + metaMode.slice(1);
 };
@@ -81,7 +81,9 @@ const PubMeta = (props) => {
 				{metaMode === 'details' && <Details pubData={pubData} />}
 				{metaMode === 'metrics' && <Metrics pubData={pubData} />}
 				{metaMode === 'social' && <Social pubData={pubData} />}
-				{metaMode === 'download' && <Download pubData={pubData} />}
+				{metaMode === 'download' && (
+					<Download pubData={pubData} updateLocalData={updateLocalData} />
+				)}
 				{metaMode === 'history' && (
 					<History
 						pubData={pubData}

--- a/client/containers/Pub/PubMeta/download.scss
+++ b/client/containers/Pub/PubMeta/download.scss
@@ -1,14 +1,8 @@
 .pub-meta_download-component {
-	h2 {
-		margin: 1em 0em 0.5em;
-	}
-	h2 + p {
-		margin: -1em 0em 2em;
-	}
+	display: flex;
+	padding-bottom: 2em;
 	.buttons-wrapper {
-		margin: 1em 0em 4em;
 		display: flex;
-		align-items: flex-end;
 	}
 	.subtext {
 		height: 0px;
@@ -17,5 +11,11 @@
 	}
 	.typset-button {
 		margin-right: 1em;
+	}
+	.formatted-download-option {
+		padding-right: 50px;
+	}
+	.export-option {
+		min-width: 40%;
 	}
 }

--- a/client/utils/pingTask.js
+++ b/client/utils/pingTask.js
@@ -1,0 +1,25 @@
+/**
+ * Given the ID of a worker task, pings the server until the task is done and resolves a promise,
+ * or rejects if there was a problem with the task.
+ */
+import { apiFetch } from '.';
+
+const pingTaskOnce = (taskId) => apiFetch(`/api/workerTasks?workerTaskId=${taskId}`);
+
+export const pingTask = (taskId, interval, startInterval = interval) =>
+	new Promise((resolve, reject) => {
+		const checkTask = () => {
+			pingTaskOnce(taskId)
+				.then((taskData) => {
+					if (taskData.isProcessing) {
+						setTimeout(checkTask, interval);
+					} else if (taskData.error) {
+						reject(new Error(taskData.error));
+					} else {
+						resolve(taskData.output);
+					}
+				})
+				.catch((err) => reject(err));
+		};
+		setTimeout(checkTask, startInterval);
+	});

--- a/server/apiRoutes/export.js
+++ b/server/apiRoutes/export.js
@@ -5,8 +5,7 @@ import { addWorkerTask } from '../utils';
 app.post('/api/export', (req, res) => {
 	const input = {
 		pubId: req.body.pubId,
-		versionId: req.body.versionId,
-		content: req.body.content,
+		branchId: req.body.branchId,
 		format: req.body.format,
 	};
 

--- a/stories/containers/Pub/PubMeta/downloadStories.js
+++ b/stories/containers/Pub/PubMeta/downloadStories.js
@@ -5,8 +5,29 @@ import { pubData } from 'data';
 
 require('containers/Pub/PubMeta/pubMeta.scss');
 
-storiesOf('containers/Pub/PubMeta/Download', module).add('default', () => (
-	<div className="pub-manage-component" style={{ margin: '20px' }}>
-		<Download pubData={pubData} />
-	</div>
-));
+const pubDataWithFormattedDownload = {
+	...pubData,
+	downloads: [{ type: 'formatted', createdAt: '2019-03-01T21:47:48.592Z', url: 'test.pdf' }],
+};
+
+storiesOf('containers/Pub/PubMeta/Download', module)
+	.add('default', () => (
+		<div className="pub-manage-component" style={{ margin: '20px' }}>
+			<Download pubData={pubData} />
+		</div>
+	))
+	.add('with-formatted-download', () => (
+		<div className="pub-manage-component" style={{ margin: '20px' }}>
+			<Download pubData={pubDataWithFormattedDownload} />
+		</div>
+	))
+	.add('add-formatted-download', () => (
+		<div className="pub-manage-component" style={{ margin: '20px' }}>
+			<Download pubData={{ ...pubData, canManage: true }} />
+		</div>
+	))
+	.add('update-formatted-download', () => (
+		<div className="pub-manage-component" style={{ margin: '20px' }}>
+			<Download pubData={{ ...pubDataWithFormattedDownload, canManage: true }} />
+		</div>
+	));

--- a/workers/tasks/export.js
+++ b/workers/tasks/export.js
@@ -6,8 +6,10 @@ import AWS from 'aws-sdk';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { buildSchema, renderStatic } from '@pubpub/editor';
-import { Pub, Version } from '../server/models';
-import { generateHash } from '../server/utils';
+
+import { Pub } from '../../server/models';
+import { generateHash } from '../../server/utils';
+import { getBranchDoc } from '../../server/utils/firebaseAdmin';
 
 AWS.config.setPromisesDependency(Promise);
 const s3bucket = new AWS.S3({ params: { Bucket: 'assets.pubpub.org' } });
@@ -15,6 +17,19 @@ const s3bucket = new AWS.S3({ params: { Bucket: 'assets.pubpub.org' } });
 tmp.setGracefulCleanup();
 const dataDir =
 	process.env.NODE_ENV === 'production' ? '--data-dir=/app/.apt/usr/share/pandoc/data ' : '';
+
+const formatTypes = {
+	docx: { output: 'docx', extension: 'docx' },
+	// pdf: { output: 'latex', extension: 'pdf', flags: ` --pdf-engine=xelatex --template=${__dirname}/template.tex` },
+	pdf: { output: 'latex', extension: 'pdf', flags: ' --pdf-engine=xelatex' },
+	epub: { output: 'epub', extension: 'epub' },
+	html: { output: 'html', extension: 'html' },
+	markdown: { output: 'markdown_strict', extension: 'md' },
+	odt: { output: 'odt', extension: 'odt' },
+	plain: { output: 'plain', extension: 'txt' },
+	jats: { output: 'jats', extension: 'xml' },
+	tex: { output: 'latex', extension: 'tex' },
+};
 
 // Interface - buttons to export in different formats.
 // On click, we check if we already have a rendered or default file for that format.
@@ -29,89 +44,64 @@ const dataDir =
 
 const filterNonExportableNodes = (nodes) => nodes.filter((n) => n.type !== 'discussion');
 
-export default (pubId, versionId, content, format) => {
-	const formatTypes = {
-		docx: { output: 'docx', extension: 'docx' },
-		// pdf: { output: 'latex', extension: 'pdf', flags: ` --pdf-engine=xelatex --template=${__dirname}/template.tex` },
-		pdf: { output: 'latex', extension: 'pdf', flags: ' --pdf-engine=xelatex' },
-		epub: { output: 'epub', extension: 'epub' },
-		html: { output: 'html', extension: 'html' },
-		markdown: { output: 'markdown_strict', extension: 'md' },
-		odt: { output: 'odt', extension: 'odt' },
-		plain: { output: 'plain', extension: 'txt' },
-		jats: { output: 'jats', extension: 'xml' },
-		tex: { output: 'latex', extension: 'tex' },
-	};
-	const findPub = Pub.findOne({
-		where: { id: pubId },
-	});
-	const findVersion =
-		versionId === 'draft'
-			? undefined
-			: Version.findOne({
-					where: { id: versionId },
-			  });
+const createStaticHtml = (pubTitle, pubDocJson) =>
+	ReactDOMServer.renderToStaticMarkup(
+		<html lang="en">
+			<head>
+				<title>{pubTitle}</title>
+			</head>
+			<body>{renderStatic(buildSchema(), filterNonExportableNodes(pubDocJson), {})}</body>
+		</html>,
+	);
 
-	return Promise.all([findPub, findVersion])
-		.then(([pubData, versionData]) => {
-			const initialContent = versionData ? versionData.content : content;
-			return ReactDOMServer.renderToStaticMarkup(
-				<html lang="en">
-					<head>
-						<title>{pubData.title}</title>
-					</head>
-					<body>
-						{renderStatic(
-							buildSchema(),
-							filterNonExportableNodes(initialContent.content),
-							{},
-						)}
-					</body>
-				</html>,
-			);
-		})
-		.then((staticHtml) => {
-			const generateTmpFile = tmp.file({ postfix: `.${formatTypes[format].extension}` });
-			return Promise.all([staticHtml, generateTmpFile]);
-		})
-		.then(([staticHtml, tmpFile]) => {
-			const args = `${dataDir}-f html -t ${formatTypes[format].output}${formatTypes[format]
-				.flags || ''} -o ${tmpFile.path}`;
-
-			const convertFile = new Promise((resolve, reject) => {
-				nodePandoc(staticHtml, args, (err, result) => {
-					if (err && err.message) {
-						console.warn(err.message);
-					}
-					/* This callback is called multiple times */
-					/* err is sent multiple times and includes warnings */
-					/* So to check if the file generated, check the size */
-					/* of the tmp file. */
-					const wroteToFile = !!fs.statSync(tmpFile.path).size;
-					if (result && wroteToFile) {
-						resolve(result);
-					}
-					if (result && !wroteToFile) {
-						reject(new Error('Error in Pandoc'));
-					}
-				});
-			});
-			return Promise.all([tmpFile, convertFile]);
-		})
-		.then(([tmpFile]) => {
-			const key = `${generateHash(8)}/${versionId}.${formatTypes[format].extension}`;
-			const params = {
-				Key: key,
-				Body: fs.createReadStream(tmpFile.path),
-				ACL: 'public-read',
-			};
-			return new Promise((resolve, reject) => {
-				s3bucket.upload(params, (err) => {
-					if (err) {
-						reject(err);
-					}
-					resolve({ url: `https://assets.pubpub.org/${key}` });
-				});
-			});
+const callPandoc = (staticHtml, tmpFile, format) => {
+	const args = `${dataDir}-f html -t ${formatTypes[format].output}${formatTypes[format].flags ||
+		''} -o ${tmpFile.path}`;
+	return new Promise((resolve, reject) => {
+		nodePandoc(staticHtml, args, (err, result) => {
+			if (err && err.message) {
+				console.warn(err.message);
+			}
+			/* This callback is called multiple times */
+			/* err is sent multiple times and includes warnings */
+			/* So to check if the file generated, check the size */
+			/* of the tmp file. */
+			const wroteToFile = !!fs.statSync(tmpFile.path).size;
+			if (result && wroteToFile) {
+				resolve(result);
+			}
+			if (result && !wroteToFile) {
+				reject(new Error('Error in Pandoc'));
+			}
 		});
+	});
+};
+
+const uploadDocument = (branchId, readableStream, extension) => {
+	const key = `${generateHash(8)}/${branchId}.${extension}`;
+	const params = {
+		Key: key,
+		Body: readableStream,
+		ACL: 'public-read',
+	};
+	return new Promise((resolve, reject) => {
+		s3bucket.upload(params, (err) => {
+			if (err) {
+				reject(err);
+			}
+			resolve({ url: `https://assets.pubpub.org/${key}` });
+		});
+	});
+};
+
+export default async (pubId, branchId, format) => {
+	const { extension } = formatTypes[format];
+	const pubData = await Pub.findOne({ where: { id: pubId } });
+	const tmpFile = await tmp.file({ postfix: `.${extension}` });
+	const {
+		content: { content: branchDocNodes },
+	} = await getBranchDoc(pubId, branchId);
+	const staticHtml = createStaticHtml(pubData.title, branchDocNodes);
+	await callPandoc(staticHtml, tmpFile, format);
+	return uploadDocument(branchId, fs.createReadStream(tmpFile.path), extension);
 };

--- a/workers/tasks/import.js
+++ b/workers/tasks/import.js
@@ -6,7 +6,7 @@ import nodePandoc from 'node-pandoc';
 import tmp from 'tmp-promise';
 import AWS from 'aws-sdk';
 import cheerio from 'cheerio';
-import { generateHash } from '../server/utils';
+import { generateHash } from '../../server/utils';
 
 const isPubPubProduction = !!process.env.PUBPUB_PRODUCTION;
 

--- a/workers/tasks/search.js
+++ b/workers/tasks/search.js
@@ -10,8 +10,8 @@ import {
 	User,
 	PubManager,
 	Page,
-} from '../server/models';
-import stopWordList from '../searchSync/stopwords';
+} from '../../server/models';
+import stopWordList from '../../searchSync/stopwords';
 
 const client = algoliasearch(process.env.ALGOLIA_ID, process.env.ALGOLIA_KEY);
 const pubsIndex = client.initIndex('pubs');

--- a/workers/worker.js
+++ b/workers/worker.js
@@ -60,8 +60,7 @@ const processTask = (channel) => {
 				if (taskData.type === 'export') {
 					taskFunction = exportTask(
 						taskData.input.pubId,
-						taskData.input.versionId,
-						taskData.input.content,
+						taskData.input.branchId,
 						taskData.input.format,
 					);
 				} else if (taskData.type === 'import') {


### PR DESCRIPTION
This PR does contains an end-to-end update that makes pub download/export work in v6. It also contains styling updates to the Download pane in PubMeta. Here it is:

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/2208769/58734904-cb5ace80-83c6-11e9-8337-ccd43b9ce100.png">

There are some more changes that I want to make in this area so that exported downloads always cache correctly — see #378.

_Test plan:_
- `npm run storybook` and look at [the Storybook fixtures](http://localhost:9001/?path=/story/containers-pub-pubmeta-download--default).
- Visit a pub that you manage and make sure you can update its custom download
- Make sure that exporting a pub works and that the resulting documents contain the expected content.