### PR TITLE
Pub page metadata and titles

### DIFF
--- a/server/routes/pub.js
+++ b/server/routes/pub.js
@@ -73,6 +73,14 @@ app.get(
 						mode: mode,
 					},
 				};
+				let primaryCollection = false;
+				pubData.collectionPubs.forEach((collection) => {
+					if (collection.isPrimary && collection.collection.kind !== 'issue') {
+						primaryCollection = collection.collection;
+					}
+				});
+				const collectionTitle = primaryCollection.title || initialData.communityData.title;
+				const pubTitle = `${pubData.title} · ${collectionTitle}`;
 				return renderToNodeStream(
 					res,
 					<Html
@@ -80,6 +88,15 @@ app.get(
 						initialData={newInitialData}
 						headerComponents={generateMetaComponents({
 							initialData: initialData,
+							title: pubTitle,
+							citationTitle: pubData.title,
+							collectionTitle: collectionTitle,
+							description: pubData.description,
+							image: pubData.avatar,
+							attributions: pubData.attributions,
+							publishedAt: pubData.firstPublishedAt,
+							doi: pubData.doi,
+							//unlisted: isUnlistedDraft,
 						})}
 					>
 						<Pub {...newInitialData} />

--- a/server/routes/pub.js
+++ b/server/routes/pub.js
@@ -80,6 +80,9 @@ app.get(
 					return prev;
 				}, {});
 				const contextTitle = primaryCollection.title || initialData.communityData.title;
+				/* We calculate titleWithContext in generateMetaComponents. Since we will use */
+				/* titleWithContext in other locations (e.g. search), we should eventually */
+				/* write a helper function that generates these parameters. */
 				return renderToNodeStream(
 					res,
 					<Html

--- a/server/routes/pub.js
+++ b/server/routes/pub.js
@@ -73,14 +73,13 @@ app.get(
 						mode: mode,
 					},
 				};
-				let primaryCollection = false;
-				pubData.collectionPubs.forEach((collection) => {
-					if (collection.isPrimary && collection.collection.kind !== 'issue') {
-						primaryCollection = collection.collection;
+				const primaryCollection = pubData.collectionPubs.reduce((prev, curr) => {
+					if (curr.isPrimary && curr.collection.kind !== 'issue') {
+						return curr;
 					}
-				});
-				const collectionTitle = primaryCollection.title || initialData.communityData.title;
-				const pubTitle = `${pubData.title} · ${collectionTitle}`;
+					return prev;
+				}, {});
+				const contextTitle = primaryCollection.title || initialData.communityData.title;
 				return renderToNodeStream(
 					res,
 					<Html
@@ -88,15 +87,14 @@ app.get(
 						initialData={newInitialData}
 						headerComponents={generateMetaComponents({
 							initialData: initialData,
-							title: pubTitle,
-							citationTitle: pubData.title,
-							collectionTitle: collectionTitle,
+							title: pubData.title,
+							contextTitle: contextTitle,
 							description: pubData.description,
 							image: pubData.avatar,
 							attributions: pubData.attributions,
 							publishedAt: pubData.firstPublishedAt,
 							doi: pubData.doi,
-							//unlisted: isUnlistedDraft,
+							// unlisted: isUnlistedDraft,
 						})}
 					>
 						<Pub {...newInitialData} />

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -210,6 +210,8 @@ export const getInitialData = (req) => {
 export const generateMetaComponents = ({
 	initialData,
 	title,
+	citationTitle,
+	collectionTitle,
 	description,
 	image,
 	attributions,
@@ -221,6 +223,7 @@ export const generateMetaComponents = ({
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;
+	const citationJournalTitle = collectionTitle || siteName;
 	let outputComponents = [];
 
 	if (!initialData.locationData.isBasePubPub) {
@@ -243,8 +246,14 @@ export const generateMetaComponents = ({
 			<meta key="t2" property="og:title" content={title} />,
 			<meta key="t3" name="twitter:title" content={title} />,
 			<meta key="t4" name="twitter:image:alt" content={title} />,
-			<meta key="t5" name="citation_title" content={title} />,
-			<meta key="t6" name="dc.title" content={title} />,
+		];
+	}
+
+	if (citationTitle) {
+		outputComponents = [
+			...outputComponents,
+			<meta key="t5" name="citation_title" content={citationTitle} />,
+			<meta key="t6" name="dc.title" content={citationTitle} />,
 		];
 	}
 
@@ -252,7 +261,13 @@ export const generateMetaComponents = ({
 		outputComponents = [
 			...outputComponents,
 			<meta key="sn1" property="og:site_name" content={siteName} />,
-			<meta key="sn2" property="citation_journal_title" content={siteName} />,
+		];
+	}
+
+	if (citationJournalTitle) {
+		outputComponents = [
+			...outputComponents,
+			<meta key="sn2" property="citation_journal_title" content={citationJournalTitle} />,
 		];
 	}
 

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -210,8 +210,7 @@ export const getInitialData = (req) => {
 export const generateMetaComponents = ({
 	initialData,
 	title,
-	citationTitle,
-	collectionTitle,
+	contextTitle,
 	description,
 	image,
 	attributions,
@@ -223,7 +222,7 @@ export const generateMetaComponents = ({
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;
-	const citationJournalTitle = collectionTitle || siteName;
+	const titleWithContext = contextTitle ? `${title} · ${contextTitle}` : title;
 	let outputComponents = [];
 
 	if (!initialData.locationData.isBasePubPub) {
@@ -242,18 +241,12 @@ export const generateMetaComponents = ({
 	if (title) {
 		outputComponents = [
 			...outputComponents,
-			<title key="t1">{title}</title>,
-			<meta key="t2" property="og:title" content={title} />,
-			<meta key="t3" name="twitter:title" content={title} />,
-			<meta key="t4" name="twitter:image:alt" content={title} />,
-		];
-	}
-
-	if (citationTitle) {
-		outputComponents = [
-			...outputComponents,
-			<meta key="t5" name="citation_title" content={citationTitle} />,
-			<meta key="t6" name="dc.title" content={citationTitle} />,
+			<title key="t1">{titleWithContext}</title>,
+			<meta key="t2" property="og:title" content={titleWithContext} />,
+			<meta key="t3" name="twitter:title" content={titleWithContext} />,
+			<meta key="t4" name="twitter:image:alt" content={titleWithContext} />,
+			<meta key="t5" name="citation_title" content={title} />,
+			<meta key="t6" name="dc.title" content={title} />,
 		];
 	}
 
@@ -264,10 +257,10 @@ export const generateMetaComponents = ({
 		];
 	}
 
-	if (citationJournalTitle) {
+	if (contextTitle) {
 		outputComponents = [
 			...outputComponents,
-			<meta key="sn2" property="citation_journal_title" content={citationJournalTitle} />,
+			<meta key="sn2" property="citation_journal_title" content={contextTitle} />,
 		];
 	}
 


### PR DESCRIPTION
Addresses #385.

If the pub is not in a primary collection or the pub's primary collection is of kind 'issue', the page title becomes: `{pubTitle} • {communityTitle}`

Otherwise, the pub is in a primary collection that is a book or conference, in which case the page title becomes: `{pubTitle} • {primaryCollection.title}`

Additionally, it appears that page metadata (title, og, twitter card, etc.) had regressed in V6. This attempts to restore this metadata, and makes modifications such that citation titles do not include community or collection titles.

One open question to resolve: what to do with unlisted in generateMetaComponents in the new pub model (server/routes/pub.js#99).