### PR TITLE
update: GDPR opt-in and third-party notices

### DIFF
--- a/client/components/Footer/Footer.js
+++ b/client/components/Footer/Footer.js
@@ -1,6 +1,14 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Button, InputGroup, Checkbox, Tooltip, Position } from '@blueprintjs/core';
+import {
+	Button,
+	InputGroup,
+	Checkbox,
+	Tooltip,
+	Position,
+	Popover,
+	PopoverInteractionKind,
+} from '@blueprintjs/core';
 import Icon from 'components/Icon/Icon';
 import { apiFetch } from 'utils';
 
@@ -188,21 +196,34 @@ class Footer extends Component {
 											onChange={this.handleConfirmChange}
 											label={
 												<span>
-													<Tooltip
-														position={Position.BOTTOM}
-														content={
-															<span>
+													<Popover
+														interactionKind={
+															PopoverInteractionKind.HOVER
+														}
+														popoverClassName="bp3-popover-content-sizing"
+														position={Position.RIGHT}
+													>
+														<p>
+															<em>
+																I agree to receive this newsletter.
+															</em>
+														</p>
+														<div>
+															<p>
 																We use a third party provider,
 																Mailchimp, to deliver our
 																newsletters. We never share your
 																data with anyone, and you can
 																unsubscribe using the link at the
-																bottom of every email.
-															</span>
-														}
-													>
-														<em>I agree to receive this newsletter.</em>
-													</Tooltip>
+																bottom of every email. Learn more by
+																visiting your&nbsp;
+																<a href="/privacy">
+																	privacy settings
+																</a>
+																.
+															</p>
+														</div>
+													</Popover>
 												</span>
 											}
 										/>

--- a/client/components/Footer/Footer.js
+++ b/client/components/Footer/Footer.js
@@ -4,7 +4,6 @@ import {
 	Button,
 	InputGroup,
 	Checkbox,
-	Tooltip,
 	Position,
 	Popover,
 	PopoverInteractionKind,

--- a/client/components/Footer/Footer.js
+++ b/client/components/Footer/Footer.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Button, InputGroup } from '@blueprintjs/core';
+import { Button, InputGroup, Checkbox, Tooltip, Position } from '@blueprintjs/core';
 import Icon from 'components/Icon/Icon';
 import { apiFetch } from 'utils';
 
@@ -20,9 +20,11 @@ class Footer extends Component {
 			email: '',
 			isLoadingSubscribe: false,
 			isSubscribed: false,
+			isConfirmed: false,
 		};
 		this.handleEmailChange = this.handleEmailChange.bind(this);
 		this.handleEmailSubmit = this.handleEmailSubmit.bind(this);
+		this.handleConfirmChange = this.handleConfirmChange.bind(this);
 		this.links = props.isBasePubPub
 			? [
 					{ id: 1, title: 'Create your community', url: '/create/community' },
@@ -48,6 +50,12 @@ class Footer extends Component {
 		this.setState({
 			isLoadingSubscribe: true,
 		});
+		if (!this.state.isConfirmed) {
+			this.setState({
+				isLoadingSubscribe: false,
+			});
+			return false;
+		}
 		return apiFetch('/api/subscribe', {
 			method: 'POST',
 			body: JSON.stringify({
@@ -67,6 +75,10 @@ class Footer extends Component {
 					isLoadingSubscribe: false,
 				});
 			});
+	}
+
+	handleConfirmChange(evt) {
+		this.setState({ isConfirmed: evt.target.checked });
 	}
 
 	render() {
@@ -149,24 +161,51 @@ class Footer extends Component {
 								<form onSubmit={this.handleEmailSubmit}>
 									<strong>Feature & Community Newsletter</strong>
 									<InputGroup
+										type="email"
 										placeholder="Your Email"
 										value={this.state.email}
 										onChange={this.handleEmailChange}
 										label="Feature & community newsletter"
 										rightElement={
 											<Button
+												type="submit"
 												icon={
 													!this.state.isSubscribed
 														? 'arrow-right'
 														: 'tick'
 												}
-												onClick={this.handleEmailSubmit}
 												minimal={true}
 												loading={this.state.isLoadingSubscribe}
 											/>
 										}
 										disabled={this.state.isSubscribed}
 									/>
+									<div className="confirm">
+										<Checkbox
+											checked={this.state.isConfirmed}
+											required="required"
+											onChange={this.handleConfirmChange}
+											label={
+												<span>
+													<Tooltip
+														position={Position.BOTTOM}
+														content={
+															<span>
+																We use a third party provider,
+																Mailchimp, to deliver our
+																newsletters. We never share your
+																data with anyone, and you can
+																unsubscribe using the link at the
+																bottom of every email.
+															</span>
+														}
+													>
+														<em>I agree to receive this newsletter.</em>
+													</Tooltip>
+												</span>
+											}
+										/>
+									</div>
 								</form>
 							</div>
 							<div className="right">

--- a/client/components/Footer/Footer.js
+++ b/client/components/Footer/Footer.js
@@ -183,6 +183,7 @@ class Footer extends Component {
 									<div className="confirm">
 										<Checkbox
 											checked={this.state.isConfirmed}
+											disabled={this.state.isSubscribed}
 											required="required"
 											onChange={this.handleConfirmChange}
 											label={

--- a/client/components/Footer/footer.scss
+++ b/client/components/Footer/footer.scss
@@ -10,6 +10,7 @@
 		margin-top: 0.25em;
 	}
 	.left {
+		max-width: 240px;
 		.title {
 			display: flex;
 			align-items: center;
@@ -19,6 +20,18 @@
 			img.logo {
 				max-width: 100px;
 				height: auto;
+			}
+		}
+		.confirm {
+			.bp3-checkbox {
+				margin-top: 0.5em;
+			}
+			font-size: 12px;
+			em {
+				text-decoration: underline;
+				text-decoration-style: dotted;
+				font-style: normal;
+				cursor: help;
 			}
 		}
 	}

--- a/client/containers/UserCreate/UserCreate.js
+++ b/client/containers/UserCreate/UserCreate.js
@@ -332,6 +332,16 @@ class UserCreate extends Component {
 												checked={this.state.subscribed}
 												onChange={this.onSubscribedChange}
 											/>
+											<p className="notice">
+												<em>
+													We use a third party provider, Mailchimp, to
+													deliver newsletters. We never share your data
+													with anyone, and you can unsubscribe using the
+													link at the bottom of every email. Learn more by
+													visiting your&nbsp;
+													<a href="/privacy">privacy settings</a>.
+												</em>
+											</p>
 										</InputField>
 
 										<InputField

--- a/client/containers/UserCreate/userCreate.scss
+++ b/client/containers/UserCreate/userCreate.scss
@@ -25,6 +25,9 @@
 			.bp3-label {
 				font-weight: bold;
 			}
+			.notice {
+				font-size: 12px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR implements:

### Footer newsletter signup (#389)
Adds an opt-in checkbox for GDPR compliance and a popover with third-party data notice.

<img width="630" alt="Screen Shot 2019-06-11 at 1 54 23 PM" src="https://user-images.githubusercontent.com/639110/59304333-0a5e0f00-8c66-11e9-9fab-b26dae342c64.png">

#### Testing
- Scroll to footer.
- Hover over new compliance language, make sure the third-party notice popover appears
- Click on privacy link in popover
- Submit email without checking confirmation box
- Check confirmation box, then submit email

### User creation page third-party notice language (#388)
<img width="647" alt="Screen Shot 2019-06-11 at 2 18 55 PM" src="https://user-images.githubusercontent.com/639110/59304573-835d6680-8c66-11e9-8b2b-966782ecc14d.png">