### PR TITLE
update: Add warning message when the Editor throws errors

### DIFF
--- a/client/containers/Pub/PubDocument/PubBody.js
+++ b/client/containers/Pub/PubDocument/PubBody.js
@@ -199,7 +199,7 @@ const PubBody = (props) => {
 					)}
 					{!showErrorTime && (
 						<p className="error-time">
-							All previous changes have been succesfully saved.
+							All previous changes have been successfully saved.
 						</p>
 					)}
 					<p>To continue editing, please refresh the page.</p>

--- a/client/containers/Pub/PubDocument/PubBody.js
+++ b/client/containers/Pub/PubDocument/PubBody.js
@@ -119,7 +119,7 @@ const PubBody = (props) => {
 				}}
 				onError={(err) => {
 					setEditorError(err);
-					if (window.sentryIsActive) {
+					if (typeof window !== 'undefined' && window.sentryIsActive) {
 						Sentry.configureScope((scope) => {
 							scope.setTag('error_source', 'editor');
 						});

--- a/client/containers/Pub/PubDocument/PubBody.js
+++ b/client/containers/Pub/PubDocument/PubBody.js
@@ -173,30 +173,34 @@ const PubBody = (props) => {
 					}}
 					cancelButtonText={showErrorTime ? 'Download backup' : undefined}
 					onCancel={showErrorTime ? downloadBackup : undefined}
+					className="pub-body-alert"
 				>
 					<h5>Uh oh! An error has occured in the editor.</h5>
 					<p>We've logged the error and will look into the cause right away.</p>
 					{showErrorTime && (
 						<React.Fragment>
-							<p>
-								<b>
-									Your changes were last saved{' '}
-									<TimeAgo
-										formatter={(value, unit, suffix) => {
-											const unitSuffix = value === 1 ? '' : 's';
-											return `${value} ${unit}${unitSuffix} ${suffix}`;
-										}}
-										date={lastSavedTime}
-										now={() => editorErrorTime}
-									/>
-									.
-								</b>
+							<p className="error-time">
+								Your changes were last saved{' '}
+								<TimeAgo
+									formatter={(value, unit, suffix) => {
+										const unitSuffix = value === 1 ? '' : 's';
+										return `${value} ${unit}${unitSuffix} ${suffix}`;
+									}}
+									date={lastSavedTime}
+									now={() => editorErrorTime}
+								/>
+								.
 							</p>
 							<p>
 								If you are concerned about unsaved changes being lost, please
 								download a backup copy of your document below.
 							</p>
 						</React.Fragment>
+					)}
+					{!showErrorTime && (
+						<p className="error-time">
+							All previous changes have been succesfully saved.
+						</p>
 					)}
 					<p>To continue editing, please refresh the page.</p>
 				</Alert>

--- a/client/containers/Pub/PubDocument/pubBody.scss
+++ b/client/containers/Pub/PubDocument/pubBody.scss
@@ -17,7 +17,7 @@
 			// border-top: 1px solid #CCC;
 			padding-top: 1em;
 			& + p {
-				border-bottom: 1px solid #CCC;
+				border-bottom: 1px solid #ccc;
 				padding-bottom: 1em;
 			}
 		}
@@ -158,7 +158,8 @@
 	}
 
 	.rendered-footnote.structured-value {
-		div.csl-bib-body, div.csl-entry {
+		div.csl-bib-body,
+		div.csl-entry {
 			display: inline;
 		}
 	}
@@ -183,5 +184,11 @@
 		h6 {
 			page-break-after: avoid;
 		}
+	}
+}
+
+.pub-body-alert {
+	.error-time {
+		font-weight: bold;
 	}
 }

--- a/client/utils/hydrateWrapper.js
+++ b/client/utils/hydrateWrapper.js
@@ -30,6 +30,7 @@ export const hydrateWrapper = (Component) => {
 
 		if (!isLocalEnv(window)) {
 			setupKeen();
+			window.sentryIsActive = true;
 			Sentry.init({ dsn: 'https://abe1c84bbb3045bd982f9fea7407efaa@sentry.io/1505439' });
 			Sentry.setUser({
 				id: initialData.loginData.id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2048,9 +2048,9 @@
 			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
 		},
 		"@pubpub/editor": {
-			"version": "6.0.7",
-			"resolved": "https://registry.npmjs.org/@pubpub/editor/-/editor-6.0.7.tgz",
-			"integrity": "sha512-ZxQTDMh12T9yv/NXYKASV4IUQDUkiuorCSfTVuKaH9OolS6Wp2a50so+qa7VfeGkIYeU4MXc2I29lHWQS6tshw==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@pubpub/editor/-/editor-6.1.0.tgz",
+			"integrity": "sha512-nFx50JwyTgyyi/EWyePy0EkCcVX6KDYN2wXFNq3bf3SP8dhu1WBOSEiqy5gOKM+oTh4VQzgb1uGLxjC1sSHUHw==",
 			"requires": {
 				"classnames": "^2.2.6",
 				"katex": "^0.10.2",
@@ -2067,7 +2067,7 @@
 				"prosemirror-state": "^1.2.3",
 				"prosemirror-tables": "^0.7.11",
 				"prosemirror-transform": "^1.1.3",
-				"prosemirror-view": "git+https://git@github.com/pubpub/prosemirror-view.git#dc82c2cca527df5c44e8320bd9f3f5f2e50762d5"
+				"prosemirror-view": "^1.9.13"
 			}
 		},
 		"@reach/router": {
@@ -16115,8 +16115,9 @@
 			}
 		},
 		"prosemirror-view": {
-			"version": "git+https://git@github.com/pubpub/prosemirror-view.git#dc82c2cca527df5c44e8320bd9f3f5f2e50762d5",
-			"from": "git+https://git@github.com/pubpub/prosemirror-view.git",
+			"version": "1.9.13",
+			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.9.13.tgz",
+			"integrity": "sha512-afJxCZR4EH04u4thl7xYHSIgyQiGALstLi+5SW9t3868ghrgcFhpQvbJAN17Yb9nwtnltD64t15Msk2UlXkPeQ==",
 			"requires": {
 				"prosemirror-model": "^1.1.0",
 				"prosemirror-state": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8648,6 +8648,11 @@
 				"schema-utils": "^1.0.0"
 			}
 		},
+		"file-saver": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
+			"integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw=="
+		},
 		"file-selector": {
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.1.12.tgz",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"@blueprintjs/core": "^3.17.1",
 		"@blueprintjs/icons": "^3.9.1",
 		"@blueprintjs/select": "^3.9.0",
-		"@pubpub/editor": "^6.0.7",
+		"@pubpub/editor": "^6.1.0",
 		"@sentry/browser": "^5.5.0",
 		"@sentry/node": "^5.5.0",
 		"algoliasearch": "^3.32.1",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
 		"express-session": "^1.14.1",
 		"express-sslify": "^1.2.0",
 		"file-loader": "^4.0.0",
+		"file-saver": "^2.0.2",
 		"filesize": "^4.1.2",
 		"firebase": "^6.1.1",
 		"firebase-admin": "^8.1.0",

--- a/server/server.js
+++ b/server/server.js
@@ -110,13 +110,7 @@ app.use((req, res, next) => {
 	}
 	if (req.hostname.indexOf('localhost') > -1) {
 		req.headers.localhost = req.headers.host;
-		req.headers.host = 'dev.pubpub.org';
-	}
-	if (req.hostname.indexOf('v6.pubpub.org') > -1) {
-		req.headers.host = 'dev.pubpub.org';
-	}
-	if (req.hostname.indexOf('dev.pubpub.org') > -1) {
-		req.headers.host = 'dev.pubpub.org';
+		req.headers.host = 'demo.pubpub.org';
 	}
 	if (req.hostname.indexOf('duqduq.org') > -1) {
 		req.headers.host = req.hostname.replace('duqduq.org', 'pubpub.org');


### PR DESCRIPTION
This PR responds to #456. The bulk of functionality updates are in [pubpub-editor](https://github.com/pubpub/pubpub-editor/commit/68468e91876bb5b408bc172305c97f5edc6fc67a). Both local Prosemirror errors and asynchronous Firebase errors are caught, and passed to a new `onError()` param on the `<Editor />` component. 

This onError function is used in `<PubBody />` to trigger an alert that blocks further typing and forces a page reload.
![Screen Shot 2019-07-30 at 12 02 03 PM](https://user-images.githubusercontent.com/1000455/62146861-46a40800-b2c4-11e9-95da-9ef32e003b80.png)


When `onError()` is triggered, we also fire a Sentry event and add a `{ error_source: 'editor'}` tag which will allow filtering from the Sentry end.
![Screen Shot 2019-07-30 at 12 11 44 PM](https://user-images.githubusercontent.com/1000455/62146853-4441ae00-b2c4-11e9-9773-3533cd81366f.png)

Feedback/commits on the language of the error is especially welcome.