### PR TITLE
dev/fix: Tests and some small fixes for branch-related code

### DIFF
--- a/server/branch/__tests__/api.test.js
+++ b/server/branch/__tests__/api.test.js
@@ -1,0 +1,268 @@
+/* global describe, it, expect, beforeAll, afterAll */
+import sinon from 'sinon';
+
+import { makeUser, makeCommunity, setup, teardown, login } from '../../../stubstub';
+import { createBranch } from '../queries';
+import { Pub, Branch, BranchPermission } from '../../models';
+import { createPub } from '../../pub/queries';
+import * as firebaseAdmin from '../../utils/firebaseAdmin';
+
+let firebaseAdminStub;
+let testCommunity;
+let pubManager;
+let unrelatedUser;
+let pub;
+
+setup(beforeAll, async () => {
+	firebaseAdminStub = sinon.stub(firebaseAdmin, 'createFirebaseBranch');
+	testCommunity = await makeCommunity();
+	pubManager = await makeUser();
+	unrelatedUser = await makeUser();
+	const { id: pubId } = await createPub({ communityId: testCommunity.community.id }, pubManager);
+	pub = await Pub.findOne({ where: { id: pubId }, include: [{ model: Branch, as: 'branches' }] });
+});
+
+describe('/api/branches', () => {
+	it('does not let a logged-out user create a branch', async () => {
+		const { community } = testCommunity;
+		const agent = await login();
+		await agent
+			.post('/api/branches')
+			.send({
+				pubId: pub.id,
+				communityId: community.id,
+				title: 'test-branch',
+				userPermissions: [],
+			})
+			.expect(403);
+	});
+
+	it('lets any logged-in user create a branch', async () => {
+		const { community } = testCommunity;
+		const agent = await login(unrelatedUser);
+		const {
+			body: { id: branchId },
+		} = await agent
+			.post('/api/branches')
+			.send({
+				pubId: pub.id,
+				communityId: community.id,
+				title: 'test-branch',
+				userPermissions: [],
+			})
+			.expect(201);
+		const branch = await Branch.findOne({
+			where: { id: branchId },
+			include: [{ model: BranchPermission, as: 'permissions' }],
+		});
+		expect(branch.title).toEqual('test-branch');
+		expect(branch.permissions.length).toEqual(1);
+		expect(branch.permissions[0].userId).toEqual(unrelatedUser.id);
+	});
+
+	it('lets a Pub manager update branches if the appropriate permissions are set', async () => {
+		const { community } = testCommunity;
+		// A branch created by a user without any association to the pub
+		const branch = await createBranch(
+			{
+				pubId: pub.id,
+				title: 'hey-a-test-branch',
+				pubManagerPermissions: 'manage',
+				userPermissions: [],
+			},
+			unrelatedUser.id,
+		);
+		const agent = await login(pubManager);
+		await agent
+			.put('/api/branches')
+			.send({
+				pubId: pub.id,
+				communityId: community.id,
+				branchId: branch.id,
+				title: 'renamed-branch',
+			})
+			.expect(200);
+		const branchNow = await Branch.findOne({ where: { id: branch.id } });
+		expect(branchNow.title).toEqual('renamed-branch');
+	});
+
+	it('does not let a Pub manager update branches if the appropriate permissions are not set', async () => {
+		const { community } = testCommunity;
+		// A branch created by a user without any association to the pub
+		const branch = await createBranch(
+			{
+				pubId: pub.id,
+				title: 'hey-a-test-branch',
+				pubManagerPermissions: 'none',
+				userPermissions: [],
+			},
+			unrelatedUser.id,
+		);
+		const agent = await login(pubManager);
+		await agent
+			.put('/api/branches')
+			.send({
+				pubId: pub.id,
+				communityId: community.id,
+				branchId: branch.id,
+				title: 'renamed-branch',
+			})
+			.expect(403);
+		const branchNow = await Branch.findOne({ where: { id: branch.id } });
+		expect(branchNow.title).toEqual('hey-a-test-branch');
+	});
+
+	it('lets a community admin update branches if the appropriate permissions are set', async () => {
+		const { admin, community } = testCommunity;
+		// A branch created by a user without any association to the pub
+		const branch = await createBranch(
+			{
+				pubId: pub.id,
+				title: 'hey-another-test-branch',
+				communityAdminPermissions: 'manage',
+				userPermissions: [],
+			},
+			unrelatedUser.id,
+		);
+		const agent = await login(admin);
+		await agent
+			.put('/api/branches')
+			.send({
+				pubId: pub.id,
+				communityId: community.id,
+				branchId: branch.id,
+				title: 'another-renamed-branch',
+			})
+			.expect(200);
+		const branchNow = await Branch.findOne({ where: { id: branch.id } });
+		expect(branchNow.title).toEqual('another-renamed-branch');
+	});
+
+	it('does not let a community admin update branches if the appropriate permissions not are set', async () => {
+		const { admin, community } = testCommunity;
+		// A branch created by a user without any association to the pub
+		const branch = await createBranch(
+			{
+				pubId: pub.id,
+				title: 'hey-another-test-branch',
+				communityAdminPermissions: 'none',
+				userPermissions: [],
+			},
+			unrelatedUser.id,
+		);
+		const agent = await login(admin);
+		await agent
+			.put('/api/branches')
+			.send({
+				pubId: pub.id,
+				communityId: community.id,
+				branchId: branch.id,
+				title: 'another-renamed-branch',
+			})
+			.expect(403);
+		const branchNow = await Branch.findOne({ where: { id: branch.id } });
+		expect(branchNow.title).toEqual('hey-another-test-branch');
+	});
+
+	it('lets someone granted branch management permissions update a branch', async () => {
+		const { community } = testCommunity;
+		const branch = await createBranch(
+			{
+				pubId: pub.id,
+				title: 'my-branch-unchanged',
+				communityAdminPermissions: 'none',
+				userPermissions: [{ user: { id: unrelatedUser.id }, permissions: 'manage' }],
+			},
+			pubManager.id,
+		);
+		const agent = await login(unrelatedUser);
+		await agent
+			.put('/api/branches')
+			.send({
+				pubId: pub.id,
+				communityId: community.id,
+				branchId: branch.id,
+				title: 'my-branch-changed',
+			})
+			.expect(200);
+		const branchNow = await Branch.findOne({ where: { id: branch.id } });
+		expect(branchNow.title).toEqual('my-branch-changed');
+	});
+
+	it('does not let some rando without permissions update a branch', async () => {
+		const { community } = testCommunity;
+		const branch = await createBranch(
+			{
+				pubId: pub.id,
+				title: 'my-next-branch-unchanged',
+				communityAdminPermissions: 'none',
+				userPermissions: [],
+			},
+			pubManager.id,
+		);
+		const agent = await login(unrelatedUser);
+		await agent
+			.put('/api/branches')
+			.send({
+				pubId: pub.id,
+				communityId: community.id,
+				branchId: branch.id,
+				title: 'i-am-hacking-your-branch',
+			})
+			.expect(403);
+		const branchNow = await Branch.findOne({ where: { id: branch.id } });
+		expect(branchNow.title).toEqual('my-next-branch-unchanged');
+	});
+
+	it('lets someone with management permissions destroy a branch', async () => {
+		const { community } = testCommunity;
+		const branch = await createBranch(
+			{
+				pubId: pub.id,
+				title: 'an-ephemeral-branch',
+				communityAdminPermissions: 'none',
+				userPermissions: [],
+			},
+			pubManager.id,
+		);
+		const agent = await login(pubManager);
+		await agent
+			.delete('/api/branches')
+			.send({
+				pubId: pub.id,
+				communityId: community.id,
+				branchId: branch.id,
+			})
+			.expect(200);
+		const branchNow = await Branch.findOne({ where: { id: branch.id } });
+		expect(branchNow).toEqual(null);
+	});
+
+	it('does not let some rando destroy a branch', async () => {
+		const { community } = testCommunity;
+		const branch = await createBranch(
+			{
+				pubId: pub.id,
+				title: 'a-slightly-more-permanent-branch',
+				communityAdminPermissions: 'none',
+				userPermissions: [],
+			},
+			pubManager.id,
+		);
+		const agent = await login(unrelatedUser);
+		await agent
+			.delete('/api/branches')
+			.send({
+				pubId: pub.id,
+				communityId: community.id,
+				branchId: branch.id,
+			})
+			.expect(403);
+		const branchNow = await Branch.findOne({ where: { id: branch.id } });
+		expect(branchNow).not.toEqual(null);
+	});
+});
+
+teardown(afterAll, () => {
+	firebaseAdminStub.restore();
+});

--- a/server/branch/__tests__/permissions.test.js
+++ b/server/branch/__tests__/permissions.test.js
@@ -1,0 +1,202 @@
+/* global describe, it, expect, beforeAll, afterAll */
+/* eslint-disable no-restricted-syntax */
+import sinon from 'sinon';
+
+import { makeUser, makeCommunity, setup, teardown } from '../../../stubstub';
+import { createBranch } from '../queries';
+import { Branch, BranchPermission } from '../../models';
+import { createPub } from '../../pub/queries';
+import * as firebaseAdmin from '../../utils/firebaseAdmin';
+import { getBranchAccess } from '../permissions';
+
+let firebaseAdminStub;
+let testCommunity;
+let dumbledore;
+let riddle;
+let filch;
+let snape;
+let salazar;
+let pub;
+let ron;
+let draco;
+let luna;
+const branches = {};
+
+setup(beforeAll, async () => {
+	firebaseAdminStub = sinon.stub(firebaseAdmin, 'createFirebaseBranch');
+	testCommunity = await makeCommunity();
+	dumbledore = testCommunity.admin;
+	filch = await makeUser();
+	snape = await makeUser();
+	riddle = await makeUser();
+	ron = await makeUser();
+	draco = await makeUser();
+	salazar = await makeUser();
+	luna = await makeUser();
+	pub = await createPub({ communityId: testCommunity.community.id }, filch);
+	await Promise.all(
+		[
+			{
+				title: 'greatHall',
+				creator: dumbledore,
+				communityAdminPermissions: 'manage',
+				pubManagerPermissions: 'edit',
+				publicPermissions: 'discuss',
+				userPermissions: [],
+			},
+			{
+				title: 'roomOfRequirement',
+				creator: luna,
+				communityAdminPermissions: 'discuss',
+				pubManagerPermissions: 'view',
+				userPermissions: [
+					{ user: dumbledore, permissions: 'manage' },
+					{ user: filch, permissions: 'edit' },
+				],
+			},
+			{
+				title: 'chamberOfSecrets',
+				creator: salazar,
+				communityAdminPermissions: 'none',
+				pubManagerPermissions: 'none',
+				publicPermissions: 'none',
+				userPermissions: [
+					{ user: riddle, permissions: 'manage' },
+					{ user: snape, permissions: 'discuss' },
+					{ user: draco, permissions: 'view' },
+				],
+			},
+		].map(async ({ creator, ...branch }) => {
+			const { id: branchId } = await createBranch({ pubId: pub.id, ...branch }, creator.id);
+			branches[branch.title] = await Branch.findOne({
+				include: [{ model: BranchPermission, as: 'permissions' }],
+				where: { id: branchId },
+			});
+		}),
+	);
+});
+
+const expectWaterfall = (access) => {
+	const { canView, canDiscuss, canEdit, canManage } = access;
+	if (canManage) {
+		expect(canView && canEdit && canDiscuss).toEqual(true);
+	}
+	if (canEdit) {
+		expect(canView && canDiscuss).toEqual(true);
+	}
+	if (canDiscuss) {
+		expect(canView).toEqual(true);
+	}
+};
+
+const expectAccess = (access, expectation) => {
+	Object.entries(expectation).forEach(([key, value]) => {
+		expect(access[key]).toEqual(value);
+	});
+	expectWaterfall(access);
+};
+
+describe('getBranchAccess', () => {
+	it('works for a user with no permissions whatsoever for a branch', () => {
+		const access = getBranchAccess(null, branches.chamberOfSecrets, ron.id, false, false);
+		expectAccess(access, { canView: false });
+	});
+
+	it('works for a user with a valid edit hash', () => {
+		const access = getBranchAccess(
+			branches.chamberOfSecrets.editHash,
+			branches.chamberOfSecrets,
+			ron.id,
+			false,
+			false,
+		);
+		expectAccess(access, { canEdit: true });
+	});
+
+	it('works for a user with a valid discuss hash', () => {
+		const access = getBranchAccess(
+			branches.chamberOfSecrets.discussHash,
+			branches.chamberOfSecrets,
+			ron.id,
+			false,
+			false,
+		);
+		expectAccess(access, { canDiscuss: true });
+	});
+
+	it('works for a user with a valid view hash', () => {
+		const access = getBranchAccess(
+			branches.chamberOfSecrets.viewHash,
+			branches.chamberOfSecrets,
+			ron.id,
+			false,
+			false,
+		);
+		expectAccess(access, { canView: true });
+	});
+
+	it('works for a user who is invited to manage a branch', () => {
+		const access = getBranchAccess(null, branches.chamberOfSecrets, riddle.id, false, false);
+		expectAccess(access, { canManage: true });
+	});
+
+	it('works for a user who is invited to view a branch', () => {
+		const access = getBranchAccess(null, branches.chamberOfSecrets, draco.id, false, false);
+		expectAccess(access, { canView: true });
+	});
+
+	it('works for a user who is invited to discuss a branch', () => {
+		const access = getBranchAccess(null, branches.chamberOfSecrets, snape.id, false, false);
+		expectAccess(access, { canDiscuss: true });
+	});
+
+	it('works for a user who created the branch', () => {
+		const access = getBranchAccess(null, branches.chamberOfSecrets, salazar.id, false, false);
+		expectAccess(access, { canManage: true });
+	});
+
+	it('works for a pub manager with no access to a branch', () => {
+		const access = getBranchAccess(null, branches.chamberOfSecrets, filch.id, false, false);
+		expectAccess(access, { canView: false });
+	});
+
+	it('works for a community admin with no access to a branch', () => {
+		const access = getBranchAccess(null, branches.chamberOfSecrets, filch.id, false, false);
+		expectAccess(access, { canView: false });
+	});
+
+	it('works for a user with no permissions who can view and discuss a branch', () => {
+		const access = getBranchAccess(null, branches.greatHall, ron.id, false, false);
+		expectAccess(access, { canDiscuss: true });
+	});
+
+	it('works for a community admin who can manage a branch', () => {
+		const access = getBranchAccess(null, branches.greatHall, dumbledore.id, true, false);
+		expectAccess(access, { canManage: true });
+	});
+
+	it('works for a pub manager who can edit a branch', () => {
+		const access = getBranchAccess(null, branches.greatHall, filch.id, false, true);
+		expectAccess(access, { canEdit: true });
+	});
+
+	it('works for a community admin who is also granted elevated manage permissions', () => {
+		const access = getBranchAccess(
+			null,
+			branches.roomOfRequirement,
+			dumbledore.id,
+			true,
+			false,
+		);
+		expectAccess(access, { canManage: true });
+	});
+
+	it('works for a pub manager who is also granted elevated edit permissions', () => {
+		const access = getBranchAccess(null, branches.roomOfRequirement, filch.id, true, false);
+		expectAccess(access, { canEdit: true });
+	});
+});
+
+teardown(afterAll, () => {
+	firebaseAdminStub.restore();
+});

--- a/server/branch/queries.js
+++ b/server/branch/queries.js
@@ -32,6 +32,7 @@ export const createBranch = (inputValues, userId) => {
 				order: (1 - maxOrder) / 2 + maxOrder,
 				viewHash: generateHash(8),
 				editHash: generateHash(8),
+				discussHash: generateHash(8),
 				pubId: inputValues.pubId,
 			});
 		})

--- a/server/branchPermission/__tests__/api.test.js
+++ b/server/branchPermission/__tests__/api.test.js
@@ -1,0 +1,167 @@
+/* global describe, it, expect, beforeAll, afterAll */
+import { makeUser, makeCommunity, setup, teardown, login } from '../../../stubstub';
+import { createBranchPermission } from '../queries';
+import { Pub, Branch, BranchPermission } from '../../models';
+import { createPub } from '../../pub/queries';
+
+let testCommunity;
+let pubManager;
+let unrelatedUser;
+let blessedUser;
+let pub;
+let draftBranch;
+
+setup(beforeAll, async () => {
+	testCommunity = await makeCommunity();
+	pubManager = await makeUser();
+	unrelatedUser = await makeUser();
+	blessedUser = await makeUser();
+	const { id: pubId } = await createPub({ communityId: testCommunity.community.id }, pubManager);
+	pub = await Pub.findOne({ where: { id: pubId }, include: [{ model: Branch, as: 'branches' }] });
+	draftBranch = pub.branches.find((br) => br.title === 'draft');
+});
+
+describe('/api/branchPermissions', () => {
+	it('lets pub managers creates a BranchPermission', async () => {
+		const { community } = testCommunity;
+		await BranchPermission.destroy({ where: { userId: unrelatedUser.id } });
+		await draftBranch.update({ pubManagerPermissions: 'manage' });
+		const agent = await login(pubManager);
+		await agent
+			.post('/api/branchPermissions')
+			.send({
+				communityId: community.id,
+				userId: unrelatedUser.id,
+				pubId: pub.id,
+				branchId: draftBranch.id,
+			})
+			.expect(201);
+		const bp = await BranchPermission.findOne({ where: { userId: unrelatedUser.id } });
+		expect(bp.pubId).toEqual(pub.id);
+		expect(bp.permissions).toEqual('view');
+	});
+
+	it('does not let pub managers creates a BranchPermission if the branch does not allow it', async () => {
+		const { community } = testCommunity;
+		await draftBranch.update({ pubManagerPermissions: 'none' });
+		const agent = await login(pubManager);
+		await agent
+			.post('/api/branchPermissions')
+			.send({
+				communityId: community.id,
+				userId: unrelatedUser.id,
+				pubId: pub.id,
+				branchId: draftBranch.id,
+			})
+			.expect(403);
+	});
+
+	it('lets community admins creates a BranchPermission', async () => {
+		const { admin, community } = testCommunity;
+		await BranchPermission.destroy({ where: { userId: unrelatedUser.id } });
+		await draftBranch.update({ communityAdminPermissions: 'manage' });
+		const agent = await login(admin);
+		await agent
+			.post('/api/branchPermissions')
+			.send({
+				communityId: community.id,
+				userId: unrelatedUser.id,
+				pubId: pub.id,
+				branchId: draftBranch.id,
+			})
+			.expect(201);
+		const bp = await BranchPermission.findOne({ where: { userId: unrelatedUser.id } });
+		expect(bp.pubId).toEqual(pub.id);
+		expect(bp.permissions).toEqual('view');
+	});
+
+	it('does not let community admins creates a BranchPermission if the branch does not allow it', async () => {
+		const { admin, community } = testCommunity;
+		await draftBranch.update({ communityAdminPermissions: 'none' });
+		const agent = await login(admin);
+		await agent
+			.post('/api/branchPermissions')
+			.send({
+				communityId: community.id,
+				userId: unrelatedUser.id,
+				pubId: pub.id,
+				branchId: draftBranch.id,
+			})
+			.expect(403);
+	});
+
+	it('lets users with a "manage" BranchPermission add more branch permissions', async () => {
+		const { community } = testCommunity;
+		await BranchPermission.destroy({ where: { userId: unrelatedUser.id } });
+		await createBranchPermission({
+			userId: blessedUser.id,
+			pubId: pub.id,
+			branchId: draftBranch.id,
+			permissions: 'manage',
+		});
+		const agent = await login(blessedUser);
+		await agent
+			.post('/api/branchPermissions')
+			.send({
+				communityId: community.id,
+				userId: unrelatedUser.id,
+				pubId: pub.id,
+				branchId: draftBranch.id,
+			})
+			.expect(201);
+		const bp = await BranchPermission.findOne({ where: { userId: unrelatedUser.id } });
+		expect(bp.pubId).toEqual(pub.id);
+		expect(bp.permissions).toEqual('view');
+	});
+
+	it('updates a BranchPermission', async () => {
+		const { community } = testCommunity;
+		await BranchPermission.destroy({ where: { userId: blessedUser.id } });
+		await draftBranch.update({ pubManagerPermissions: 'manage' });
+		const bp = await createBranchPermission({
+			userId: blessedUser.id,
+			pubId: pub.id,
+			branchId: draftBranch.id,
+		});
+		expect(bp.permissions).toEqual('view');
+		const agent = await login(pubManager);
+		await agent
+			.put('/api/branchPermissions')
+			.send({
+				communityId: community.id,
+				pubId: pub.id,
+				branchId: draftBranch.id,
+				branchPermissionId: bp.id,
+				permissions: 'manage',
+			})
+			.expect(200);
+		const bpNow = await BranchPermission.findOne({ where: { id: bp.id } });
+		expect(bpNow.permissions).toEqual('manage');
+	});
+
+	it('destroys a BranchPermission', async () => {
+		const { community } = testCommunity;
+		await BranchPermission.destroy({ where: { userId: blessedUser.id } });
+		await draftBranch.update({ pubManagerPermissions: 'manage' });
+		const bp = await createBranchPermission({
+			userId: blessedUser.id,
+			pubId: pub.id,
+			branchId: draftBranch.id,
+		});
+		const agent = await login(pubManager);
+		await agent
+			.delete('/api/branchPermissions')
+			.send({
+				communityId: community.id,
+				pubId: pub.id,
+				branchId: draftBranch.id,
+				branchPermissionId: bp.id,
+				permissions: 'manage',
+			})
+			.expect(200);
+		const bpNow = await BranchPermission.findOne({ where: { id: bp.id } });
+		expect(bpNow).toEqual(null);
+	});
+});
+
+teardown(afterAll);

--- a/server/branchPermission/permissions.js
+++ b/server/branchPermission/permissions.js
@@ -41,7 +41,7 @@ export const getPermissions = ({ branchId, userId, pubId, communityId }) => {
 		}, canManageAsPubManager || canManageAsCommunityAdmin || isSuperAdmin);
 
 		return {
-			create: true,
+			create: canManage,
 			update: canManage && ['permissions'],
 			destroy: canManage,
 		};

--- a/server/branchPermission/queries.js
+++ b/server/branchPermission/queries.js
@@ -6,7 +6,7 @@ export const createBranchPermission = ({ userId, pubId, branchId, permissions = 
 		userId: userId,
 		pubId: pubId,
 		branchId: branchId,
-		permissions: permissions || 'view',
+		permissions: permissions,
 	}).then((newBranchPermission) => {
 		return BranchPermission.findOne({
 			where: { id: newBranchPermission.id },

--- a/server/branchPermission/queries.js
+++ b/server/branchPermission/queries.js
@@ -1,12 +1,12 @@
 import { BranchPermission, User } from '../models';
 import { attributesPublicUser } from '../utils';
 
-export const createBranchPermission = (inputValues) => {
+export const createBranchPermission = ({ userId, pubId, branchId, permissions = 'view' }) => {
 	return BranchPermission.create({
-		userId: inputValues.userId,
-		pubId: inputValues.pubId,
-		branchId: inputValues.branchId,
-		permissions: 'view',
+		userId: userId,
+		pubId: pubId,
+		branchId: branchId,
+		permissions: permissions || 'view',
 	}).then((newBranchPermission) => {
 		return BranchPermission.findOne({
 			where: { id: newBranchPermission.id },


### PR DESCRIPTION
This PR adds tests for `branch` and `branchPermission` code, and shores up some of the code that we're testing as well. It also updates the branch-related API routes to use semantically-meaningful HTTP error codes.

_Test plan:_
`npm run test server/branch`