### PR TITLE
dev/fix: Tests and a tiny fix for collections-related code

### DIFF
--- a/server/collection/__tests__/api.test.js
+++ b/server/collection/__tests__/api.test.js
@@ -1,0 +1,143 @@
+/* global describe, it, expect, beforeAll, afterAll */
+import { makeUser, makeCommunity, setup, teardown, login } from '../../../stubstub';
+import { createCollection } from '../queries';
+import { Collection, CollectionPub } from '../../models';
+import { createPub } from '../../pub/queries';
+import { createCollectionPub } from '../../collectionPub/queries';
+
+let testCommunity;
+let anotherTestCommunity;
+let user;
+let pub;
+
+setup(beforeAll, async () => {
+	testCommunity = await makeCommunity();
+	anotherTestCommunity = await makeCommunity();
+	user = await makeUser();
+	pub = await createPub({ communityId: testCommunity.community.id }, user);
+});
+
+describe('/api/collections', () => {
+	it('creates a new collection', async () => {
+		const { admin, community } = testCommunity;
+		const agent = await login(admin);
+		const {
+			body: { communityId, title, kind, isPublic },
+		} = await agent
+			.post('/api/collections')
+			.send({
+				communityId: community.id,
+				title: 'My test collection',
+				kind: 'issue',
+			})
+			.expect(201);
+		expect(communityId).toEqual(community.id);
+		expect(title).toEqual('My test collection');
+		expect(kind).toEqual('issue');
+		expect(isPublic).toEqual(true);
+	});
+
+	it('does not all admins of another community to create a collection', async () => {
+		const { community } = testCommunity;
+		const { admin: anotherAdmin } = anotherTestCommunity;
+		const agent = await login(anotherAdmin);
+		await agent
+			.post('/api/collections')
+			.send({
+				communityId: community.id,
+				title: 'My test collection',
+				kind: 'issue',
+			})
+			.expect(403);
+	});
+
+	it('does not allow normal users to create a collection', async () => {
+		const { community } = testCommunity;
+		const agent = await login(user);
+		await agent
+			.post('/api/collections')
+			.send({
+				communityId: community.id,
+				title: 'My test collection',
+				kind: 'issue',
+			})
+			.expect(403);
+	});
+
+	it('updates only expected values on an existing collection', async () => {
+		const { admin, community } = testCommunity;
+		const collection = await createCollection({
+			communityId: community.id,
+			kind: 'issue',
+			title: 'The Book of Tests',
+		});
+		const agent = await login(admin);
+		const { body: updatedCollection } = await agent
+			.put('/api/collections')
+			.send({
+				id: collection.id,
+				title: 'The Updated Book of Tests',
+				communityId: community.id,
+				doi: 'dont_change_me_lol',
+			})
+			.expect(200);
+		expect(updatedCollection.title).toEqual('The Updated Book of Tests');
+		expect(updatedCollection.doi).not.toEqual('dont_change_me_lol');
+	});
+
+	it('unsets a collectionPub as primary when its collection is made private', async () => {
+		const { admin, community } = testCommunity;
+		const issue = await createCollection({
+			communityId: community.id,
+			kind: 'issue',
+			title: 'The Book of Tests',
+		});
+		const collectionPub = await createCollectionPub({ pubId: pub.id, collectionId: issue.id });
+		expect(collectionPub.isPrimary).toEqual(true);
+		const agent = await login(admin);
+		await agent
+			.put('/api/collections')
+			.send({
+				id: issue.id,
+				communityId: community.id,
+				isPublic: false,
+			})
+			.expect(200);
+		const collectionPubAgain = await CollectionPub.findOne({ where: { id: collectionPub.id } });
+		expect(collectionPubAgain.isPrimary).toEqual(false);
+	});
+
+	it('deletes an existing collection with appropriate permissions', async () => {
+		const { admin, community } = testCommunity;
+		const collection = await createCollection({
+			communityId: community.id,
+			kind: 'issue',
+			title: 'The Book of Tests',
+		});
+		const agent = await login(admin);
+		await agent
+			.delete('/api/collections')
+			.send({ id: collection.id, communityId: community.id })
+			.expect(200);
+		const collectionNow = await Collection.findOne({ where: { id: collection.id } });
+		expect(collectionNow).toEqual(null);
+	});
+
+	it('does not allow normal users to delete a collection', async () => {
+		const { community } = testCommunity;
+		const collection = await createCollection({
+			communityId: community.id,
+			kind: 'issue',
+			title: 'The Book of Tests',
+		});
+		const agent = await login(user);
+		await agent
+			.delete('/api/collections')
+			.send({ id: collection.id, communityId: community.id })
+			.expect(403);
+		const collectionNow = await Collection.findOne({ where: { id: collection.id } });
+		expect(collectionNow.id).toEqual(collection.id);
+	});
+
+	teardown(afterAll);
+});

--- a/server/collectionAttribution/__tests__/api.test.js
+++ b/server/collectionAttribution/__tests__/api.test.js
@@ -1,0 +1,110 @@
+/* global describe, it, expect, beforeAll, afterAll */
+import { makeUser, makeCommunity, setup, teardown, login } from '../../../stubstub';
+import { createCollection } from '../../collection/queries';
+import { createCollectionAttribution } from '../queries';
+import { CollectionAttribution } from '../../models';
+
+let user;
+let testCommunity;
+let collection;
+
+setup(beforeAll, async () => {
+	user = await makeUser();
+	testCommunity = await makeCommunity();
+	collection = await createCollection({
+		communityId: testCommunity.community.id,
+		kind: 'issue',
+		title: 'Just a test collection',
+	});
+});
+
+describe('/api/collectionAttribution', () => {
+	it('creates a collection attribution', async () => {
+		const { admin, community } = testCommunity;
+		const agent = await login(admin);
+		const { body: attr } = await agent
+			.post('/api/collectionAttributions')
+			.send({
+				order: 0,
+				name: 'Test Person',
+				communityId: community.id,
+				collectionId: collection.id,
+			})
+			.expect(201);
+		expect(attr.name).toEqual('Test Person');
+	});
+
+	it('creates a collection attribution associated to a user', async () => {
+		const { admin, community } = testCommunity;
+		const agent = await login(admin);
+		const { body: attr } = await agent
+			.post('/api/collectionAttributions')
+			.send({
+				order: 0,
+				name: 'Test Person',
+				communityId: community.id,
+				collectionId: collection.id,
+				userId: user.id,
+			})
+			.expect(201);
+		expect(attr.user.id).toEqual(user.id);
+	});
+
+	it("does not create a collection attribution if you're just some schmoe", async () => {
+		const { community } = testCommunity;
+		const agent = await login(user);
+		await agent
+			.post('/api/collectionAttributions')
+			.send({
+				order: 0,
+				name: 'Some Schmoe',
+				communityId: community.id,
+				collectionId: collection.id,
+			})
+			.expect(403);
+	});
+
+	it('updates collection attributions', async () => {
+		const { admin, community } = testCommunity;
+		const ca = await createCollectionAttribution({
+			order: 0,
+			name: 'Test Person',
+			communityId: community.id,
+			collectionId: collection.id,
+		});
+		const agent = await login(admin);
+		const { body: attr } = await agent
+			.put('/api/collectionAttributions')
+			.send({
+				affiliation: 'Test University of Testing',
+				communityId: community.id,
+				collectionId: collection.id,
+				id: ca.id,
+			})
+			.expect(200);
+		expect(attr.affiliation).toEqual('Test University of Testing');
+	});
+
+	it('destroys collection attributions', async () => {
+		const { admin, community } = testCommunity;
+		const ca = await createCollectionAttribution({
+			order: 0,
+			name: 'Test Person',
+			communityId: community.id,
+			collectionId: collection.id,
+		});
+		const agent = await login(admin);
+		await agent
+			.delete('/api/collectionAttributions')
+			.send({
+				communityId: community.id,
+				collectionId: collection.id,
+				id: ca.id,
+			})
+			.expect(200);
+		const caNow = await CollectionAttribution.findOne({ where: { id: ca.id } });
+		expect(caNow).toEqual(null);
+	});
+});
+
+teardown(afterAll);

--- a/server/collectionPub/__tests__/api.test.js
+++ b/server/collectionPub/__tests__/api.test.js
@@ -1,0 +1,212 @@
+/* global describe, it, expect, beforeAll, afterAll */
+import { makeUser, makeCommunity, setup, teardown, login } from '../../../stubstub';
+import { createCollection } from '../../collection/queries';
+import { Collection, CollectionPub } from '../../models';
+import { createPub } from '../../pub/queries';
+import { createCollectionPub } from '../queries';
+
+let user;
+let testCommunity;
+let anotherTestCommunity;
+let tag;
+let issue;
+let book;
+let pub;
+let anotherPub;
+
+setup(beforeAll, async () => {
+	user = await makeUser();
+	testCommunity = await makeCommunity();
+	anotherTestCommunity = await makeCommunity();
+	tag = await createCollection({
+		communityId: testCommunity.community.id,
+		kind: 'tag',
+		title: 'Just a test tag',
+	});
+	issue = await createCollection({
+		communityId: testCommunity.community.id,
+		kind: 'issue',
+		title: 'Just a test issue',
+	});
+	book = await createCollection({
+		communityId: testCommunity.community.id,
+		kind: 'book',
+		title: 'Just a test book',
+	});
+	pub = await createPub({ communityId: testCommunity.community.id }, user);
+	anotherPub = await createPub({ communityId: testCommunity.community.id }, user);
+});
+
+describe('/api/collectionPubs', () => {
+	it('creates a collectionPub and sets its rank', async () => {
+		const { admin, community } = testCommunity;
+		const agent = await login(admin);
+		const { body: collectionPub } = await agent
+			.post('/api/collectionPubs')
+			.send({ pubId: pub.id, collectionId: issue.id, communityId: community.id })
+			.expect(201);
+		const queriedCollectionPub = await CollectionPub.findOne({
+			where: { id: collectionPub.id },
+		});
+		expect(queriedCollectionPub.collectionId).toEqual(issue.id);
+		expect(queriedCollectionPub.rank).toEqual('h');
+	});
+
+	it('does not let administrators of other communities create a collectionPub', async () => {
+		const { community } = testCommunity;
+		const { admin: anotherAdmin } = anotherTestCommunity;
+		const agent = await login(anotherAdmin);
+		await agent
+			.post('/api/collectionPubs')
+			.send({ pubId: pub.id, collectionId: issue.id, communityId: community.id })
+			.expect(403);
+	});
+
+	it('handles ranks correctly', async () => {
+		const { community, admin } = testCommunity;
+		await CollectionPub.destroy({ where: { collectionId: issue.id } });
+		const agent = await login(admin);
+		// Add the pub to the issue
+		const { body: firstCollectionPub } = await agent
+			.post('/api/collectionPubs')
+			.send({ pubId: pub.id, collectionId: issue.id, communityId: community.id })
+			.expect(201);
+		expect(firstCollectionPub.rank).toEqual('h');
+		// Add another pub to the issue
+		const { body: secondCollectionPub } = await agent
+			.post('/api/collectionPubs')
+			.send({ pubId: anotherPub.id, collectionId: issue.id, communityId: community.id })
+			.expect(201);
+		expect(secondCollectionPub.rank).toEqual('q');
+	});
+
+	it('makes a non-tag collectionPub primary when it is the first non-tag collection for a pub', async () => {
+		const { community, admin } = testCommunity;
+		await CollectionPub.destroy({ where: { pubId: pub.id } });
+		const agent = await login(admin);
+		// Add the pub to a tag
+		await agent
+			.post('/api/collectionPubs')
+			.send({ pubId: pub.id, collectionId: tag.id, communityId: community.id })
+			.expect(201);
+		// Add the pub to a book
+		const { body: collectionPub } = await agent
+			.post('/api/collectionPubs')
+			.send({ pubId: pub.id, collectionId: book.id, communityId: community.id })
+			.expect(201);
+		expect(collectionPub.isPrimary).toEqual(true);
+	});
+
+	it('does not make a collectionPub primary when there is already a primary collection', async () => {
+		const { community, admin } = testCommunity;
+		await CollectionPub.destroy({ where: { pubId: pub.id } });
+		const agent = await login(admin);
+		// Add the pub to an issue
+		const { body: firstCollectionPub } = await agent
+			.post('/api/collectionPubs')
+			.send({ pubId: pub.id, collectionId: issue.id, communityId: community.id })
+			.expect(201);
+		expect(firstCollectionPub.isPrimary).toEqual(true);
+		// Add the pub to a book
+		const { body: secondCollectionPub } = await agent
+			.post('/api/collectionPubs')
+			.send({ pubId: pub.id, collectionId: book.id, communityId: community.id })
+			.expect(201);
+		expect(secondCollectionPub.isPrimary).toEqual(false);
+	});
+
+	it('does not set a private collection as a primary collection', async () => {
+		const { community, admin } = testCommunity;
+		// Make the book private for a bit
+		await Collection.update({ isPublic: false }, { where: { id: book.id } });
+		await CollectionPub.destroy({ where: { pubId: pub.id } });
+		const agent = await login(admin);
+		// Add the pub to a book
+		const { body: collectionPub } = await agent
+			.post('/api/collectionPubs')
+			.send({ pubId: pub.id, collectionId: book.id, communityId: community.id })
+			.expect(201);
+		// Should be false because the book is private
+		expect(collectionPub.isPrimary).toEqual(false);
+		await Collection.update({ isPublic: true }, { where: { id: book.id } });
+	});
+
+	it('sets a collectionPub to be the primary collection for a pub', async () => {
+		const { admin, community } = testCommunity;
+		await CollectionPub.destroy({ where: { pubId: pub.id } });
+		const first = await createCollectionPub({ pubId: pub.id, collectionId: issue.id });
+		const second = await createCollectionPub({ pubId: pub.id, collectionId: book.id });
+		expect(first.isPrimary).toEqual(true);
+		expect(second.isPrimary).toEqual(false);
+		const agent = await login(admin);
+		await agent
+			.put('/api/collectionPubs/setPrimary')
+			.send({
+				id: second.id,
+				collectionId: book.id,
+				isPrimary: true,
+				communityId: community.id,
+			})
+			.expect(200);
+		const firstAgain = await CollectionPub.findOne({ where: { id: first.id } });
+		const secondAgain = await CollectionPub.findOne({ where: { id: second.id } });
+		expect(secondAgain.isPrimary).toEqual(true);
+		expect(firstAgain.isPrimary).toEqual(false);
+		await agent
+			.put('/api/collectionPubs/setPrimary')
+			.send({
+				id: second.id,
+				collectionId: book.id,
+				isPrimary: false,
+				communityId: community.id,
+			})
+			.expect(200);
+		const firstAgainAgain = await CollectionPub.findOne({ where: { id: first.id } });
+		const secondAgainAgain = await CollectionPub.findOne({ where: { id: second.id } });
+		expect(firstAgainAgain.isPrimary).toEqual(false);
+		expect(secondAgainAgain.isPrimary).toEqual(false);
+	});
+
+	it('updates reasonable values on a pubCollection', async () => {
+		const { admin, community } = testCommunity;
+		await CollectionPub.destroy({ where: { pubId: pub.id } });
+		const collectionPub = await createCollectionPub({ pubId: pub.id, collectionId: issue.id });
+		const agent = await login(admin);
+		await agent
+			.put('/api/collectionPubs')
+			.send({
+				id: collectionPub.id,
+				collectionId: issue.id,
+				communityId: community.id,
+				rank: 'zzz',
+				contextHint: 'boo',
+			})
+			.expect(200);
+		const resultingCollectionPub = await CollectionPub.findOne({
+			where: { id: collectionPub.id },
+		});
+		expect(resultingCollectionPub.rank).toEqual('zzz');
+		expect(resultingCollectionPub.contextHint).toEqual('boo');
+	});
+
+	it('deletes a pubCollection', async () => {
+		const { admin, community } = testCommunity;
+		await CollectionPub.destroy({ where: { pubId: pub.id } });
+		const collectionPub = await createCollectionPub({ pubId: pub.id, collectionId: issue.id });
+		const agent = await login(admin);
+		await agent
+			.delete('/api/collectionPubs')
+			.send({
+				id: collectionPub.id,
+				collectionId: issue.id,
+				communityId: community.id,
+			})
+			.expect(200);
+		const deletedCollectionPub = await CollectionPub.findOne({
+			where: { id: collectionPub.id },
+		});
+		expect(deletedCollectionPub).toEqual(null);
+	});
+});
+
+teardown(afterAll);

--- a/server/collectionPub/queries.js
+++ b/server/collectionPub/queries.js
@@ -61,7 +61,8 @@ export const createCollectionPub = (inputValues) => {
 		// If this is the first non-tag collection in the bunch, make it the primary one
 		const isPrimary =
 			pubLevelPeers.filter((peer) => peer.collection.kind !== 'tag').length === 0 &&
-			collection.kind !== 'tag';
+			collection.kind !== 'tag' &&
+			collection.isPublic;
 		// If a rank wasn't provided, move the CollectionPub to the end of the collection
 		let setRank = inputValues.rank;
 		if (!setRank) {
@@ -73,7 +74,7 @@ export const createCollectionPub = (inputValues) => {
 			{
 				collectionId: inputValues.collectionId,
 				pubId: inputValues.pubId,
-				rank: inputValues.rank,
+				rank: setRank,
 				isPrimary: isPrimary,
 			},
 			/* Unclear why this is included */


### PR DESCRIPTION
This PR adds tests to collections-related code on the server, and also adds some small fixes to CollectionPub logic. It also refactors the collections-related API routes so that they return semantically meaningful error codes.

_Test plan:_
`npm run test server/collection`
