### PR TITLE
dev: Tests for community-related code

### DIFF
--- a/server/community/__tests__/api.test.js
+++ b/server/community/__tests__/api.test.js
@@ -1,0 +1,91 @@
+/* global describe, it, expect, beforeAll, afterAll */
+import sinon from 'sinon';
+import uuid from 'uuid';
+
+import { makeUser, makeCommunity, setup, teardown, login } from '../../../stubstub';
+import { Community } from '../../models';
+
+import * as mailchimp from '../../utils/mailchimp';
+import * as webhooks from '../../utils/webhooks';
+
+let mailchimpStub;
+let slackStub;
+let existingCommunity;
+let someOtherCommunity;
+
+setup(beforeAll, async () => {
+	mailchimpStub = sinon.stub(mailchimp, 'subscribeUser');
+	slackStub = sinon.stub(webhooks, 'alertNewCommunity');
+	existingCommunity = await makeCommunity();
+	someOtherCommunity = await makeCommunity();
+});
+
+describe('/api/communities', () => {
+	it('creates a community', async () => {
+		const user = await makeUser();
+		const agent = await login(user);
+		const subdomain = 'burn-book-' + uuid.v4();
+		const { body: url } = await agent
+			.post('/api/communities')
+			.send({
+				subdomain: subdomain,
+				title: 'Burn Book',
+				description: "Get in loser we're testing our code",
+			})
+			.expect(201);
+		expect(url).toEqual(`https://${subdomain}.pubpub.org`);
+		const newCommunity = await Community.findOne({ where: { subdomain: subdomain } });
+		expect(newCommunity.title).toEqual('Burn Book');
+	});
+
+	it('does not create a community if you are logged out', async () => {
+		await (await login())
+			.post('/api/communities')
+			.send({
+				subdomain: 'notloggedin',
+				title: 'Journal of Forgetting To Log In First',
+				description: 'oops, I forgot',
+			})
+			.expect(403);
+	});
+
+	it('does not allow admins of other communities to update fields on a community', async () => {
+		const {
+			community: { id: communityId, title: oldTitle },
+		} = existingCommunity;
+		const { admin: someOtherAdmin } = someOtherCommunity;
+		const agent = await login(someOtherAdmin);
+		await agent
+			.put('/api/communities')
+			.send({
+				communityId: communityId,
+				title: 'I Hear She Does Car Commericals, In Japan',
+			})
+			.expect(403);
+		const communityNow = await Community.findOne({ where: { id: communityId } });
+		expect(communityNow.title).toEqual(oldTitle);
+	});
+
+	it('allows community admins to update reasonable fields on the community', async () => {
+		const { admin, community } = existingCommunity;
+		const agent = await login(admin);
+		await agent
+			.put('/api/communities')
+			.send({
+				communityId: community.id,
+				// We expect this field to be updated...
+				title: 'Journal of Trying To Lose Three Pounds',
+				// ...but not this one!
+				isFeatured: true,
+			})
+			.expect(200);
+		const communityNow = await Community.findOne({ where: { id: community.id } });
+		expect(communityNow.title).toEqual('Journal of Trying To Lose Three Pounds');
+		expect(communityNow.isFeatured).not.toBeTruthy();
+	});
+});
+
+teardown(afterAll, () => {
+	mailchimpStub.restore();
+	slackStub.restore();
+});

--- a/server/community/api.js
+++ b/server/community/api.js
@@ -1,6 +1,7 @@
-import app from '../server';
+import app, { wrap } from '../server';
 import { getPermissions } from './permissions';
 import { createCommunity, updateCommunity } from './queries';
+import { ForbiddenError } from '../errors';
 
 const getRequestIds = (req) => {
 	const user = req.user || {};
@@ -10,38 +11,28 @@ const getRequestIds = (req) => {
 	};
 };
 
-app.post('/api/communities', (req, res) => {
-	const requestIds = getRequestIds(req);
-	getPermissions(requestIds)
-		.then((permissions) => {
-			if (!permissions.create) {
-				throw new Error('Not Authorized');
-			}
-			return createCommunity(req.body, req.user);
-		})
-		.then((newCommunity) => {
-			return res.status(201).json(`https://${newCommunity.subdomain}.pubpub.org`);
-		})
-		.catch((err) => {
-			console.error('Error in postCommunity: ', err);
-			return res.status(500).json(err.message);
-		});
-});
+app.post(
+	'/api/communities',
+	wrap(async (req, res) => {
+		const requestIds = getRequestIds(req);
+		const permissions = await getPermissions(requestIds);
+		if (!permissions.create) {
+			throw new ForbiddenError();
+		}
+		const newCommunity = await createCommunity(req.body, req.user);
+		return res.status(201).json(`https://${newCommunity.subdomain}.pubpub.org`);
+	}),
+);
 
-app.put('/api/communities', (req, res) => {
-	const requestIds = getRequestIds(req);
-	getPermissions(requestIds)
-		.then((permissions) => {
-			if (!permissions.update) {
-				throw new Error('Not Authorized');
-			}
-			return updateCommunity(req.body, permissions.update);
-		})
-		.then((updatedValues) => {
-			return res.status(201).json(updatedValues);
-		})
-		.catch((err) => {
-			console.error('Error in putCommunity: ', err);
-			return res.status(500).json(err.message);
-		});
-});
+app.put(
+	'/api/communities',
+	wrap(async (req, res) => {
+		const requestIds = getRequestIds(req);
+		const permissions = await getPermissions(requestIds);
+		if (!permissions.update) {
+			throw new ForbiddenError();
+		}
+		const updatedValues = await updateCommunity(req.body, permissions.update);
+		return res.status(200).json(updatedValues);
+	}),
+);

--- a/server/communityAdmin/__tests__/api.test.js
+++ b/server/communityAdmin/__tests__/api.test.js
@@ -1,0 +1,93 @@
+/* global describe, it, expect, beforeAll, afterAll */
+import sinon from 'sinon';
+
+import { makeUser, makeCommunity, setup, teardown, login } from '../../../stubstub';
+import { CommunityAdmin } from '../../models';
+
+import * as mailchimp from '../../utils/mailchimp';
+import { createCommunityAdmin } from '../queries';
+
+let mailchimpStub;
+let testCommunity;
+
+setup(beforeAll, async () => {
+	mailchimpStub = sinon.stub(mailchimp, 'subscribeUser');
+	testCommunity = await makeCommunity();
+});
+
+describe('/api/communityAdmins', () => {
+	it('prevents users from making themselves admins', async () => {
+		const { community } = testCommunity;
+		const pretenderToTheThrone = await makeUser();
+		const agent = await login(pretenderToTheThrone);
+		await agent
+			.post('/api/communityAdmins')
+			.send({ userId: pretenderToTheThrone.id, communityId: community.id })
+			.expect(403);
+		const caNow = await CommunityAdmin.findOne({
+			where: {
+				userId: pretenderToTheThrone.id,
+				communityId: community.id,
+			},
+		});
+		expect(caNow).toBeNull();
+	});
+
+	it('allows community admins to make other community admins', async () => {
+		const { admin, community } = testCommunity;
+		const newlyMintedAdmin = await makeUser();
+		const agent = await login(admin);
+		await agent
+			.post('/api/communityAdmins')
+			.send({ userId: newlyMintedAdmin.id, communityId: community.id })
+			.expect(201);
+		const caNow = await CommunityAdmin.findOne({
+			where: {
+				userId: newlyMintedAdmin.id,
+				communityId: community.id,
+			},
+		});
+		expect(caNow).toBeTruthy();
+	});
+
+	it('permits backstabbing removals of other community admins', async () => {
+		const { admin, community } = testCommunity;
+		const treacherousAdmin = await makeUser();
+		await createCommunityAdmin({ userId: treacherousAdmin.id, communityId: community.id });
+		const agent = await login(treacherousAdmin);
+		await agent
+			.delete('/api/communityAdmins')
+			.send({ userId: admin.id, communityId: community.id })
+			.expect(201);
+		const caNow = await CommunityAdmin.findOne({
+			where: {
+				userId: admin.id,
+				communityId: community.id,
+			},
+		});
+		expect(caNow).toBeNull();
+		// Calm down bro it was just a prank
+		await createCommunityAdmin({ userId: admin.id, communityId: community.id });
+	});
+
+	it('prevents users from deleting community admins without permission', async () => {
+		const { admin, community } = testCommunity;
+		const expensivePentestingContractor = await makeUser();
+		const agent = await login(expensivePentestingContractor);
+		await agent
+			.delete('/api/communityAdmins')
+			.send({ userId: admin.id, communityId: community.id })
+			.expect(403);
+		const caNow = await CommunityAdmin.findOne({
+			where: {
+				userId: admin.id,
+				communityId: community.id,
+			},
+		});
+		expect(caNow).toBeTruthy();
+	});
+});
+
+teardown(afterAll, async () => {
+	mailchimpStub.restore();
+});


### PR DESCRIPTION
This PR adds tests to community-related code on the server. It also refactors the community-related API routes so that they return semantically meaningful error codes.

_Test plan:_
`npm run test server/community`