### PR TITLE
dev/update: Tests and updates to discussions-related code

### DIFF
--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionInput.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionInput.js
@@ -44,6 +44,7 @@ const DiscussionInput = (props) => {
 		return apiFetch('/api/discussions', {
 			method: 'POST',
 			body: JSON.stringify({
+				discussHash: locationData.query.access,
 				discussionId: isNewThread ? threadData[0].id : undefined,
 				threadNumber: isNewThread ? undefined : threadData[0].threadNumber,
 				pubId: pubData.id,

--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionInput.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionInput.js
@@ -46,7 +46,6 @@ const DiscussionInput = (props) => {
 			body: JSON.stringify({
 				discussionId: isNewThread ? threadData[0].id : undefined,
 				threadNumber: isNewThread ? undefined : threadData[0].threadNumber,
-				userId: loginData.id,
 				pubId: pubData.id,
 				branchId: pubData.activeBranch.id,
 				communityId: communityData.id,

--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionItem.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionItem.js
@@ -47,7 +47,6 @@ const DiscussionItem = (props) => {
 			body: JSON.stringify({
 				...discussionUpdates,
 				discussionId: discussionData.id,
-				userId: loginData.id,
 				pubId: pubData.id,
 				branchId: pubData.activeBranch.id,
 				communityId: communityData.id,

--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionItem.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionItem.js
@@ -35,7 +35,7 @@ const DiscussionItem = (props) => {
 		isRootThread,
 		isPreview,
 	} = props;
-	const { loginData, communityData } = useContext(PageContext);
+	const { loginData, communityData, locationData } = useContext(PageContext);
 	const [isEditing, setIsEditing] = useState(false);
 	const [changeObject, setChangeObject] = useState({});
 	const [isLoadingEdit, setIsLoadingEdit] = useState(false);
@@ -46,6 +46,7 @@ const DiscussionItem = (props) => {
 			method: 'PUT',
 			body: JSON.stringify({
 				...discussionUpdates,
+				discussHash: locationData.query.access,
 				discussionId: discussionData.id,
 				pubId: pubData.id,
 				branchId: pubData.activeBranch.id,

--- a/server/discussion/__tests__/api.test.js
+++ b/server/discussion/__tests__/api.test.js
@@ -1,0 +1,415 @@
+/* global describe, it, expect, beforeAll, afterAll, beforeEach, afterEach */
+import uuid from 'uuid';
+
+import { makeUser, makeCommunity, setup, teardown, login, stub } from '../../../stubstub';
+import { Discussion, Branch } from '../../models';
+
+import * as firebaseAdmin from '../../utils/firebaseAdmin';
+import { createDiscussion } from '../queries';
+import { createPub } from '../../pub/queries';
+import { createBranch } from '../../branch/queries';
+
+let firebaseStub;
+let testCommunity;
+let pub;
+let pubManager;
+let branchCreator;
+let randomVisitor;
+let invitedToView;
+let invitedToDiscuss;
+let invitedToManage;
+let openBranch;
+let closedBranch;
+let secretiveBranch;
+let makeDiscussion;
+
+beforeEach(() => {
+	firebaseStub = stub(firebaseAdmin, 'updateFirebaseDiscussion');
+});
+
+afterEach(() => {
+	firebaseStub.restore();
+});
+
+setup(beforeAll, async () => {
+	firebaseStub = stub(firebaseAdmin, 'createFirebaseBranch');
+	testCommunity = await makeCommunity();
+	pubManager = await makeUser();
+	randomVisitor = await makeUser();
+	invitedToView = await makeUser();
+	invitedToDiscuss = await makeUser();
+	invitedToManage = await makeUser();
+	branchCreator = await makeUser();
+	pub = await createPub({ communityId: testCommunity.community.id }, pubManager);
+	openBranch = await createBranch(
+		{
+			pubId: pub.id,
+			title: 'branch-for-open-discussions',
+			publicPermissions: 'discuss',
+			userPermissions: [],
+			// These should not make a difference because they're superseded by publicPermissions
+			pubManagerPermissions: 'none',
+			communityAdminPermissions: 'none',
+		},
+		branchCreator.id,
+	);
+	closedBranch = await createBranch(
+		{
+			pubId: pub.id,
+			title: 'branch-for-secret-discussions',
+			publicPermissions: 'none',
+			pubManagerPermissions: 'discuss',
+			communityAdminPermissions: 'discuss',
+			userPermissions: [],
+		},
+		branchCreator.id,
+	);
+	secretiveBranch = await createBranch(
+		{
+			pubId: pub.id,
+			title: 'branch-for-secret-discussions',
+			publicPermissions: 'none',
+			pubManagerPermissions: 'none',
+			communityAdminPermissions: 'none',
+			userPermissions: [
+				{ user: invitedToView, permissions: 'view' },
+				{ user: invitedToDiscuss, permissions: 'discuss' },
+				{ user: invitedToManage, permissions: 'manage' },
+			],
+		},
+		branchCreator.id,
+	);
+
+	makeDiscussion = ({
+		discussionId,
+		branchId,
+		threadNumber,
+		title = 'Uhh yeah a title',
+		text = 'Hello, a discussion!',
+		content = 'Some test content',
+		initAnchorText = 'Some anchor text',
+		...whateverElse
+	}) => ({
+		discussionId: discussionId,
+		title: title,
+		content: content,
+		text: text,
+		initAnchorText: initAnchorText,
+		pubId: pub.id,
+		communityId: testCommunity.community.id,
+		branchId: branchId,
+		threadNumber: threadNumber,
+		...whateverElse,
+	});
+});
+
+describe('/api/discussions', () => {
+	it('forbids logged-out visitors from making discussions', async () => {
+		const agent = await login();
+		await agent
+			.post('/api/discussions')
+			.send(makeDiscussion({ branchId: openBranch.id, text: 'Hello world!' }))
+			.expect(403);
+		expect(firebaseStub.stubs.updateFirebaseDiscussion.called).toEqual(false);
+	});
+
+	it('creates a database entry and updates Firebase', async () => {
+		const agent = await login(randomVisitor);
+		const {
+			body: { id: discussionId },
+		} = await agent
+			.post('/api/discussions')
+			.send(makeDiscussion({ branchId: openBranch.id, text: 'Hello world!' }))
+			.expect(201);
+		const discussion = await Discussion.findOne({ where: { id: discussionId } });
+		expect(firebaseStub.stubs.updateFirebaseDiscussion.called).toEqual(true);
+		expect(discussion.text).toEqual('Hello world!');
+	});
+
+	it('respects client-created discussion IDs', async () => {
+		const discussionId = uuid.v4();
+		const agent = await login(randomVisitor);
+		const {
+			body: { id: receivedDiscussionId },
+		} = await agent
+			.post('/api/discussions')
+			.send(
+				makeDiscussion({
+					discussionId: discussionId,
+					branchId: openBranch.id,
+					text: 'Hello world!',
+				}),
+			)
+			.expect(201);
+		expect(receivedDiscussionId).toEqual(discussionId);
+	});
+
+	it('increments thread numbers correctly', async () => {
+		const agent = await login(randomVisitor);
+		const {
+			body: { threadNumber },
+		} = await agent
+			.post('/api/discussions')
+			.send(
+				makeDiscussion({
+					branchId: openBranch.id,
+					text: "Like if you're watching this in 2019!",
+				}),
+			)
+			.expect(201);
+		const {
+			body: { threadNumber: nextThreadNumber },
+		} = await agent
+			.post('/api/discussions')
+			.send(
+				makeDiscussion({
+					branchId: openBranch.id,
+					text: "Like if you're watching this in 2020!",
+				}),
+			)
+			.expect(201);
+		expect(nextThreadNumber).toEqual(threadNumber + 1);
+	});
+
+	it('lets publicPermissions supersede communityAdminPermissions', async () => {
+		const { admin } = testCommunity;
+		const agent = await login(admin);
+		const {
+			body: { id: discussionId },
+		} = await agent
+			.post('/api/discussions')
+			.send(makeDiscussion({ branchId: openBranch.id, text: "I'm a admin!" }))
+			.expect(201);
+		const discussion = await Discussion.findOne({ where: { id: discussionId } });
+		expect(discussion.text).toEqual("I'm a admin!");
+	});
+
+	it('lets publicPermissions supersede pubManagerPermissions', async () => {
+		const agent = await login(pubManager);
+		const {
+			body: { id: discussionId },
+		} = await agent
+			.post('/api/discussions')
+			.send(makeDiscussion({ branchId: openBranch.id, text: "I'm an pub manager!" }))
+			.expect(201);
+		const discussion = await Discussion.findOne({ where: { id: discussionId } });
+		expect(discussion.text).toEqual("I'm an pub manager!");
+	});
+
+	it('respects communityAdminPermissions="discuss"', async () => {
+		const { admin } = testCommunity;
+		const agent = await login(admin);
+		const {
+			body: { id: discussionId },
+		} = await agent
+			.post('/api/discussions')
+			.send(makeDiscussion({ branchId: closedBranch.id, text: "I'm a admin!" }))
+			.expect(201);
+		const discussion = await Discussion.findOne({ where: { id: discussionId } });
+		expect(discussion.text).toEqual("I'm a admin!");
+	});
+
+	it('respects pubManagerPermissions="discuss"', async () => {
+		const agent = await login(pubManager);
+		const {
+			body: { id: discussionId },
+		} = await agent
+			.post('/api/discussions')
+			.send(makeDiscussion({ branchId: closedBranch.id, text: "I'm an pub manager!" }))
+			.expect(201);
+		const discussion = await Discussion.findOne({ where: { id: discussionId } });
+		expect(discussion.text).toEqual("I'm an pub manager!");
+	});
+
+	it('forbids users without appropriate permissions from adding discussions', async () => {
+		const agent = await login(randomVisitor);
+		await agent
+			.post('/api/discussions')
+			.send(makeDiscussion({ branchId: closedBranch.id, text: 'Hello world!' }))
+			.expect(403);
+	});
+
+	it('respects discuss hashes', async () => {
+		const agent = await login(randomVisitor);
+		const { discussHash } = await Branch.findOne({ where: { id: secretiveBranch.id } });
+		const {
+			body: { id: discussionId },
+		} = await agent
+			.post('/api/discussions')
+			.send(
+				makeDiscussion({
+					branchId: secretiveBranch.id,
+					discussHash: discussHash,
+					text: 'Lol what now',
+				}),
+			)
+			.expect(201);
+		const discussion = await Discussion.findOne({ where: { id: discussionId } });
+		expect(discussion.text).toEqual('Lol what now');
+	});
+
+	it('respects individual discuss permissions', async () => {
+		const agent = await login(invitedToDiscuss);
+		const {
+			body: { id: discussionId },
+		} = await agent
+			.post('/api/discussions')
+			.send(makeDiscussion({ branchId: secretiveBranch.id, text: 'Henlo world!' }))
+			.expect(201);
+		const discussion = await Discussion.findOne({ where: { id: discussionId } });
+		expect(discussion.text).toEqual('Henlo world!');
+	});
+
+	it('does not confuse discuss permissions for view permissions', async () => {
+		const agent = await login(invitedToView);
+		await agent
+			.post('/api/discussions')
+			.send(makeDiscussion({ branchId: secretiveBranch.id, text: 'Henlo world!' }))
+			.expect(403);
+	});
+
+	it('respects communityAdminPermissions="none"', async () => {
+		const { admin } = testCommunity;
+		const agent = await login(admin);
+		await agent
+			.post('/api/discussions')
+			.send(makeDiscussion({ branchId: secretiveBranch.id, text: "I'm...an admin?" }))
+			.expect(403);
+	});
+
+	it('respects pubManagerPermissions="none"', async () => {
+		const agent = await login(pubManager);
+		await agent
+			.post('/api/discussions')
+			.send(
+				makeDiscussion({
+					branchId: secretiveBranch.id,
+					text: "You can't do this to me! Do you have any idea who I am?",
+				}),
+			)
+			.expect(403);
+	});
+
+	it('updates reasonable values on Discussion', async () => {
+		const discussion = await createDiscussion(
+			makeDiscussion({
+				branchId: openBranch.id,
+				text: 'old text',
+			}),
+			randomVisitor,
+		);
+		const agent = await login(randomVisitor);
+		await agent
+			.put('/api/discussions')
+			.send(
+				makeDiscussion({
+					branchId: openBranch.id,
+					discussionId: discussion.id,
+					text: 'new text',
+					isArchived: true,
+				}),
+			)
+			.expect(200);
+		const discussionNow = await Discussion.findOne({ where: { id: discussion.id } });
+		expect(discussionNow.text).toEqual('new text');
+		expect(discussionNow.isArchived).toEqual(true);
+	});
+
+	it('allows users to update their discussion even after permissions have changed', async () => {
+		// This user doesn't actually have permissions to create a discussion on this branch,
+		// but maybe they did at some point in the past.
+		const discussion = await createDiscussion(
+			makeDiscussion({
+				branchId: secretiveBranch.id,
+				text: "THERE'S A PLACE OFF OCEAN AVENUE",
+			}),
+			randomVisitor,
+		);
+		const agent = await login(randomVisitor);
+		await agent
+			.put('/api/discussions')
+			.send(
+				makeDiscussion({
+					branchId: secretiveBranch.id,
+					discussionId: discussion.id,
+					text: 'WHERE I USED TO SIT AND TALK WITH YOU',
+				}),
+			)
+			.expect(200);
+	});
+
+	it('updates reasonable values on discussions', async () => {
+		const discussion = await createDiscussion(
+			makeDiscussion({
+				branchId: openBranch.id,
+				text: 'old text',
+			}),
+			randomVisitor,
+		);
+		const agent = await login(randomVisitor);
+		await agent
+			.put('/api/discussions')
+			.send(
+				makeDiscussion({
+					branchId: openBranch.id,
+					discussionId: discussion.id,
+					text: 'new text',
+					isArchived: true,
+				}),
+			)
+			.expect(200);
+		const discussionNow = await Discussion.findOne({ where: { id: discussion.id } });
+		expect(discussionNow.text).toEqual('new text');
+		expect(discussionNow.isArchived).toEqual(true);
+	});
+
+	it('lets users with canManage permissions on a branch archive its discussions', async () => {
+		const discussion = await createDiscussion(
+			makeDiscussion({
+				branchId: secretiveBranch.id,
+				text: 'some text',
+			}),
+			invitedToDiscuss,
+		);
+		const agent = await login(invitedToManage);
+		await agent
+			.put('/api/discussions')
+			.send(
+				makeDiscussion({
+					branchId: secretiveBranch.id,
+					discussionId: discussion.id,
+					text: 'new text',
+					isArchived: true,
+				}),
+			)
+			.expect(200);
+		const discussionNow = await Discussion.findOne({ where: { id: discussion.id } });
+		expect(discussionNow.text).toEqual('new text');
+		expect(discussionNow.isArchived).toEqual(true);
+	});
+
+	it("forbids users from updating other users' discussions", async () => {
+		const discussion = await createDiscussion(
+			makeDiscussion({
+				branchId: secretiveBranch.id,
+				text: "THERE'S A PLACE OFF OCEAN AVENUE",
+			}),
+			invitedToDiscuss,
+		);
+		const agent = await login(randomVisitor);
+		await agent
+			.put('/api/discussions')
+			.send(
+				makeDiscussion({
+					branchId: secretiveBranch.id,
+					discussionId: discussion.id,
+					text: 'WHERE I USED TO SIT AND TALK WITH YOU',
+				}),
+			)
+			.expect(403);
+	});
+});
+
+teardown(afterAll, () => {
+	firebaseStub.restore();
+});

--- a/server/discussion/__tests__/permissions.test.js
+++ b/server/discussion/__tests__/permissions.test.js
@@ -1,0 +1,66 @@
+/* global describe, it, expect, beforeAll, afterAll */
+
+import { makeUser, makeCommunity, setup, teardown, stub } from '../../../stubstub';
+
+import { createPub } from '../../pub/queries';
+import { createBranch } from '../../branch/queries';
+import { getPermissions } from '../permissions';
+
+import * as firebaseAdmin from '../../utils/firebaseAdmin';
+
+let firebaseStub;
+let targetCommunity;
+let targetPubManager;
+let targetPub;
+let targetBranch;
+let attackerCommunity;
+let attacker;
+
+setup(beforeAll, async () => {
+	firebaseStub = stub(firebaseAdmin, 'createFirebaseBranch');
+	targetCommunity = await makeCommunity();
+	targetPubManager = await makeUser();
+	targetPub = await createPub({ communityId: targetCommunity.community.id }, targetPubManager);
+	targetBranch = await createBranch(
+		{
+			pubId: targetPub.id,
+			title: 'just-doing-normal-stuff',
+			publicPermissions: 'none',
+			pubManagerPermissions: 'manage',
+			communityAdminPermissions: 'manage',
+			userPermissions: [],
+		},
+		targetPubManager.id,
+	);
+	attackerCommunity = await makeCommunity();
+	attacker = attackerCommunity.admin;
+	await createPub({ communityId: attackerCommunity.community.id }, attacker);
+	await createPub({ communityId: targetCommunity.community.id }, attacker);
+	await createBranch(
+		{
+			pubId: targetPub.id,
+			title: 'nothing-to-see-here',
+			pubManagerPermissions: 'manage',
+			communityAdminPermissions: 'manage',
+			userPermissions: [],
+		},
+		attacker.id,
+	);
+});
+
+describe('getPermissions', () => {
+	it('does not leak permissions to managers of adjacent communities, pubs, or branches', async () => {
+		const permissions = await getPermissions({
+			userId: attacker.id,
+			pubId: targetPub.id,
+			communityId: targetCommunity.community.id,
+			branchId: targetBranch.id,
+		});
+		expect(permissions.create).toEqual(false);
+		expect(permissions.update).toEqual(false);
+	});
+});
+
+teardown(afterAll, () => {
+	firebaseStub.restore();
+});

--- a/server/discussion/permissions.js
+++ b/server/discussion/permissions.js
@@ -12,9 +12,7 @@ export const getPermissions = async ({
 	discussHash,
 }) => {
 	if (!userId) {
-		return new Promise((resolve) => {
-			resolve({});
-		});
+		return {};
 	}
 
 	const [discussionOnBranch, branch, pub, pubManager, communityAdmin] = await Promise.all([

--- a/server/discussion/permissions.js
+++ b/server/discussion/permissions.js
@@ -1,55 +1,61 @@
-import { Discussion, Pub, CommunityAdmin, PubManager } from '../models';
-import { checkIfSuperAdmin } from '../utils';
+import { Discussion, Pub, CommunityAdmin, PubManager, Branch, BranchPermission } from '../models';
+import { getBranchAccess } from '../branch/permissions';
 
-export const getPermissions = ({ discussionId, pubId, userId, communityId }) => {
+const userEditableFields = ['title', 'content', 'text', 'isArchived', 'highlights', 'labels'];
+
+export const getPermissions = async ({
+	branchId,
+	discussionId,
+	pubId,
+	userId,
+	communityId,
+	discussHash,
+}) => {
 	if (!userId) {
 		return new Promise((resolve) => {
 			resolve({});
 		});
 	}
-	const isSuperAdmin = checkIfSuperAdmin(userId);
 
-	// Find if the user is allowed to admin this pub
-	const findPubManager = PubManager.findOne({
-		where: { userId: userId, pubId: pubId },
-		raw: true,
-	});
+	const [discussionOnBranch, branch, pub, pubManager, communityAdmin] = await Promise.all([
+		discussionId &&
+			Discussion.findOne({
+				where: { id: discussionId, branchId: branchId },
+				raw: true,
+			}),
+		Branch.findOne({
+			where: { id: branchId, pubId: pubId },
+			include: [
+				{
+					model: BranchPermission,
+					as: 'permissions',
+					required: false,
+				},
+			],
+		}),
+		Pub.findOne({ where: { id: pubId, communityId: communityId }, raw: true }),
+		PubManager.findOne({
+			where: { userId: userId, pubId: pubId },
+			raw: true,
+		}),
+		CommunityAdmin.findOne({
+			where: { userId: userId, communityId: communityId },
+			raw: true,
+		}),
+	]);
 
-	// Find if the user is admins of the community the pub is in
-	const findCommunityAdmin = CommunityAdmin.findOne({
-		where: { userId: userId, communityId: communityId },
-		raw: true,
-	});
-
-	// Find if community admins are allowed to manage pubs
-	const findPub = Pub.findOne({
-		where: { id: pubId, communityId: communityId },
-		raw: true,
-	});
-
-	// Find if the user is the author of the discussion
-	const findDiscussion = Discussion.findOne({
-		where: { id: discussionId, userId: userId },
-		raw: true,
-	});
-
-	return Promise.all([findPubManager, findCommunityAdmin, findPub, findDiscussion]).then(
-		([isPubManager, isCommunityAdmin, pubData, isDiscussionAuthor]) => {
-			if (!pubData) {
-				return {};
-			}
-			const editProps =
-				isSuperAdmin ||
-				isPubManager ||
-				(isCommunityAdmin && pubData.isCommunityAdminManaged) ||
-				isDiscussionAuthor
-					? ['title', 'content', 'text', 'isArchived', 'highlights', 'labels']
-					: false;
-
-			return {
-				create: true,
-				update: editProps,
-			};
-		},
+	const { canManage, canDiscuss } = await getBranchAccess(
+		discussHash,
+		branch,
+		userId,
+		pub && communityAdmin,
+		pub && pubManager,
 	);
+
+	const userCreatedDiscussion = discussionOnBranch && discussionOnBranch.userId === userId;
+
+	return {
+		create: canDiscuss,
+		update: (canManage || !!userCreatedDiscussion) && userEditableFields,
+	};
 };

--- a/server/discussion/queries.js
+++ b/server/discussion/queries.js
@@ -16,7 +16,7 @@ const findDiscussionWithUser = (id) =>
 		],
 	});
 
-export const createDiscussion = (inputValues) => {
+export const createDiscussion = (inputValues, user) => {
 	return Discussion.findAll({
 		where: {
 			pubId: inputValues.pubId,
@@ -59,7 +59,7 @@ export const createDiscussion = (inputValues) => {
 				content: inputValues.content,
 				text: inputValues.text,
 				initAnchorText: inputValues.initAnchorText,
-				userId: inputValues.userId,
+				userId: user.id,
 				pubId: inputValues.pubId,
 				communityId: inputValues.communityId,
 				branchId: inputValues.branchId,


### PR DESCRIPTION
This PR adds tests for discussions-related code. It also makes some fairly significant changes to the way discussion permissions are handled, so they now respect branch permissions. This is adequately covered by the new tests, but I'll do some manual testing before merging this as well.

_Test plan:_
- `npm run test server/discussion`
- Also manually poke around a pub and make sure you can still add discussions as a user with `discuss` branch permissions