### PR TITLE
feature: Enable unanchored discussions in V6

### DIFF
--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionInput.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionInput.js
@@ -28,7 +28,7 @@ const defaultProps = {
 
 const getPlaceholderText = (isNewThread, isPubBottomInput) => {
 	if (isPubBottomInput) {
-		return 'Add a discussion here (or highlight some text in the Pub to begin a discussion inline)';
+		return 'Start a discussion here (or highlight some text above to begin one inline)';
 	}
 	return isNewThread ? 'Add your discussion...' : 'Add a reply...';
 };

--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionInput.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionInput.js
@@ -18,19 +18,29 @@ const propTypes = {
 	firebaseBranchRef: PropTypes.object,
 	threadData: PropTypes.array.isRequired,
 	updateLocalData: PropTypes.func.isRequired,
+	isPubBottomInput: PropTypes.bool,
 };
 
 const defaultProps = {
 	firebaseBranchRef: undefined,
+	isPubBottomInput: false,
+};
+
+const getPlaceholderText = (isNewThread, isPubBottomInput) => {
+	if (isPubBottomInput) {
+		return 'Add a discussion here (or highlight some text in the Pub to begin a discussion inline)';
+	}
+	return isNewThread ? 'Add your discussion...' : 'Add a reply...';
 };
 
 const DiscussionInput = (props) => {
-	const { pubData, collabData, updateLocalData, threadData } = props;
+	const { pubData, collabData, updateLocalData, threadData, isPubBottomInput } = props;
 	const { loginData, locationData, communityData } = useContext(PageContext);
 	const pubView = collabData.editorChangeObject.view;
 	const [changeObject, setChangeObject] = useState({});
 	const [isLoading, setIsLoading] = useState(false);
 	const [didFocus, setDidFocus] = useState(false);
+	const [editorKey, setEditorKey] = useState(Date.now());
 	const isNewThread = !threadData[0].threadNumber;
 	useEffect(() => {
 		if ((isNewThread || didFocus) && changeObject.view) {
@@ -72,6 +82,8 @@ const DiscussionInput = (props) => {
 				updateLocalData('pub', {
 					discussions: [...pubData.discussions, discussionData],
 				});
+				setIsLoading(false);
+				setEditorKey(Date.now());
 			});
 	};
 
@@ -80,7 +92,7 @@ const DiscussionInput = (props) => {
 		locationData.queryString.length > 1 ? locationData.queryString : ''
 	}`;
 	return (
-		<div className="discussion-item input">
+		<div className="discussion-item-component input">
 			<div className="avatar-wrapper">
 				<Avatar width={18} userInitials={loginData.intials} userAvatar={loginData.avatar} />
 			</div>
@@ -92,7 +104,7 @@ const DiscussionInput = (props) => {
 						href={`/login${redirectString}`}
 						small={true}
 					/>
-					{isNewThread && (
+					{isNewThread && !isPubBottomInput && (
 						<Button
 							className="discussion-cancel-button"
 							text="Cancel"
@@ -118,7 +130,8 @@ const DiscussionInput = (props) => {
 				<div className="content-wrapper">
 					<div className="discussion-body-wrapper editable">
 						<Editor
-							placeholder={isNewThread ? 'Add your discussion...' : 'Add a reply...'}
+							key={editorKey}
+							placeholder={getPlaceholderText(isNewThread, isPubBottomInput)}
 							onChange={(editorChangeObject) => {
 								setChangeObject(editorChangeObject);
 							}}
@@ -140,7 +153,7 @@ const DiscussionInput = (props) => {
 						onClick={handlePostDiscussion}
 						small={true}
 					/>
-					{isNewThread && (
+					{isNewThread && !isPubBottomInput && (
 						<Button
 							className="discussion-cancel-button"
 							text="Cancel"

--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionItem.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionItem.js
@@ -10,6 +10,8 @@ import { apiFetch } from 'utils';
 import LabelSelect from './LabelSelect';
 import DiscussionReanchor from './DiscussionReanchor';
 
+require('./discussionItem.scss');
+
 const propTypes = {
 	collabData: PropTypes.object.isRequired,
 	firebaseBranchRef: PropTypes.object,
@@ -69,7 +71,7 @@ const DiscussionItem = (props) => {
 
 	const isDiscussionAuthor = loginData.id === discussionData.userId;
 	return (
-		<div className="discussion-item">
+		<div className="discussion-item-component">
 			<div className="avatar-wrapper">
 				<Avatar
 					width={18}

--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/discussionItem.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/discussionItem.scss
@@ -1,0 +1,68 @@
+@import 'styles/variables.scss';
+
+.discussion-item-component {
+	display: flex;
+	&:not(:last-child) {
+		margin-bottom: 1em;
+		border-bottom: 1px solid #f0f0f7;
+	}
+	.avatar-wrapper {
+		margin-right: 0.5em;
+	}
+	.content-wrapper {
+		flex: 1 1 auto;
+		min-width: 0;
+		margin-bottom: 1em;
+	}
+	.preview-text {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		font-style: 14px;
+	}
+	.discussion-body-wrapper {
+		.editor.ProseMirror {
+			min-height: 0px;
+			h1,
+			h2,
+			h3,
+			h4,
+			h5,
+			h6,
+			p,
+			li {
+				font-family: $base-font;
+				line-height: 1.3;
+			}
+		}
+		&.editable {
+			.editor {
+				min-height: 75px;
+				border: 1px solid #ddd;
+				background: white;
+				border-radius: 2px;
+				padding: 0.5em;
+				margin-bottom: 0.5em;
+			}
+		}
+	}
+	.simple-input {
+		background: #f4f4f7;
+		border-radius: 2px;
+		border: 0px solid white;
+		padding: 0.5em;
+		width: 100%;
+		font-style: italic;
+	}
+	.formatting-bar-component {
+		margin: -0.5em 0em 0.5em;
+	}
+	.discussion-primary-button,
+	.discussion-cancel-button {
+		margin-bottom: 1em;
+		white-space: nowrap;
+		&:not(:last-child) {
+			margin-right: 1em;
+		}
+	}
+}

--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/discussionThread.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/discussionThread.scss
@@ -24,21 +24,6 @@
 			color: #000;
 		}
 	}
-	.discussion-item {
-		display: flex;
-		&:not(:last-child) {
-			margin-bottom: 1em;
-			border-bottom: 1px solid #f0f0f7;
-		}
-		.avatar-wrapper {
-			margin-right: 0.5em;
-		}
-		.content-wrapper {
-			flex: 1 1 auto;
-			min-width: 0;
-			margin-bottom: 1em;
-		}
-	}
 	.item-header {
 		display: flex;
 		align-items: center;
@@ -70,55 +55,5 @@
 			min-height: 17px;
 		}
 	}
-	.preview-text {
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		font-style: 14px;
-	}
-	.discussion-body-wrapper {
-		.editor.ProseMirror {
-			min-height: 0px;
-			h1,
-			h2,
-			h3,
-			h4,
-			h5,
-			h6,
-			p,
-			li {
-				font-family: $base-font;
-				line-height: 1.3;
-			}
-		}
-		&.editable {
-			.editor {
-				min-height: 75px;
-				border: 1px solid #ddd;
-				background: white;
-				border-radius: 2px;
-				padding: 0.5em;
-				margin-bottom: 0.5em;
-			}
-		}
-	}
-	.simple-input {
-		background: #f4f4f7;
-		border-radius: 2px;
-		border: 0px solid white;
-		padding: 0.5em;
-		width: 100%;
-		font-style: italic;
-	}
-	.formatting-bar-component {
-		margin: -0.5em 0em 0.5em;
-	}
-	.discussion-primary-button,
-	.discussion-cancel-button {
-		margin-bottom: 1em;
-		white-space: nowrap;
-		&:not(:last-child) {
-			margin-right: 1em;
-		}
-	}
+
 }

--- a/client/containers/Pub/PubDocument/PubDiscussions/PubDiscussions.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/PubDiscussions.js
@@ -10,6 +10,7 @@ import { PubSuspendWhileTyping } from '../../PubSuspendWhileTyping';
 import ThreadGroup from './ThreadGroup';
 import DiscussionThread from './DiscussionThread';
 import DiscussionFilterBar from './DiscussionFilterBar';
+import DiscussionInput from './DiscussionThread/DiscussionInput';
 import { groupThreadsByLine, nestDiscussionsToThreads } from './discussionUtils';
 
 require('./pubDiscussions.scss');
@@ -96,32 +97,43 @@ const PubDiscussions = (props) => {
 				<h2>Discussions</h2>
 				<PubSuspendWhileTyping delay={1000}>
 					{() => (
-						<DiscussionFilterBar
-							pubData={pubData}
-							communityData={communityData}
-							threadData={threads}
-							updateLocalData={updateLocalData}
-						>
-							{(filteredThreads) => {
-								return (
-									<React.Fragment>
-										{filteredThreads.map((thread) => {
-											return (
-												<DiscussionThread
-													key={thread[0].id}
-													pubData={pubData}
-													collabData={collabData}
-													firebaseBranchRef={firebaseBranchRef}
-													threadData={thread}
-													updateLocalData={updateLocalData}
-													canPreview={true}
-												/>
-											);
-										})}
-									</React.Fragment>
-								);
-							}}
-						</DiscussionFilterBar>
+						<React.Fragment>
+							{pubData.canDiscussBranch && (
+								<DiscussionInput
+									pubData={pubData}
+									collabData={collabData}
+									updateLocalData={updateLocalData}
+									threadData={[{ id: undefined }]}
+									isPubBottomInput={true}
+								/>
+							)}
+							<DiscussionFilterBar
+								pubData={pubData}
+								communityData={communityData}
+								threadData={threads}
+								updateLocalData={updateLocalData}
+							>
+								{(filteredThreads) => {
+									return (
+										<React.Fragment>
+											{filteredThreads.map((thread) => {
+												return (
+													<DiscussionThread
+														key={thread[0].id}
+														pubData={pubData}
+														collabData={collabData}
+														firebaseBranchRef={firebaseBranchRef}
+														threadData={thread}
+														updateLocalData={updateLocalData}
+														canPreview={true}
+													/>
+												);
+											})}
+										</React.Fragment>
+									);
+								}}
+							</DiscussionFilterBar>
+						</React.Fragment>
 					)}
 				</PubSuspendWhileTyping>
 			</GridWrapper>

--- a/client/containers/Pub/PubDocument/PubDiscussions/pubDiscussions.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/pubDiscussions.scss
@@ -11,7 +11,7 @@
 			&.preview {
 				padding: 1em;
 				cursor: pointer;
-				.discussion-item {
+				.discussion-item-component {
 					margin-bottom: 0.5em;
 					border-bottom: 0px solid #f0f0f7; 
 					&:last-child {


### PR DESCRIPTION
While there's no technical reason we can't have discussions at the bottom of the Pub unassociated with any highlight, we haven't had this capability at least since v6 launched. This PR adds a comment box at the bottom of the pub to enable this.

_Test plan:_
- Load a pub and make sure you can add (multiple) comments using the bottom discussion box
- Make sure the box does not appear when you don't have discuss permissions. 

![image](https://user-images.githubusercontent.com/2208769/63030335-2194c500-be80-11e9-8fe3-857eacbdfb83.png)
