### PR TITLE
fix: Position PubInlineMenu away from mobile browsers' built-in inline controls

### DIFF
--- a/client/containers/Pub/PubDocument/PubInlineMenu.js
+++ b/client/containers/Pub/PubDocument/PubInlineMenu.js
@@ -24,6 +24,12 @@ const defaultProps = {
 	// onNewHighlightDiscussion: () => {},
 };
 
+const shouldOpenBelowSelection = () => {
+	return ['Android', 'iPad', 'iPhone'].some((device) =>
+		navigator.userAgent.toLowerCase().includes(device.toLowerCase()),
+	);
+};
+
 const PubInlineMenu = (props) => {
 	const { pubData, collabData, historyData } = props;
 	const { locationData, communityData } = useContext(PageContext);
@@ -38,9 +44,14 @@ const PubInlineMenu = (props) => {
 		return null;
 	}
 
+	const topPosition =
+		window.scrollY +
+		(shouldOpenBelowSelection()
+			? selectionBoundingBox.bottom + 10
+			: selectionBoundingBox.top - 50);
 	const menuStyle = {
 		position: 'absolute',
-		top: selectionBoundingBox.top - 50 + window.scrollY,
+		top: topPosition,
 		left: selectionBoundingBox.left,
 	};
 	const menuItems = collabData.editorChangeObject.menuItems;


### PR DESCRIPTION
On mobile, both Chrome and Safari have a context menu that appears around selected text...right where we put our `PubInlineMenu`. In these contexts (specifically, on devices with `iPad`, `iPhone`, or `Android` in the user-agent string) we'll move the menu to the bottom of the selection where it remains accessible.

_Test plan:_
- Patch the devserver so it accepts connections on the local network from other devices. I changed `if (req.hostname.indexOf('localhost') > -1)` in `server.js` to `if (true)`.
- Fire up a pub on your mobile device and verify the `PubInlineMenu` does not overlap your mobile browser's inline context menu when text is selected in a Pub.
- Open the same Pub in a desktop browser and verify that the menu positioning is the same as before.

_Screenshots:_

Desktop (same as always):
<img width="400" alt="image" src="https://user-images.githubusercontent.com/2208769/63051343-13a86980-beab-11e9-9745-2ac67afb8b3e.png">

Android Chrome:
<img width="300" src="https://user-images.githubusercontent.com/2208769/63051353-1905b400-beab-11e9-9931-465eb35891c8.png">

Android Chrome (bigger selection):
<img width="300" src="https://user-images.githubusercontent.com/2208769/63051381-2622a300-beab-11e9-82a2-4c13f1b29b8c.png">

