### PR TITLE
update: Make /collection/:id requests redirect to collection page, where applicable

### DIFF
--- a/server/routes/__tests__/collection.test.js
+++ b/server/routes/__tests__/collection.test.js
@@ -1,0 +1,61 @@
+/* global describe, it, expect, beforeAll, afterAll */
+
+import { makeCommunity, setup, teardown, login } from '../../../stubstub';
+import { createCollection } from '../../collection/queries';
+import { createPage } from '../../page/queries';
+
+let testCommunity;
+
+setup(beforeAll, async () => {
+	testCommunity = await makeCommunity();
+});
+
+describe('/collection', () => {
+	it('redirects to a search when a Collection does not have a linked Page', async () => {
+		const { community } = testCommunity;
+		const collection = await createCollection({
+			communityId: community.id,
+			kind: 'issue',
+			title: 'The Book of Tests',
+		});
+		const agent = await login();
+		const { headers } = await agent
+			.get('/collection/' + collection.id.slice(0, 8))
+			.send()
+			.expect(302);
+		expect(headers.location).toEqual('/search?q=' + escape(collection.title));
+	});
+
+	it('redirects to the linked Page for a Collection, when it exists', async () => {
+		const { community } = testCommunity;
+		const collection = await createCollection({
+			communityId: community.id,
+			kind: 'issue',
+			title: 'The Book of Tests',
+		});
+		const page = await createPage({
+			communityId: community.id,
+			title: 'The Page of Tests',
+			description: 'I sure hope this works!',
+			slug: 'test-page',
+		});
+		collection.pageId = page.id;
+		await collection.save();
+		const agent = await login();
+		const { headers } = await agent
+			.get('/collection/' + collection.id.slice(0, 8))
+			.send()
+			.expect(302);
+		expect(headers.location).toEqual('/' + page.slug);
+	});
+
+	it('responds with a 404 for invalid collection IDs', async () => {
+		const agent = await login();
+		await agent
+			.get('/collection/qwertyuiop')
+			.send()
+			.expect(404);
+	});
+});
+
+teardown(afterAll);

--- a/server/routes/collection.js
+++ b/server/routes/collection.js
@@ -1,6 +1,6 @@
 import { Op } from 'sequelize';
 import app from '../server';
-import { Collection, sequelize } from '../models';
+import { Collection, sequelize, Page } from '../models';
 import { hostIsValid } from '../utils';
 
 app.get('/collection/:slug', (req, res, next) => {
@@ -15,10 +15,15 @@ app.get('/collection/:slug', (req, res, next) => {
 				[Op.iLike]: `${slug}%`,
 			}),
 		],
+		include: [{ model: Page, as: 'page', attributes: ['slug'] }],
 	})
 		.then((collection) => {
 			if (collection) {
-				res.redirect(`/search?q=${collection.title}`);
+				if (collection.page) {
+					res.redirect('/' + collection.page.slug);
+				} else {
+					res.redirect(`/search?q=${collection.title}`);
+				}
 			} else {
 				res.status(404).json('Collection not found');
 			}

--- a/stubstub/modelHelpers.js
+++ b/stubstub/modelHelpers.js
@@ -45,6 +45,7 @@ export const makeCommunity = async (communityData, communityAdminInfo = {}) => {
 	const community = await Community.create({
 		title: 'Community ' + unique,
 		subdomain: unique,
+		navigation: [],
 		...communityData,
 	});
 	if (communityAdminInfo) {


### PR DESCRIPTION
This PR updates the behavior of the `/collection/:id` route (notable for being referenced in DOI deposits) so that it resolves to the Page associated with a Collection, where one exists.

_Test plan:_
- Create a collection and copy its URL (from the Metadata tab of the collection editor) into the search bar. Verify that it redirects to a `/search` URL.
- Now link your collection to a Page (from the Details tab of same). Verify that the same collection URL now redirects to the Page.
- `npm test server/routes`