### PR TITLE
feature: Wire new citations/footnotes fields into new pub footer (3/x)

### DIFF
--- a/client/components/PubNoteContent/PubNoteContent.js
+++ b/client/components/PubNoteContent/PubNoteContent.js
@@ -13,15 +13,16 @@ const defaultProps = {
 	unstructured: '',
 };
 
-const PubNoteContent = (props) => {
+const PubNoteContent = React.forwardRef((props, ref) => {
 	const { structured, unstructured } = props;
 	return (
-		<span className="pub-note-content-component">
+		<span ref={ref} className="pub-note-content-component">
 			<span dangerouslySetInnerHTML={{ __html: structured }} />
 			<span dangerouslySetInnerHTML={{ __html: unstructured }} />
 		</span>
 	);
-};
+});
+
 PubNoteContent.propTypes = propTypes;
 PubNoteContent.defaultProps = defaultProps;
 export default PubNoteContent;

--- a/client/components/PubNoteContent/pubNoteContent.scss
+++ b/client/components/PubNoteContent/pubNoteContent.scss
@@ -1,2 +1,3 @@
 .pub-note-content-component {
+	
 }

--- a/client/components/PubNoteContent/pubNoteContent.scss
+++ b/client/components/PubNoteContent/pubNoteContent.scss
@@ -1,3 +1,2 @@
 .pub-note-content-component {
-    
 }

--- a/client/components/PubNoteContent/pubNoteContent.scss
+++ b/client/components/PubNoteContent/pubNoteContent.scss
@@ -1,3 +1,3 @@
 .pub-note-content-component {
-	
+    
 }

--- a/client/containers/Pub/PubDocument/PubBottom/Discussions/FilterMenu.js
+++ b/client/containers/Pub/PubDocument/PubBottom/Discussions/FilterMenu.js
@@ -9,8 +9,8 @@ const propTypes = {
 	...labelFilterPropTypes,
 	isBrowsingArchive: PropTypes.bool.isRequired,
 	isShowingAnchoredComments: PropTypes.bool.isRequired,
-	onBrowseArchive: PropTypes.bool.isRequired,
-	onShowAnchoredComments: PropTypes.bool.isRequired,
+	onBrowseArchive: PropTypes.func.isRequired,
+	onShowAnchoredComments: PropTypes.func.isRequired,
 };
 
 const FilterMenu = (props) => {

--- a/client/containers/Pub/PubDocument/PubBottom/Footnotes.js
+++ b/client/containers/Pub/PubDocument/PubBottom/Footnotes.js
@@ -1,41 +1,107 @@
-import React from 'react';
+import React, { useState, useRef, useLayoutEffect } from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 
-import Icon from 'components/Icon/Icon';
+import { Icon, PubNoteContent } from 'components';
 
 require('./footnotes.scss');
 
-const footnotePropType = PropTypes.shape({
-	content: PropTypes.node,
-	href: PropTypes.string,
-	number: PropTypes.number,
+export const footnotePropType = PropTypes.shape({
+	html: PropTypes.string,
+	unstructuredValue: PropTypes.string,
+	count: PropTypes.number,
 });
 
 const propTypes = {
 	accentColor: PropTypes.string.isRequired,
 	footnotes: PropTypes.arrayOf(footnotePropType).isRequired,
+	targetFootnoteElement: PropTypes.func.isRequired,
 };
 
-const Footnotes = (props) => {
-	const { accentColor, footnotes } = props;
+const scrollToNode = (node) => {
+	if (node) {
+		node.scrollIntoView();
+		const currentTop = document.body.scrollTop || document.documentElement.scrollTop;
+		document.body.scrollTop = currentTop - 75;
+		document.documentElement.scrollTop = currentTop - 75;
+	}
+};
+
+const findLastElementChild = (node) => {
+	let child = node;
+	// eslint-disable-next-line no-constant-condition
+	while (true) {
+		const { lastElementChild } = child;
+		if (lastElementChild) {
+			child = lastElementChild;
+		} else {
+			break;
+		}
+	}
+	return child;
+};
+
+const Footnote = (props) => {
+	const { footnote, accentColor, targetFootnoteElement } = props;
+	const contentRef = useRef();
+	const [returnLinkTarget, setReturnLinkTarget] = useState(null);
+
+	useLayoutEffect(() => {
+		const contentNode = contentRef.current;
+		if (contentNode) {
+			const lastChild = findLastElementChild(contentNode);
+			if (lastChild) {
+				const newReturnLinkTarget = document.createElement('span');
+				lastChild.appendChild(newReturnLinkTarget);
+				setReturnLinkTarget(newReturnLinkTarget);
+			}
+		}
+	}, []);
+
 	return (
-		<ul className="footnotes-component">
-			{footnotes.map((fn) => (
-				<li className="footnote">
-					<div className="number">{fn.number}.</div>
-					<div className="inner">
-						{fn.content}
-						<a href={fn.href}>
+		<li className="footnote">
+			<div className="number">{footnote.number}.</div>
+			<div className="inner">
+				<PubNoteContent
+					ref={contentRef}
+					structured={footnote.html}
+					unstructured={footnote.unstructuredValue}
+				/>
+				{returnLinkTarget &&
+					ReactDOM.createPortal(
+						<span
+							role="button"
+							aria-label="Jump back to source"
+							tabIndex="0"
+							style={{ cursor: 'pointer' }}
+							onClick={() => scrollToNode(targetFootnoteElement(footnote))}
+						>
 							<Icon
 								className="jump-back-icon"
 								icon="return"
 								color={accentColor}
 								iconSize={10}
-								ariaLabel="Jump back to source"
 							/>
-						</a>
-					</div>
-				</li>
+						</span>,
+						returnLinkTarget,
+					)}
+			</div>
+		</li>
+	);
+};
+
+Footnote.propTypes = {
+	accentColor: PropTypes.string.isRequired,
+	footnote: footnotePropType.isRequired,
+	targetFootnoteElement: PropTypes.func.isRequired,
+};
+
+const Footnotes = (props) => {
+	const { footnotes, ...restProps } = props;
+	return (
+		<ul className="footnotes-component">
+			{footnotes.map((fn) => (
+				<Footnote key={fn.number} footnote={fn} {...restProps} />
 			))}
 		</ul>
 	);
@@ -43,4 +109,3 @@ const Footnotes = (props) => {
 
 Footnotes.propTypes = propTypes;
 export default Footnotes;
-export { propTypes as footnotePropType };

--- a/client/containers/Pub/PubDocument/PubBottom/PubBottomSection.js
+++ b/client/containers/Pub/PubDocument/PubBottom/PubBottomSection.js
@@ -9,7 +9,7 @@ const propTypes = {
 	accentColor: PropTypes.string,
 	centerItems: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 	children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-	iconItems: PropTypes.node,
+	iconItems: PropTypes.func,
 	isSearchable: PropTypes.bool,
 	searchPlaceholder: PropTypes.string,
 	onSearch: PropTypes.func,
@@ -20,7 +20,7 @@ const defaultProps = {
 	accentColor: 'black',
 	centerItems: [],
 	children: null,
-	iconItems: [],
+	iconItems: () => null,
 	isSearchable: false,
 	onSearch: () => {},
 	searchPlaceholder: 'Enter keywords to search for...',
@@ -40,7 +40,11 @@ export const AccentedIconButton = (props) => {
 AccentedIconButton.propTypes = {
 	accentColor: PropTypes.string.isRequired,
 	icon: PropTypes.string.isRequired,
-	title: PropTypes.string.isRequired,
+	title: PropTypes.string,
+};
+
+AccentedIconButton.defaultProps = {
+	title: null,
 };
 
 export const SectionBullets = ({ children }) => {

--- a/client/containers/Pub/PubDocument/PubMouseEvents/PubMouseEvents.js
+++ b/client/containers/Pub/PubDocument/PubMouseEvents/PubMouseEvents.js
@@ -14,7 +14,7 @@ const propTypes = {
 
 /* Specify the types of elems we want events for */
 const mouseElemTypes = [
-	{ key: 'note', querySelector: '.footnote, .citation' },
+	{ key: 'note', querySelector: '.pub-body-component .footnote, .pub-body-component .citation' },
 	{ key: 'header', querySelector: 'h1, h2, h3, h4, h5, h6' },
 ];
 

--- a/stories/containers/Pub/PubBottom/footnotesStories.js
+++ b/stories/containers/Pub/PubBottom/footnotesStories.js
@@ -10,23 +10,12 @@ storiesOf('containers/Pub/PubDocument/PubBottom/Footnotes', module).add('default
 				accentColor="#a2273e"
 				footnotes={[
 					{
-						content:
-							'This footnote is purely for demonstration purposes. It is neither too long, nor too short, making it the perfect size to illustrate what an informal text block of footnote looks like in real life.',
-						href: '#1',
-						number: 1,
+						structuredValue: 'https://doi.org/10.21428/8f7503e4',
+						unstructuredValue: '<p>Some text for folks.</p>',
+						html:
+							'<div class="csl-bib-body">\n  <div data-csl-entry-id="temp_id_9869594710326501" class="csl-entry">Ito, J. (2017). Resisting Reduction: A Manifesto. <i>Journal of Design and Science</i>. https://doi.org/10.21428/8f7503e4</div>\n</div>',
 					},
-					{
-						content:
-							'This footnote is purely for demonstration purposes. It is neither too... oh it is short.',
-						href: '#2',
-						number: 2,
-					},
-					{
-						content:
-							'And this one is purely for demonstration purposes. It is a long one to make sure that we all know what a super long footnote will look like in rea world situations where authors may tend to be verbose and not really know how to punctuate their sentences like what is happening with this very long sentence right now. When I add more gibberish words to it like this asdfas dh h1o and then bf kh ygaisgd fih then we really have a long footnote which noone is going to read.',
-						href: '#3',
-						number: 3,
-					},
+					{ structuredValue: '', unstructuredValue: '<p>okok</p>', html: '' },
 				]}
 			/>
 		</div>

--- a/stories/containers/Pub/PubBottom/pubBottomStories.js
+++ b/stories/containers/Pub/PubBottom/pubBottomStories.js
@@ -4,34 +4,41 @@ import { storiesOf } from '@storybook/react';
 import { discussionsData as discussions, discussionLabels as labels } from 'data';
 import PubBottom from 'containers/Pub/PubDocument/PubBottom/PubBottom';
 
-const footnotes = [
-	'This footnote is purely for demonstration purposes. It is neither too long, nor too short, making it the perfect size to illustrate what an informal text block of footnote looks like in real life.',
-	'This footnote is purely for demonstration purposes. It is neither too... oh it is short.',
-	'And this one is purely for demonstration purposes. It is a long one to make sure that we all know what a super long footnote will look like in rea world situations where authors may tend to be verbose and not really know how to punctuate their sentences like what is happening with this very long sentence right now. When I add more gibberish words to it like this asdfas dh h1o and then bf kh ygaisgd fih then we really have a long footnote which noone is going to read.',
-].map((str, index) => ({
-	content: str,
-	href: '#' + index.toString(),
-	number: index + 1,
-}));
-
 const citations = [
-	'Huntford, R., “The Last Place on Earth – Scott and Amundsen’s Race to the South Pole”, The Modern Library, New York, 1999',
-	'Discussion with Paul Sheppard, Chief Program Officer, Antarctic Infrastructure and Logistics Section, Office of Polar Programs, National Science Foundation',
-	'Lunney, G.S., “Discussion of Several Problem Areas During the Apollo 13 Operation”, AIAA 70-1260, AIAA 7th Annual Meeting and Technical Display, October 19-22, 1970, Houston TX',
-	'Portree, D.S.F., “Mir Hardware Heritage”, NASA Reference Publication 1357, NASA Lyndon B. Johnson Space Center, Houston, TX, March 1995',
-	'Harland, D.M., “The Story of Space Station Mir”, Praxis Publishing, Chichester, UK, 2005',
-	'Space Station Program Office, “International Space Station Logistics and Maintenance Lessons Learned for Future Programs”, briefing by W. W. Robbins, Chief, Logistics and Maintenance Office, Johnson Space Center, 30 June 2005.',
-	'National Aeronautics and Space Administration, “Mars Human Landing Sites Study (HLS2) Overview,” https://www.nasa.gov/sites/default/files/atoms/files/hls2-overview-v3tagged.pdf',
-	'National Aeronautics and Space Administration, “Lunar L1 Gateway Conceptual Design Report, V.1.0,” EX15-01-001, NASA/JSC, October 2001.',
-	'Troutman, P., Mazanek, D., et al., “Orbital Aggregation and Space Infrastructure Systems (OASIS),” IAC-02-IAA.13.2.06, 53rd International Astronautical Congress, Houston, TX, 10-19 October 2002.',
-	'Space Studies Program Team, Operations and Service Infrastructure for Space (OASIS) Final Report, International Space University, 2012.',
-	'Whitley, R., Martinez, R., “Options for Staging Orbits in Cislunar Space,” 2016 IEEE Aerospace Conference, 5-12 March 2016.',
-	'Woolley, R., Landau, D., et al., “Human Cargo Resupply Logistics at Mars Using 150kW SEP Tug Cyclers,” IEEE Aerospace Conference, Big Sky, MT, 2017.',
-].map((str, index) => ({
-	content: str,
-	href: '#' + index.toString(),
-	number: index + 1,
-}));
+	{
+		structuredValue: 'https://doi.org/10.21428/8f7503e4',
+		unstructuredValue: '<p>Some text for folks.</p>',
+		html:
+			'<div class="csl-bib-body">\n  <div data-csl-entry-id="temp_id_9869594710326501" class="csl-entry">Ito, J. (2017). Resisting Reduction: A Manifesto. <i>Journal of Design and Science</i>. https://doi.org/10.21428/8f7503e4</div>\n</div>',
+	},
+	{ structuredValue: '', unstructuredValue: '<p>okok</p>', html: '' },
+];
+
+const footnotes = [
+	{
+		structuredValue:
+			'@article{spier2002history,\n  title={The history of the peer-review pzro212121asasa2cess},\n  author={Spier, Ray},\n  journal={TReeeeeeENDS in Biotechnology},\n  volume={20},\n  number={8},\n  pages={357--358},\n  year={2002},\n  publisher={Elsevier}\n}',
+		unstructuredValue: '<p>Tigers are stri1234567ped.</p>',
+		html:
+			'<div class="csl-bib-body">\n  <div data-csl-entry-id="spier2002history" class="csl-entry">Spier, R. (2002). The history of the peer-review pzro212121asasa2cess. <i>TReeeeeeENDS in Biotechnology</i>, <i>20</i>(8), 357–358.</div>\n</div>',
+	},
+	{
+		structuredValue:
+			'@article{spier2002history,\n  title={The history of the peer-review process},\n  author={Spier, Ray},\n  journal={TeNDS in Biotechnology},\n  volume={20},\n  number={8},\n  pages={357--358},\n  year={2002},\n  publisher={Elsevier}\n}',
+		unstructuredValue: '<p>Tigers are 123.!</p>',
+		html:
+			'<div class="csl-bib-body">\n  <div data-csl-entry-id="spier2002history" class="csl-entry">Spier, R. (2002). The history of the peer-review process. <i>TeNDS in Biotechnology</i>, <i>20</i>(8), 357–358.</div>\n</div>',
+	},
+	{ structuredValue: '', unstructuredValue: '<p>Tigers are striped.njn</p>', html: '' },
+	{ structuredValue: '', unstructuredValue: '<p>Tigers are striped.</p>', html: '' },
+	{
+		structuredValue: 'https://doi.org/10.21428/8f7503e4',
+		unstructuredValue: '<p>Tigers are striped.</p>',
+		html:
+			'<div class="csl-bib-body">\n  <div data-csl-entry-id="temp_id_7637804677847417" class="csl-entry">Ito, J. (2017). Resisting Reduction: A Manifesto. <i>Journal of Design and Science</i>. https://doi.org/10.21428/8f7503e4</div>\n</div>',
+	},
+	{ structuredValue: '', unstructuredValue: '<p>Tigers are striped!</p>', html: '' },
+];
 
 const pubData = {
 	footnotes: footnotes,


### PR DESCRIPTION
This PR connects the new `pubData.citations` and `pubData.footnotes` fields from our NodeView refactor to the new PubBottom UI, so that citations and footnotes in the document will be reflected live in the footer.

_Test plan:_
-  Visit a Pub with some footnotes and citations ([like this one](http://localhost:9876/pub/xiyvipgb))
- Test that the footnotes and citations in the document are visible in the footer
- Test that editing the document updates these footnotes and citations
- Test that clicking the "return" link on a footnote/citation takes you back to its position in the Pub.

<img width="697" alt="image" src="https://user-images.githubusercontent.com/2208769/63620655-eac95800-c5bf-11e9-8387-6b149d9e6fd6.png">
