### PR TITLE
fix: Update page title when Pub title changes

### DIFF
--- a/client/containers/Pub/Pub.js
+++ b/client/containers/Pub/Pub.js
@@ -35,6 +35,7 @@ const Pub = (props) => {
 					<PubSyncManager
 						pubData={props.pubData}
 						locationData={props.locationData}
+						communityData={props.communityData}
 						loginData={props.loginData}
 					>
 						{({

--- a/client/containers/Pub/PubSyncManager.js
+++ b/client/containers/Pub/PubSyncManager.js
@@ -1,15 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import queryString from 'query-string';
 
 import { loginDataProps } from 'types/base';
 import { apiFetch, getRandomColor } from 'utils';
-import queryString from 'query-string';
 import { initFirebase } from 'utils/firebaseClient';
+import { getPubPageTitle } from 'shared/utils/pubPageTitle';
 
 const propTypes = {
 	pubData: PropTypes.object.isRequired,
 	children: PropTypes.func.isRequired,
 	locationData: PropTypes.object.isRequired,
+	communityData: PropTypes.object.isRequired,
 	loginData: loginDataProps.isRequired,
 };
 
@@ -169,10 +171,11 @@ class PubSyncManager extends React.Component {
 	}
 
 	updatePubData(newPubData) {
-		/* First, set the local state. */
+		/* Firs t, set the local state. */
 		/* Then, sync appropriate data to firebase. */
 		/* Other clients will receive updates which */
 		/* triggers the syncMetadata function. */
+		document.title = getPubPageTitle(this.state.pubData, this.props.communityData);
 		this.setState(
 			(prevState) => {
 				const nextData =
@@ -212,6 +215,7 @@ class PubSyncManager extends React.Component {
 				if (this.state.firebaseRootRef && hasUpdates) {
 					this.state.firebaseRootRef.child('metadata').update(firebaseSyncData);
 				}
+				document.title = getPubPageTitle(this.state.pubData, this.props.communityData);
 			},
 		);
 	}

--- a/client/containers/Pub/PubSyncManager.js
+++ b/client/containers/Pub/PubSyncManager.js
@@ -171,11 +171,10 @@ class PubSyncManager extends React.Component {
 	}
 
 	updatePubData(newPubData) {
-		/* Firs t, set the local state. */
+		/* First, set the local state. */
 		/* Then, sync appropriate data to firebase. */
 		/* Other clients will receive updates which */
 		/* triggers the syncMetadata function. */
-		document.title = getPubPageTitle(this.state.pubData, this.props.communityData);
 		this.setState(
 			(prevState) => {
 				const nextData =

--- a/server/routes/pub.js
+++ b/server/routes/pub.js
@@ -2,6 +2,7 @@ import React from 'react';
 import uuidValidate from 'uuid-validate';
 import { Pub } from 'containers';
 
+import { getPubPageContextTitle } from 'shared/utils/pubPageTitle';
 import Html from '../Html';
 import app from '../server';
 import {
@@ -112,13 +113,6 @@ app.get(
 					mode: mode,
 				},
 			};
-			const primaryCollection = pubData.collectionPubs.reduce((prev, curr) => {
-				if (curr.isPrimary && curr.collection.kind !== 'issue') {
-					return curr;
-				}
-				return prev;
-			}, {});
-			const contextTitle = primaryCollection.title || initialData.communityData.title;
 			/* We calculate titleWithContext in generateMetaComponents. Since we will use */
 			/* titleWithContext in other locations (e.g. search), we should eventually */
 			/* write a helper function that generates these parameters. */
@@ -130,7 +124,7 @@ app.get(
 					headerComponents={generateMetaComponents({
 						initialData: initialData,
 						title: pubData.title,
-						contextTitle: contextTitle,
+						contextTitle: getPubPageContextTitle(pubData, initialData.communityData),
 						description: pubData.description,
 						image: pubData.avatar,
 						attributions: pubData.attributions,

--- a/shared/utils/pubPageTitle.js
+++ b/shared/utils/pubPageTitle.js
@@ -1,0 +1,15 @@
+export const getPubPageContextTitle = (pubData, communityData) => {
+	const primaryCollection = pubData.collectionPubs.reduce((prev, curr) => {
+		if (curr.isPrimary && curr.collection.kind !== 'issue') {
+			return curr;
+		}
+		return prev;
+	}, {});
+	return primaryCollection.title || communityData.title;
+};
+
+export const getPubPageTitle = (pubData, communityData) => {
+	const { title } = pubData;
+	const contextTitle = getPubPageContextTitle(pubData, communityData);
+	return `${title} · ${contextTitle}`;
+};


### PR DESCRIPTION
Does what it say on the tin — makes the page title change when we edit the Pub title in real time.

_Test plan:_
Open a pub, edit the title by clicking on it in the header, make sure the page title changes.