### PR TITLE
feature: Add footnotes/citations to export

### DIFF
--- a/client/components/SimpleNotesList/SimpleNotesList.js
+++ b/client/components/SimpleNotesList/SimpleNotesList.js
@@ -18,7 +18,7 @@ const SimpleNotesList = (props) => {
 		return null;
 	}
 	return (
-		<div>
+		<React.Fragment>
 			<h1>{title}</h1>
 			<ol>
 				{notes.map((note, index) => (
@@ -31,7 +31,7 @@ const SimpleNotesList = (props) => {
 					</li>
 				))}
 			</ol>
-		</div>
+		</React.Fragment>
 	);
 };
 

--- a/client/components/SimpleNotesList/SimpleNotesList.js
+++ b/client/components/SimpleNotesList/SimpleNotesList.js
@@ -1,0 +1,39 @@
+/**
+ * This component is used in generated exports to render footnote and citation lists.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { PubNoteContent } from 'components';
+import { notePropType } from 'containers/Pub/PubDocument/PubBottom/Notes';
+
+const propTypes = {
+	notes: PropTypes.arrayOf(notePropType).isRequired,
+	title: PropTypes.string.isRequired,
+};
+
+const SimpleNotesList = (props) => {
+	const { notes, title } = props;
+	if (notes.length === 0) {
+		return null;
+	}
+	return (
+		<div>
+			<h1>{title}</h1>
+			<ol>
+				{notes.map((note, index) => (
+					// eslint-disable-next-line react/no-array-index-key
+					<li key={index}>
+						<PubNoteContent
+							structured={note.html}
+							unstructured={note.unstructuredValue}
+						/>
+					</li>
+				))}
+			</ol>
+		</div>
+	);
+};
+
+SimpleNotesList.propTypes = propTypes;
+export default SimpleNotesList;

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -31,4 +31,5 @@ export { default as PubNoteContent } from './PubNoteContent/PubNoteContent';
 export { default as SettingsSection } from './SettingsSection/SettingsSection';
 export { default as SharingCard } from './SharingCard/SharingCard';
 export { default as SimpleEditor } from './SimpleEditor/SimpleEditor';
+export { default as SimpleNotesList } from './SimpleNotesList/SimpleNotesList';
 export { default as UserAutocomplete } from './UserAutocomplete/UserAutocomplete';


### PR DESCRIPTION
Since we no longer render citation or footnote lists in our Prosemirror docs, we'll now append these to the bottom of the export that we send to Pandoc.

_Test plan:_
- Create a pub with some footnotes and citations. Test that you can export it to several formats, and that the exports contain footnotes and citations.
- Test that exporting pubs without footnotes/citations still works.

_Example output:_
<img width="664" alt="image" src="https://user-images.githubusercontent.com/2208769/64370414-65489d80-cfec-11e9-8d18-f2d78188c270.png">
