### PR TITLE
feature: Add metadata to Pub exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22649,6 +22649,15 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
 			"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 		},
+		"yaml": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.6.0.tgz",
+			"integrity": "sha512-iZfse3lwrJRoSlfs/9KQ9iIXxs9++RvBFVzAqbbBiFT+giYtyanevreF9r61ZTbGMgWQBxAua3FzJiniiJXWWw==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.5"
+			}
+		},
 		"yargs": {
 			"version": "13.3.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
 		"require-context.macro": "^1.0.4",
 		"sinon": "^7.3.2",
 		"webpack-bundle-analyzer": "^3.1.0",
-		"webpack-cli": "^3.3.1"
+		"webpack-cli": "^3.3.1",
+		"yaml": "^1.6.0"
 	},
 	"dependencies": {
 		"@babel/core": "^7.4.4",


### PR DESCRIPTION
Oops, forgot to put this up yesterday. This PR adds passes the `author` and `date` metadata values into Pandoc, showing them in our Pub exports. Where applicable we also include "Updated at" and "DOI" fields at the top of the export.

_Test plan:_
- Check that an exported pub contains a date and a correctly-sorted list of contributors under the title.
- Try exporting a pub with (and without) a DOI and check that it appears (or doesn't) as expected in the result
- Test that the "Updated at" field appears iff the pub has been updated, and the updated date is not the same as the published date

_Screenshot:_
<img width="603" alt="image" src="https://user-images.githubusercontent.com/2208769/65056116-4fb56b00-d93e-11e9-82a7-c550ef5e79a6.png">
