### PR TITLE
fix: Non-document pub views cause redirect when no public branch exists

### DIFF
--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionInput.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionThread/DiscussionInput.js
@@ -46,7 +46,7 @@ const DiscussionInput = (props) => {
 		if (!isPubBottomInput && (isNewThread || didFocus) && changeObject.view) {
 			changeObject.view.focus();
 		}
-	}, [isNewThread, changeObject.view, didFocus]);
+	}, [isNewThread, changeObject.view, didFocus, isPubBottomInput]);
 
 	const handlePostDiscussion = () => {
 		setIsLoading(true);

--- a/server/routes/__tests__/pub.test.js
+++ b/server/routes/__tests__/pub.test.js
@@ -104,6 +104,15 @@ describe('/pub', () => {
 			.expect(200);
 	});
 
+	it('200s for a pub manager seeking to visit /manage', async () => {
+		await publicBranch.update({ firstKeyAt: new Date() });
+		const agent = await login(pubManager);
+		await agent
+			.get(`/pub/${pub.slug}/manage`)
+			.set('Host', host)
+			.expect(200);
+	});
+
 	it('200s for a user seeking to visit #public, when it has content', async () => {
 		await publicBranch.update({ firstKeyAt: new Date() });
 		const agent = await login(visitor);

--- a/server/routes/__tests__/pub.test.js
+++ b/server/routes/__tests__/pub.test.js
@@ -95,20 +95,19 @@ describe('/pub', () => {
 			.expect(200);
 	});
 
+	it('200s for a pub manager seeking to visit /manage', async () => {
+		const agent = await login(pubManager);
+		await agent
+			.get(`/pub/${pub.slug}/manage`)
+			.set('Host', host)
+			.expect(200);
+	});
+
 	it('200s for a pub manager seeking to visit #public, when it has content', async () => {
 		await publicBranch.update({ firstKeyAt: new Date() });
 		const agent = await login(pubManager);
 		await agent
 			.get(`/pub/${pub.slug}`)
-			.set('Host', host)
-			.expect(200);
-	});
-
-	it('200s for a pub manager seeking to visit /manage', async () => {
-		await publicBranch.update({ firstKeyAt: new Date() });
-		const agent = await login(pubManager);
-		await agent
-			.get(`/pub/${pub.slug}/manage`)
 			.set('Host', host)
 			.expect(200);
 	});

--- a/server/utils/formatPub.js
+++ b/server/utils/formatPub.js
@@ -58,9 +58,9 @@ const formatBranches = ({
 		visibleBranches.includes(branchesWithAccessData[0])
 		? // Then return it
 		  branchesWithAccessData[0]
-		: // Otherwise, return null. This will cause the caller to throw an error, triggering a
+		: // Otherwise, return an empty object. This will cause the caller to throw an error, triggering a
 		  // redirect to one of the other visibleBranches
-		  null;
+		  {};
 	return { activeBranch: activeBranch, branches: visibleBranches };
 };
 
@@ -113,12 +113,16 @@ export const formatAndAuthenticatePub = (
 		branchShortId: branchShortId,
 	});
 
-	if (!activeBranch) {
-		if (matchActiveBranch) {
-			throw new PubBranchNotVisibleError(branches);
-		} else {
-			return null;
-		}
+	/* If the activeBranch is note visible, throw an error that will trigger */
+	/* a redirect. */
+	if (!activeBranch.id && matchActiveBranch) {
+		throw new PubBranchNotVisibleError(branches);
+	}
+
+	/* If a user has access to no branches, they don't have access to the pub. */
+	/* Returning null will cause a 404 error to be returned. */
+	if (!branches.length) {
+		return null;
 	}
 
 	return {

--- a/server/utils/formatPub.js
+++ b/server/utils/formatPub.js
@@ -115,7 +115,7 @@ export const formatAndAuthenticatePub = (
 
 	/* If the activeBranch is note visible, throw an error that will trigger */
 	/* a redirect. */
-	if (!activeBranch.id && matchActiveBranch) {
+	if (!activeBranch || (!activeBranch.id && matchActiveBranch)) {
 		throw new PubBranchNotVisibleError(branches);
 	}
 

--- a/server/utils/pubQueries.js
+++ b/server/utils/pubQueries.js
@@ -159,14 +159,18 @@ export const findPub = (req, initialData, mode) => {
 				throw new Error('Pub Not Found');
 			}
 			const pubDataJson = pubData.toJSON();
-			const formattedPubData = formatAndAuthenticatePub({
-				pub: pubDataJson,
-				loginData: initialData.loginData,
-				communityAdminData: communityAdminData,
-				accessHash: req.query.access,
-				branchShortId: req.params.branchShortId,
-				versionNumber: req.params.versionNumber,
-			});
+			const matchActiveBranch = mode === 'document';
+			const formattedPubData = formatAndAuthenticatePub(
+				{
+					pub: pubDataJson,
+					loginData: initialData.loginData,
+					communityAdminData: communityAdminData,
+					accessHash: req.query.access,
+					branchShortId: req.params.branchShortId,
+					versionNumber: req.params.versionNumber,
+				},
+				matchActiveBranch,
+			);
 
 			if (!formattedPubData) {
 				throw new Error('Pub Not Found');


### PR DESCRIPTION
This PR fixes a bug that was introduced when implementing the branch-redirect logic. This addresses #538.

The issue was that non-document views (e.g. /manage or /review) were triggering a redirect if a public branch was not visible (or was empty), as the "default branch" would resolve to null given that there was no public branch, and no specific sub-branch specified in the URL.