### PR TITLE
feature: New accessible menu component

### DIFF
--- a/client/components/Header/Header.js
+++ b/client/components/Header/Header.js
@@ -1,17 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {
-	Popover,
-	PopoverInteractionKind,
-	Position,
-	Menu,
-	MenuItem,
-	MenuDivider,
-	Button,
-	AnchorButton,
-	Intent,
-} from '@blueprintjs/core';
+import { Button, AnchorButton, Intent } from '@blueprintjs/core';
+
 import { GridWrapper } from 'components';
+import { Menu, MenuItem } from 'components/Menu';
 import Avatar from 'components/Avatar/Avatar';
 import DropdownButton from 'components/DropdownButton/DropdownButton';
 import { apiFetch, getResizedUrl } from 'utils';
@@ -296,57 +288,29 @@ class Header extends Component {
 								/>
 							)}
 							{loggedIn && (
-								<Popover
-									content={
-										<Menu>
-											<li>
-												<a
-													href={`/user/${this.props.loginData.slug}`}
-													className="bp3-menu-item bp3-popover-dismiss"
-												>
-													<div>{this.props.loginData.fullName}</div>
-													<div className="subtext">View Profile</div>
-												</a>
-											</li>
-											<li>
-												<a
-													href="/privacy/settings"
-													className="bp3-menu-item bp3-popover-dismiss"
-												>
-													<div>Privacy settings</div>
-												</a>
-											</li>
-											<MenuDivider />
-											{/* !isBasePubPub &&
-														<li>
-															<a href="/pub/create" className="bp3-menu-item bp3-popover-dismiss">
-																Create New Pub
-															</a>
-														</li>
-													*/}
-											{/* !isBasePubPub && isAdmin &&
-														<li>
-															<a href="/dashboard" className="bp3-menu-item bp3-popover-dismiss">
-																Manage Community
-															</a>
-														</li>
-													*/}
-											<MenuItem text="Logout" onClick={this.handleLogout} />
-										</Menu>
-									}
-									interactionKind={PopoverInteractionKind.CLICK}
-									position={Position.BOTTOM_RIGHT}
-									transitionDuration={-1}
-									inheritDarkTheme={false}
+								<Menu
+									disclosure={(discProps) => (
+										<button {...discProps} type="button">
+											<Avatar
+												userInitials={this.props.loginData.initials}
+												userAvatar={this.props.loginData.avatar}
+												width={30}
+											/>
+										</button>
+									)}
 								>
-									<Button large={true} minimal={true}>
-										<Avatar
-											userInitials={this.props.loginData.initials}
-											userAvatar={this.props.loginData.avatar}
-											width={30}
-										/>
-									</Button>
-								</Popover>
+									<MenuItem
+										href={`/user/${this.props.loginData.slug}`}
+										text={
+											<React.Fragment>
+												<div>{this.props.loginData.fullName}</div>
+												<div className="subtext">View Profile</div>
+											</React.Fragment>
+										}
+									/>
+									<MenuItem href="/privacy/settings" text="Privacy settings" />
+									<MenuItem onClick={this.handleLogout} text="Logout" />
+								</Menu>
 							)}
 							{!loggedIn && (
 								<AnchorButton

--- a/client/components/Header/Header.js
+++ b/client/components/Header/Header.js
@@ -243,6 +243,8 @@ class Header extends Component {
 							{loggedIn && (
 								<MenuButton
 									placement="auto-end"
+									// The z-index of the PubHeaderFormatting is 19
+									menuStyle={{ zIndex: 20 }}
 									buttonProps={{
 										minimal: true,
 										large: true,

--- a/client/components/Header/Header.js
+++ b/client/components/Header/Header.js
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types';
 import { Button, AnchorButton, Intent } from '@blueprintjs/core';
 
 import { GridWrapper } from 'components';
-import { Menu, MenuItem } from 'components/Menu';
+import { MenuButton, MenuItem } from 'components/Menu';
 import Avatar from 'components/Avatar/Avatar';
-import DropdownButton from 'components/DropdownButton/DropdownButton';
 import { apiFetch, getResizedUrl } from 'utils';
 
 require('./header.scss');
@@ -146,7 +145,6 @@ class Header extends Component {
 	}
 
 	render() {
-		const headerLinks = this.props.communityData.headerLinks || [];
 		const hideHero = this.props.locationData.path !== '/' || this.props.communityData.hideHero;
 		const hideHeaderLogo = !hideHero && this.props.communityData.hideHeaderLogo;
 		const componentClasses = this.calculateComponentClasses(hideHero);
@@ -209,51 +207,6 @@ class Header extends Component {
 							)}
 						</div>
 						<div className="buttons-wrapper">
-							{headerLinks.map((linkItem, index) => {
-								const key = `${index}-${linkItem.title}`;
-								if (linkItem.children) {
-									return (
-										<DropdownButton
-											key={key}
-											label={linkItem.title}
-											isMinimal={true}
-											isLarge={true}
-											className="hide-on-mobile"
-										>
-											<Menu>
-												{linkItem.children.map((child, cIndex) => {
-													const childKey = `${cIndex}-${child.title}`;
-													return (
-														<MenuItem
-															key={childKey}
-															text={child.title}
-															href={child.url}
-															target={child.external ? '_blank' : ''}
-															rel={
-																child.external
-																	? 'noopener noreferrer'
-																	: ''
-															}
-														/>
-													);
-												})}
-											</Menu>
-										</DropdownButton>
-									);
-								}
-								return (
-									<AnchorButton
-										key={key}
-										minimal={true}
-										large={true}
-										text={linkItem.title}
-										href={linkItem.url}
-										target={linkItem.external ? '_blank' : ''}
-										rel={linkItem.external ? 'noopener noreferrer' : ''}
-										className="hide-on-mobile"
-									/>
-								);
-							})}
 							{!isBasePubPub &&
 								loggedIn &&
 								(!this.props.communityData.hideCreatePubButton || isAdmin) && (
@@ -288,29 +241,35 @@ class Header extends Component {
 								/>
 							)}
 							{loggedIn && (
-								<Menu
-									disclosure={(discProps) => (
-										<button {...discProps} type="button">
-											<Avatar
-												userInitials={this.props.loginData.initials}
-												userAvatar={this.props.loginData.avatar}
-												width={30}
-											/>
-										</button>
-									)}
+								<MenuButton
+									placement="auto-end"
+									buttonProps={{
+										minimal: true,
+										large: true,
+										'aria-label': 'User menu',
+									}}
+									buttonContent={
+										<Avatar
+											userInitials={this.props.loginData.initials}
+											userAvatar={this.props.loginData.avatar}
+											width={30}
+										/>
+									}
 								>
 									<MenuItem
 										href={`/user/${this.props.loginData.slug}`}
 										text={
 											<React.Fragment>
-												<div>{this.props.loginData.fullName}</div>
-												<div className="subtext">View Profile</div>
+												{this.props.loginData.fullName}
+												<span className="subtext" style={{ marginLeft: 4 }}>
+													View Profile
+												</span>
 											</React.Fragment>
 										}
 									/>
 									<MenuItem href="/privacy/settings" text="Privacy settings" />
 									<MenuItem onClick={this.handleLogout} text="Logout" />
-								</Menu>
+								</MenuButton>
 							)}
 							{!loggedIn && (
 								<AnchorButton

--- a/client/components/Menu/Menu.js
+++ b/client/components/Menu/Menu.js
@@ -10,12 +10,14 @@ const propTypes = {
 	children: PropTypes.node.isRequired,
 	disclosure: PropTypes.oneOf(PropTypes.func, PropTypes.node).isRequired,
 	gutter: PropTypes.number,
+	menuStyle: PropTypes.shape({}),
 	onDismiss: PropTypes.func,
 	placement: PropTypes.string,
 };
 
 const defaultProps = {
 	gutter: undefined,
+	menuStyle: {},
 	onDismiss: () => {},
 	placement: undefined,
 };
@@ -28,7 +30,7 @@ const renderDisclosure = (disclosure, disclosureProps) => {
 };
 
 export const Menu = (props) => {
-	const { children, disclosure, placement, onDismiss, gutter } = props;
+	const { children, disclosure, placement, onDismiss, gutter, menuStyle } = props;
 
 	const menu = RK.useMenuState({
 		placement: placement,
@@ -51,7 +53,7 @@ export const Menu = (props) => {
 			</RK.MenuDisclosure>
 			<RK.Menu
 				as="ul"
-				style={{ zIndex: 1 }}
+				style={{ zIndex: 1, ...menuStyle }}
 				className={classNames(Classes.MENU, Classes.ELEVATION_1)}
 				unstable_portal={true}
 				{...menu}

--- a/client/components/Menu/Menu.js
+++ b/client/components/Menu/Menu.js
@@ -1,0 +1,66 @@
+import React, { useContext } from 'react';
+import classNames from 'classnames';
+import { MenuItem as BPMenuItem } from '@blueprintjs/core';
+import {
+	Menu as RKMenu,
+	MenuItem as RKMenuItem,
+	MenuDisclosure as RKMenuDisclosure,
+	MenuSeparator as RKMenuSeparator,
+	useMenuState,
+} from 'reakit/Menu';
+
+const MenuContext = React.createContext(null);
+
+export const Menu = (props) => {
+	const menu = useMenuState();
+	return (
+		<React.Fragment>
+			<RKMenuDisclosure {...menu}>Hello there!</RKMenuDisclosure>
+			<RKMenu {...menu} as="ul" className="bp3-menu bp3-elevation-1">
+				<MenuContext.Provider value={menu}>
+					<MenuItem text="Cut" icon="cut" />
+					<MenuItem text="Copy" icon="clipboard" />
+					<MenuItem text="Paste" icon="duplicate" />
+					<MenuItem text="Stuff" icon="cube" />
+				</MenuContext.Provider>
+			</RKMenu>
+		</React.Fragment>
+	);
+};
+
+const DisplayMenuItem = React.forwardRef((props, ref) => {
+	const { text, ...restProps } = props;
+	return (
+		<li ref={ref} {...restProps}>
+			<a className="bp3-menu-item">{text}</a>
+		</li>
+	);
+});
+
+export const MenuItem = React.forwardRef((props, ref) => {
+	const { children, ...restProps } = props;
+	const parentMenu = useContext(MenuContext);
+	const subMenu = useMenuState();
+	console.log(parentMenu);
+	if (children) {
+		return (
+			<React.Fragment>
+				<RKMenuDisclosure ref={ref} {...subMenu} {...parentMenu} {...restProps}>
+					{(disclosureProps) => <DisplayMenuItem {...props} {...disclosureProps} />}
+				</RKMenuDisclosure>
+				<MenuContext.Provider value={subMenu}>
+					<RKMenu {...subMenu} as="ul" className="bp3-menu bp3-elevation-1">
+						{children}
+					</RKMenu>
+				</MenuContext.Provider>
+			</React.Fragment>
+		);
+	}
+	return (
+		<RKMenuItem ref={ref} {...parentMenu} {...restProps}>
+			{(menuItemProps) => <DisplayMenuItem {...props} {...menuItemProps} />}
+		</RKMenuItem>
+	);
+});
+
+MenuItem.propTypes = {};

--- a/client/components/Menu/Menu.js
+++ b/client/components/Menu/Menu.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
-import { MenuItem as BPMenuItem } from '@blueprintjs/core';
+import { MenuItem as BPMenuItem, Icon } from '@blueprintjs/core';
 import {
 	Menu as RKMenu,
 	MenuItem as RKMenuItem,
@@ -14,25 +14,37 @@ require('./menu.scss');
 const MenuContext = React.createContext(null);
 
 export const Menu = (props) => {
-	const { children, disclosure } = props;
+	const { children, disclosure, isRoot = true } = props;
 	const menu = useMenuState();
 	return (
-		<React.Fragment>
+		<div className="menu-component">
 			<RKMenuDisclosure {...menu}>
 				{(disclosureProps) => disclosure(disclosureProps)}
 			</RKMenuDisclosure>
 			<RKMenu {...menu} as="ul" className="bp3-menu bp3-elevation-1">
 				<MenuContext.Provider value={menu}>{children}</MenuContext.Provider>
 			</RKMenu>
-		</React.Fragment>
+		</div>
 	);
 };
 
 const DisplayMenuItem = React.forwardRef((props, ref) => {
-	const { children, ...restProps } = props;
+	const {
+		children,
+		disabled,
+		icon,
+		hasSubmenu,
+		rightElement: propRightElement,
+		...restProps
+	} = props;
+	const rightElement = hasSubmenu ? <Icon icon="caret-right" /> : propRightElement;
 	return (
 		<li {...restProps} ref={ref}>
-			<a className="bp3-menu-item">{children}</a>
+			<a className={classNames('bp3-menu-item', disabled && 'bp3-disabled')}>
+				{icon && <Icon icon={icon} />}
+				<div className="bp3-text-overflow-ellipsis bp3-fill">{children}</div>
+				{rightElement && <span className="bp3-menu-item-label">{rightElement}</span>}
+			</a>
 		</li>
 	);
 });
@@ -44,7 +56,13 @@ export const MenuItem = React.forwardRef((props, ref) => {
 		return (
 			<Menu
 				disclosure={(dProps) => (
-					<RKMenuItem as={DisplayMenuItem} {...dProps} {...parentMenu}>
+					<RKMenuItem
+						as={DisplayMenuItem}
+						{...dProps}
+						{...parentMenu}
+						{...restProps}
+						hasSubmenu={true}
+					>
 						{text}
 					</RKMenuItem>
 				)}
@@ -61,3 +79,11 @@ export const MenuItem = React.forwardRef((props, ref) => {
 });
 
 MenuItem.propTypes = {};
+
+export const MenuItemDivider = () => {
+	return (
+		<RKMenuSeparator>
+			{(props) => <li className="bp3-menu-divider" {...props} />}
+		</RKMenuSeparator>
+	);
+};

--- a/client/components/Menu/Menu.js
+++ b/client/components/Menu/Menu.js
@@ -1,89 +1,50 @@
-import React, { useContext } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { MenuItem as BPMenuItem, Icon } from '@blueprintjs/core';
-import {
-	Menu as RKMenu,
-	MenuItem as RKMenuItem,
-	MenuDisclosure as RKMenuDisclosure,
-	MenuSeparator as RKMenuSeparator,
-	useMenuState,
-} from 'reakit/Menu';
+import { Classes } from '@blueprintjs/core';
+import * as RK from 'reakit/Menu';
 
-require('./menu.scss');
+import { MenuContext } from './menuContext';
 
-const MenuContext = React.createContext(null);
+const propTypes = {
+	children: PropTypes.node.isRequired,
+	disclosure: PropTypes.func.isRequired,
+	placement: PropTypes.string,
+	gutter: PropTypes.number,
+};
+
+const defaultProps = {
+	gutter: undefined,
+	placement: undefined,
+};
 
 export const Menu = (props) => {
-	const { children, disclosure, isRoot = true } = props;
-	const menu = useMenuState();
+	const { children, disclosure, placement, gutter } = props;
+	const menu = RK.useMenuState({
+		placement: placement,
+		gutter: gutter,
+		unstable_preventOverflow: false,
+	});
 	return (
-		<div className="menu-component">
-			<RKMenuDisclosure {...menu}>
-				{(disclosureProps) => disclosure(disclosureProps)}
-			</RKMenuDisclosure>
-			<RKMenu {...menu} as="ul" className="bp3-menu bp3-elevation-1">
-				<MenuContext.Provider value={menu}>{children}</MenuContext.Provider>
-			</RKMenu>
-		</div>
-	);
-};
-
-const DisplayMenuItem = React.forwardRef((props, ref) => {
-	const {
-		children,
-		disabled,
-		icon,
-		hasSubmenu,
-		rightElement: propRightElement,
-		...restProps
-	} = props;
-	const rightElement = hasSubmenu ? <Icon icon="caret-right" /> : propRightElement;
-	return (
-		<li {...restProps} ref={ref}>
-			<a className={classNames('bp3-menu-item', disabled && 'bp3-disabled')}>
-				{icon && <Icon icon={icon} />}
-				<div className="bp3-text-overflow-ellipsis bp3-fill">{children}</div>
-				{rightElement && <span className="bp3-menu-item-label">{rightElement}</span>}
-			</a>
-		</li>
-	);
-});
-
-export const MenuItem = React.forwardRef((props, ref) => {
-	const { children, text, ...restProps } = props;
-	const parentMenu = useContext(MenuContext);
-	if (children) {
-		return (
-			<Menu
-				disclosure={(dProps) => (
-					<RKMenuItem
-						as={DisplayMenuItem}
-						{...dProps}
-						{...parentMenu}
-						{...restProps}
-						hasSubmenu={true}
-					>
-						{text}
-					</RKMenuItem>
-				)}
+		<React.Fragment>
+			<RK.MenuDisclosure
+				style={{ display: 'inline-block', '-webkit-appearance': 'unset' }}
+				{...menu}
 			>
-				{children}
-			</Menu>
-		);
-	}
-	return (
-		<RKMenuItem as={DisplayMenuItem} ref={ref} {...parentMenu} {...restProps}>
-			{text}
-		</RKMenuItem>
-	);
-});
-
-MenuItem.propTypes = {};
-
-export const MenuItemDivider = () => {
-	return (
-		<RKMenuSeparator>
-			{(props) => <li className="bp3-menu-divider" {...props} />}
-		</RKMenuSeparator>
+				{(disclosureProps) => disclosure(disclosureProps)}
+			</RK.MenuDisclosure>
+			<RK.Menu
+				as="ul"
+				style={{ zIndex: 1 }}
+				className={classNames(Classes.MENU, Classes.ELEVATION_1)}
+				unstable_portal={true}
+				{...menu}
+			>
+				<MenuContext.Provider value={menu}>{children}</MenuContext.Provider>
+			</RK.Menu>
+		</React.Fragment>
 	);
 };
+
+Menu.propTypes = propTypes;
+Menu.defaultProps = defaultProps;

--- a/client/components/Menu/Menu.js
+++ b/client/components/Menu/Menu.js
@@ -9,56 +9,53 @@ import {
 	useMenuState,
 } from 'reakit/Menu';
 
+require('./menu.scss');
+
 const MenuContext = React.createContext(null);
 
 export const Menu = (props) => {
+	const { children, disclosure } = props;
 	const menu = useMenuState();
 	return (
 		<React.Fragment>
-			<RKMenuDisclosure {...menu}>Hello there!</RKMenuDisclosure>
+			<RKMenuDisclosure {...menu}>
+				{(disclosureProps) => disclosure(disclosureProps)}
+			</RKMenuDisclosure>
 			<RKMenu {...menu} as="ul" className="bp3-menu bp3-elevation-1">
-				<MenuContext.Provider value={menu}>
-					<MenuItem text="Cut" icon="cut" />
-					<MenuItem text="Copy" icon="clipboard" />
-					<MenuItem text="Paste" icon="duplicate" />
-					<MenuItem text="Stuff" icon="cube" />
-				</MenuContext.Provider>
+				<MenuContext.Provider value={menu}>{children}</MenuContext.Provider>
 			</RKMenu>
 		</React.Fragment>
 	);
 };
 
 const DisplayMenuItem = React.forwardRef((props, ref) => {
-	const { text, ...restProps } = props;
+	const { children, ...restProps } = props;
 	return (
-		<li ref={ref} {...restProps}>
-			<a className="bp3-menu-item">{text}</a>
+		<li {...restProps} ref={ref}>
+			<a className="bp3-menu-item">{children}</a>
 		</li>
 	);
 });
 
 export const MenuItem = React.forwardRef((props, ref) => {
-	const { children, ...restProps } = props;
+	const { children, text, ...restProps } = props;
 	const parentMenu = useContext(MenuContext);
-	const subMenu = useMenuState();
-	console.log(parentMenu);
 	if (children) {
 		return (
-			<React.Fragment>
-				<RKMenuDisclosure ref={ref} {...subMenu} {...parentMenu} {...restProps}>
-					{(disclosureProps) => <DisplayMenuItem {...props} {...disclosureProps} />}
-				</RKMenuDisclosure>
-				<MenuContext.Provider value={subMenu}>
-					<RKMenu {...subMenu} as="ul" className="bp3-menu bp3-elevation-1">
-						{children}
-					</RKMenu>
-				</MenuContext.Provider>
-			</React.Fragment>
+			<Menu
+				disclosure={(dProps) => (
+					<RKMenuItem as={DisplayMenuItem} {...dProps} {...parentMenu}>
+						{text}
+					</RKMenuItem>
+				)}
+			>
+				{children}
+			</Menu>
 		);
 	}
 	return (
-		<RKMenuItem ref={ref} {...parentMenu} {...restProps}>
-			{(menuItemProps) => <DisplayMenuItem {...props} {...menuItemProps} />}
+		<RKMenuItem as={DisplayMenuItem} ref={ref} {...parentMenu} {...restProps}>
+			{text}
 		</RKMenuItem>
 	);
 });

--- a/client/components/Menu/MenuButton.js
+++ b/client/components/Menu/MenuButton.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '@blueprintjs/core';
+
+import { Menu } from './Menu';
+
+const propTypes = {
+	buttonContent: PropTypes.node.isRequired,
+	buttonProps: PropTypes.shape({}),
+	children: PropTypes.node.isRequired,
+};
+
+const defaultProps = {
+	buttonProps: {},
+};
+
+export const MenuButton = (props) => {
+	const { buttonProps, buttonContent, children, ...restProps } = props;
+	return (
+		<Menu
+			disclosure={({ ref, ...restDisclosureProps }) => (
+				<Button
+					children={buttonContent}
+					{...buttonProps}
+					{...restDisclosureProps}
+					elementRef={ref}
+				/>
+			)}
+			{...restProps}
+		>
+			{children}
+		</Menu>
+	);
+};
+
+MenuButton.propTypes = propTypes;
+MenuButton.defaultProps = defaultProps;

--- a/client/components/Menu/MenuItem.js
+++ b/client/components/Menu/MenuItem.js
@@ -10,19 +10,19 @@ import { Menu } from './Menu';
 const sharedPropTypes = {
 	disabled: PropTypes.boolean,
 	href: PropTypes.string,
-	target: PropTypes.string,
 	icon: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 	onClick: PropTypes.func,
 	rightElement: PropTypes.node,
+	target: PropTypes.string,
 };
 
 const sharedDefaultProps = {
 	disabled: false,
 	href: null,
-	target: '_self',
 	icon: null,
 	onClick: null,
 	rightElement: null,
+	target: '_self',
 };
 
 const DisplayMenuItem = React.forwardRef((props, ref) => {
@@ -34,6 +34,7 @@ const DisplayMenuItem = React.forwardRef((props, ref) => {
 		icon,
 		hasSubmenu,
 		onClick,
+		onDismiss,
 		rightElement,
 		...restProps
 	} = props;
@@ -43,6 +44,9 @@ const DisplayMenuItem = React.forwardRef((props, ref) => {
 	const onClickWithHref = (evt) => {
 		if (onClick) {
 			onClick(evt);
+		}
+		if (onDismiss) {
+			onDismiss();
 		}
 		if (href) {
 			window.open(href, target);
@@ -71,18 +75,21 @@ const DisplayMenuItem = React.forwardRef((props, ref) => {
 DisplayMenuItem.propTypes = {
 	...sharedPropTypes,
 	hasSubmenu: PropTypes.bool.isRequired,
+	onDismiss: PropTypes.func,
 };
 
 DisplayMenuItem.defaultProps = {
 	...sharedDefaultProps,
+	onDismiss: null,
 };
 
 export const MenuItem = React.forwardRef((props, ref) => {
-	const { children, text, ...restProps } = props;
-	const parentMenu = useContext(MenuContext);
+	const { children, text, dismissOnClick, ...restProps } = props;
+	const { dismissMenu, parentMenu } = useContext(MenuContext);
 	if (children) {
 		return (
 			<Menu
+				onDismiss={dismissMenu}
 				disclosure={(dProps) => (
 					<RK.MenuItem
 						as={DisplayMenuItem}
@@ -101,7 +108,13 @@ export const MenuItem = React.forwardRef((props, ref) => {
 		);
 	}
 	return (
-		<RK.MenuItem as={DisplayMenuItem} ref={ref} {...parentMenu} {...restProps}>
+		<RK.MenuItem
+			as={DisplayMenuItem}
+			ref={ref}
+			{...parentMenu}
+			{...restProps}
+			onDismiss={dismissOnClick && dismissMenu}
+		>
 			{text}
 		</RK.MenuItem>
 	);
@@ -111,11 +124,13 @@ MenuItem.propTypes = {
 	...sharedPropTypes,
 	children: PropTypes.arrayOf(PropTypes.node),
 	text: PropTypes.string.isRequired,
+	dismissOnClick: PropTypes.bool,
 };
 
 MenuItem.defaultProps = {
 	...sharedDefaultProps,
 	children: null,
+	dismissOnClick: true,
 };
 
 export const MenuItemDivider = () => {

--- a/client/components/Menu/MenuItem.js
+++ b/client/components/Menu/MenuItem.js
@@ -1,0 +1,127 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { Icon, Classes } from '@blueprintjs/core';
+import * as RK from 'reakit/Menu';
+
+import { MenuContext } from './menuContext';
+import { Menu } from './Menu';
+
+const sharedPropTypes = {
+	disabled: PropTypes.boolean,
+	href: PropTypes.string,
+	target: PropTypes.string,
+	icon: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+	onClick: PropTypes.func,
+	rightElement: PropTypes.node,
+};
+
+const sharedDefaultProps = {
+	disabled: false,
+	href: null,
+	target: '_self',
+	icon: null,
+	onClick: null,
+	rightElement: null,
+};
+
+const DisplayMenuItem = React.forwardRef((props, ref) => {
+	const {
+		children,
+		disabled,
+		href,
+		target,
+		icon,
+		hasSubmenu,
+		onClick,
+		rightElement,
+		...restProps
+	} = props;
+
+	const label = hasSubmenu ? <Icon icon="caret-right" /> : rightElement;
+
+	const onClickWithHref = (evt) => {
+		if (onClick) {
+			onClick(evt);
+		}
+		if (href) {
+			window.open(href, target);
+		}
+	};
+
+	return (
+		// The ...restProps are from Reakit and help us handle the interactions accessibly.
+		// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+		<li {...restProps} ref={ref} onClick={onClickWithHref}>
+			<a
+				href={href}
+				target={target}
+				className={classNames(Classes.MENU_ITEM, disabled && Classes.DISABLED)}
+			>
+				{icon && (typeof icon === 'string' ? <Icon icon={icon} /> : icon)}
+				<div className={classNames(Classes.TEXT_OVERFLOW_ELLIPSIS, Classes.FILL)}>
+					{children}
+				</div>
+				{label && <span className={Classes.MENU_ITEM_LABEL}>{label}</span>}
+			</a>
+		</li>
+	);
+});
+
+DisplayMenuItem.propTypes = {
+	...sharedPropTypes,
+	hasSubmenu: PropTypes.bool.isRequired,
+};
+
+DisplayMenuItem.defaultProps = {
+	...sharedDefaultProps,
+};
+
+export const MenuItem = React.forwardRef((props, ref) => {
+	const { children, text, ...restProps } = props;
+	const parentMenu = useContext(MenuContext);
+	if (children) {
+		return (
+			<Menu
+				disclosure={(dProps) => (
+					<RK.MenuItem
+						as={DisplayMenuItem}
+						{...dProps}
+						{...parentMenu}
+						{...restProps}
+						style={{ display: 'block', '-webkit-appearance': 'unset' }}
+						hasSubmenu={true}
+					>
+						{text}
+					</RK.MenuItem>
+				)}
+			>
+				{children}
+			</Menu>
+		);
+	}
+	return (
+		<RK.MenuItem as={DisplayMenuItem} ref={ref} {...parentMenu} {...restProps}>
+			{text}
+		</RK.MenuItem>
+	);
+});
+
+MenuItem.propTypes = {
+	...sharedPropTypes,
+	children: PropTypes.arrayOf(PropTypes.node),
+	text: PropTypes.string.isRequired,
+};
+
+MenuItem.defaultProps = {
+	...sharedDefaultProps,
+	children: null,
+};
+
+export const MenuItemDivider = () => {
+	return (
+		<RK.MenuSeparator>
+			{(props) => <li className={Classes.MENU_DIVIDER} {...props} />}
+		</RK.MenuSeparator>
+	);
+};

--- a/client/components/Menu/index.js
+++ b/client/components/Menu/index.js
@@ -1,2 +1,3 @@
 export { Menu } from './Menu';
 export { MenuItem, MenuItemDivider } from './MenuItem';
+export { MenuButton } from './MenuButton';

--- a/client/components/Menu/index.js
+++ b/client/components/Menu/index.js
@@ -1,0 +1,2 @@
+export { Menu } from './Menu';
+export { MenuItem, MenuItemDivider } from './MenuItem';

--- a/client/components/Menu/menu.scss
+++ b/client/components/Menu/menu.scss
@@ -1,0 +1,3 @@
+.bp3-menu > li[type='button'] {
+    -webkit-appearance: unset;
+}

--- a/client/components/Menu/menu.scss
+++ b/client/components/Menu/menu.scss
@@ -1,6 +1,0 @@
-.menu-component {
-    position: relative;
-    & [type='button'] {
-        -webkit-appearance: unset;
-    }
-}

--- a/client/components/Menu/menu.scss
+++ b/client/components/Menu/menu.scss
@@ -1,3 +1,6 @@
-.bp3-menu > li[type='button'] {
-    -webkit-appearance: unset;
+.menu-component {
+    position: relative;
+    & [type='button'] {
+        -webkit-appearance: unset;
+    }
 }

--- a/client/components/Menu/menuContext.js
+++ b/client/components/Menu/menuContext.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const MenuContext = React.createContext(null);

--- a/client/components/NavBar/NavBar.js
+++ b/client/components/NavBar/NavBar.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Popover, PopoverInteractionKind, Position, Menu } from '@blueprintjs/core';
+import { Popover, PopoverInteractionKind, Position } from '@blueprintjs/core';
 
 import { GridWrapper } from 'components';
 import Icon from 'components/Icon/Icon';
+import { Menu, MenuItem } from 'components/Menu/Menu';
 
 require('./navBar.scss');
 
@@ -35,45 +36,26 @@ const NavBar = function(props) {
 							}
 							/* Return Dropdown */
 							return (
-								<Popover
-									content={
-										<Menu>
-											{item.children.map((subitem) => {
-												return (
-													<a
-														href={`/${subitem.slug}`}
-														className="bp3-menu-item bp3-popover-dismiss"
-														key={`nav-item-${subitem.id}`}
-													>
-														<li>
-															{!subitem.isPublic && (
-																<Icon icon="lock2" iconSize={14} />
-															)}
-															{subitem.title}
-														</li>
-													</a>
-												);
-											})}
-										</Menu>
-									}
-									popoverClassName="bp3-minimal nav-bar-popover"
-									inheritDarkTheme={false}
-									position={Position.BOTTOM_LEFT}
-									modifiers={{
-										preventOverflow: { enabled: false },
-										hide: { enabled: false },
-										flip: { enabled: false },
-									}}
-									interactionKind={PopoverInteractionKind.CLICK}
-									key={`dropdown-${item.title}`}
-								>
-									<span className="dropdown">
-										<li>
+								<Menu
+									disclosure={(discProps) => (
+										<li {...discProps} className="dropdown">
 											{item.title}
 											<span className="bp3-icon-standard bp3-icon-caret-down bp3-align-right" />
 										</li>
-									</span>
-								</Popover>
+									)}
+								>
+									{item.children.map((subitem) => (
+										<MenuItem
+											href={`/${subitem.slug}`}
+											icon={
+												!subitem.isPublic && (
+													<Icon icon="lock2" iconSize={14} />
+												)
+											}
+											text={subitem.title}
+										/>
+									))}
+								</Menu>
 							);
 						})}
 				</ul>

--- a/client/components/NavBar/NavBar.js
+++ b/client/components/NavBar/NavBar.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Popover, PopoverInteractionKind, Position } from '@blueprintjs/core';
 
 import { GridWrapper } from 'components';
 import Icon from 'components/Icon/Icon';
-import { Menu, MenuItem } from 'components/Menu/Menu';
+import { Menu, MenuItem } from 'components/Menu';
 
 require('./navBar.scss');
 
@@ -37,12 +36,12 @@ const NavBar = function(props) {
 							/* Return Dropdown */
 							return (
 								<Menu
-									disclosure={(discProps) => (
-										<li {...discProps} className="dropdown">
+									disclosure={
+										<li className="dropdown">
 											{item.title}
 											<span className="bp3-icon-standard bp3-icon-caret-down bp3-align-right" />
 										</li>
-									)}
+									}
 								>
 									{item.children.map((subitem) => (
 										<MenuItem

--- a/client/containers/Pub/PubSuspendWhileTyping.js
+++ b/client/containers/Pub/PubSuspendWhileTyping.js
@@ -45,6 +45,7 @@ export const PubSuspendWhileTyping = (props) => {
 	const setForceUpdate = useState()[1];
 	const timeRemainingToUpdate = getTimeRemainingToUpdate(delay, Date.now());
 	const shouldUpdate = timeRemainingToUpdate === 0;
+
 	const maybeClearTimeout = () => {
 		if (checkAgainRef.current) {
 			clearTimeout(checkAgainRef.current);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4676,6 +4676,11 @@
 				}
 			}
 		},
+		"body-scroll-lock": {
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-2.6.4.tgz",
+			"integrity": "sha512-NP08WsovlmxEoZP9pdlqrE+AhNaivlTrz9a0FF37BQsnOrpN48eNqivKkE7SYpM9N+YIPjsdVzfLAUQDBm6OQw=="
+		},
 		"boolbase": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -18428,6 +18433,27 @@
 			"requires": {
 				"picomatch": "^2.0.4"
 			}
+		},
+		"reakit": {
+			"version": "1.0.0-beta.9",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.0-beta.9.tgz",
+			"integrity": "sha512-rWHW3QnuKDrxfgL3hv/ah/nqbhEozpApLWtrwNpWPMZOoRAuzydgKM2l6rsmxS1aCVR7SmOt6Bv4iwl651SuIg==",
+			"requires": {
+				"body-scroll-lock": "^2.6.4",
+				"popper.js": "^1.15.0",
+				"reakit-system": "^0.6.6",
+				"reakit-utils": "^0.6.6"
+			}
+		},
+		"reakit-system": {
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.6.6.tgz",
+			"integrity": "sha512-EzhnYAuYTqRci7xkv68PiquHRJpRGDWGEJKTO+0s5cr1f4soooJ3ms0tE7/dQRSSseGon+79jJ4bvfVDvCNing=="
+		},
+		"reakit-utils": {
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.6.6.tgz",
+			"integrity": "sha512-YbyHQ310biVmDkhl4wRhXMvn2cl4ooL2nlpfI753dwPJxEsSqvyayhqLth/j+a4+44J0YeqBCCH3LDoYBrGg2Q=="
 		},
 		"realpath-native": {
 			"version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
 		"react-timeago": "^4.4.0",
 		"react-transition-group": "^4.0.0",
 		"react-use": "^9.4.0",
+		"reakit": "^1.0.0-beta.9",
 		"rebound": "^0.1.0",
 		"recharts": "^1.5.0",
 		"request": "^2.88.0",

--- a/stories/components/menuStories.js
+++ b/stories/components/menuStories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { Menu, MenuItem, MenuItemDivider } from 'components/Menu';
+import { Menu, MenuItem, MenuItemDivider, MenuButton } from 'components/Menu';
 import { Button } from '@blueprintjs/core';
 
 const items = (
@@ -13,6 +13,7 @@ const items = (
 			<MenuItem text="what's in here">
 				<MenuItem
 					text="i wonder if you can click me"
+					// eslint-disable-next-line no-alert
 					onClick={() => alert('You found it!')}
 				/>
 			</MenuItem>
@@ -21,10 +22,9 @@ const items = (
 );
 
 storiesOf('components/Menu', module)
-	.add('button', () => {
+	.add('manual-button', () => {
 		return (
 			<Menu
-				shift={100}
 				disclosure={(props) => {
 					const { ref, ...restProps } = props;
 					return (
@@ -38,6 +38,13 @@ storiesOf('components/Menu', module)
 			</Menu>
 		);
 	})
+	.add('menu-button', () => {
+		return (
+			<MenuButton buttonContent="Click me!" buttonProps={{ rightIcon: 'caret-down' }}>
+				{items}
+			</MenuButton>
+		);
+	})
 	.add('div', () => {
-		return <Menu disclosure={(props) => <div {...props}>Hello!</div>}>{items}</Menu>;
+		return <Menu disclosure={<div>Hello!</div>}>{items}</Menu>;
 	});

--- a/stories/components/menuStories.js
+++ b/stories/components/menuStories.js
@@ -1,5 +1,17 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { Menu } from 'components/Menu/Menu';
+import { Menu, MenuItem } from 'components/Menu/Menu';
+import { Button } from '@blueprintjs/core';
 
-storiesOf('components/Menu', module).add('default', () => <Menu />);
+storiesOf('components/Menu', module).add('default', () => {
+	return (
+		<Menu disclosure={(props) => <Button {...props}>Hello!</Button>}>
+			<MenuItem text="hello" />
+			<MenuItem text="hi" />
+			<MenuItem text="hey">
+				<MenuItem text="hola" />
+				<MenuItem text="ni hao" />
+			</MenuItem>
+		</Menu>
+	);
+});

--- a/stories/components/menuStories.js
+++ b/stories/components/menuStories.js
@@ -1,17 +1,39 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { Menu, MenuItem } from 'components/Menu/Menu';
+import { Menu, MenuItem, MenuItemDivider } from 'components/Menu/Menu';
 import { Button } from '@blueprintjs/core';
 
-storiesOf('components/Menu', module).add('default', () => {
-	return (
-		<Menu disclosure={(props) => <Button {...props}>Hello!</Button>}>
-			<MenuItem text="hello" />
-			<MenuItem text="hi" />
-			<MenuItem text="hey">
-				<MenuItem text="hola" />
-				<MenuItem text="ni hao" />
+const items = (
+	<React.Fragment>
+		<MenuItem icon="doughnut-chart" text="hello" />
+		<MenuItem icon="git-branch" text="hi" />
+		<MenuItemDivider />
+		<MenuItem icon="paperclip" text="what's up">
+			<MenuItem text="hola — a longer item" />
+			<MenuItem text="你好">
+				<MenuItem text="还要菜单吗" onClick={() => alert('You found it!')} />
 			</MenuItem>
-		</Menu>
-	);
-});
+		</MenuItem>
+	</React.Fragment>
+);
+
+storiesOf('components/Menu', module)
+	.add('button', () => {
+		return (
+			<Menu
+				disclosure={(props) => {
+					const { ref, ...restProps } = props;
+					return (
+						<Button rightIcon="caret-down" {...restProps} elementRef={props.ref}>
+							Hello there
+						</Button>
+					);
+				}}
+			>
+				{items}
+			</Menu>
+		);
+	})
+	.add('div', () => {
+		return <Menu disclosure={(props) => <div {...props}>Hello!</div>}>{items}</Menu>;
+	});

--- a/stories/components/menuStories.js
+++ b/stories/components/menuStories.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Menu } from 'components/Menu/Menu';
+
+storiesOf('components/Menu', module).add('default', () => <Menu />);

--- a/stories/components/menuStories.js
+++ b/stories/components/menuStories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { Menu, MenuItem, MenuItemDivider } from 'components/Menu/Menu';
+import { Menu, MenuItem, MenuItemDivider } from 'components/Menu';
 import { Button } from '@blueprintjs/core';
 
 const items = (
@@ -10,8 +10,11 @@ const items = (
 		<MenuItemDivider />
 		<MenuItem icon="paperclip" text="what's up">
 			<MenuItem text="hola — a longer item" />
-			<MenuItem text="你好">
-				<MenuItem text="还要菜单吗" onClick={() => alert('You found it!')} />
+			<MenuItem text="what's in here">
+				<MenuItem
+					text="i wonder if you can click me"
+					onClick={() => alert('You found it!')}
+				/>
 			</MenuItem>
 		</MenuItem>
 	</React.Fragment>
@@ -21,6 +24,7 @@ storiesOf('components/Menu', module)
 	.add('button', () => {
 		return (
 			<Menu
+				shift={100}
 				disclosure={(props) => {
 					const { ref, ...restProps } = props;
 					return (


### PR DESCRIPTION
While Blueprint serves us well as a UI framework, it's unfortunately not very good for keyboard and screenreader users, especially in places where complex interactions and portals are involved. In particular, dropdown menus are practically unusable with a keyboard. [This appears to be a known issue](https://github.com/palantir/blueprint/issues/3079) with a `help wanted` tag, but given the amount of work that goes into correctly implementing accessible UI elements _and_ merging that code into a complicated foreign codebase, I decided against trying to submit a PR to Blueprint to fix this.

Instead, I've used a very promising new UI framework called [Reakit](https://reakit.io/) to build a new menu component, which can be navigated using the keyboard and provides useful screenreader announcements. We use the Blueprint CSS classes in the component, so the look and feel matches the rest of PubPub. I'm very excited about Reakit, and I'd like to push us to use it to "a11y-ize" a few more questionable Blueprint components such as `Dialog`, and as a basis for our custom components such as `Discussion` as well. Using [ARIA](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) correctly is incredibly difficult, and it makes sense to build off this developer's efforts and put them on the shortlist of projects to eventually consider funding.

Anyway, back to the menu. As a proof-of-concept, I've added it to the global nav user menu, and to dropdowns in the site nav, which makes these items newly keyboard/screenreader accessible. In the medium term I'll be replacing Blueprint menus as I come across them with this component, and fleshing out its props as necessary.

_Actually, Frankenstein was the doctor. The real monster is this mashup of two UI frameworks:_
![Screen Recording 2019-10-25 at 1 45 04 PM 2019-10-25 14_01_23](https://user-images.githubusercontent.com/2208769/67593319-f1935900-f72f-11e9-8b03-98230f1afe2f.gif)

_Test plan:_
Visit a community and make sure that the global nav user menu in the top right, as well as dropdowns in the site nav, are usable with mouse, keyboard, and keyboard + screenreader.