### PR TITLE
feature: Skip links

### DIFF
--- a/client/components/PageWrapper/PageWrapper.js
+++ b/client/components/PageWrapper/PageWrapper.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Header, Footer, GdprBanner, AccentStyle, NavBar, Icon } from 'components';
+import { Header, Footer, GdprBanner, AccentStyle, NavBar, Icon, SkipLink } from 'components';
 import { populateNavigationIds } from 'utils';
 
 require('./pageWrapper.scss');
@@ -95,6 +95,8 @@ const PageWrapper = (props) => {
 					<div className="duqduq-warning">Development Environment</div>
 				)}
 
+				<SkipLink targetId="main-content">Skip to main content</SkipLink>
+
 				<GdprBanner loginData={props.loginData} />
 
 				<Header
@@ -111,7 +113,9 @@ const PageWrapper = (props) => {
 					<NavBar navItems={navItems} socialItems={socialItems} />
 				)}
 
-				<div className="page-content">{props.children}</div>
+				<div id="main-content" tabIndex="-1" className="page-content">
+					{props.children}
+				</div>
 
 				{!props.hideFooter && (
 					<Footer

--- a/client/components/SkipLink/SkipLink.js
+++ b/client/components/SkipLink/SkipLink.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { TabToShow } from 'components';
+
+require('./skipLink.scss');
+
+const propTypes = {
+	children: PropTypes.node.isRequired,
+	targetId: PropTypes.string.isRequired,
+};
+
+const SkipLink = ({ targetId, children }) => {
+	return <TabToShow className="skip-link-component" href={`#${targetId}`} children={children} />;
+};
+
+SkipLink.propTypes = propTypes;
+export default SkipLink;

--- a/client/components/SkipLink/skipLink.scss
+++ b/client/components/SkipLink/skipLink.scss
@@ -1,0 +1,9 @@
+.skip-link-component {
+    display: block;
+    position: fixed;
+    top: 10px;
+    left: 10px;
+    padding: 10px;
+    background: white;
+    z-index: 100000;
+}

--- a/client/components/TabToShow/TabToShow.js
+++ b/client/components/TabToShow/TabToShow.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+require('./tab-to-show.scss');
+
+const propTypes = {
+	children: PropTypes.node.isRequired,
+	className: PropTypes.string,
+	holdOpen: PropTypes.bool,
+	onFocus: PropTypes.func,
+	tagName: PropTypes.string,
+};
+
+const defaultProps = {
+	className: '',
+	holdOpen: false,
+	tagName: 'a',
+	onFocus: () => {},
+};
+
+const TabToShow = React.forwardRef((props, ref) => {
+	const { children, className, holdOpen, onFocus, tagName, ...restProps } = props;
+	return React.createElement(
+		tagName,
+		{
+			...restProps,
+			ref: ref,
+			tabIndex: 0,
+			onFocus: onFocus,
+			className: classNames(className, 'tab-to-show-component', holdOpen && 'hold-open'),
+		},
+		children,
+	);
+});
+
+TabToShow.propTypes = propTypes;
+TabToShow.defaultProps = defaultProps;
+export default TabToShow;

--- a/client/components/TabToShow/tab-to-show.scss
+++ b/client/components/TabToShow/tab-to-show.scss
@@ -1,0 +1,10 @@
+.tab-to-show-component {
+    &:not(:focus):not(:active):not(.hold-open) {
+        position: fixed;
+        top: auto;
+        overflow: hidden;
+        opacity: 0;
+        transform: translateX(-4000px);
+        z-index: -999;
+    }
+}

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -32,4 +32,6 @@ export { default as SettingsSection } from './SettingsSection/SettingsSection';
 export { default as SharingCard } from './SharingCard/SharingCard';
 export { default as SimpleEditor } from './SimpleEditor/SimpleEditor';
 export { default as SimpleNotesList } from './SimpleNotesList/SimpleNotesList';
+export { default as SkipLink } from './SkipLink/SkipLink';
+export { default as TabToShow } from './TabToShow/TabToShow';
 export { default as UserAutocomplete } from './UserAutocomplete/UserAutocomplete';

--- a/client/containers/Dashboard/Dashboard.js
+++ b/client/containers/Dashboard/Dashboard.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { PageWrapper, GridWrapper } from 'components';
+import { PageWrapper, GridWrapper, SkipLink } from 'components';
 import { hydrateWrapper } from 'utils';
 import DashboardSide from './DashboardSide';
 import DashboardContent from './DashboardContent';
@@ -32,6 +32,7 @@ const Dashboard = (props) => {
 			>
 				<GridWrapper columnClassName="dashboard-columns">
 					<div className="side-content">
+						<SkipLink targetId="dashboard-content">Skip to dashboard content</SkipLink>
 						<DashboardSide
 							pages={communityData.pages}
 							activeSlug={activeSlug}
@@ -39,7 +40,7 @@ const Dashboard = (props) => {
 						/>
 					</div>
 
-					<div className="main-content">
+					<div id="dashboard-content" tabIndex="-1" className="main-content">
 						<DashboardContent
 							mode={activeMode}
 							slug={activeSlug}


### PR DESCRIPTION
A skip link is an `<a>` element that allows keyboard users to jump past generic navigation elements such as headers and navbars to get to the page's main content. The link is invisible unless it is tabbed to, at which point we make it visible and it is announced to screenreaders. This PR adds a global skip link that bypasses the global and page navigation, and as a proof of concept I've added one that skips past the dashboard sidebar into the dashboard content as well. We could use these everywhere, potentially even in the soon-to-be redesigned Pub header.

_Screenshot:_
<img width="1552" alt="Screen Shot 2019-10-25 at 3 33 31 PM" src="https://user-images.githubusercontent.com/2208769/67599342-d891a480-f73d-11e9-89ac-c2379adb17b1.png">

_Test plan:_
Visit any Page and tab to focus the page content. The "skip to main content" link should be visible and when activated should skip the user past the header and into the Page content. Likewise, it should skip the global nav on Pubs and the admin dashboard. The dashboard should have a second "Skip to dashboard content" that bypasses the dashboard sidebar.

See #542