### PR TITLE
update: a11y-focused improvements to Collections editor

### DIFF
--- a/client/components/DragDropListing/DragDropListing.js
+++ b/client/components/DragDropListing/DragDropListing.js
@@ -44,6 +44,7 @@ const DragDropListing = (props) => {
 				<div
 					{...droppableProvided.droppableProps}
 					className={classNames(className, 'drag-drop-listing-component')}
+					role="list"
 					ref={droppableProvided.innerRef}
 				>
 					{renderEmptyState && items.length === 0 && (

--- a/client/containers/Dashboard/DashboardContent/Collection/CollectionEditor/CollectionEditor.js
+++ b/client/containers/Dashboard/DashboardContent/Collection/CollectionEditor/CollectionEditor.js
@@ -63,6 +63,10 @@ class CollectionEditor extends React.Component {
 	handleAddSelection(pubToAdd, index) {
 		const { collection } = this.props;
 		const { selections } = this.state;
+		if (index === undefined) {
+			// eslint-disable-next-line no-param-reassign
+			index = selections.length;
+		}
 		const rank = findRankForSelection(selections, index);
 		const selection = createPubSelection(pubToAdd, collection, rank);
 		this.setState({

--- a/client/containers/Dashboard/DashboardContent/Collection/CollectionEditor/PubListingControls.js
+++ b/client/containers/Dashboard/DashboardContent/Collection/CollectionEditor/PubListingControls.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, ControlGroup } from '@blueprintjs/core';
+
+const propTypes = {
+	onAdd: PropTypes.func.isRequired,
+};
+
+const PubListingControls = (props) => {
+	const { onAdd } = props;
+	return (
+		<ControlGroup>
+			<Button minimal aria-label="Add pub to collection" icon="plus" onClick={onAdd} />
+		</ControlGroup>
+	);
+};
+
+PubListingControls.propTypes = propTypes;
+export default PubListingControls;

--- a/client/containers/Dashboard/DashboardContent/Collection/CollectionEditor/PubRow.js
+++ b/client/containers/Dashboard/DashboardContent/Collection/CollectionEditor/PubRow.js
@@ -8,7 +8,6 @@ import classNames from 'classnames';
 
 import { pubDataProps } from 'types/pub';
 import Icon from 'components/Icon/Icon';
-import { AnchorButton } from '@blueprintjs/core';
 
 import { authorsNamesFromPub } from './utils';
 
@@ -36,30 +35,14 @@ const PubRow = (props) => {
 			)}
 			<div className="contents">
 				<div className="info">
-					<div>
-						{dragHandleProps ? (
-							<a href={`/pub/${pub.slug}`}>{pub.title}</a>
-						) : (
-							<span className="left-title">
-								{pub.title}
-								<AnchorButton
-									href={`/pub/${pub.slug}`}
-									target="_blank"
-									rel="noopener noreferrer"
-									minimal={true}
-									small={true}
-									className="out-link"
-									icon={
-										<Icon
-											icon="share"
-											alt="open in new tab icon"
-											iconSize={11}
-										/>
-									}
-								/>
-							</span>
-						)}
-					</div>
+					<a
+						className="pub-title"
+						href={`/pub/${pub.slug}`}
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{pub.title}
+					</a>
 					<div className="bp3-text-muted">
 						<em>{authorsNamesFromPub(pub).join(', ')}</em>
 					</div>
@@ -72,5 +55,4 @@ const PubRow = (props) => {
 
 PubRow.propTypes = propTypes;
 PubRow.defaultProps = defaultProps;
-
 export default PubRow;

--- a/client/containers/Dashboard/DashboardContent/Collection/CollectionEditor/PubSelectionControls.js
+++ b/client/containers/Dashboard/DashboardContent/Collection/CollectionEditor/PubSelectionControls.js
@@ -43,7 +43,12 @@ const PubSelectionControls = ({ onRemove, onSetContext, pubSelection }) => {
 					</Button>
 				</Select>
 			)}
-			<Button minimal icon="cross" onClick={onRemove} />
+			<Button
+				minimal
+				icon="cross"
+				aria-label="Remove pub from selections"
+				onClick={onRemove}
+			/>
 		</ControlGroup>
 	);
 };

--- a/client/containers/Dashboard/DashboardContent/Collection/CollectionEditor/collectionEditor.scss
+++ b/client/containers/Dashboard/DashboardContent/Collection/CollectionEditor/collectionEditor.scss
@@ -1,5 +1,19 @@
 $pubs-pane-width: 300px;
 
+.collection-editor-keyboard-explainer-component {
+    position: fixed;
+    left: 10px;
+    bottom: 10px;
+    z-index: 1;
+    ul {
+        list-style-type: none;
+        padding-left: 0;
+        li {
+            margin-bottom: 5px;
+        }
+    }
+}
+
 .collection-editor-component {
     display: flex;
     width: 100%;
@@ -34,6 +48,7 @@ $pubs-pane-width: 300px;
             display: flex;
             align-items: center;
             flex-grow: 1;
+            flex-basis: 0;
             justify-content: space-between;
             padding: 10px;
         }
@@ -44,14 +59,17 @@ $pubs-pane-width: 300px;
             justify-content: center;
         }
         .controls {
+            flex-shrink: 0;
             opacity: 1;
             transition: 0.1s ease-out opacity;
+            .bp3-control-group > * {
+                flex-shrink: unset;
+            }
         }
-        .left-title {
-            display: flex;
-            align-items: center;
-            .out-link {
-                margin-left: 0.5em;
+        .pub-title {
+            text-decoration: none;
+            &:hover, &:focus {
+                text-decoration: underline;
             }
         }
     }

--- a/client/containers/Dashboard/DashboardContent/Collections/CollectionTile.js
+++ b/client/containers/Dashboard/DashboardContent/Collections/CollectionTile.js
@@ -101,7 +101,7 @@ const CollectionTile = (props) => {
 						{collection.isPublic ? 'Public' : 'Private'}
 					</div>
 					{collection.page && (
-						<div className="info-label shrinks">
+						<div className="info-label shrinks" title={collection.page.title}>
 							<Icon iconSize={10} icon="link" />
 							{collection.page.title}
 						</div>

--- a/client/containers/Dashboard/DashboardContent/Collections/NewCollectionCard.js
+++ b/client/containers/Dashboard/DashboardContent/Collections/NewCollectionCard.js
@@ -61,10 +61,12 @@ const NewCollectionCard = ({ schema, description, header, onCreateCollection }) 
 				</div>
 			</Overlay>
 			<Card className="top-controls-card" onClick={() => setIsOpen(true)}>
-				<h6>
-					<Icon icon={bpDisplayIcon} iconSize={20} />
-					{header}
-				</h6>
+				<button type="button" className="top-controls-card-button">
+					<h6>
+						<Icon icon={bpDisplayIcon} iconSize={20} />
+						{header}
+					</h6>
+				</button>
 				<p>{description}</p>
 			</Card>
 		</React.Fragment>

--- a/client/containers/Dashboard/DashboardContent/Collections/collections.scss
+++ b/client/containers/Dashboard/DashboardContent/Collections/collections.scss
@@ -2,6 +2,12 @@
 	.top-controls {
 		.top-controls-cards {
 			display: flex;
+			.top-controls-card-button {
+				border: 0;
+				padding: 0;
+				font-size: 100%;
+				background: none;
+			}
 			.top-controls-card {
 				padding: 10px;
 				width: 25%;


### PR DESCRIPTION
This PR contains a few improvements to the collection editor:
- The buttons at the top of `/dashboard/collections` are now actually buttons that can be accessed with the keyboard
- The collection editor itself has better screenreader announcements and new buttons that make it a little easier to add a Pub to a collection without dragging it.
- While the drag-and-drop interface for the collection editor does have keyboard/screenreader support thanks to `react-beautiful-dnd`, I've made that more transparent by adding a "keyboard shortcuts" pane that it shown to keyboard and screenreader users who are accessing the page, as well as some new keyboard shortcuts that should make jumping around this complicated piece of UI somewhat easier. The pane appears automatically for keyboard users, using the same pattern as the skip links in #583.
- Finally I've shored up the look and feel of this page a little bit, making pub titles links by default and fixing a few CSS glitches.

There are more improvements we can make once #582 lands — see #585

Addresses #544 #543 

_Screenshot:_
<img width="1552" alt="Screen Shot 2019-10-25 at 3 47 01 PM" src="https://user-images.githubusercontent.com/2208769/67600177-85205600-f73f-11e9-85e6-765d8a811d52.png">

_Test plan:_

Verify all of the following...
- You are able to create new collections with the keyboard
- When you tab through the collection editor, the keyboard help dialog appears, and that all the listed keyboard shortcuts work as expected
- When using a screenreader, acceptable announcements are made when moving a Pub between sections with the keyboard, including clear descriptions of which pane the Pub is in.
- All icon buttons in the collections editor have an `aria-label`.