### PR TITLE
update: More resilient worker queue

### DIFF
--- a/client/containers/Pub/PubHeader/Download.js
+++ b/client/containers/Pub/PubHeader/Download.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Tooltip, Icon, Menu, MenuItem, Spinner } from '@blueprintjs/core';
 import { apiFetch } from 'utils';
 import { pingTask } from 'utils/pingTask';
-import { getFormattedDownload, getExistingDownload } from './headerUtils';
+import { getFormattedDownload } from './headerUtils';
 
 require('./download.scss');
 
@@ -37,13 +37,7 @@ const Download = (props) => {
 			return;
 		}
 		setIsError(false);
-		// Check if that format is available for download -- if not, request it from the server.
-		const existingDownload = getExistingDownload(downloads, activeBranch.id, selectedType);
-		if (existingDownload) {
-			setIsLoading(false);
-			window.open(existingDownload.url);
-			return;
-		}
+
 		// Kicks off an export task on the backend
 		apiFetch('/api/export', {
 			method: 'POST',
@@ -62,7 +56,7 @@ const Download = (props) => {
 				setIsError(true);
 				setIsLoading(false);
 			});
-	}, [pubData.id, activeBranch.id, downloads, isLoading, selectedType]);
+	}, [isLoading, selectedType, pubData.id, activeBranch.id]);
 
 	const formattedDownload = getFormattedDownload(downloads);
 	const formattedOptionsClassName = formattedDownload ? 'with-formatted' : '';

--- a/client/containers/Pub/PubHeader/Download.js
+++ b/client/containers/Pub/PubHeader/Download.js
@@ -39,25 +39,23 @@ const Download = (props) => {
 		setIsError(false);
 
 		// Kicks off an export task on the backend
-		for (let i = 0; i < 50; i++) {
-			apiFetch('/api/export', {
-				method: 'POST',
-				body: JSON.stringify({
-					pubId: pubData.id,
-					branchId: activeBranch.id,
-					format: selectedType.format,
-				}),
+		apiFetch('/api/export', {
+			method: 'POST',
+			body: JSON.stringify({
+				pubId: pubData.id,
+				branchId: activeBranch.id,
+				format: selectedType.format,
+			}),
+		})
+			.then((newTaskId) => pingTask(newTaskId, 1500))
+			.then((taskOutput) => {
+				setIsLoading(false);
+				window.open(taskOutput.url);
 			})
-				.then((newTaskId) => pingTask(newTaskId, 1500))
-				.then((taskOutput) => {
-					setIsLoading(false);
-					window.open(taskOutput.url);
-				})
-				.catch(() => {
-					setIsError(true);
-					setIsLoading(false);
-				});
-		}
+			.catch(() => {
+				setIsError(true);
+				setIsLoading(false);
+			});
 	}, [isLoading, selectedType, pubData.id, activeBranch.id]);
 
 	const formattedDownload = getFormattedDownload(downloads);

--- a/client/containers/Pub/PubHeader/Download.js
+++ b/client/containers/Pub/PubHeader/Download.js
@@ -39,23 +39,25 @@ const Download = (props) => {
 		setIsError(false);
 
 		// Kicks off an export task on the backend
-		apiFetch('/api/export', {
-			method: 'POST',
-			body: JSON.stringify({
-				pubId: pubData.id,
-				branchId: activeBranch.id,
-				format: selectedType.format,
-			}),
-		})
-			.then((newTaskId) => pingTask(newTaskId, 1500))
-			.then((taskOutput) => {
-				setIsLoading(false);
-				window.open(taskOutput.url);
+		for (let i = 0; i < 50; i++) {
+			apiFetch('/api/export', {
+				method: 'POST',
+				body: JSON.stringify({
+					pubId: pubData.id,
+					branchId: activeBranch.id,
+					format: selectedType.format,
+				}),
 			})
-			.catch(() => {
-				setIsError(true);
-				setIsLoading(false);
-			});
+				.then((newTaskId) => pingTask(newTaskId, 1500))
+				.then((taskOutput) => {
+					setIsLoading(false);
+					window.open(taskOutput.url);
+				})
+				.catch(() => {
+					setIsError(true);
+					setIsLoading(false);
+				});
+		}
 	}, [isLoading, selectedType, pubData.id, activeBranch.id]);
 
 	const formattedDownload = getFormattedDownload(downloads);

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
 		"start": "npm run build-dev-once && concurrently --kill-others \"npm run api-dev\" \"npm run build-dev\"",
 		"storybook": "start-storybook -p 9001 -c .storybook -s ./",
 		"test": "jest --forceExit --silent --detectOpenHandles",
-		"workers-dev": "NODE_PATH=./client:./ WORKER=true nodemon workers/init.js --watch workers",
-		"workers-prod": "NODE_PATH=./client:./ WORKER=true node workers/init.js"
+		"workers-dev": "SEQUELIZE_MAX_CONNECTIONS=1 NODE_PATH=./client:./ WORKER=true nodemon workers/init.js --watch workers",
+		"workers-prod": "SEQUELIZE_MAX_CONNECTIONS=1 NODE_PATH=./client:./ WORKER=true node workers/init.js"
 	},
 	"devDependencies": {
 		"@storybook/addon-storyshots": "^5.0.11",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
 		"yargs": "^13.2.4"
 	},
 	"engines": {
-		"node": "10.14.1"
+		"node": "12.13.0"
 	},
 	"jest": {
 		"testEnvironment": "node",

--- a/server/models.js
+++ b/server/models.js
@@ -9,6 +9,11 @@ const useSSL = process.env.DATABASE_URL.indexOf('localhost') === -1;
 export const sequelize = new Sequelize(process.env.DATABASE_URL, {
 	logging: false,
 	dialectOptions: { ssl: useSSL },
+	pool: {
+		max: process.env.SEQUELIZE_MAX_CONNECTIONS
+			? parseInt(process.env.SEQUELIZE_MAX_CONNECTIONS, 10)
+			: 5,
+	},
 });
 
 /* Change to true to update the model in the database. */

--- a/workers/environment.js
+++ b/workers/environment.js
@@ -1,0 +1,14 @@
+const Module = require('module');
+
+/* Since we are server-rendering components, we 	*/
+/* need to ensure we don't require things intended 	*/
+/* for webpack. Namely, .scss files 				*/
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function(...args) {
+	if (args[0].indexOf('.scss') > -1) {
+		return () => {};
+	}
+	return originalRequire.apply(this, args);
+};
+
+require('@babel/register');

--- a/workers/initWorker.js
+++ b/workers/initWorker.js
@@ -1,2 +1,2 @@
 require('./environment');
-require('./queue');
+require('./worker');

--- a/workers/queue.js
+++ b/workers/queue.js
@@ -1,5 +1,6 @@
 /* eslint-disable global-require, no-console */
 import path from 'path';
+// eslint-disable-next-line import/no-unresolved
 import { Worker } from 'worker_threads';
 
 import amqplib from 'amqplib';

--- a/workers/queue.js
+++ b/workers/queue.js
@@ -1,0 +1,114 @@
+/* eslint-disable global-require, no-console */
+import path from 'path';
+import { Worker } from 'worker_threads';
+
+import amqplib from 'amqplib';
+import * as Sentry from '@sentry/node';
+
+import { WorkerTask } from '../server/models';
+
+const maxWorkerTimeSeconds = 10000;
+const maxWorkerThreads = 5;
+let currentWorkerThreads = 0;
+
+if (process.env.NODE_ENV !== 'production') {
+	require('../server/config.js');
+}
+
+// Every worker task should be run exactly once, but we keep an attemptCount field in the database
+// to account for cases where a task is interrupted, never acked, and then resent from the queue.
+// This could happen if a task causes the worker dyno to crash, for instance.
+const incrementAttemptCount = async (taskId, maxAttemptCount = 2) => {
+	const workerTaskData = await WorkerTask.findOne({ where: { id: taskId } });
+	if (workerTaskData.attemptCount >= maxAttemptCount) {
+		throw new Error('Too many attempts');
+	}
+	const newAttemptCount = workerTaskData.attemptCount ? workerTaskData.attemptCount + 1 : 1;
+	await WorkerTask.update({ attemptCount: newAttemptCount }, { where: { id: taskId } });
+};
+
+const processTask = (channel) => async (message) => {
+	currentWorkerThreads += 1;
+	const taskData = JSON.parse(message.content.toString());
+	let hasFinished = false;
+	let taskTimeout;
+	console.log(`Beginning ${taskData.id} (load ${currentWorkerThreads}/${maxWorkerThreads})`);
+
+	const worker = new Worker(path.join(__dirname, 'initWorker.js'), {
+		execArgv: ['-r', 'esm'],
+		workerData: taskData,
+	});
+
+	const onWorkerFinished = async (updatedTaskData) => {
+		if (hasFinished) {
+			return;
+		}
+		clearTimeout(taskTimeout);
+		hasFinished = true;
+		currentWorkerThreads -= 1;
+		console.log(`Finished ${taskData.id} (load ${currentWorkerThreads}/${maxWorkerThreads})`);
+		await WorkerTask.update(updatedTaskData, {
+			where: { id: taskData.id },
+		});
+		channel.ack(message);
+	};
+
+	const onWorkerError = async (error) => {
+		console.error('In task:', error);
+		if (process.env.NODE_ENV === 'production') {
+			Sentry.captureException(error);
+		}
+		await onWorkerFinished({
+			isProcessing: false,
+			error: error.message ? error.message : error,
+			output: null,
+		});
+	};
+
+	const onWorkerMessage = async ({ result, error }) => {
+		if (error) {
+			await onWorkerError(error);
+		} else {
+			await onWorkerFinished({
+				isProcessing: false,
+				error: null,
+				output: result,
+			});
+		}
+	};
+
+	try {
+		await incrementAttemptCount(taskData.id);
+	} catch (err) {
+		await onWorkerError(err);
+		return;
+	}
+
+	worker.on('error', onWorkerError);
+	worker.on('message', onWorkerMessage);
+	taskTimeout = setTimeout(() => {
+		worker.terminate();
+		onWorkerError(`Worker terminated after ${maxWorkerTimeSeconds} seconds`);
+	}, maxWorkerTimeSeconds * 1000);
+};
+
+// Initialize the connection to the queue and set the processTask function to run on new messages
+amqplib
+	.connect(process.env.CLOUDAMQP_URL)
+	.then((conn) => {
+		process.once('SIGINT', () => {
+			conn.close();
+		});
+		return conn.createConfirmChannel().then((ch) => {
+			let ok = ch.assertQueue('pubpubTaskQueue', { durable: true });
+			ok = ok.then(() => {
+				ch.prefetch(maxWorkerThreads);
+			});
+			ok = ok.then(() => {
+				ch.consume('pubpubTaskQueue', processTask(ch), { noAck: false });
+				console.log(' [*] Waiting for messages. To exit press CTRL+C');
+			});
+			return ok;
+		});
+	})
+	.catch(console.warn);

--- a/workers/queue.js
+++ b/workers/queue.js
@@ -7,7 +7,7 @@ import * as Sentry from '@sentry/node';
 
 import { WorkerTask } from '../server/models';
 
-const maxWorkerTimeSeconds = 10000;
+const maxWorkerTimeSeconds = 120;
 const maxWorkerThreads = 5;
 let currentWorkerThreads = 0;
 

--- a/workers/tasks/export.js
+++ b/workers/tasks/export.js
@@ -150,7 +150,7 @@ const uploadDocument = (branchId, readableStream, extension) => {
 	});
 };
 
-export default async (pubId, branchId, format) => {
+export const exportTask = async (pubId, branchId, format) => {
 	const { extension } = formatTypes[format];
 	const pubData = await Pub.findOne({
 		where: { id: pubId },

--- a/workers/tasks/import-export/import.js
+++ b/workers/tasks/import-export/import.js
@@ -140,7 +140,7 @@ const importFiles = async ({ sourceFiles }) => {
 	return { doc: prosemirrorDoc, warnings: warnings };
 };
 
-export default ({ sourceFiles }) =>
+export const importTask = ({ sourceFiles }) =>
 	importFiles({ sourceFiles: sourceFiles }).catch((error) => ({
 		error: {
 			message: error.toString(),

--- a/workers/worker.js
+++ b/workers/worker.js
@@ -1,164 +1,55 @@
-/* eslint-disable global-require */
-/* eslint-disable no-console */
-import amqplib from 'amqplib';
-import * as Sentry from '@sentry/node';
-import exportTask from './tasks/export';
-import importTask from './tasks/import-export/import';
-import {
+const { parentPort, isMainThread, workerData } = require('worker_threads');
+
+const {
 	deletePageSearchData,
 	setPageSearchData,
 	deletePubSearchData,
 	setPubSearchData,
 	updateCommunityData,
 	updateUserData,
-} from './tasks/search';
-import { WorkerTask } from '../server/models';
+} = require('./tasks/search');
+const { importTask } = require('./tasks/import-export/import');
+const { exportTask } = require('./tasks/export');
 
-if (process.env.NODE_ENV !== 'production') {
-	require('../server/config.js');
+if (isMainThread) {
+	// Don't run outside of a thread spawned by worker_threads in queue.js
+	process.exit(1);
 }
 
-const processTask = (channel) => {
-	return (msg) => {
-		const taskData = JSON.parse(msg.content.toString());
-		console.log('Beginning task ', taskData.id);
-
-		/* Set the variable for updatedWorkerTaskData */
-		/* We will update this data depending on whether */
-		/* the task succeeds or fails, and have a single */
-		/* request to update the database WorkerTask row. */
-		let updatedWorkerTaskData;
-
-		return WorkerTask.findOne({
-			where: { id: taskData.id },
-		})
-			.then((workerTaskData) => {
-				/* Sometimes tasks fail in ways that do not trigger the */
-				/* catch and finally functions of this Promise chain. */
-				/* My hunch is memory quotas are exceeded, or other */
-				/* pandoc runtime errors cause it to hang/fail. */
-				/* In these cases, let's try it a couple times, and */
-				/* if it winds up back in the queue after those attempts, */
-				/* finish and ack the task. */
-				if (workerTaskData.attemptCount >= 2) {
-					throw new Error('Too many attempts');
-				}
-				/* If we are below the allowed attemptCount, increment */
-				/* attemptCount in the database and continue. */
-				const newAttemptCount = workerTaskData.attemptCount
-					? workerTaskData.attemptCount + 1
-					: 1;
-				return WorkerTask.update(
-					{ attemptCount: newAttemptCount },
-					{
-						where: { id: taskData.id },
-					},
-				);
-			})
-			.then(() => {
-				/* Specify which task function to run based on the type as set in the msg */
-				let taskFunction;
-				if (taskData.type === 'export') {
-					taskFunction = exportTask(
-						taskData.input.pubId,
-						taskData.input.branchId,
-						taskData.input.format,
-					);
-				} else if (taskData.type === 'import') {
-					taskFunction = importTask(taskData.input);
-				} else if (taskData.type === 'deletePageSearchData') {
-					taskFunction = deletePageSearchData(taskData.input);
-				} else if (taskData.type === 'setPageSearchData') {
-					taskFunction = setPageSearchData(taskData.input);
-				} else if (taskData.type === 'deletePubSearchData') {
-					taskFunction = deletePubSearchData(taskData.input);
-				} else if (taskData.type === 'setPubSearchData') {
-					taskFunction = setPubSearchData(taskData.input);
-				} else if (taskData.type === 'updateCommunityData') {
-					taskFunction = updateCommunityData(taskData.input);
-				} else if (taskData.type === 'updateUserData') {
-					taskFunction = updateUserData(taskData.input);
-				} else {
-					taskFunction = new Promise((resolve, reject) => {
-						reject(new Error('Invalid Task Type'));
-					});
-				}
-
-				/* Run the task as determined by the msg type */
-				return taskFunction;
-			})
-			.then((taskOutput) => {
-				/* On success, set the taskOutput to output */
-				updatedWorkerTaskData = {
-					isProcessing: false,
-					error: null,
-					output: taskOutput,
-				};
-			})
-			.catch((taskErr) => {
-				if (process.env.NODE_ENV === 'production') {
-					Sentry.captureException(taskErr);
-				}
-				/* On failure, set the taskError to error */
-				updatedWorkerTaskData = {
-					isProcessing: false,
-					error: taskErr.message ? taskErr.message : taskErr,
-					output: null,
-				};
-				console.error(taskErr);
-			})
-			.finally(() => {
-				/* On either success or failure, update */
-				/* the WorkTask database row with the  */
-				/* result of the function and ack the queue msg */
-				return WorkerTask.update(updatedWorkerTaskData, {
-					where: { id: taskData.id },
-				}).then(() => {
-					console.log('Finished task ', taskData.id);
-					channel.ack(msg);
-				});
-			});
-	};
+const main = async (taskData) => {
+	let taskPromise;
+	if (taskData.type === 'export') {
+		taskPromise = exportTask(
+			taskData.input.pubId,
+			taskData.input.branchId,
+			taskData.input.format,
+		);
+	} else if (taskData.type === 'import') {
+		taskPromise = importTask(taskData.input);
+	} else if (taskData.type === 'deletePageSearchData') {
+		taskPromise = deletePageSearchData(taskData.input);
+	} else if (taskData.type === 'setPageSearchData') {
+		taskPromise = setPageSearchData(taskData.input);
+	} else if (taskData.type === 'deletePubSearchData') {
+		taskPromise = deletePubSearchData(taskData.input);
+	} else if (taskData.type === 'setPubSearchData') {
+		taskPromise = setPubSearchData(taskData.input);
+	} else if (taskData.type === 'updateCommunityData') {
+		taskPromise = updateCommunityData(taskData.input);
+	} else if (taskData.type === 'updateUserData') {
+		taskPromise = updateUserData(taskData.input);
+	} else {
+		throw new Error('Invalid task type');
+	}
+	let taskResult;
+	try {
+		taskResult = await taskPromise;
+		parentPort.postMessage({ result: taskResult });
+		process.exit(0);
+	} catch (error) {
+		parentPort.postMessage({ error: error });
+		process.exit(1);
+	}
 };
 
-/* Initialize the connection to the queue and set */
-/* the processTask function to run on new msgs */
-amqplib
-	.connect(process.env.CLOUDAMQP_URL)
-	.then((conn) => {
-		process.once('SIGINT', () => {
-			conn.close();
-		});
-		return conn.createConfirmChannel().then((ch) => {
-			let ok = ch.assertQueue('pubpubTaskQueue', { durable: true });
-			ok = ok.then(() => {
-				ch.prefetch(1);
-			});
-			ok = ok.then(() => {
-				ch.consume('pubpubTaskQueue', processTask(ch), { noAck: false });
-				console.log(' [*] Waiting for messages. To exit press CTRL+C');
-			});
-			return ok;
-		});
-	})
-	.catch(console.warn);
-
-// importTask('https://assets.pubpub.org/_testing/01540904698402.html')
-// .then((result)=> {
-// 	console.log(result.html);
-// })
-// .catch((err)=> {
-// 	console.error(err);
-// });
-
-// importTask('https://assets.pubpub.org/_testing/31553876712636.html'); /* Smart Enough City */
-// importTask('https://assets.pubpub.org/_testing/31553876712636.html'); /* Smart Enough City */
-// importTask('https://assets.pubpub.org/_testing/71553878171064.html'); /* Hacking Life */
-
-// exportTask('3ecac2f5-8065-4bde-aa0e-c1ab222fd673', '427a3c55-993a-4083-918c-85c682bedccf', null, 'pdf')
-// .then((output)=> {
-// 	console.log('got output', output);
-// })
-// .catch((err)=> {
-// 	console.log('Caught err', err.message);
-// });
+main(workerData);

--- a/workers/worker.js
+++ b/workers/worker.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 const { parentPort, isMainThread, workerData } = require('worker_threads');
 
 const {


### PR DESCRIPTION
We've been having issues where heavy Pub imports/exports have clogged up the job queue, preventing others from running imports or exports. The problem is twofold:

- There is no way for jobs that could potentially take forever to be killed after a timeout
- There is no way for one Heroku dyno to run `n > 1` jobs at once, though I suspect there are gains to be squeezed from parallelism here, at least for low `n`.

This PR addresses these issues by restructuring the worker dyno code so it spawns one thread per job using the relatively new `worker_threads` Node module. This lets us kill jobs if they take too long, as well as kick off multiple jobs at once. One caveat is that large numbers of parallel jobs can create more database connections than our Postgres instance allows, leading to errors. To handle this, I've introduced the `SEQUELIZE_MAX_CONNECTIONS` environment variable that we can run the worker dyno with, and set that to `1` to start with. This forces all the jobs on a given dyno to share a database connection, which shouldn't be a huge issue — our commonly-run jobs are CPU rather than I/O-bound. To summarize, I've added three new parameters to the worker that we can tweak to our liking:

- `SEQUELIZE_MAX_CONNECTIONS = 1` to prevent database issues. I doubt a higher value would noticeably improve performance.
- `maxWorkerThreads = 5`. I make no claims that this number is ideal, but it's likely better than `1`. We can benchmark when this becomes an issue.
- `maxWorkerTimeSeconds = 120`. This has the most immediate user-facing implications. Some files do take longer than 120 seconds to import or export, but we have to balance that fact with the need to keep the queue clear.

When we have more bandwidth to handle this issue, which has appeared somewhat unexpectedly, we can play with better UX for timeouts, queue prioritization and backoff, etc.

_Test plan:_
- Run `npm start` and separately `npm run workers-dev`. Verify that you can perform worker tasks (i.e. imports and exports) successfully.
- To stress-test the system, I modified `Download.js` so it looks like this:
```
// Kicks off an export task on the backend
for (let i = 0; i < 50; i++) {
    apiFetch('/api/export', {
        method: 'POST',
        body: JSON.stringify({
            pubId: pubData.id,
            branchId: activeBranch.id,
            format: selectedType.format,
        }),
    })
        .then((newTaskId) => pingTask(newTaskId, 1500))
        .then((taskOutput) => {
            setIsLoading(false);
            window.open(taskOutput.url);
        })
        .catch(() => {
            setIsError(true);
            setIsLoading(false);
        });
}
```
I observed that the single worker on my machine was able to successfully process 50 tasks, 5 at a time, without any issues, database or otherwise.