### PR TITLE
dev: Update to Node 12.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
 		"yargs": "^13.2.4"
 	},
 	"engines": {
-		"node": "10.14.1"
+		"node": "12.13.0"
 	},
 	"jest": {
 		"testEnvironment": "node",


### PR DESCRIPTION
Adding this to a PR so we can have a standalone conversation about it.

Node.js version 12 [just entered its long-term support period](https://nodejs.org/en/about/releases/). Coincidentally, I'm working on some stuff over in #590 which requires us to upgrade to a newer version of `10.x` or `12.x` (which are on parallel LTS tracks). I see no reason not to try for `12.x`.

_Test plan:_
- Run `npm test`
- Check some routes to make sure the site generally works with Node 12.
- After this is approved I'll push it to duqduq and we can observe it in situ on Heroku for a bit before pushing it to production.