### PR TITLE
Mailchimp account update

### DIFF
--- a/server/community/queries.js
+++ b/server/community/queries.js
@@ -71,7 +71,7 @@ export const createCommunity = (inputValues, userData) => {
 			return Page.create(newpage);
 		})
 		.then(() => {
-			subscribeUser(userData.email, '2847d5271c', ['Community Admins']);
+			subscribeUser(userData.email, 'be26e45660', ['Community Admins']);
 			alertNewCommunity(inputValues.title, subdomain, userData.fullName, userData.email);
 			return CommunityAdmin.create({
 				communityId: newCommunityId,

--- a/server/communityAdmin/queries.js
+++ b/server/communityAdmin/queries.js
@@ -13,7 +13,7 @@ export const createCommunityAdmin = (inputValues) => {
 			});
 		})
 		.then((newAdminData) => {
-			subscribeUser(newAdminData.email, '2847d5271c', ['Community Admins']);
+			subscribeUser(newAdminData.email, 'be26e45660', ['Community Admins']);
 			const adminDataJson = newAdminData.toJSON();
 			delete adminDataJson.email;
 			return adminDataJson;

--- a/server/subscribe/queries.js
+++ b/server/subscribe/queries.js
@@ -2,7 +2,7 @@ import { subscribeUser } from '../utils/mailchimp';
 
 export const subscribeToMailchimp = (inputValues) => {
 	const email = inputValues.email;
-	const list = inputValues.list || '2847d5271c';
+	const list = inputValues.list || 'be26e45660';
 	const tags = inputValues.tags || [];
 	return subscribeUser(email, list, tags);
 };

--- a/server/user/queries.js
+++ b/server/user/queries.js
@@ -44,7 +44,7 @@ export const createUser = (inputValues) => {
 		})
 		.then(() => {
 			if (inputValues.subscribed) {
-				subscribeUser(inputValues.email, '2847d5271c', ['Users']);
+				subscribeUser(inputValues.email, 'be26e45660', ['Users']);
 			}
 			return Signup.update(
 				{ completed: true },

--- a/server/utils/mailchimp.js
+++ b/server/utils/mailchimp.js
@@ -3,7 +3,7 @@ import md5 from 'crypto-js/md5';
 
 const key = process.env.MAILCHIMP_API_KEY;
 
-const base = 'https://us2.api.mailchimp.com/3.0/lists';
+const base = 'https://us5.api.mailchimp.com/3.0/lists';
 
 const emailHash = (email) => {
 	return md5(email.toLowerCase()).toString();


### PR DESCRIPTION
Switches to our new mailchimp account.

_Test plan_
1. Replace mailchimp api key in config.js with new key
1. Signup for the newsletter in the footer
1. Signup for the newsletter as part of user login – your new mailchimp user should be given the `users` in mailchimp
1. Add your user as a community admin – your user should be tagged as a `community admin` in mailchimp
1. Create a new community (is this possible on dev?) - your user should be tagged as a `community admin` in mailchimp

Deploying will require updating mailchimp env variable in heroku.