### PR TITLE
feature: Cache exports and automatically create them on merge

### DIFF
--- a/client/containers/Pub/PubDocument/PubBottom/ReadNextSection.js
+++ b/client/containers/Pub/PubDocument/PubBottom/ReadNextSection.js
@@ -9,7 +9,7 @@ import {
 } from 'utils/collections';
 import { pubDataProps } from 'types/pub';
 import { pubUrl } from 'shared/utils/canonicalUrls';
-import { usePageContext } from '../../usePageContext';
+import { usePageContext } from '../../pubHooks';
 import PubBottomSection, { SectionBullets } from './PubBottomSection';
 
 const propTypes = {

--- a/client/containers/Pub/PubHeader/Download.js
+++ b/client/containers/Pub/PubHeader/Download.js
@@ -5,7 +5,7 @@ import { Button, Icon, Menu, MenuItem, Spinner, Tooltip } from '@blueprintjs/cor
 import { apiFetch } from 'utils';
 import { pingTask } from 'utils/pingTask';
 import { getFormattedDownload } from './headerUtils';
-import { usePubHistory } from '../pubHooks';
+import { usePubHistory, usePageContext } from '../pubHooks';
 
 require('./download.scss');
 
@@ -35,6 +35,7 @@ const Download = (props) => {
 	const [selectedType, setSelectedType] = useState(null);
 	const [downloadUrl, setDownloadUrl] = useState(null);
 	const { latestKey } = usePubHistory();
+	const { locationData } = usePageContext();
 	const formattedDownload = getFormattedDownload(downloads);
 
 	const download = (url) => {
@@ -78,6 +79,7 @@ const Download = (props) => {
 				branchId: activeBranch.id,
 				format: selectedType.format,
 				historyKey: latestKey,
+				accessHash: locationData.query.access,
 			}),
 		}).then(({ taskId, url }) => {
 			if (url) {
@@ -91,7 +93,14 @@ const Download = (props) => {
 					});
 			}
 		});
-	}, [isLoading, selectedType, pubData.id, activeBranch.id, latestKey]);
+	}, [
+		isLoading,
+		selectedType,
+		pubData.id,
+		activeBranch.id,
+		latestKey,
+		locationData.query.access,
+	]);
 
 	return (
 		<div className="pub-download-component">

--- a/client/containers/Pub/PubHeader/Download.js
+++ b/client/containers/Pub/PubHeader/Download.js
@@ -58,7 +58,7 @@ const Download = (props) => {
 	};
 
 	useEffect(() => {
-		const downloadOrShowDialog = (url) => {
+		const downloadOrShowButton = (url) => {
 			if (mustShowDownloadButton()) {
 				setDownloadUrl(url);
 				setIsLoading(false);
@@ -83,10 +83,10 @@ const Download = (props) => {
 			}),
 		}).then(({ taskId, url }) => {
 			if (url) {
-				downloadOrShowDialog(url);
+				downloadOrShowButton(url);
 			} else if (taskId) {
 				pingTask(taskId, 1500)
-					.then(({ url: laterUrl }) => downloadOrShowDialog(laterUrl))
+					.then(({ url: laterUrl }) => downloadOrShowButton(laterUrl))
 					.catch(() => {
 						setIsError(true);
 						setIsLoading(false);

--- a/client/containers/Pub/PubHeader/Download.js
+++ b/client/containers/Pub/PubHeader/Download.js
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Tooltip, Icon, Menu, MenuItem, Spinner } from '@blueprintjs/core';
+import { Button, Icon, Menu, MenuItem, Spinner, Tooltip } from '@blueprintjs/core';
+
 import { apiFetch } from 'utils';
 import { pingTask } from 'utils/pingTask';
 import { getFormattedDownload } from './headerUtils';
+import { usePubHistory } from '../pubHooks';
 
 require('./download.scss');
 
@@ -23,21 +25,51 @@ const formatTypes = [
 	{ format: 'tex', title: 'LaTeX' },
 ];
 
+const mustShowDownloadButton = () => navigator.userAgent.match(/iP(ad|hone|od)/i);
+
 const Download = (props) => {
 	const { pubData } = props;
-
-	const { downloads: maybeDownloads, activeBranch } = pubData;
-	const downloads = maybeDownloads || [];
+	const { downloads = [], activeBranch } = pubData;
 	const [isLoading, setIsLoading] = useState(false);
 	const [isError, setIsError] = useState(false);
-	const [selectedType, setSelectedType] = useState(undefined);
+	const [selectedType, setSelectedType] = useState(null);
+	const [downloadUrl, setDownloadUrl] = useState(null);
+	const { latestKey } = usePubHistory();
+	const formattedDownload = getFormattedDownload(downloads);
+
+	const download = (url) => {
+		setIsLoading(false);
+		setDownloadUrl(null);
+		window.open(url);
+	};
+
+	const handleStartDownload = (type) => {
+		const matchingExport = pubData.activeBranch.exports.find(
+			(ex) => ex.format === type.format && ex.historyKey >= latestKey,
+		);
+		if (matchingExport && matchingExport.url) {
+			download(matchingExport.url);
+		} else {
+			setSelectedType(type);
+			setIsError(false);
+			setIsLoading(true);
+		}
+	};
 
 	useEffect(() => {
+		const downloadOrShowDialog = (url) => {
+			if (mustShowDownloadButton()) {
+				setDownloadUrl(url);
+				setIsLoading(false);
+			} else {
+				download(url);
+			}
+		};
+
 		if (!isLoading) {
 			return;
 		}
 		setIsError(false);
-
 		// Kicks off an export task on the backend
 		apiFetch('/api/export', {
 			method: 'POST',
@@ -45,23 +77,24 @@ const Download = (props) => {
 				pubId: pubData.id,
 				branchId: activeBranch.id,
 				format: selectedType.format,
+				historyKey: latestKey,
 			}),
-		})
-			.then((newTaskId) => pingTask(newTaskId, 1500))
-			.then((taskOutput) => {
-				setIsLoading(false);
-				window.open(taskOutput.url);
-			})
-			.catch(() => {
-				setIsError(true);
-				setIsLoading(false);
-			});
-	}, [isLoading, selectedType, pubData.id, activeBranch.id]);
+		}).then(({ taskId, url }) => {
+			if (url) {
+				downloadOrShowDialog(url);
+			} else if (taskId) {
+				pingTask(taskId, 1500)
+					.then(({ url: laterUrl }) => downloadOrShowDialog(laterUrl))
+					.catch(() => {
+						setIsError(true);
+						setIsLoading(false);
+					});
+			}
+		});
+	}, [isLoading, selectedType, pubData.id, activeBranch.id, latestKey]);
 
-	const formattedDownload = getFormattedDownload(downloads);
-	const formattedOptionsClassName = formattedDownload ? 'with-formatted' : '';
 	return (
-		<div className={`pub-download-component ${formattedOptionsClassName}`}>
+		<div className="pub-download-component">
 			<Menu>
 				{formattedDownload && (
 					<React.Fragment>
@@ -88,37 +121,45 @@ const Download = (props) => {
 						{formattedDownload ? 'Auto Generated Download' : 'Download'}
 					</h6>
 				</li>
-				{formatTypes.map((type, i) => (
-					<MenuItem
-						// eslint-disable-next-line react/no-array-index-key
-						key={`${i}-${type.format}`}
-						shouldDismissPopover={false}
-						disabled={isLoading && selectedType.format !== type.format}
-						// loading={isLoading && selectedType.format === type.format}
-						labelElement={
-							<span>
-								{isLoading && selectedType.format === type.format && (
-									<Spinner size={Spinner.SIZE_SMALL} />
-								)}
-							</span>
-						}
-						onClick={() => {
-							setSelectedType(type);
-							setIsError(false);
-							setIsLoading(true);
-						}}
-						rel="nofollow"
-						text={
-							<Tooltip
-								key={type.format}
-								isOpen={isError && selectedType.format === type.format}
-								content="There was a problem generating the file."
-							>
-								{type.title}
-							</Tooltip>
-						}
-					/>
-				))}
+				{formatTypes.map((type, i) => {
+					const shouldRenderButton = downloadUrl && selectedType.format === type.format;
+					return (
+						<MenuItem
+							// eslint-disable-next-line react/no-array-index-key
+							key={`${i}-${type.format}`}
+							shouldDismissPopover={false}
+							disabled={isLoading && selectedType.format !== type.format}
+							// loading={isLoading && selectedType.format === type.format}
+							labelElement={
+								<span>
+									{isLoading && selectedType.format === type.format && (
+										<Spinner size={Spinner.SIZE_SMALL} />
+									)}
+								</span>
+							}
+							onClick={() => handleStartDownload(type)}
+							rel="nofollow"
+							text={
+								<Tooltip
+									key={type.format}
+									isOpen={isError && selectedType.format === type.format}
+									content="There was a problem generating the file."
+								>
+									{shouldRenderButton ? (
+										<Button
+											icon="download"
+											onClick={() => download(downloadUrl)}
+										>
+											Download {type.title} file
+										</Button>
+									) : (
+										type.title
+									)}
+								</Tooltip>
+							}
+						/>
+					);
+				})}
 			</Menu>
 		</div>
 	);

--- a/client/containers/Pub/PubHeader/download.scss
+++ b/client/containers/Pub/PubHeader/download.scss
@@ -1,9 +1,4 @@
 .pub-download-component {
-	// &.with-formatted {
-		// padding: 1em;	
-	// }
-	// display: flex;
-	// flex-direction: column;
 	.formatted-button {
 		margin-bottom: 1em;
 	}

--- a/client/containers/Pub/PubSyncManager.js
+++ b/client/containers/Pub/PubSyncManager.js
@@ -7,6 +7,8 @@ import { apiFetch, getRandomColor } from 'utils';
 import { initFirebase } from 'utils/firebaseClient';
 import { getPubPageTitle } from 'shared/utils/pubPageTitle';
 
+export const PubContext = React.createContext({});
+
 const propTypes = {
 	pubData: PropTypes.object.isRequired,
 	children: PropTypes.func.isRequired,
@@ -332,13 +334,18 @@ class PubSyncManager extends React.Component {
 	}
 
 	render() {
-		return this.props.children({
+		const context = {
 			pubData: this.state.pubData,
 			collabData: this.state.collabData,
 			historyData: this.state.historyData,
 			firebaseBranchRef: this.state.firebaseBranchRef,
 			updateLocalData: this.updateLocalData,
-		});
+		};
+		return (
+			<PubContext.Provider value={context}>
+				{this.props.children(context)}
+			</PubContext.Provider>
+		);
 	}
 }
 

--- a/client/containers/Pub/pubHooks.js
+++ b/client/containers/Pub/pubHooks.js
@@ -1,0 +1,19 @@
+import { useContext } from 'react';
+
+// TODO(ian): Move this here?
+import { PageContext } from 'components/PageWrapper/PageWrapper';
+import { PubContext } from './PubSyncManager';
+
+export const usePageContext = () => {
+	return useContext(PageContext);
+};
+
+export const useCollab = () => {
+	const { collabData } = useContext(PubContext);
+	return collabData;
+};
+
+export const usePubHistory = () => {
+	const { historyData } = useContext(PubContext);
+	return historyData;
+};

--- a/client/containers/Pub/usePageContext.js
+++ b/client/containers/Pub/usePageContext.js
@@ -1,7 +1,0 @@
-import { useContext } from 'react';
-
-import { PageContext } from 'components/PageWrapper/PageWrapper';
-
-export const usePageContext = () => {
-	return useContext(PageContext);
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,17 +13,17 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.2.tgz",
-			"integrity": "sha512-eeD7VEZKfhK1KUXGiyPFettgF3m513f8FoBSWiQ1xTvl1RAopLs42Wp9+Ze911I6H0N9lNqJMDgoZT7gHsipeQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.4.tgz",
+			"integrity": "sha512-+bYbx56j4nYBmpsWtnPUsKW3NdnYxbqyfrP2w9wILBuHzdfIKz9prieZK0DFPyIzkjYVUe4QkusGL07r5pXznQ==",
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.7.2",
-				"@babel/helpers": "^7.7.0",
-				"@babel/parser": "^7.7.2",
-				"@babel/template": "^7.7.0",
-				"@babel/traverse": "^7.7.2",
-				"@babel/types": "^7.7.2",
+				"@babel/generator": "^7.7.4",
+				"@babel/helpers": "^7.7.4",
+				"@babel/parser": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
@@ -34,155 +34,155 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
-			"integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.4.tgz",
+			"integrity": "sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==",
 			"requires": {
-				"@babel/types": "^7.7.2",
+				"@babel/types": "^7.7.4",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
 				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.0.tgz",
-			"integrity": "sha512-k50CQxMlYTYo+GGyUGFwpxKVtxVJi9yh61sXZji3zYHccK9RYliZGSTOgci85T+r+0VFN2nWbGM04PIqwfrpMg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
+			"integrity": "sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==",
 			"requires": {
-				"@babel/types": "^7.7.0"
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.0.tgz",
-			"integrity": "sha512-Cd8r8zs4RKDwMG/92lpZcnn5WPQ3LAMQbCw42oqUh4s7vsSN5ANUZjMel0OOnxDLq57hoDDbai+ryygYfCTOsw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.4.tgz",
+			"integrity": "sha512-Biq/d/WtvfftWZ9Uf39hbPBYDUo986m5Bb4zhkeYDGUllF43D+nUe5M6Vuo6/8JDK/0YX/uBdeoQpyaNhNugZQ==",
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.7.0",
-				"@babel/types": "^7.7.0"
+				"@babel/helper-explode-assignable-expression": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.0.tgz",
-			"integrity": "sha512-LSln3cexwInTMYYoFeVLKnYPPMfWNJ8PubTBs3hkh7wCu9iBaqq1OOyW+xGmEdLxT1nhsl+9SJ+h2oUDYz0l2A==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.4.tgz",
+			"integrity": "sha512-kvbfHJNN9dg4rkEM4xn1s8d1/h6TYNvajy9L1wx4qLn9HFg0IkTsQi4rfBe92nxrPUFcMsHoMV+8rU7MJb3fCA==",
 			"requires": {
-				"@babel/types": "^7.7.0",
+				"@babel/types": "^7.7.4",
 				"esutils": "^2.0.0"
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.0.tgz",
-			"integrity": "sha512-Su0Mdq7uSSWGZayGMMQ+z6lnL00mMCnGAbO/R0ZO9odIdB/WNU/VfQKqMQU0fdIsxQYbRjDM4BixIa93SQIpvw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.4.tgz",
+			"integrity": "sha512-8JH9/B7J7tCYJ2PpWVpw9JhPuEVHztagNVuQAFBVFYluRMlpG7F1CgKEgGeL6KFqcsIa92ZYVj6DSc0XwmN1ZA==",
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.7.0",
-				"@babel/traverse": "^7.7.0",
-				"@babel/types": "^7.7.0"
+				"@babel/helper-hoist-variables": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.0.tgz",
-			"integrity": "sha512-MZiB5qvTWoyiFOgootmRSDV1udjIqJW/8lmxgzKq6oDqxdmHUjeP2ZUOmgHdYjmUVNABqRrHjYAYRvj8Eox/UA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.4.tgz",
+			"integrity": "sha512-l+OnKACG4uiDHQ/aJT8dwpR+LhCJALxL0mJ6nzjB25e5IPwqV1VOsY7ah6UB1DG+VOXAIMtuC54rFJGiHkxjgA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-function-name": "^7.7.0",
-				"@babel/helper-member-expression-to-functions": "^7.7.0",
-				"@babel/helper-optimise-call-expression": "^7.7.0",
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/helper-member-expression-to-functions": "^7.7.4",
+				"@babel/helper-optimise-call-expression": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.7.0",
-				"@babel/helper-split-export-declaration": "^7.7.0"
+				"@babel/helper-replace-supers": "^7.7.4",
+				"@babel/helper-split-export-declaration": "^7.7.4"
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.2.tgz",
-			"integrity": "sha512-pAil/ZixjTlrzNpjx+l/C/wJk002Wo7XbbZ8oujH/AoJ3Juv0iN/UTcPUHXKMFLqsfS0Hy6Aow8M31brUYBlQQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
+			"integrity": "sha512-Mt+jBKaxL0zfOIWrfQpnfYCN7/rS6GKx6CCCfuoqVVd+17R8zNDlzVYmIi9qyb2wOk002NsmSTDymkIygDUH7A==",
 			"requires": {
 				"@babel/helper-regex": "^7.4.4",
 				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.0.tgz",
-			"integrity": "sha512-kPKWPb0dMpZi+ov1hJiwse9dWweZsz3V9rP4KdytnX1E7z3cTNmFGglwklzFPuqIcHLIY3bgKSs4vkwXXdflQA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.4.tgz",
+			"integrity": "sha512-v5LorqOa0nVQUvAUTUF3KPastvUt/HzByXNamKQ6RdJRTV7j8rLL+WB5C/MzzWAwOomxDhYFb1wLLxHqox86lg==",
 			"requires": {
-				"@babel/helper-function-name": "^7.7.0",
-				"@babel/types": "^7.7.0",
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/types": "^7.7.4",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.0.tgz",
-			"integrity": "sha512-CDs26w2shdD1urNUAji2RJXyBFCaR+iBEGnFz3l7maizMkQe3saVw9WtjG1tz8CwbjvlFnaSLVhgnu1SWaherg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
+			"integrity": "sha512-2/SicuFrNSXsZNBxe5UGdLr+HZg+raWBLE9vC98bdYOKX/U6PY0mdGlYUJdtTDPSU0Lw0PNbKKDpwYHJLn2jLg==",
 			"requires": {
-				"@babel/traverse": "^7.7.0",
-				"@babel/types": "^7.7.0"
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz",
-			"integrity": "sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+			"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.7.0",
-				"@babel/template": "^7.7.0",
-				"@babel/types": "^7.7.0"
+				"@babel/helper-get-function-arity": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz",
-			"integrity": "sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+			"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
 			"requires": {
-				"@babel/types": "^7.7.0"
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.0.tgz",
-			"integrity": "sha512-LUe/92NqsDAkJjjCEWkNe+/PcpnisvnqdlRe19FahVapa4jndeuJ+FBiTX1rcAKWKcJGE+C3Q3tuEuxkSmCEiQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.4.tgz",
+			"integrity": "sha512-wQC4xyvc1Jo/FnLirL6CEgPgPCa8M74tOdjWpRhQYapz5JC7u3NYU1zCVoVAGCE3EaIP9T1A3iW0WLJ+reZlpQ==",
 			"requires": {
-				"@babel/types": "^7.7.0"
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.0.tgz",
-			"integrity": "sha512-QaCZLO2RtBcmvO/ekOLp8p7R5X2JriKRizeDpm5ChATAFWrrYDcDxPuCIBXKyBjY+i1vYSdcUTMIb8psfxHDPA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
+			"integrity": "sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==",
 			"requires": {
-				"@babel/types": "^7.7.0"
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
-			"integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
+			"integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
 			"requires": {
-				"@babel/types": "^7.7.0"
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.0.tgz",
-			"integrity": "sha512-rXEefBuheUYQyX4WjV19tuknrJFwyKw0HgzRwbkyTbB+Dshlq7eqkWbyjzToLrMZk/5wKVKdWFluiAsVkHXvuQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.4.tgz",
+			"integrity": "sha512-ehGBu4mXrhs0FxAqN8tWkzF8GSIGAiEumu4ONZ/hD9M88uHcD+Yu2ttKfOCgwzoesJOJrtQh7trI5YPbRtMmnA==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.7.0",
-				"@babel/helper-simple-access": "^7.7.0",
-				"@babel/helper-split-export-declaration": "^7.7.0",
-				"@babel/template": "^7.7.0",
-				"@babel/types": "^7.7.0",
+				"@babel/helper-module-imports": "^7.7.4",
+				"@babel/helper-simple-access": "^7.7.4",
+				"@babel/helper-split-export-declaration": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/types": "^7.7.4",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.0.tgz",
-			"integrity": "sha512-48TeqmbazjNU/65niiiJIJRc5JozB8acui1OS7bSd6PgxfuovWsvjfWSzlgx+gPFdVveNzUdpdIg5l56Pl5jqg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
+			"integrity": "sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==",
 			"requires": {
-				"@babel/types": "^7.7.0"
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -199,64 +199,64 @@
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.0.tgz",
-			"integrity": "sha512-pHx7RN8X0UNHPB/fnuDnRXVZ316ZigkO8y8D835JlZ2SSdFKb6yH9MIYRU4fy/KPe5sPHDFOPvf8QLdbAGGiyw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
+			"integrity": "sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.7.0",
-				"@babel/helper-wrap-function": "^7.7.0",
-				"@babel/template": "^7.7.0",
-				"@babel/traverse": "^7.7.0",
-				"@babel/types": "^7.7.0"
+				"@babel/helper-annotate-as-pure": "^7.7.4",
+				"@babel/helper-wrap-function": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.0.tgz",
-			"integrity": "sha512-5ALYEul5V8xNdxEeWvRsBzLMxQksT7MaStpxjJf9KsnLxpAKBtfw5NeMKZJSYDa0lKdOcy0g+JT/f5mPSulUgg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
+			"integrity": "sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==",
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.7.0",
-				"@babel/helper-optimise-call-expression": "^7.7.0",
-				"@babel/traverse": "^7.7.0",
-				"@babel/types": "^7.7.0"
+				"@babel/helper-member-expression-to-functions": "^7.7.4",
+				"@babel/helper-optimise-call-expression": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.0.tgz",
-			"integrity": "sha512-AJ7IZD7Eem3zZRuj5JtzFAptBw7pMlS3y8Qv09vaBWoFsle0d1kAn5Wq6Q9MyBXITPOKnxwkZKoAm4bopmv26g==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz",
+			"integrity": "sha512-zK7THeEXfan7UlWsG2A6CI/L9jVnI5+xxKZOdej39Y0YtDYKx9raHk5F2EtK9K8DHRTihYwg20ADt9S36GR78A==",
 			"requires": {
-				"@babel/template": "^7.7.0",
-				"@babel/types": "^7.7.0"
+				"@babel/template": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz",
-			"integrity": "sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+			"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
 			"requires": {
-				"@babel/types": "^7.7.0"
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.0.tgz",
-			"integrity": "sha512-sd4QjeMgQqzshSjecZjOp8uKfUtnpmCyQhKQrVJBBgeHAB/0FPi33h3AbVlVp07qQtMD4QgYSzaMI7VwncNK/w==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
+			"integrity": "sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==",
 			"requires": {
-				"@babel/helper-function-name": "^7.7.0",
-				"@babel/template": "^7.7.0",
-				"@babel/traverse": "^7.7.0",
-				"@babel/types": "^7.7.0"
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.0.tgz",
-			"integrity": "sha512-VnNwL4YOhbejHb7x/b5F39Zdg5vIQpUUNzJwx0ww1EcVRt41bbGRZWhAURrfY32T5zTT3qwNOQFWpn+P0i0a2g==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
+			"integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
 			"requires": {
-				"@babel/template": "^7.7.0",
-				"@babel/traverse": "^7.7.0",
-				"@babel/types": "^7.7.0"
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/highlight": {
@@ -270,27 +270,27 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
-			"integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A=="
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
+			"integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.0.tgz",
-			"integrity": "sha512-ot/EZVvf3mXtZq0Pd0+tSOfGWMizqmOohXmNZg6LNFjHOV+wOPv7BvVYh8oPR8LhpIP3ye8nNooKL50YRWxpYA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
+			"integrity": "sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.7.0",
-				"@babel/plugin-syntax-async-generators": "^7.2.0"
+				"@babel/helper-remap-async-to-generator": "^7.7.4",
+				"@babel/plugin-syntax-async-generators": "^7.7.4"
 			}
 		},
 		"@babel/plugin-proposal-class-properties": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.7.0.tgz",
-			"integrity": "sha512-tufDcFA1Vj+eWvwHN+jvMN6QsV5o+vUlytNKrbMiCeDL0F2j92RURzUsUMWE5EJkLyWxjdUslCsMQa9FWth16A==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.7.4.tgz",
+			"integrity": "sha512-EcuXeV4Hv1X3+Q1TsuOmyyxeTRiSqurGJ26+I/FW1WbymmRRapVORm6x1Zl3iDIHyRxEs+VXWp6qnlcfcJSbbw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.7.0",
+				"@babel/helper-create-class-features-plugin": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
@@ -306,483 +306,483 @@
 			}
 		},
 		"@babel/plugin-proposal-dynamic-import": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.0.tgz",
-			"integrity": "sha512-7poL3Xi+QFPC7sGAzEIbXUyYzGJwbc2+gSD0AkiC5k52kH2cqHdqxm5hNFfLW3cRSTcx9bN0Fl7/6zWcLLnKAQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz",
+			"integrity": "sha512-StH+nGAdO6qDB1l8sZ5UBV8AC3F2VW2I8Vfld73TMKyptMU9DY5YsJAS8U81+vEtxcH3Y/La0wG0btDrhpnhjQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-dynamic-import": "^7.2.0"
+				"@babel/plugin-syntax-dynamic-import": "^7.7.4"
 			}
 		},
 		"@babel/plugin-proposal-json-strings": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz",
-			"integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz",
+			"integrity": "sha512-wQvt3akcBTfLU/wYoqm/ws7YOAQKu8EVJEvHip/mzkNtjaclQoCCIqKXFP5/eyfnfbQCDV3OLRIK3mIVyXuZlw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-json-strings": "^7.2.0"
+				"@babel/plugin-syntax-json-strings": "^7.7.4"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
-			"integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
+			"integrity": "sha512-rnpnZR3/iWKmiQyJ3LKJpSwLDcX/nSXhdLk4Aq/tXOApIvyu7qoabrige0ylsAJffaUC51WiBu209Q0U+86OWQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+				"@babel/plugin-syntax-object-rest-spread": "^7.7.4"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz",
-			"integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
+			"integrity": "sha512-DyM7U2bnsQerCQ+sejcTNZh8KQEUuC3ufzdnVnSiUv/qoGJp2Z3hanKL18KDhsBT5Wj6a7CMT5mdyCNJsEaA9w==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+				"@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.0.tgz",
-			"integrity": "sha512-mk34H+hp7kRBWJOOAR0ZMGCydgKMD4iN9TpDRp3IIcbunltxEY89XSimc6WbtSLCDrwcdy/EEw7h5CFCzxTchw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.4.tgz",
+			"integrity": "sha512-cHgqHgYvffluZk85dJ02vloErm3Y6xtH+2noOBOJ2kXOJH3aVCDnj5eR/lVNlTnYu4hndAPJD3rTFjW3qee0PA==",
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.7.0",
+				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz",
-			"integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
+			"integrity": "sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-decorators": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
-			"integrity": "sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.7.4.tgz",
+			"integrity": "sha512-0oNLWNH4k5ZbBVfAwiTU53rKFWIeTh6ZlaWOXWJc4ywxs0tjz5fc3uZ6jKAnZSxN98eXVgg7bJIuzjX+3SXY+A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-dynamic-import": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
-			"integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz",
+			"integrity": "sha512-jHQW0vbRGvwQNgyVxwDh4yuXu4bH1f5/EICJLAhl1SblLs2CDhrsmCk+v5XLdE9wxtAFRyxx+P//Iw+a5L/tTg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-flow": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.7.0.tgz",
-			"integrity": "sha512-vQMV07p+L+jZeUnvX3pEJ9EiXGCjB5CTTvsirFD9rpEuATnoAvLBLoYbw1v5tyn3d2XxSuvEKi8cV3KqYUa0vQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.7.4.tgz",
+			"integrity": "sha512-2AMAWl5PsmM5KPkB22cvOkUyWk6MjUaqhHNU5nSPUl/ns3j5qLfw2SuYP5RbVZ0tfLvePr4zUScbICtDP2CUNw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-json-strings": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz",
-			"integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz",
+			"integrity": "sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
-			"integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.7.4.tgz",
+			"integrity": "sha512-wuy6fiMe9y7HeZBWXYCGt2RGxZOj0BImZ9EyXJVnVGBKO/Br592rbR3rtIQn0eQhAk9vqaKP5n8tVqEFBQMfLg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
-			"integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
+			"integrity": "sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-optional-catch-binding": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
-			"integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
+			"integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-top-level-await": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.0.tgz",
-			"integrity": "sha512-hi8FUNiFIY1fnUI2n1ViB1DR0R4QeK4iHcTlW6aJkrPoTdb8Rf1EMQ6GT3f67DDkYyWgew9DFoOZ6gOoEsdzTA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.4.tgz",
+			"integrity": "sha512-wdsOw0MvkL1UIgiQ/IFr3ETcfv1xb8RMM0H9wbiDyLaJFyiDg5oZvDLCXosIXmFeIlweML5iOBXAkqddkYNizg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-syntax-typescript": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
-			"integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.7.4.tgz",
+			"integrity": "sha512-77blgY18Hud4NM1ggTA8xVT/dBENQf17OpiToSa2jSmEY3fWXD2jwrdVlO4kq5yzUTeF15WSQ6b4fByNvJcjpQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
-			"integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz",
+			"integrity": "sha512-zUXy3e8jBNPiffmqkHRNDdZM2r8DWhCB7HhcoyZjiK1TxYEluLHAvQuYnTT+ARqRpabWqy/NHkO6e3MsYB5YfA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.0.tgz",
-			"integrity": "sha512-vLI2EFLVvRBL3d8roAMqtVY0Bm9C1QzLkdS57hiKrjUBSqsQYrBsMCeOg/0KK7B0eK9V71J5mWcha9yyoI2tZw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
+			"integrity": "sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.7.0",
+				"@babel/helper-module-imports": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.7.0"
+				"@babel/helper-remap-async-to-generator": "^7.7.4"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
-			"integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
+			"integrity": "sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.3.tgz",
-			"integrity": "sha512-7hvrg75dubcO3ZI2rjYTzUrEuh1E9IyDEhhB6qfcooxhDA33xx2MasuLVgdxzcP6R/lipAC6n9ub9maNW6RKdw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz",
+			"integrity": "sha512-2VBe9u0G+fDt9B5OV5DQH4KBf5DoiNkwFKOz0TCvBWvdAN2rOykCTkrL+jTLxfCAm76l9Qo5OqL7HBOx2dWggg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.0.tgz",
-			"integrity": "sha512-/b3cKIZwGeUesZheU9jNYcwrEA7f/Bo4IdPmvp7oHgvks2majB5BoT5byAql44fiNQYOPzhk2w8DbgfuafkMoA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.4.tgz",
+			"integrity": "sha512-sK1mjWat7K+buWRuImEzjNf68qrKcrddtpQo3swi9j7dUcG6y6R6+Di039QN2bD1dykeswlagupEmpOatFHHUg==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.7.0",
-				"@babel/helper-define-map": "^7.7.0",
-				"@babel/helper-function-name": "^7.7.0",
-				"@babel/helper-optimise-call-expression": "^7.7.0",
+				"@babel/helper-annotate-as-pure": "^7.7.4",
+				"@babel/helper-define-map": "^7.7.4",
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/helper-optimise-call-expression": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.7.0",
-				"@babel/helper-split-export-declaration": "^7.7.0",
+				"@babel/helper-replace-supers": "^7.7.4",
+				"@babel/helper-split-export-declaration": "^7.7.4",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz",
-			"integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.7.4.tgz",
+			"integrity": "sha512-bSNsOsZnlpLLyQew35rl4Fma3yKWqK3ImWMSC/Nc+6nGjC9s5NFWAer1YQ899/6s9HxO2zQC1WoFNfkOqRkqRQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
-			"integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.7.4.tgz",
+			"integrity": "sha512-4jFMXI1Cu2aXbcXXl8Lr6YubCn6Oc7k9lLsu8v61TZh+1jny2BWmdtvY9zSUlLdGUvcy9DMAWyZEOqjsbeg/wA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.0.tgz",
-			"integrity": "sha512-3QQlF7hSBnSuM1hQ0pS3pmAbWLax/uGNCbPBND9y+oJ4Y776jsyujG2k0Sn2Aj2a0QwVOiOFL5QVPA7spjvzSA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.4.tgz",
+			"integrity": "sha512-mk0cH1zyMa/XHeb6LOTXTbG7uIJ8Rrjlzu91pUx/KS3JpcgaTDwMS8kM+ar8SLOvlL2Lofi4CGBAjCo3a2x+lw==",
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.7.0",
+				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.5.0.tgz",
-			"integrity": "sha512-igcziksHizyQPlX9gfSjHkE2wmoCH3evvD2qR5w29/Dk0SMKE/eOI7f1HhBdNhR/zxJDqrgpoDTq5YSLH/XMsQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz",
+			"integrity": "sha512-g1y4/G6xGWMD85Tlft5XedGaZBCIVN+/P0bs6eabmcPP9egFleMAo65OOjlhcz1njpwagyY3t0nsQC9oTFegJA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.2.0.tgz",
-			"integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz",
+			"integrity": "sha512-MCqiLfCKm6KEA1dglf6Uqq1ElDIZwFuzz1WH5mTf8k2uQSxEJMbOIEh7IZv7uichr7PMfi5YVSrr1vz+ipp7AQ==",
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-flow-strip-types": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.6.3.tgz",
-			"integrity": "sha512-l0ETkyEofkqFJ9LS6HChNIKtVJw2ylKbhYMlJ5C6df+ldxxaLIyXY4yOdDQQspfFpV8/vDiaWoJlvflstlYNxg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.7.4.tgz",
+			"integrity": "sha512-w9dRNlHY5ElNimyMYy0oQowvQpwt/PRHI0QS98ZJCTZU2bvSnKXo5zEiD5u76FBPigTm8TkqzmnUTg16T7qbkA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-flow": "^7.2.0"
+				"@babel/plugin-syntax-flow": "^7.7.4"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
-			"integrity": "sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz",
+			"integrity": "sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.0.tgz",
-			"integrity": "sha512-P5HKu0d9+CzZxP5jcrWdpe7ZlFDe24bmqP6a6X8BHEBl/eizAsY8K6LX8LASZL0Jxdjm5eEfzp+FIrxCm/p8bA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.4.tgz",
+			"integrity": "sha512-E/x09TvjHNhsULs2IusN+aJNRV5zKwxu1cpirZyRPw+FyyIKEHPXTsadj48bVpc1R5Qq1B5ZkzumuFLytnbT6g==",
 			"requires": {
-				"@babel/helper-function-name": "^7.7.0",
+				"@babel/helper-function-name": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz",
-			"integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.7.4.tgz",
+			"integrity": "sha512-X2MSV7LfJFm4aZfxd0yLVFrEXAgPqYoDG53Br/tCKiKYfX0MjVjQeWPIhPHHsCqzwQANq+FLN786fF5rgLS+gw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-member-expression-literals": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
-			"integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.7.4.tgz",
+			"integrity": "sha512-9VMwMO7i69LHTesL0RdGy93JU6a+qOPuvB4F4d0kR0zyVjJRVJRaoaGjhtki6SzQUu8yen/vxPKN6CWnCUw6bA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.5.0.tgz",
-			"integrity": "sha512-n20UsQMKnWrltocZZm24cRURxQnWIvsABPJlw/fvoy9c6AgHZzoelAIzajDHAQrDpuKFFPPcFGd7ChsYuIUMpg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.4.tgz",
+			"integrity": "sha512-/542/5LNA18YDtg1F+QHvvUSlxdvjZoD/aldQwkq+E3WCkbEjNSN9zdrOXaSlfg3IfGi22ijzecklF/A7kVZFQ==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-module-transforms": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.0.tgz",
-			"integrity": "sha512-KEMyWNNWnjOom8vR/1+d+Ocz/mILZG/eyHHO06OuBQ2aNhxT62fr4y6fGOplRx+CxCSp3IFwesL8WdINfY/3kg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.4.tgz",
+			"integrity": "sha512-k8iVS7Jhc367IcNF53KCwIXtKAH7czev866ThsTgy8CwlXjnKZna2VHwChglzLleYrcHz1eQEIJlGRQxB53nqA==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.7.0",
+				"@babel/helper-module-transforms": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-simple-access": "^7.7.0",
+				"@babel/helper-simple-access": "^7.7.4",
 				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.0.tgz",
-			"integrity": "sha512-ZAuFgYjJzDNv77AjXRqzQGlQl4HdUM6j296ee4fwKVZfhDR9LAGxfvXjBkb06gNETPnN0sLqRm9Gxg4wZH6dXg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz",
+			"integrity": "sha512-y2c96hmcsUi6LrMqvmNDPBBiGCiQu0aYqpHatVVu6kD4mFEXKjyNxd/drc18XXAf9dv7UXjrZwBVmTTGaGP8iw==",
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.7.0",
+				"@babel/helper-hoist-variables": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.0.tgz",
-			"integrity": "sha512-u7eBA03zmUswQ9LQ7Qw0/ieC1pcAkbp5OQatbWUzY1PaBccvuJXUkYzoN1g7cqp7dbTu6Dp9bXyalBvD04AANA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz",
+			"integrity": "sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.7.0",
+				"@babel/helper-module-transforms": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.0.tgz",
-			"integrity": "sha512-+SicSJoKouPctL+j1pqktRVCgy+xAch1hWWTMy13j0IflnyNjaoskj+DwRQFimHbLqO3sq2oN2CXMvXq3Bgapg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.4.tgz",
+			"integrity": "sha512-jBUkiqLKvUWpv9GLSuHUFYdmHg0ujC1JEYoZUfeOOfNydZXp1sXObgyPatpcwjWgsdBGsagWW0cdJpX/DO2jMw==",
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.7.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.7.4"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz",
-			"integrity": "sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz",
+			"integrity": "sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
-			"integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
+			"integrity": "sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.5.5"
+				"@babel/helper-replace-supers": "^7.7.4"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz",
-			"integrity": "sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.4.tgz",
+			"integrity": "sha512-VJwhVePWPa0DqE9vcfptaJSzNDKrWU/4FbYCjZERtmqEs05g3UMXnYMZoXja7JAJ7Y7sPZipwm/pGApZt7wHlw==",
 			"requires": {
-				"@babel/helper-call-delegate": "^7.4.4",
-				"@babel/helper-get-function-arity": "^7.0.0",
+				"@babel/helper-call-delegate": "^7.7.4",
+				"@babel/helper-get-function-arity": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-property-literals": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
-			"integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.7.4.tgz",
+			"integrity": "sha512-MatJhlC4iHsIskWYyawl53KuHrt+kALSADLQQ/HkhTjX954fkxIEh4q5slL4oRAnsm/eDoZ4q0CIZpcqBuxhJQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-react-constant-elements": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.6.3.tgz",
-			"integrity": "sha512-1/YogSSU7Tby9rq2VCmhuRg+6pxsHy2rI7w/oo8RKoBt6uBUFG+mk6x13kK+FY1/ggN92HAfg7ADd1v1+NCOKg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.7.4.tgz",
+			"integrity": "sha512-U6XkHZ8RnmeEb8jBUOpeo6oFka5RhLgxAVvK4/fBbwoYlsHQYLb8I37ymTPDVsrWjqb94+hueuWQA/1OAA4rAQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-annotate-as-pure": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-react-display-name": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
-			"integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.7.4.tgz",
+			"integrity": "sha512-sBbIvqYkthai0X0vkD2xsAwluBp+LtNHH+/V4a5ydifmTtb8KOVOlrMIk/MYmIc4uTYDnjZUHQildYNo36SRJw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.0.tgz",
-			"integrity": "sha512-mXhBtyVB1Ujfy+0L6934jeJcSXj/VCg6whZzEcgiiZHNS0PGC7vUCsZDQCxxztkpIdF+dY1fUMcjAgEOC3ZOMQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.4.tgz",
+			"integrity": "sha512-LixU4BS95ZTEAZdPaIuyg/k8FiiqN9laQ0dMHB4MlpydHY53uQdWCUrwjLr5o6ilS6fAgZey4Q14XBjl5tL6xw==",
 			"requires": {
-				"@babel/helper-builder-react-jsx": "^7.7.0",
+				"@babel/helper-builder-react-jsx": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.2.0"
+				"@babel/plugin-syntax-jsx": "^7.7.4"
 			}
 		},
 		"@babel/plugin-transform-react-jsx-self": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.2.0.tgz",
-			"integrity": "sha512-v6S5L/myicZEy+jr6ielB0OR8h+EH/1QFx/YJ7c7Ua+7lqsjj/vW6fD5FR9hB/6y7mGbfT4vAURn3xqBxsUcdg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.7.4.tgz",
+			"integrity": "sha512-PWYjSfqrO273mc1pKCRTIJXyqfc9vWYBax88yIhQb+bpw3XChVC7VWS4VwRVs63wFHKxizvGSd00XEr+YB9Q2A==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.2.0"
+				"@babel/plugin-syntax-jsx": "^7.7.4"
 			}
 		},
 		"@babel/plugin-transform-react-jsx-source": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.5.0.tgz",
-			"integrity": "sha512-58Q+Jsy4IDCZx7kqEZuSDdam/1oW8OdDX8f+Loo6xyxdfg1yF0GE2XNJQSTZCaMol93+FBzpWiPEwtbMloAcPg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.7.4.tgz",
+			"integrity": "sha512-5ZU9FnPhqtHsOXxutRtXZAzoEJwDaP32QcobbMP1/qt7NYcsCNK8XgzJcJfoEr/ZnzVvUNInNjIW22Z6I8p9mg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.2.0"
+				"@babel/plugin-syntax-jsx": "^7.7.4"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.0.tgz",
-			"integrity": "sha512-AXmvnC+0wuj/cFkkS/HFHIojxH3ffSXE+ttulrqWjZZRaUOonfJc60e1wSNT4rV8tIunvu/R3wCp71/tLAa9xg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.4.tgz",
+			"integrity": "sha512-e7MWl5UJvmPEwFJTwkBlPmqixCtr9yAASBqff4ggXTNicZiwbF8Eefzm6NVgfiBp7JdAGItecnctKTgH44q2Jw==",
 			"requires": {
 				"regenerator-transform": "^0.14.0"
 			}
 		},
 		"@babel/plugin-transform-reserved-words": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz",
-			"integrity": "sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.7.4.tgz",
+			"integrity": "sha512-OrPiUB5s5XvkCO1lS7D8ZtHcswIC57j62acAnJZKqGGnHP+TIc/ljQSrgdX/QyOTdEK5COAhuc820Hi1q2UgLQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz",
-			"integrity": "sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.4.tgz",
+			"integrity": "sha512-O8kSkS5fP74Ad/8pfsCMGa8sBRdLxYoSReaARRNSz3FbFQj3z/QUvoUmJ28gn9BO93YfnXc3j+Xyaqe8cKDNBQ==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-module-imports": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"resolve": "^1.8.1",
 				"semver": "^5.5.1"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
-			"integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.7.4.tgz",
+			"integrity": "sha512-q+suddWRfIcnyG5YiDP58sT65AJDZSUhXQDZE3r04AuqD6d/XLaQPPXSBzP2zGerkgBivqtQm9XKGLuHqBID6Q==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.6.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
-			"integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.7.4.tgz",
+			"integrity": "sha512-8OSs0FLe5/80cndziPlg4R0K6HcWSM0zyNhHhLsmw/Nc5MaA49cAsnoJ/t/YZf8qkG7fD+UjTRaApVDB526d7Q==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.2.0.tgz",
-			"integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.7.4.tgz",
+			"integrity": "sha512-Ls2NASyL6qtVe1H1hXts9yuEeONV2TJZmplLONkMPUG158CtmnrzW5Q5teibM5UVOFjG0D3IC5mzXR6pPpUY7A==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz",
-			"integrity": "sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz",
+			"integrity": "sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
+				"@babel/helper-annotate-as-pure": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz",
-			"integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz",
+			"integrity": "sha512-KQPUQ/7mqe2m0B8VecdyaW5XcQYaePyl9R7IsKd+irzj6jvbhoGnRE+M0aNkyAzI07VfUQ9266L5xMARitV3wg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-typescript": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.7.2.tgz",
-			"integrity": "sha512-UWhDaJRqdPUtdK1s0sKYdoRuqK0NepjZto2UZltvuCgMoMZmdjhgz5hcRokie/3aYEaSz3xvusyoayVaq4PjRg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.7.4.tgz",
+			"integrity": "sha512-X8e3tcPEKnwwPVG+vP/vSqEShkwODOEeyQGod82qrIuidwIrfnsGn11qPM1jBLF4MqguTXXYzm58d0dY+/wdpg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.7.0",
+				"@babel/helper-create-class-features-plugin": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-typescript": "^7.2.0"
+				"@babel/plugin-syntax-typescript": "^7.7.4"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.0.tgz",
-			"integrity": "sha512-RrThb0gdrNwFAqEAAx9OWgtx6ICK69x7i9tCnMdVrxQwSDp/Abu9DXFU5Hh16VP33Rmxh04+NGW28NsIkFvFKA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.4.tgz",
+			"integrity": "sha512-N77UUIV+WCvE+5yHw+oks3m18/umd7y392Zv7mYTpFqHtkpcc+QUz+gLJNTWVlWROIWeLqY0f3OjZxV5TcXnRw==",
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.7.0",
+				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
@@ -803,56 +803,56 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.1.tgz",
-			"integrity": "sha512-/93SWhi3PxcVTDpSqC+Dp4YxUu3qZ4m7I76k0w73wYfn7bGVuRIO4QUz95aJksbS+AD1/mT1Ie7rbkT0wSplaA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.4.tgz",
+			"integrity": "sha512-Dg+ciGJjwvC1NIe/DGblMbcGq1HOtKbw8RLl4nIjlfcILKEOkWT/vRqPpumswABEBVudii6dnVwrBtzD7ibm4g==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.7.0",
+				"@babel/helper-module-imports": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-proposal-async-generator-functions": "^7.7.0",
-				"@babel/plugin-proposal-dynamic-import": "^7.7.0",
-				"@babel/plugin-proposal-json-strings": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.6.2",
-				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.7.0",
-				"@babel/plugin-syntax-async-generators": "^7.2.0",
-				"@babel/plugin-syntax-dynamic-import": "^7.2.0",
-				"@babel/plugin-syntax-json-strings": "^7.2.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-syntax-top-level-await": "^7.7.0",
-				"@babel/plugin-transform-arrow-functions": "^7.2.0",
-				"@babel/plugin-transform-async-to-generator": "^7.7.0",
-				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-				"@babel/plugin-transform-block-scoping": "^7.6.3",
-				"@babel/plugin-transform-classes": "^7.7.0",
-				"@babel/plugin-transform-computed-properties": "^7.2.0",
-				"@babel/plugin-transform-destructuring": "^7.6.0",
-				"@babel/plugin-transform-dotall-regex": "^7.7.0",
-				"@babel/plugin-transform-duplicate-keys": "^7.5.0",
-				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-				"@babel/plugin-transform-for-of": "^7.4.4",
-				"@babel/plugin-transform-function-name": "^7.7.0",
-				"@babel/plugin-transform-literals": "^7.2.0",
-				"@babel/plugin-transform-member-expression-literals": "^7.2.0",
-				"@babel/plugin-transform-modules-amd": "^7.5.0",
-				"@babel/plugin-transform-modules-commonjs": "^7.7.0",
-				"@babel/plugin-transform-modules-systemjs": "^7.7.0",
-				"@babel/plugin-transform-modules-umd": "^7.7.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.7.0",
-				"@babel/plugin-transform-new-target": "^7.4.4",
-				"@babel/plugin-transform-object-super": "^7.5.5",
-				"@babel/plugin-transform-parameters": "^7.4.4",
-				"@babel/plugin-transform-property-literals": "^7.2.0",
-				"@babel/plugin-transform-regenerator": "^7.7.0",
-				"@babel/plugin-transform-reserved-words": "^7.2.0",
-				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
-				"@babel/plugin-transform-spread": "^7.6.2",
-				"@babel/plugin-transform-sticky-regex": "^7.2.0",
-				"@babel/plugin-transform-template-literals": "^7.4.4",
-				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-				"@babel/plugin-transform-unicode-regex": "^7.7.0",
-				"@babel/types": "^7.7.1",
+				"@babel/plugin-proposal-async-generator-functions": "^7.7.4",
+				"@babel/plugin-proposal-dynamic-import": "^7.7.4",
+				"@babel/plugin-proposal-json-strings": "^7.7.4",
+				"@babel/plugin-proposal-object-rest-spread": "^7.7.4",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.7.4",
+				"@babel/plugin-syntax-async-generators": "^7.7.4",
+				"@babel/plugin-syntax-dynamic-import": "^7.7.4",
+				"@babel/plugin-syntax-json-strings": "^7.7.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.7.4",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.7.4",
+				"@babel/plugin-syntax-top-level-await": "^7.7.4",
+				"@babel/plugin-transform-arrow-functions": "^7.7.4",
+				"@babel/plugin-transform-async-to-generator": "^7.7.4",
+				"@babel/plugin-transform-block-scoped-functions": "^7.7.4",
+				"@babel/plugin-transform-block-scoping": "^7.7.4",
+				"@babel/plugin-transform-classes": "^7.7.4",
+				"@babel/plugin-transform-computed-properties": "^7.7.4",
+				"@babel/plugin-transform-destructuring": "^7.7.4",
+				"@babel/plugin-transform-dotall-regex": "^7.7.4",
+				"@babel/plugin-transform-duplicate-keys": "^7.7.4",
+				"@babel/plugin-transform-exponentiation-operator": "^7.7.4",
+				"@babel/plugin-transform-for-of": "^7.7.4",
+				"@babel/plugin-transform-function-name": "^7.7.4",
+				"@babel/plugin-transform-literals": "^7.7.4",
+				"@babel/plugin-transform-member-expression-literals": "^7.7.4",
+				"@babel/plugin-transform-modules-amd": "^7.7.4",
+				"@babel/plugin-transform-modules-commonjs": "^7.7.4",
+				"@babel/plugin-transform-modules-systemjs": "^7.7.4",
+				"@babel/plugin-transform-modules-umd": "^7.7.4",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
+				"@babel/plugin-transform-new-target": "^7.7.4",
+				"@babel/plugin-transform-object-super": "^7.7.4",
+				"@babel/plugin-transform-parameters": "^7.7.4",
+				"@babel/plugin-transform-property-literals": "^7.7.4",
+				"@babel/plugin-transform-regenerator": "^7.7.4",
+				"@babel/plugin-transform-reserved-words": "^7.7.4",
+				"@babel/plugin-transform-shorthand-properties": "^7.7.4",
+				"@babel/plugin-transform-spread": "^7.7.4",
+				"@babel/plugin-transform-sticky-regex": "^7.7.4",
+				"@babel/plugin-transform-template-literals": "^7.7.4",
+				"@babel/plugin-transform-typeof-symbol": "^7.7.4",
+				"@babel/plugin-transform-unicode-regex": "^7.7.4",
+				"@babel/types": "^7.7.4",
 				"browserslist": "^4.6.0",
 				"core-js-compat": "^3.1.1",
 				"invariant": "^2.2.2",
@@ -861,25 +861,25 @@
 			}
 		},
 		"@babel/preset-flow": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.0.0.tgz",
-			"integrity": "sha512-bJOHrYOPqJZCkPVbG1Lot2r5OSsB+iUOaxiHdlOeB1yPWS6evswVHwvkDLZ54WTaTRIk89ds0iHmGZSnxlPejQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.7.4.tgz",
+			"integrity": "sha512-6LbUqcHD8BcRtXMOp5bc5nJeU8RlKh6q5U8TgZeCrf9ebBdW8Wyy5ujAUnbJfmzQ56Kkq5XtwErC/5+5RHyFYA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-transform-flow-strip-types": "^7.0.0"
+				"@babel/plugin-transform-flow-strip-types": "^7.7.4"
 			}
 		},
 		"@babel/preset-react": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.7.0.tgz",
-			"integrity": "sha512-IXXgSUYBPHUGhUkH+89TR6faMcBtuMW0h5OHbMuVbL3/5wK2g6a2M2BBpkLa+Kw0sAHiZ9dNVgqJMDP/O4GRBA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.7.4.tgz",
+			"integrity": "sha512-j+vZtg0/8pQr1H8wKoaJyGL2IEk3rG/GIvua7Sec7meXVIvGycihlGMx5xcU00kqCJbwzHs18xTu3YfREOqQ+g==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-transform-react-display-name": "^7.0.0",
-				"@babel/plugin-transform-react-jsx": "^7.7.0",
-				"@babel/plugin-transform-react-jsx-self": "^7.0.0",
-				"@babel/plugin-transform-react-jsx-source": "^7.0.0"
+				"@babel/plugin-transform-react-display-name": "^7.7.4",
+				"@babel/plugin-transform-react-jsx": "^7.7.4",
+				"@babel/plugin-transform-react-jsx-self": "^7.7.4",
+				"@babel/plugin-transform-react-jsx-source": "^7.7.4"
 			}
 		},
 		"@babel/preset-typescript": {
@@ -893,9 +893,9 @@
 			}
 		},
 		"@babel/register": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.7.0.tgz",
-			"integrity": "sha512-HV3GJzTvSoyOMWGYn2TAh6uL6g+gqKTgEZ99Q3+X9UURT1VPT/WcU46R61XftIc5rXytcOHZ4Z0doDlsjPomIg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.7.4.tgz",
+			"integrity": "sha512-/fmONZqL6ZMl9KJUYajetCrID6m0xmL4odX7v+Xvoxcv0DdbP/oO0TWIeLUCHqczQ6L6njDMqmqHFy2cp3FFsA==",
 			"requires": {
 				"find-cache-dir": "^2.0.0",
 				"lodash": "^4.17.13",
@@ -905,17 +905,17 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-			"integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
+			"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/runtime-corejs2": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.2.tgz",
-			"integrity": "sha512-GfVnHchOBvIMsweQ13l4jd9lT4brkevnavnVOej5g2y7PpTRY+R4pcQlCjWMZoUla5rMLFzaS/Ll2s59cB1TqQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz",
+			"integrity": "sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==",
 			"requires": {
 				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.2"
@@ -929,35 +929,35 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.0.tgz",
-			"integrity": "sha512-OKcwSYOW1mhWbnTBgQY5lvg1Fxg+VyfQGjcBduZFljfc044J5iDlnDSfhQ867O17XHiSCxYHUxHg2b7ryitbUQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+			"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.7.0",
-				"@babel/types": "^7.7.0"
+				"@babel/parser": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
-			"integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+			"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.7.2",
-				"@babel/helper-function-name": "^7.7.0",
-				"@babel/helper-split-export-declaration": "^7.7.0",
-				"@babel/parser": "^7.7.2",
-				"@babel/types": "^7.7.2",
+				"@babel/generator": "^7.7.4",
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/helper-split-export-declaration": "^7.7.4",
+				"@babel/parser": "^7.7.4",
+				"@babel/types": "^7.7.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/types": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
-			"integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+			"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.13",
@@ -965,20 +965,21 @@
 			}
 		},
 		"@blueprintjs/core": {
-			"version": "3.17.2",
-			"resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.17.2.tgz",
-			"integrity": "sha512-zjBHXGaxBd7LMTW8MbpyWW3VFyB2Zxxzeu6cTo6fcK0Y1nVG3vQaREXBiBQGg2WxhbbcuiWI3gcs3jB15KfeTw==",
+			"version": "3.21.0",
+			"resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.21.0.tgz",
+			"integrity": "sha512-yrv0zf9ZUhBDHkPGgxGlwWqUZtmmGgDVEvyn8vXjMsM1sMJIuNiLkFSJICcRNOJn/Hr77qQNRS1Aw9bef/WAeA==",
 			"requires": {
-				"@blueprintjs/icons": "^3.8.0",
+				"@blueprintjs/icons": "^3.12.0",
 				"@types/dom4": "^2.0.1",
 				"classnames": "^2.2",
-				"dom4": "^2.0.1",
-				"normalize.css": "^8.0.0",
-				"popper.js": "^1.14.1",
-				"react-popper": "^1.0.0",
-				"react-transition-group": "^2.2.1",
-				"resize-observer-polyfill": "^1.5.0",
-				"tslib": "^1.9.0"
+				"dom4": "^2.1.5",
+				"normalize.css": "^8.0.1",
+				"popper.js": "^1.15.0",
+				"react-lifecycles-compat": "^3.0.4",
+				"react-popper": "^1.3.3",
+				"react-transition-group": "^2.9.0",
+				"resize-observer-polyfill": "^1.5.1",
+				"tslib": "~1.9.0"
 			},
 			"dependencies": {
 				"react-transition-group": {
@@ -1001,13 +1002,6 @@
 			"requires": {
 				"classnames": "^2.2",
 				"tslib": "~1.9.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-					"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
-				}
 			}
 		},
 		"@blueprintjs/select": {
@@ -1018,42 +1012,6 @@
 				"@blueprintjs/core": "^3.20.0",
 				"classnames": "^2.2",
 				"tslib": "~1.9.0"
-			},
-			"dependencies": {
-				"@blueprintjs/core": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.20.0.tgz",
-					"integrity": "sha512-0ndz/lLMbSgWu1Z5hdpScfMbkQIOFESejsSW7Jjpin7Hmsjr8fRDU1efoVyG1uHBPmA4B6aYh+uShZHcZGJtig==",
-					"requires": {
-						"@blueprintjs/icons": "^3.12.0",
-						"@types/dom4": "^2.0.1",
-						"classnames": "^2.2",
-						"dom4": "^2.1.5",
-						"normalize.css": "^8.0.1",
-						"popper.js": "^1.15.0",
-						"react-lifecycles-compat": "^3.0.4",
-						"react-popper": "^1.3.3",
-						"react-transition-group": "^2.9.0",
-						"resize-observer-polyfill": "^1.5.1",
-						"tslib": "~1.9.0"
-					}
-				},
-				"react-transition-group": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-					"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-					"requires": {
-						"dom-helpers": "^3.4.0",
-						"loose-envify": "^1.4.0",
-						"prop-types": "^15.6.2",
-						"react-lifecycles-compat": "^3.0.4"
-					}
-				},
-				"tslib": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-					"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
-				}
 			}
 		},
 		"@citation-js/core": {
@@ -1330,6 +1288,13 @@
 				"dom-storage": "2.1.0",
 				"tslib": "1.10.0",
 				"xmlhttprequest": "1.8.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+				}
 			}
 		},
 		"@firebase/app-types": {
@@ -1360,6 +1325,13 @@
 				"@firebase/util": "0.2.28",
 				"faye-websocket": "0.11.3",
 				"tslib": "1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+				}
 			}
 		},
 		"@firebase/database-types": {
@@ -1382,6 +1354,13 @@
 				"@grpc/proto-loader": "^0.5.0",
 				"grpc": "1.23.3",
 				"tslib": "1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+				}
 			}
 		},
 		"@firebase/firestore-types": {
@@ -1398,6 +1377,13 @@
 				"@firebase/messaging-types": "0.3.2",
 				"isomorphic-fetch": "2.2.1",
 				"tslib": "1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+				}
 			}
 		},
 		"@firebase/functions-types": {
@@ -1414,6 +1400,13 @@
 				"@firebase/util": "0.2.28",
 				"idb": "3.0.2",
 				"tslib": "1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+				}
 			}
 		},
 		"@firebase/installations-types": {
@@ -1434,6 +1427,13 @@
 				"@firebase/messaging-types": "0.3.2",
 				"@firebase/util": "0.2.28",
 				"tslib": "1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+				}
 			}
 		},
 		"@firebase/messaging-types": {
@@ -1451,6 +1451,13 @@
 				"@firebase/performance-types": "0.0.3",
 				"@firebase/util": "0.2.28",
 				"tslib": "1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+				}
 			}
 		},
 		"@firebase/performance-types": {
@@ -1483,6 +1490,13 @@
 				"@firebase/storage-types": "0.3.3",
 				"@firebase/util": "0.2.28",
 				"tslib": "1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+				}
 			}
 		},
 		"@firebase/storage-types": {
@@ -1496,6 +1510,13 @@
 			"integrity": "sha512-ZQMAWtXj8y5kvB6izs0aTM/jG+WO8HpqhXA/EwD6LckJ+1P5LnAhaLZt1zR4HpuCE+jeP5I32Id5RJ/aifFs6A==",
 			"requires": {
 				"tslib": "1.10.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+				}
 			}
 		},
 		"@firebase/webchannel-wrapper": {
@@ -3086,9 +3107,9 @@
 			"integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
 		},
 		"@types/node": {
-			"version": "12.12.11",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.11.tgz",
-			"integrity": "sha512-O+x6uIpa6oMNTkPuHDa9MhMMehlxLAd5QcOvKRjAFsBVpeFWTOPnXbDvILvFgFFZfQ1xh1EZi1FbXxUix+zpsQ=="
+			"version": "12.12.12",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.12.tgz",
+			"integrity": "sha512-MGuvYJrPU0HUwqF7LqvIj50RZUX23Z+m583KBygKYUZLlZ88n6w28XRNJRJgsHukLEnLz6w6SvxZoLgbr5wLqQ=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -3125,9 +3146,9 @@
 			}
 		},
 		"@types/react": {
-			"version": "16.9.11",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.11.tgz",
-			"integrity": "sha512-UBT4GZ3PokTXSWmdgC/GeCGEJXE5ofWyibCcecRLUVN2ZBpXQGVgQGtG2foS7CrTKFKlQVVswLvf7Js6XA/CVQ==",
+			"version": "16.9.13",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.13.tgz",
+			"integrity": "sha512-LikzRslbiufJYHyzbHSW0GrAiff8QYLMBFeZmSxzCYGXKxi8m/1PHX+rsVOwhr7mJNq+VIu2Dhf7U6mjFERK6w==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
@@ -4008,9 +4029,9 @@
 			}
 		},
 		"aws-sdk": {
-			"version": "2.575.0",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.575.0.tgz",
-			"integrity": "sha512-GgqiThKKmN9CJcGDApJq+TuHkCYIx7A7QF01KPCn2nvxC5efrrJt/0GtrPXe+yJlKh3cl1HQTVobWiSfMV/xhA==",
+			"version": "2.578.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.578.0.tgz",
+			"integrity": "sha512-QOot7ha8J+w+AQf1UNzpGpbcZtCaK/mqjenG177ybm2nvm00a4PKa5dz/kF/bYi2qMx9yJmiQ17kn32Q5ar8Kg==",
 			"requires": {
 				"buffer": "^4.9.1",
 				"events": "^1.1.1",
@@ -4222,9 +4243,9 @@
 			}
 		},
 		"babel-plugin-macros": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.7.0.tgz",
-			"integrity": "sha512-eV/9IWjmwT/TDCrNzA9sgO/j+x1dWAdLds7KLTY/emkLimzYbiXugfa0EO9IMkLeBBYvS0OdY+6pkF5VGf0iog==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.7.1.tgz",
+			"integrity": "sha512-HNM284amlKSQ6FddI4jLXD+XTqF0cTYOe5uemOIZxHJHnamC+OhFQ57rMF9sgnYhkJQptVl9U1SKVZsV9/GLQQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.7.2",
@@ -4589,6 +4610,24 @@
 						"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
 					}
 				},
+				"@babel/plugin-syntax-dynamic-import": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+					"integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-destructuring": {
+					"version": "7.6.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
+					"integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
 				"@babel/plugin-transform-flow-strip-types": {
 					"version": "7.4.4",
 					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.4.tgz",
@@ -4597,6 +4636,15 @@
 					"requires": {
 						"@babel/helper-plugin-utils": "^7.0.0",
 						"@babel/plugin-syntax-flow": "^7.2.0"
+					}
+				},
+				"@babel/plugin-transform-react-display-name": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+					"integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
 					}
 				},
 				"@babel/plugin-transform-runtime": {
@@ -5384,9 +5432,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001011",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001011.tgz",
-			"integrity": "sha512-h+Eqyn/YA6o6ZTqpS86PyRmNWOs1r54EBDcd2NTwwfsXQ8re1B38SnB+p2RKF8OUsyEIjeDU8XGec1RGO/wYCg=="
+			"version": "1.0.30001012",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001012.tgz",
+			"integrity": "sha512-7RR4Uh04t9K1uYRWzOJmzplgEOAXbfK72oVNokCdMzA67trrhPzy93ahKk1AWHiA0c58tD2P+NHqxrA8FZ+Trg=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -6262,11 +6310,11 @@
 			"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
 		},
 		"core-js-compat": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.1.tgz",
-			"integrity": "sha512-YdeJI26gLc0CQJ9asLE5obEgBz2I0+CIgnoTbS2T0d5IPQw/OCgCIFR527RmpduxjrB3gSEHoGOCTq9sigOyfw==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.2.tgz",
+			"integrity": "sha512-W0Aj+LM3EAxxjD0Kp2o4be8UlnxIZHNupBv2znqrheR4aY2nOn91794k/xoSp+SxqqriiZpTsSwBtZr60cbkwQ==",
 			"requires": {
-				"browserslist": "^4.7.2",
+				"browserslist": "^4.7.3",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
@@ -6278,9 +6326,9 @@
 			}
 		},
 		"core-js-pure": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.4.1.tgz",
-			"integrity": "sha512-q3FgAYoFGS0LaqV4K7oMsJUpGU7Ud3IR6D2qcu7BAvg0OQPuwakrdNlal+0Zsm3bUPBpI5i/r9C6W3uQCcCrSw==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.4.2.tgz",
+			"integrity": "sha512-6+iSif/3zO0bSkhjVY9o4MTdv36X+rO6rqs/UxQ+uxBevmC4fsfwyQwFVdZXXONmLlKVLiXCG8PDvQ2Gn/iteA==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -6736,9 +6784,9 @@
 			}
 		},
 		"d3-interpolate": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.3.3.tgz",
-			"integrity": "sha512-wTsi4AqnC2raZ3Q9eqFxiZGUf5r6YiEdi23vXjjKSWXFYLCQNUtBVMk6uk2tg4cOY6YrjRdmSmI/Mf0ze1zPzQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+			"integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
 			"requires": {
 				"d3-color": "1"
 			}
@@ -7312,9 +7360,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.307",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.307.tgz",
-			"integrity": "sha512-01rTsAqHwf3D2X6NtlUvzB2hxDj67kiTVIO5GWdFb2unA0QvFvrjyrtc993ByRLF+surlr+9AvJdD0UYs5HzwA=="
+			"version": "1.3.314",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.314.tgz",
+			"integrity": "sha512-IKDR/xCxKFhPts7h+VaSXS02Z1mznP3fli1BbXWXeN89i2gCzKraU8qLpEid8YzKcmZdZD3Mly3cn5/lY9xsBQ=="
 		},
 		"element-resize-detector": {
 			"version": "1.1.15",
@@ -7326,9 +7374,9 @@
 			}
 		},
 		"elliptic": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
-			"integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -7619,17 +7667,17 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
-			"integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
+			"integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
 			"requires": {
-				"es-to-primitive": "^1.2.0",
+				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.0",
+				"has-symbols": "^1.0.1",
 				"is-callable": "^1.1.4",
 				"is-regex": "^1.0.4",
-				"object-inspect": "^1.6.0",
+				"object-inspect": "^1.7.0",
 				"object-keys": "^1.1.1",
 				"string.prototype.trimleft": "^2.1.0",
 				"string.prototype.trimright": "^2.1.0"
@@ -7646,12 +7694,12 @@
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.52",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz",
-			"integrity": "sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==",
+			"version": "0.10.53",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+			"integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
 			"requires": {
 				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.2",
+				"es6-symbol": "~3.1.3",
 				"next-tick": "~1.0.0"
 			}
 		},
@@ -8894,12 +8942,12 @@
 			}
 		},
 		"file-loader": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-4.2.0.tgz",
-			"integrity": "sha512-+xZnaK5R8kBJrHK0/6HRlrKNamvVS5rjyuju+rnyxRGuwUJwpAMsVzUl5dz6rK8brkzjV6JpcFNjp6NqV0g1OQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-4.3.0.tgz",
+			"integrity": "sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==",
 			"requires": {
 				"loader-utils": "^1.2.3",
-				"schema-utils": "^2.0.0"
+				"schema-utils": "^2.5.0"
 			}
 		},
 		"file-saver": {
@@ -9062,39 +9110,39 @@
 			},
 			"dependencies": {
 				"@firebase/app-types": {
-					"version": "0.4.7",
-					"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.4.7.tgz",
-					"integrity": "sha512-4LnhDYsUhgxMBnCfQtWvrmMy9XxeZo059HiRbpt3ufdpUcZZOBDOouQdjkODwHLhcnNrB7LeyiqYpS2jrLT8Mw=="
+					"version": "0.4.8",
+					"resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.4.8.tgz",
+					"integrity": "sha512-VTjWRooelMExK/rKArp6WqnWJJfi8Vs6VuDYDSeMcQ3NpSux2bW1dfJFuzYmiK1+37hEJP1F43DyUDv2lCJquw=="
 				},
 				"@firebase/database": {
-					"version": "0.5.12",
-					"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.5.12.tgz",
-					"integrity": "sha512-DIljaH+XspE6hRHErAkXAKLDiNIJkdmz0QaAWxSxqIumXgNDcxP8jEoJUXtuztWIqAhgD8z8q9/eNyYpM/p3nA==",
+					"version": "0.5.13",
+					"resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.5.13.tgz",
+					"integrity": "sha512-B1+6Ns3jbpryDUi6ZohByXk8EPcuD5rUla1UchzdCjsU1waq06QyUrakow5Hr5RugqmziMAOfzpXid+wV4+bvw==",
 					"requires": {
-						"@firebase/database-types": "0.4.7",
-						"@firebase/logger": "0.1.30",
-						"@firebase/util": "0.2.33",
+						"@firebase/database-types": "0.4.8",
+						"@firebase/logger": "0.1.31",
+						"@firebase/util": "0.2.34",
 						"faye-websocket": "0.11.3",
 						"tslib": "1.10.0"
 					}
 				},
 				"@firebase/database-types": {
-					"version": "0.4.7",
-					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.4.7.tgz",
-					"integrity": "sha512-7UHZ0n6aj3sR5W4HsU18dysHMSIS6348xWTMypoA0G4mORaQSuleCSL6zJLaCosarDEojnncy06yW69fyFxZtA==",
+					"version": "0.4.8",
+					"resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.4.8.tgz",
+					"integrity": "sha512-bYGzvcwjGOSWuL43nldY3kD3ldPDLTiiOF0TItsJx2JdL58PzGiGaR71dvPJhueNBn+bwJ5KPJxpqTSVqM/j8w==",
 					"requires": {
-						"@firebase/app-types": "0.4.7"
+						"@firebase/app-types": "0.4.8"
 					}
 				},
 				"@firebase/logger": {
-					"version": "0.1.30",
-					"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.30.tgz",
-					"integrity": "sha512-smlUDMiOLZD7kgBzcdSbICCvDblglq0X3NUcvV450kjZxOOPY1jPK54Qd/m0qbKrRlHWwr83reJGcPQDVBXd+A=="
+					"version": "0.1.31",
+					"resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.31.tgz",
+					"integrity": "sha512-1OEJaCMMaaT0VleNwer3bocbd25beR6KZUaHBweLNHEFxaNvniSv+lm83g08dWLBml3ZVOb945hp6m8REFx6/Q=="
 				},
 				"@firebase/util": {
-					"version": "0.2.33",
-					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.33.tgz",
-					"integrity": "sha512-Z4gUew2wtPhLU9SKrHL8c3H66+MjY2JKtrlGLNdIVJGgR4i7AoNPnPdi13mpTXPKVuHe9ANDq/O04GfY89WXug==",
+					"version": "0.2.34",
+					"resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.34.tgz",
+					"integrity": "sha512-k8pNIzNLncvxDrqYVZN6/lnqZWy0OCJuZmK5urodARwdLy3sVLw5p9PWce0v9qzMO8tLdrBbCpnm1KJ8jg/kBQ==",
 					"requires": {
 						"tslib": "1.10.0"
 					}
@@ -9103,6 +9151,11 @@
 					"version": "8.10.59",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
 					"integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ=="
+				},
+				"tslib": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+					"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
 				}
 			}
 		},
@@ -10117,9 +10170,9 @@
 			"dev": true
 		},
 		"fuse.js": {
-			"version": "3.4.5",
-			"resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.5.tgz",
-			"integrity": "sha512-s9PGTaQIkT69HaeoTVjwGsLfb8V8ScJLx5XGFcKHg0MqLUH/UZ4EKOtqtXX9k7AFqCGxD1aJmYb8Q5VYDibVRQ==",
+			"version": "3.4.6",
+			"resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.6.tgz",
+			"integrity": "sha512-H6aJY4UpLFwxj1+5nAvufom5b2BT2v45P1MkPvdGIK8fWjQx/7o6tTT1+ALV0yawQvbmvCF0ufl2et8eJ7v7Cg==",
 			"dev": true
 		},
 		"fuzzysearch": {
@@ -12182,11 +12235,11 @@
 			"dev": true
 		},
 		"is-symbol": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
 			"requires": {
-				"has-symbols": "^1.0.0"
+				"has-symbols": "^1.0.1"
 			}
 		},
 		"is-typedarray": {
@@ -15452,9 +15505,9 @@
 			"integrity": "sha1-1GV3zQpyr0FTU/y4oBF622JC+cg="
 		},
 		"node-releases": {
-			"version": "1.1.40",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.40.tgz",
-			"integrity": "sha512-r4LPcC5b/bS8BdtWH1fbeK88ib/wg9aqmg6/s3ngNLn2Ewkn/8J6Iw3P9RTlfIAdSdvYvQl2thCY5Y+qTAQ2iQ==",
+			"version": "1.1.41",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.41.tgz",
+			"integrity": "sha512-+IctMa7wIs8Cfsa8iYzeaLTFwv5Y4r5jZud+4AnfymzeEXKBCavFX0KBgzVaPVqf0ywa6PrO8/b+bPqdwjGBSg==",
 			"requires": {
 				"semver": "^6.3.0"
 			},
@@ -18453,9 +18506,9 @@
 			}
 		},
 		"react-dropzone": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-10.2.0.tgz",
-			"integrity": "sha512-VvJtg6GKtM1Xu+SsMcBNBcB2XcOi27xbNLBMDkrpqsk3cSILFiBVoCuW96FSOWkCK1IFeNg67FjKu/c/KuUhkg==",
+			"version": "10.2.1",
+			"resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-10.2.1.tgz",
+			"integrity": "sha512-Me5nOu8hK9/Xyg5easpdfJ6SajwUquqYR/2YTdMotsCUgJ1pHIIwNsv0n+qcIno0tWR2V2rVQtj2r/hXYs2TnQ==",
 			"requires": {
 				"attr-accept": "^2.0.0",
 				"file-selector": "^0.1.12",
@@ -18843,25 +18896,25 @@
 			}
 		},
 		"reakit": {
-			"version": "1.0.0-beta.12",
-			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.0-beta.12.tgz",
-			"integrity": "sha512-jf/0RWmJypG9wFbbCSj9mFxb474TCFnAweKnrh3yLJiMjKDEAFXic0cNyhqxSuOUUyZeT67bUFbu25DXBNfRmQ==",
+			"version": "1.0.0-beta.13",
+			"resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.0-beta.13.tgz",
+			"integrity": "sha512-lQ50v2801aBi6+8pZ3iD09U7URYNGEo99vrF+NSPlDzYWofbiIAiEZ2hpTnNtc/8OXZusrkrVW1d8rsmJGNWhw==",
 			"requires": {
 				"body-scroll-lock": "^2.6.4",
 				"popper.js": "^1.16.0",
-				"reakit-system": "^0.7.0",
-				"reakit-utils": "^0.7.1"
+				"reakit-system": "^0.7.1",
+				"reakit-utils": "^0.7.2"
 			}
 		},
 		"reakit-system": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.7.0.tgz",
-			"integrity": "sha512-6MaQsoyIhU0b0RGfIfGSSGujCx0XVBtfJkRcn+TviiWwMXGS9liTCDBE1vn7fLnUYiR6kqll50Nmw//oIn97cg=="
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.7.1.tgz",
+			"integrity": "sha512-a7hGv5hVe2yjSmy9EgCe6wgeBC/EPoLXxp9XFuP2VWmFw8ufJ4K7hvY/OWRgqxZHgoEoUWbO6fxYYEfZ7YfoPg=="
 		},
 		"reakit-utils": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.7.1.tgz",
-			"integrity": "sha512-xQJctof9V+wkC7OxSL7P14d5Se6l/apCfhY8liIfVihtakzXOkvKea4Ka/TbEfpoTKN7MRO4xNMxjfzuGFexHQ=="
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.7.2.tgz",
+			"integrity": "sha512-cHG5QjimeYQEWJjmrEK+p2YwaOiqbwkbhzZlqQHOfYj5h7B/MrpyssVYlDBSQozEXM9pZwtUFGQSI2bG9jok9A=="
 		},
 		"realpath-native": {
 			"version": "1.1.0",
@@ -19315,9 +19368,9 @@
 			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
 		},
 		"resolve": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.2.tgz",
+			"integrity": "sha512-cAVTI2VLHWYsGOirfeYVVQ7ZDejtQ9fp4YhYckWDEkFfqbVjaT11iM8k6xSAfGFMM+gDpZjMnFssPu8we+mqFw==",
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -21173,16 +21226,16 @@
 			}
 		},
 		"telejson": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/telejson/-/telejson-3.1.0.tgz",
-			"integrity": "sha512-mhiVy+xp2atri1bzSzdy/gVGXlOhibaoZ092AUq5xhnrZGdzhF0fLaOduHJQghkro+qmjYMwhsOL9CkD2zTicg==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/telejson/-/telejson-3.3.0.tgz",
+			"integrity": "sha512-er08AylQ+LEbDLp1GRezORZu5wKOHaBczF6oYJtgC3Idv10qZ8A3p6ffT+J5BzDKkV9MqBvu8HAKiIIOp6KJ2w==",
 			"dev": true,
 			"requires": {
 				"@types/is-function": "^1.0.0",
 				"global": "^4.4.0",
 				"is-function": "^1.0.1",
 				"is-regex": "^1.0.4",
-				"is-symbol": "^1.0.2",
+				"is-symbol": "^1.0.3",
 				"isobject": "^4.0.0",
 				"lodash": "^4.17.15",
 				"memoizerific": "^1.11.3"
@@ -21628,9 +21681,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
 		},
 		"tty-browserify": {
 			"version": "0.0.0",
@@ -22042,14 +22095,14 @@
 			"integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g="
 		},
 		"url-loader": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-2.2.0.tgz",
-			"integrity": "sha512-G8nk3np8ZAnwhHXas1JxJEwJyQdqFXAKJehfgZ/XrC48volFBRtO+FIKtF2u0Ma3bw+4vnDVjHPAQYlF9p2vsw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-2.3.0.tgz",
+			"integrity": "sha512-goSdg8VY+7nPZKUEChZSEtW5gjbS66USIGCeSJ1OVOJ7Yfuh/36YxCwMi5HVEJh6mqUYOoy3NJ0vlOMrWsSHog==",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^1.2.3",
 				"mime": "^2.4.4",
-				"schema-utils": "^2.4.1"
+				"schema-utils": "^2.5.0"
 			},
 			"dependencies": {
 				"mime": {

--- a/server/branch/model.js
+++ b/server/branch/model.js
@@ -34,10 +34,15 @@ export default (sequelize, dataTypes) => {
 		{
 			classMethods: {
 				associate: (models) => {
-					const { Branch, BranchPermission } = models;
+					const { Branch, BranchPermission, Export } = models;
 					Branch.hasMany(BranchPermission, {
 						onDelete: 'CASCADE',
 						as: 'permissions',
+						foreignKey: 'branchId',
+					});
+					Branch.hasMany(Export, {
+						onDelete: 'CASCADE',
+						as: 'exports',
 						foreignKey: 'branchId',
 					});
 				},

--- a/server/branch/permissions.js
+++ b/server/branch/permissions.js
@@ -36,6 +36,33 @@ export const getBranchAccess = (accessHash, branchData, userId, isCommunityAdmin
 	};
 };
 
+export const getBranchAccessForUser = async ({ branchId, userId, accessHash }) => {
+	const branchData = await Branch.findOne({
+		where: { id: branchId },
+		include: [
+			{
+				model: BranchPermission,
+				as: 'permissions',
+				required: false,
+			},
+		],
+	});
+	const pubData = await Pub.findOne({ where: { id: branchData.pubId } });
+	const [pubManager, communityAdmin] = userId
+		? await Promise.all([
+				PubManager.findOne({
+					where: { userId: userId, pubId: branchData.pubId },
+					raw: true,
+				}),
+				CommunityAdmin.findOne({
+					where: { userId: userId, communityId: pubData.communityId },
+					raw: true,
+				}),
+		  ])
+		: [null, null];
+	return getBranchAccess(accessHash, branchData, userId, communityAdmin, pubManager);
+};
+
 export const getPermissions = ({ branchId, userId, pubId, communityId }) => {
 	if (!userId || !communityId || !pubId) {
 		return new Promise((resolve) => {

--- a/server/export/__tests__/api.test.js
+++ b/server/export/__tests__/api.test.js
@@ -1,0 +1,209 @@
+/* global describe, it, expect, beforeAll, afterAll, afterEach */
+import {
+	makeUser,
+	makePub,
+	makeCommunity,
+	setup,
+	teardown,
+	login,
+	stubOut,
+} from '../../../stubstub';
+import { Export, WorkerTask } from '../../models';
+import * as serverUtils from '../../utils';
+
+let pubManager;
+let pub;
+let branch;
+
+setup(beforeAll, async () => {
+	const mc = await makeCommunity();
+	pubManager = await makeUser();
+	pub = await makePub(mc.community, pubManager);
+	branch = pub.branches.find((br) => br.title === 'draft');
+});
+
+afterEach(async () => {
+	await Export.destroy({ where: { pubId: pub.id } });
+});
+
+teardown(afterAll);
+
+stubOut(serverUtils, 'addWorkerTask');
+
+const makeExportQuery = (
+	historyKey,
+	{ format = 'pdf', accessHash = null, branchId = branch.id } = {},
+) => {
+	return {
+		pubId: pub.id,
+		branchId: branchId,
+		historyKey: historyKey,
+		accessHash: accessHash,
+		format: format,
+	};
+};
+
+describe('/api/export', () => {
+	it('Does not create an export of #draft for a user without permission', async () => {
+		const agent = await login();
+		await agent
+			.post('/api/export')
+			.send(makeExportQuery(0))
+			.expect(403);
+	});
+
+	it('Creates an export of #draft for a user with a valid access hash', async () => {
+		const agent = await login();
+		await agent
+			.post('/api/export')
+			.send(makeExportQuery(0, { accessHash: branch.viewHash }))
+			.expect(201);
+	});
+
+	it('Creates an export of #draft for the pub manager', async () => {
+		const agent = await login(pubManager);
+		await agent
+			.post('/api/export')
+			.send(makeExportQuery(0))
+			.expect(201);
+	});
+
+	it('Creates an export of #public for anyone', async () => {
+		const agent = await login();
+		await agent
+			.post('/api/export')
+			.send(
+				makeExportQuery(0, {
+					branchId: pub.branches.find((br) => br.title === 'public').id,
+				}),
+			)
+			.expect(201);
+	});
+
+	it('Creates a new worker task or returns an existing one, appropriately', async () => {
+		const agent = await login(pubManager);
+		// Kick off a worker task
+		const {
+			body: { taskId },
+		} = await agent
+			.post('/api/export')
+			.send(makeExportQuery(0))
+			.expect(201);
+		const workerTask = await WorkerTask.findOne({ where: { id: taskId } });
+		expect(workerTask.type).toEqual('export');
+		// Now query again and check that we refer to the same worker task
+		const { body: bodyAgain } = await agent
+			.post('/api/export')
+			.send(makeExportQuery(0))
+			.expect(201);
+		expect(bodyAgain.taskId).toEqual(taskId);
+	});
+
+	it('Returns the URL of a completed export', async () => {
+		const agent = await login(pubManager);
+		// Kick off a worker task
+		const {
+			body: { taskId },
+		} = await agent
+			.post('/api/export')
+			.send(makeExportQuery(0))
+			.expect(201);
+		// Now simulate the worker task completing
+		await Export.update({ url: 'any_url' }, { where: { workerTaskId: taskId } });
+		// Hit the API again and make sure we are served the right URL
+		const {
+			body: { url },
+		} = await agent
+			.post('/api/export')
+			.send(makeExportQuery(0))
+			.expect(201);
+		expect(url).toEqual('any_url');
+	});
+
+	it('Does not conflate the formats of existing exports', async () => {
+		const agent = await login(pubManager);
+		// Kick off a worker task
+		const {
+			body: { taskId: docxTaskId },
+		} = await agent
+			.post('/api/export')
+			.send(makeExportQuery(0, { format: 'docx' }))
+			.expect(201);
+		// Ask for the same history key but in a different format
+		const {
+			body: { taskId: pdfTaskId },
+		} = await agent
+			.post('/api/export')
+			.send(makeExportQuery(0, { format: 'pdf' }))
+			.expect(201);
+
+		expect(docxTaskId).not.toEqual(pdfTaskId);
+		// Now simulate the first worker task completing
+		await Export.update({ url: 'any_url' }, { where: { workerTaskId: docxTaskId } });
+		// Ask for the PDF again and ensure we are given the pending task rather than the completed
+		// URL in the wrong format.
+		const {
+			body: { taskId: pdfTaskIdAgain },
+		} = await agent
+			.post('/api/export')
+			.send(makeExportQuery(0, { format: 'pdf' }))
+			.expect(201);
+		expect(pdfTaskIdAgain).toEqual(pdfTaskId);
+	});
+
+	it('Creates a new export if the key has advanced', async () => {
+		const agent = await login(pubManager);
+		// Kick off a worker task
+		const {
+			body: { taskId: taskId0 },
+		} = await agent
+			.post('/api/export')
+			.send(makeExportQuery(0))
+			.expect(201);
+		// Kick off another worker task for a different history key
+		const {
+			body: { taskId: taskId1 },
+		} = await agent
+			.post('/api/export')
+			.send(makeExportQuery(1))
+			.expect(201);
+		// Make sure these are two different tasks
+		expect(taskId0).not.toEqual(taskId1);
+		// Now let one of the tasks finish
+		await Export.update({ url: 'any_url' }, { where: { workerTaskId: taskId0 } });
+		// And query for yet another history key
+		const {
+			body: { taskId: taskId2 },
+		} = await agent
+			.post('/api/export')
+			.send(makeExportQuery(2))
+			.expect(201);
+		// And make sure that this creates yet another task.
+		expect([taskId0, taskId1]).not.toContain(taskId2);
+	});
+
+	it('Restarts the export if another task failed', async () => {
+		const agent = await login(pubManager);
+		// Kick off a worker task
+		const {
+			body: { taskId: failingTaskId },
+		} = await agent
+			.post('/api/export')
+			.send(makeExportQuery(0))
+			.expect(201);
+		// Now make the worker task fail.
+		await WorkerTask.update(
+			{ error: 'something terrible happened' },
+			{ where: { id: failingTaskId } },
+		);
+		// Now try again...
+		const {
+			body: { taskId: retryingTaskId },
+		} = await agent
+			.post('/api/export')
+			.send(makeExportQuery(0))
+			.expect(201);
+		// ...And expect to see a new task ID.
+		expect(retryingTaskId).not.toEqual(failingTaskId);
+	});
+});

--- a/server/export/api.js
+++ b/server/export/api.js
@@ -1,10 +1,10 @@
 import app from '../server';
-import { startExportTask } from './queries';
+import { getOrStartExportTask } from './queries';
 
 app.post('/api/export', (req, res) => {
-	return startExportTask(req.body)
-		.then((exportData) => {
-			return res.status(200).json(exportData.workerTaskId);
+	return getOrStartExportTask(req.body)
+		.then((result) => {
+			return res.status(200).json(result);
 		})
 		.catch((err) => {
 			console.error('Error in postExport: ', err);

--- a/server/export/api.js
+++ b/server/export/api.js
@@ -1,10 +1,10 @@
 import app from '../server';
-import { createExport } from './queries';
+import { startExportTask } from './queries';
 
 app.post('/api/export', (req, res) => {
-	return createExport(req.body)
-		.then((taskData) => {
-			return res.status(200).json(taskData.id);
+	return startExportTask(req.body)
+		.then((exportData) => {
+			return res.status(200).json(exportData.workerTaskId);
 		})
 		.catch((err) => {
 			console.error('Error in postExport: ', err);

--- a/server/export/api.js
+++ b/server/export/api.js
@@ -1,13 +1,43 @@
-import app from '../server';
-import { getOrStartExportTask } from './queries';
+import app, { wrap } from '../server';
+import { ForbiddenError } from '../errors';
 
-app.post('/api/export', (req, res) => {
-	return getOrStartExportTask(req.body)
-		.then((result) => {
-			return res.status(200).json(result);
-		})
-		.catch((err) => {
-			console.error('Error in postExport: ', err);
-			return res.status(500).json(err.message);
+import { getOrStartExportTask } from './queries';
+import { getPermissions } from './permissions';
+
+const getRequestData = (req) => {
+	const user = req.user || {};
+	const { accessHash, branchId, format, historyKey, pubId } = req;
+	return {
+		accessHash: accessHash,
+		branchId: branchId,
+		format: format,
+		historyKey: historyKey,
+		pubId: pubId,
+		userId: user.id,
+	};
+};
+
+app.post(
+	'/api/export',
+	wrap(async (req, res) => {
+		const { accessHash, branchId, format, historyKey, pubId, userId } = getRequestData(req);
+		const permissions = await getPermissions({
+			accessHash: accessHash,
+			branchId: branchId,
+			userId: userId,
 		});
-});
+
+		if (!permissions.create) {
+			throw new ForbiddenError();
+		}
+
+		const result = await getOrStartExportTask({
+			branchId: branchId,
+			format: format,
+			historyKey: historyKey,
+			pubId: pubId,
+		});
+
+		return res.status(201).json(result);
+	}),
+);

--- a/server/export/api.js
+++ b/server/export/api.js
@@ -6,7 +6,7 @@ import { getPermissions } from './permissions';
 
 const getRequestData = (req) => {
 	const user = req.user || {};
-	const { accessHash, branchId, format, historyKey, pubId } = req;
+	const { accessHash, branchId, format, historyKey, pubId } = req.body;
 	return {
 		accessHash: accessHash,
 		branchId: branchId,

--- a/server/export/model.js
+++ b/server/export/model.js
@@ -1,0 +1,25 @@
+export default (sequelize, dataTypes) => {
+	return sequelize.define(
+		'Export',
+		{
+			id: sequelize.idType,
+			branchId: { type: dataTypes.UUID, allowNull: false },
+			format: { type: dataTypes.STRING, allowNull: false },
+			historyKey: { type: dataTypes.INTEGER, allowNull: false },
+			pubId: { type: dataTypes.UUID, allowNull: false },
+			workerTaskId: { type: dataTypes.UUID, allowNull: true },
+		},
+		{
+			classMethods: {
+				associate: (models) => {
+					const { Export, WorkerTask } = models;
+					Export.belongsTo(WorkerTask, {
+						onDelete: 'SET NULL',
+						as: 'workerTask',
+						foreignKey: 'workerTaskId',
+					});
+				},
+			},
+		},
+	);
+};

--- a/server/export/model.js
+++ b/server/export/model.js
@@ -5,6 +5,7 @@ export default (sequelize, dataTypes) => {
 			id: sequelize.idType,
 			branchId: { type: dataTypes.UUID, allowNull: false },
 			format: { type: dataTypes.STRING, allowNull: false },
+			url: { type: dataTypes.STRING, allowNull: true },
 			historyKey: { type: dataTypes.INTEGER, allowNull: false },
 			pubId: { type: dataTypes.UUID, allowNull: false },
 			workerTaskId: { type: dataTypes.UUID, allowNull: true },

--- a/server/export/permissions.js
+++ b/server/export/permissions.js
@@ -1,25 +1,11 @@
-import { CommunityAdmin, PubManager, Branch } from '../models';
-import { getBranchAccess } from '../branch/permissions';
+import { getBranchAccessForUser } from '../branch/permissions';
 
 export const getPermissions = async ({ branchId, userId, accessHash }) => {
-	const branchData = await Branch.findOne({ where: { id: branchId } });
-	const [pubManager, communityAdmin] = Promise.all(
-		PubManager.findOne({
-			where: { userId: userId, pubId: branchData.pubId },
-			raw: true,
-		}),
-		CommunityAdmin.findOne({
-			where: { userId: userId, communityId: branchData.pubId },
-			raw: true,
-		}),
-	);
-	const branchAccess = getBranchAccess(
-		accessHash,
-		branchData,
-		userId,
-		communityAdmin,
-		pubManager,
-	);
+	const branchAccess = await getBranchAccessForUser({
+		branchId: branchId,
+		userId: userId,
+		accessHash: accessHash,
+	});
 	return {
 		create: branchAccess.canView,
 	};

--- a/server/export/permissions.js
+++ b/server/export/permissions.js
@@ -1,0 +1,26 @@
+import { CommunityAdmin, PubManager, Branch } from '../models';
+import { getBranchAccess } from '../branch/permissions';
+
+export const getPermissions = async ({ branchId, userId, accessHash }) => {
+	const branchData = await Branch.findOne({ where: { id: branchId } });
+	const [pubManager, communityAdmin] = Promise.all(
+		PubManager.findOne({
+			where: { userId: userId, pubId: branchData.pubId },
+			raw: true,
+		}),
+		CommunityAdmin.findOne({
+			where: { userId: userId, communityId: branchData.pubId },
+			raw: true,
+		}),
+	);
+	const branchAccess = getBranchAccess(
+		accessHash,
+		branchData,
+		userId,
+		communityAdmin,
+		pubManager,
+	);
+	return {
+		create: branchAccess.canView,
+	};
+};

--- a/server/merge/queries.js
+++ b/server/merge/queries.js
@@ -1,6 +1,7 @@
 import { Merge, Review, Branch } from '../models';
 import { mergeFirebaseBranch } from '../utils/firebaseAdmin';
 import { createMergedReviewEvent } from '../reviewEvent/queries';
+import { createBranchExports } from '../export/queries';
 
 export const createMerge = (inputValues, userData) => {
 	return mergeFirebaseBranch(
@@ -51,7 +52,8 @@ export const createMerge = (inputValues, userData) => {
 				: undefined;
 			return Promise.all([newMergeData, createMergeEvent, updateReview]);
 		})
-		.then(([newMergeData, newReviewEvent]) => {
+		.then(async ([newMergeData, newReviewEvent]) => {
+			await createBranchExports(inputValues.pubId, inputValues.destinationBranchId);
 			return { newMerge: newMergeData, newReviewEvents: [newReviewEvent] };
 		});
 };

--- a/server/migrations.js
+++ b/server/migrations.js
@@ -5,6 +5,7 @@ import {
 	sequelize,
 	Pub,
 	Branch,
+	Export,
 	Version,
 	PubManager,
 	Collaborator,
@@ -679,6 +680,10 @@ new Promise((resolve) => {
 	// 		defaultValue: false,
 	// 	});
 	// })
+	.then(() => {
+		// Handle addition of Export model and Branch.exports field
+		return sequelize.sync();
+	})
 	.catch((err) => {
 		console.log('Error with Migration', err);
 	})

--- a/server/models.js
+++ b/server/models.js
@@ -39,6 +39,7 @@ export const CollectionPub = sequelize.import('./collectionPub/model.js');
 export const Community = sequelize.import('./community/model.js');
 export const CommunityAdmin = sequelize.import('./communityAdmin/model.js');
 export const Discussion = sequelize.import('./discussion/model.js');
+export const Export = sequelize.import('./export/model.js');
 export const Merge = sequelize.import('./merge/model.js');
 export const Page = sequelize.import('./page/model.js');
 export const Pub = sequelize.import('./pub/model.js');

--- a/server/utils/pubQueries.js
+++ b/server/utils/pubQueries.js
@@ -10,6 +10,7 @@ import {
 	CollectionPub,
 	CommunityAdmin,
 	Discussion,
+	Export,
 	Page,
 	Pub,
 	PubAttribution,
@@ -120,6 +121,10 @@ export const findPubQuery = (slug, communityId) =>
 								attributes: attributesPublicUser,
 							},
 						],
+					},
+					{
+						model: Export,
+						as: 'exports',
 					},
 				],
 			},

--- a/shared/export/formats.js
+++ b/shared/export/formats.js
@@ -1,0 +1,14 @@
+const exportFormatTypes = {
+	html: { extension: 'html', title: 'HTML' },
+	pdf: { extension: 'pdf', pagedTarget: true, title: 'PDF' },
+	docx: { pandocTarget: 'docx', extension: 'docx', title: 'Word' },
+	epub: { pandocTarget: 'epub', extension: 'epub', title: 'EPUB' },
+	markdown: { pandocTarget: 'markdown_strict', extension: 'md', title: 'Markdown' },
+	odt: { pandocTarget: 'odt', extension: 'odt', title: 'OpenDocument' },
+	plain: { pandocTarget: 'plain', extension: 'txt', title: 'Plain Text' },
+	jats: { pandocTarget: 'jats', extension: 'xml', title: 'JATS XML' },
+	tex: { pandocTarget: 'latex', extension: 'tex', title: 'LaTeX' },
+};
+
+export const getExportFormats = () => Object.keys(exportFormatTypes);
+export const getExportFormatDetails = (key) => exportFormatTypes[key];

--- a/stubstub/global/setup.js
+++ b/stubstub/global/setup.js
@@ -12,6 +12,6 @@ export default async () => {
 		process.env.DATABASE_URL = await setupTestDatabase();
 	}
 	// eslint-disable-next-line global-require
-	const { sequelize } = require('../../server/models.js');
+	const { sequelize } = require('esm')(module)('../../server/models.js');
 	await sequelize.sync({ force: false });
 };

--- a/stubstub/index.js
+++ b/stubstub/index.js
@@ -1,4 +1,4 @@
 export { setup, teardown } from './prepare';
-export { makeUser, makeCommunity } from './modelHelpers';
+export { makeUser, makeCommunity, makePub } from './modelHelpers';
 export { login } from './userToAgentMap';
-export { stubModule as stub, stubFirebaseAdmin } from './stub';
+export { stubModule as stub, stubOut, stubFirebaseAdmin } from './stub';

--- a/stubstub/modelHelpers.js
+++ b/stubstub/modelHelpers.js
@@ -2,7 +2,8 @@ import uuid from 'uuid';
 import SHA3 from 'crypto-js/sha3';
 import encHex from 'crypto-js/enc-hex';
 
-import { Community, CommunityAdmin, User } from '../server/models';
+import { Branch, Community, CommunityAdmin, User, Pub } from '../server/models';
+import { createPub } from '../server/pub/queries';
 
 export const makeUser = async (info = {}) => {
 	const uniqueness = uuid.v4();
@@ -57,4 +58,13 @@ export const makeCommunity = async (communityData, communityAdminInfo = {}) => {
 		};
 	}
 	return { community: community };
+};
+
+export const makePub = async (community, manager) => {
+	if (!manager) {
+		// eslint-disable-next-line no-param-reassign
+		manager = await makeUser();
+	}
+	const { id: pubId } = await createPub({ communityId: community.id }, manager);
+	return Pub.findOne({ where: { id: pubId }, include: [{ model: Branch, as: 'branches' }] });
 };

--- a/stubstub/stub.js
+++ b/stubstub/stub.js
@@ -1,3 +1,4 @@
+/* global beforeAll, afterAll */
 import sinon from 'sinon';
 
 import { getEmptyDoc } from '@pubpub/editor/dist/utils';
@@ -21,8 +22,19 @@ export const stubModule = (module, functionNames) => {
 	};
 };
 
+export const stubOut = (module, functionNames, before = beforeAll, after = afterAll) => {
+	let restore;
+	before(() => {
+		restore = stubModule(module, functionNames).restore;
+	});
+	after(() => {
+		if (restore) {
+			restore();
+		}
+	});
+};
+
 export const stubFirebaseAdmin = () => {
-	/* global beforeAll, afterAll */
 	let stubs;
 
 	beforeAll(() => {

--- a/workers/tasks/export/export.js
+++ b/workers/tasks/export/export.js
@@ -1,10 +1,11 @@
+import { getExportFormatDetails } from 'shared/export/formats';
+
 import { createStaticHtml } from './html';
 import { getPubMetadata } from './metadata';
 import { callPandoc } from './pandoc';
 import { getProsemirrorPubData } from './prosemirror';
 import {
 	getExportById,
-	getFormatDetails,
 	getTmpFileForExtension,
 	uploadDocument,
 	writeToFile,
@@ -13,11 +14,15 @@ import {
 import { callPaged } from './paged';
 
 export const exportTask = async ({ exportId }, collectSubprocess) => {
-	const { pubId, branchId, format } = await getExportById(exportId);
-	const { extension, pandocTarget, pagedTarget } = getFormatDetails(format);
+	const { pubId, branchId, format, historyKey } = await getExportById(exportId);
+	const { extension, pandocTarget, pagedTarget } = getExportFormatDetails(format);
 	const tmpFile = await getTmpFileForExtension(extension);
 	const pubMetadata = await getPubMetadata(pubId);
-	const { prosemirrorDoc, citations, footnotes } = await getProsemirrorPubData(pubId, branchId);
+	const { prosemirrorDoc, citations, footnotes } = await getProsemirrorPubData(
+		pubId,
+		branchId,
+		historyKey,
+	);
 	const staticHtml = await createStaticHtml(
 		{
 			prosemirrorDoc: prosemirrorDoc,

--- a/workers/tasks/export/export.js
+++ b/workers/tasks/export/export.js
@@ -2,10 +2,18 @@ import { createStaticHtml } from './html';
 import { getPubMetadata } from './metadata';
 import { callPandoc } from './pandoc';
 import { getProsemirrorPubData } from './prosemirror';
-import { getFormatDetails, getTmpFileForExtension, uploadDocument, writeToFile } from './util';
+import {
+	getExportById,
+	getFormatDetails,
+	getTmpFileForExtension,
+	uploadDocument,
+	writeToFile,
+	assignFileToExportById,
+} from './util';
 import { callPaged } from './paged';
 
-export const exportTask = async ({ pubId, branchId, format }, collectSubprocess) => {
+export const exportTask = async ({ exportId }, collectSubprocess) => {
+	const { pubId, branchId, format } = await getExportById(exportId);
 	const { extension, pandocTarget, pagedTarget } = getFormatDetails(format);
 	const tmpFile = await getTmpFileForExtension(extension);
 	const pubMetadata = await getPubMetadata(pubId);
@@ -32,5 +40,7 @@ export const exportTask = async ({ pubId, branchId, format }, collectSubprocess)
 	} else {
 		await writeToFile(staticHtml, tmpFile);
 	}
-	return uploadDocument(branchId, tmpFile, extension);
+	const url = await uploadDocument(branchId, tmpFile, extension);
+	await assignFileToExportById(exportId, url);
+	return { url: url };
 };

--- a/workers/tasks/export/prosemirror.js
+++ b/workers/tasks/export/prosemirror.js
@@ -4,8 +4,8 @@ import discussionSchema from 'containers/Pub/PubDocument/DiscussionAddon/discuss
 import { getBranchDoc } from '../../../server/utils/firebaseAdmin';
 import { generateCiteHtmls } from '../../../server/editor/queries';
 
-export const getProsemirrorPubData = async (pubId, branchId) => {
-	const { content: prosemirrorDoc } = await getBranchDoc(pubId, branchId);
+export const getProsemirrorPubData = async (pubId, branchId, historyKey) => {
+	const { content: prosemirrorDoc } = await getBranchDoc(pubId, branchId, historyKey);
 	const schema = buildSchema(discussionSchema);
 	const doc = jsonToNode(prosemirrorDoc, schema);
 	const { footnotes: rawFootnotes, citations: rawCitations } = getNotes(doc);

--- a/workers/tasks/export/util.js
+++ b/workers/tasks/export/util.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import AWS from 'aws-sdk';
 import tmp from 'tmp-promise';
 
+import { Export } from '../../../server/models';
 import { generateHash } from '../../../server/utils';
 
 const formatTypes = {
@@ -34,7 +35,7 @@ export const uploadDocument = (branchId, tmpFile, extension) => {
 			if (err) {
 				reject(err);
 			}
-			resolve({ url: `https://assets.pubpub.org/${key}` });
+			resolve(`https://assets.pubpub.org/${key}`);
 		});
 	});
 };
@@ -53,3 +54,8 @@ export const writeToFile = (html, file) => {
 		});
 	});
 };
+
+export const getExportById = (exportId) => Export.findOne({ where: { id: exportId } });
+
+export const assignFileToExportById = (exportId, fileUrl) =>
+	Export.update({ url: fileUrl }, { where: { id: exportId } });

--- a/workers/tasks/export/util.js
+++ b/workers/tasks/export/util.js
@@ -5,18 +5,6 @@ import tmp from 'tmp-promise';
 import { Export } from '../../../server/models';
 import { generateHash } from '../../../server/utils';
 
-const formatTypes = {
-	html: { extension: 'html' },
-	pdf: { extension: 'pdf', pagedTarget: true },
-	docx: { pandocTarget: 'docx', extension: 'docx' },
-	epub: { pandocTarget: 'epub', extension: 'epub' },
-	markdown: { pandocTarget: 'markdown_strict', extension: 'md' },
-	odt: { pandocTarget: 'odt', extension: 'odt' },
-	plain: { pandocTarget: 'plain', extension: 'txt' },
-	jats: { pandocTarget: 'jats', extension: 'xml' },
-	tex: { pandocTarget: 'latex', extension: 'tex' },
-};
-
 tmp.setGracefulCleanup();
 
 AWS.config.setPromisesDependency(Promise);
@@ -41,8 +29,6 @@ export const uploadDocument = (branchId, tmpFile, extension) => {
 };
 
 export const getTmpFileForExtension = (extension) => tmp.file({ postfix: `.${extension}` });
-
-export const getFormatDetails = (key) => formatTypes[key];
 
 export const writeToFile = (html, file) => {
 	return new Promise((resolve, reject) => {


### PR DESCRIPTION
This PR adds an `Exports` table to our database schema, which keeps a record of all exports that are created, keyed on `(branchId, historyKey, format)`. From now on we will check this table for an existing export URL before spinning up a worker task to create one. I also added code to trigger creating all exports when a branch merge is completed — hopefully this means most visitors will not have to wait at all for an export to complete.

In passing, I updated the Download menu so that this fixes #553.

There is more work to be done here on keying exports against the _version_ of the exporter, in case of major improvements. That's out of scope for this PR and for the time being can be accomplished with manual manipulation of the `Exports` table.

_Test plan:_
- Run `npm test server/export`
- Try exporting the same file twice on the same page. The first time the query to `/api/exports` should resolve with a worker task ID. Subsequent downloads should cause the API route to resolve the URL of the existing export. Refreshing the page and trying the same thing should open the download URL without even making an API call.
- Typing into a document to advance the history key should invalidate existing exports — so you should be able to do the above again after a single keypress.
- Merging into the `#public` branch should kick off an export task for every format.
- On an iOS device, when visiting the Download menu triggers an API call, you should see a button appear in the dropdown to download the export when it finishes.