### PR TITLE
Paged tweaks

### DIFF
--- a/workers/tasks/export/html.js
+++ b/workers/tasks/export/html.js
@@ -96,7 +96,16 @@ const addHrefsToNotes = (nodes) =>
 		nodes,
 	);
 
-const blankIframes = (nodes) => addAttrsToNodes({ url: 'about:blank' }, ['iframe'], nodes);
+const blankIframes = (nodes) =>
+	addAttrsToNodes(
+		{
+			url:
+				'data:text/html;charset=utf-8,%3Chtml%3E%3Cbody%20frameborder%3D%220%22%20style%3D%22background-color%3A%23ccc%3Bborder%3A0%3Btext-align%3Acenter%3B%22%3EVisit%20the%20web%20version%20of%20this%20article%20to%20view%20interactive%20content.%3C%2Fbody%3E%3C%2Fhtml%3E',
+			height: '50',
+		},
+		['iframe'],
+		nodes,
+	);
 
 const renderFrontMatterForPandoc = ({ updatedDateString, publishedDateString, doi }) => {
 	const showUpdatedDate = updatedDateString && updatedDateString !== publishedDateString;

--- a/workers/tasks/export/styles/printDocument.scss
+++ b/workers/tasks/export/styles/printDocument.scss
@@ -110,12 +110,15 @@ section.cover {
     }
 
     figure {
+        break-inside: avoid;
         display: flex;
         flex-direction: column;
-        max-height: 100%;
+        max-height: 100vh;
         img, video {
+            break-inside: avoid;
             width: 100%;
             min-height: 0;
+            max-height: 700px;
             flex-shrink: 1;
             object-fit: contain;
         }

--- a/workers/tasks/export/styles/printDocument.scss
+++ b/workers/tasks/export/styles/printDocument.scss
@@ -162,6 +162,11 @@ section.cover {
         font-size: 10px;
     }
 
+    [data-node-type='math-block'] {
+        font-size: 16px;
+        break-inside: avoid;
+    }
+
     section.cover {
         page: cover;
     }

--- a/workers/tasks/export/styles/printDocument.scss
+++ b/workers/tasks/export/styles/printDocument.scss
@@ -113,12 +113,12 @@ section.cover {
         break-inside: avoid;
         display: flex;
         flex-direction: column;
-        max-height: 100vh;
+        max-height: 800px;
         img, video {
             break-inside: avoid;
             width: 100%;
             min-height: 0;
-            max-height: 700px;
+            max-height: 100%;
             flex-shrink: 1;
             object-fit: contain;
         }


### PR DESCRIPTION
Makes a few initial tweaks to pagedjs to fix a few small bugs that are prevalent in top HDSR articles.

- Default content for iframes
- Break-avoid for figures, images, and image captions
- Max-height on figures of 800px.
- Smaller font size and break-avoid for math to avoid math breaking onto multiple pages

_Test plan_

- Manually delete export for Glickman (1.1)
- Export PDF
- Verify that:
   - Images and figures/captions do not break onto multiple pages
   - iFrames appear small, grey, and with default text
   - Math appears in smaller font and does not break onto multiple pages

- Manually delete export for Gibbons (1.2)
- Export PDF
- Verify that:
   - Large supplement table images 2 and 5 at the bottom are resized properly
   - Images and figures/captions do not break onto multiple pages

- Manually delete export for Gibbons (1.2) DRAFT branch
- Export PDF
- Verify that:
   - Supplement Table 2 image (with large caption) displays correctly