### PR TITLE
fix: Remove media query effective PDF images

### DIFF
--- a/workers/tasks/export/styles/editorBase.scss
+++ b/workers/tasks/export/styles/editorBase.scss
@@ -1,0 +1,1631 @@
+.ProseMirror {
+  position: relative; }
+
+.ProseMirror {
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  white-space: break-spaces;
+  -webkit-font-variant-ligatures: none;
+  font-variant-ligatures: none;
+  font-feature-settings: "liga" 0;
+  /* the above doesn't seem to work in Edge */ }
+
+.ProseMirror pre {
+  white-space: pre-wrap; }
+
+.ProseMirror li {
+  position: relative; }
+
+.ProseMirror-hideselection *::selection {
+  background: transparent; }
+
+.ProseMirror-hideselection *::-moz-selection {
+  background: transparent; }
+
+.ProseMirror-hideselection {
+  caret-color: transparent; }
+
+.ProseMirror-selectednode {
+  outline: 2px solid #8cf; }
+
+/* Make sure li selections wrap around markers */
+li.ProseMirror-selectednode {
+  outline: none; }
+
+li.ProseMirror-selectednode:after {
+  content: "";
+  position: absolute;
+  left: -32px;
+  right: -2px;
+  top: -2px;
+  bottom: -2px;
+  border: 2px solid #8cf;
+  pointer-events: none; }
+
+.ProseMirror-gapcursor {
+  display: none;
+  pointer-events: none;
+  position: absolute; }
+
+.ProseMirror-gapcursor:after {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -2px;
+  width: 20px;
+  border-top: 1px solid black;
+  animation: ProseMirror-cursor-blink 1.1s steps(2, start) infinite; }
+
+@keyframes ProseMirror-cursor-blink {
+  to {
+    visibility: hidden; } }
+
+.ProseMirror-focused .ProseMirror-gapcursor {
+  display: block; }
+
+.ProseMirror .tableWrapper {
+  overflow-x: auto; }
+
+.ProseMirror table {
+  border-collapse: collapse;
+  table-layout: fixed;
+  width: 100%;
+  overflow: hidden; }
+
+.ProseMirror td, .ProseMirror th {
+  vertical-align: top;
+  box-sizing: border-box;
+  position: relative; }
+
+.ProseMirror .column-resize-handle {
+  position: absolute;
+  right: -2px;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  z-index: 20;
+  background-color: #adf;
+  pointer-events: none; }
+
+.ProseMirror.resize-cursor {
+  cursor: ew-resize;
+  cursor: col-resize; }
+
+/* Give selected cells a blue overlay */
+.ProseMirror .selectedCell:after {
+  z-index: 2;
+  position: absolute;
+  content: "";
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background: rgba(200, 200, 255, 0.4);
+  pointer-events: none; }
+
+/* stylelint-disable font-family-no-missing-generic-family-keyword */
+@font-face {
+  font-family: 'KaTeX_AMS';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_AMS-Regular.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_AMS-Regular.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_AMS-Regular.ttf) format("truetype");
+  font-weight: normal;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_Caligraphic';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Caligraphic-Bold.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Caligraphic-Bold.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Caligraphic-Bold.ttf) format("truetype");
+  font-weight: bold;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_Caligraphic';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Caligraphic-Regular.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Caligraphic-Regular.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Caligraphic-Regular.ttf) format("truetype");
+  font-weight: normal;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_Fraktur';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Fraktur-Bold.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Fraktur-Bold.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Fraktur-Bold.ttf) format("truetype");
+  font-weight: bold;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_Fraktur';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Fraktur-Regular.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Fraktur-Regular.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Fraktur-Regular.ttf) format("truetype");
+  font-weight: normal;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_Main';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Main-Bold.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Main-Bold.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Main-Bold.ttf) format("truetype");
+  font-weight: bold;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_Main';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Main-BoldItalic.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Main-BoldItalic.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Main-BoldItalic.ttf) format("truetype");
+  font-weight: bold;
+  font-style: italic; }
+
+@font-face {
+  font-family: 'KaTeX_Main';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Main-Italic.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Main-Italic.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Main-Italic.ttf) format("truetype");
+  font-weight: normal;
+  font-style: italic; }
+
+@font-face {
+  font-family: 'KaTeX_Main';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Main-Regular.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Main-Regular.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Main-Regular.ttf) format("truetype");
+  font-weight: normal;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_Math';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Math-BoldItalic.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Math-BoldItalic.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Math-BoldItalic.ttf) format("truetype");
+  font-weight: bold;
+  font-style: italic; }
+
+@font-face {
+  font-family: 'KaTeX_Math';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Math-Italic.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Math-Italic.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Math-Italic.ttf) format("truetype");
+  font-weight: normal;
+  font-style: italic; }
+
+@font-face {
+  font-family: 'KaTeX_SansSerif';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_SansSerif-Bold.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_SansSerif-Bold.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_SansSerif-Bold.ttf) format("truetype");
+  font-weight: bold;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_SansSerif';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_SansSerif-Italic.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_SansSerif-Italic.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_SansSerif-Italic.ttf) format("truetype");
+  font-weight: normal;
+  font-style: italic; }
+
+@font-face {
+  font-family: 'KaTeX_SansSerif';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_SansSerif-Regular.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_SansSerif-Regular.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_SansSerif-Regular.ttf) format("truetype");
+  font-weight: normal;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_Script';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Script-Regular.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Script-Regular.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Script-Regular.ttf) format("truetype");
+  font-weight: normal;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_Size1';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Size1-Regular.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Size1-Regular.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Size1-Regular.ttf) format("truetype");
+  font-weight: normal;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_Size2';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Size2-Regular.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Size2-Regular.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Size2-Regular.ttf) format("truetype");
+  font-weight: normal;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_Size3';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Size3-Regular.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Size3-Regular.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Size3-Regular.ttf) format("truetype");
+  font-weight: normal;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_Size4';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Size4-Regular.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Size4-Regular.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Size4-Regular.ttf) format("truetype");
+  font-weight: normal;
+  font-style: normal; }
+
+@font-face {
+  font-family: 'KaTeX_Typewriter';
+  src: url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Typewriter-Regular.woff2) format("woff2"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Typewriter-Regular.woff) format("woff"), url(https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/fonts/KaTeX_Typewriter-Regular.ttf) format("truetype");
+  font-weight: normal;
+  font-style: normal; }
+
+.katex {
+  font: normal 1.21em KaTeX_Main, Times New Roman, serif;
+  line-height: 1.2;
+  text-indent: 0;
+  text-rendering: auto; }
+
+.katex * {
+  -ms-high-contrast-adjust: none !important; }
+
+.katex .katex-version::after {
+  content: "0.10.2"; }
+
+.katex .katex-mathml {
+  position: absolute;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 0;
+  border: 0;
+  height: 1px;
+  width: 1px;
+  overflow: hidden; }
+
+.katex .katex-html {
+  /* \newline is an empty block at top level, between .base elements */ }
+
+.katex .katex-html > .newline {
+  display: block; }
+
+.katex .base {
+  position: relative;
+  display: inline-block;
+  white-space: nowrap;
+  width: min-content; }
+
+.katex .strut {
+  display: inline-block; }
+
+.katex .textbf {
+  font-weight: bold; }
+
+.katex .textit {
+  font-style: italic; }
+
+.katex .textrm {
+  font-family: KaTeX_Main; }
+
+.katex .textsf {
+  font-family: KaTeX_SansSerif; }
+
+.katex .texttt {
+  font-family: KaTeX_Typewriter; }
+
+.katex .mathdefault {
+  font-family: KaTeX_Math;
+  font-style: italic; }
+
+.katex .mathit {
+  font-family: KaTeX_Main;
+  font-style: italic; }
+
+.katex .mathrm {
+  font-style: normal; }
+
+.katex .mathbf {
+  font-family: KaTeX_Main;
+  font-weight: bold; }
+
+.katex .boldsymbol {
+  font-family: KaTeX_Math;
+  font-weight: bold;
+  font-style: italic; }
+
+.katex .amsrm {
+  font-family: KaTeX_AMS; }
+
+.katex .mathbb,
+.katex .textbb {
+  font-family: KaTeX_AMS; }
+
+.katex .mathcal {
+  font-family: KaTeX_Caligraphic; }
+
+.katex .mathfrak,
+.katex .textfrak {
+  font-family: KaTeX_Fraktur; }
+
+.katex .mathtt {
+  font-family: KaTeX_Typewriter; }
+
+.katex .mathscr,
+.katex .textscr {
+  font-family: KaTeX_Script; }
+
+.katex .mathsf,
+.katex .textsf {
+  font-family: KaTeX_SansSerif; }
+
+.katex .mathboldsf,
+.katex .textboldsf {
+  font-family: KaTeX_SansSerif;
+  font-weight: bold; }
+
+.katex .mathitsf,
+.katex .textitsf {
+  font-family: KaTeX_SansSerif;
+  font-style: italic; }
+
+.katex .mainrm {
+  font-family: KaTeX_Main;
+  font-style: normal; }
+
+.katex .vlist-t {
+  display: inline-table;
+  table-layout: fixed; }
+
+.katex .vlist-r {
+  display: table-row; }
+
+.katex .vlist {
+  display: table-cell;
+  vertical-align: bottom;
+  position: relative; }
+
+.katex .vlist > span {
+  display: block;
+  height: 0;
+  position: relative; }
+
+.katex .vlist > span > span {
+  display: inline-block; }
+
+.katex .vlist > span > .pstrut {
+  overflow: hidden;
+  width: 0; }
+
+.katex .vlist-t2 {
+  margin-right: -2px; }
+
+.katex .vlist-s {
+  display: table-cell;
+  vertical-align: bottom;
+  font-size: 1px;
+  width: 2px;
+  min-width: 2px; }
+
+.katex .msupsub {
+  text-align: left; }
+
+.katex .mfrac > span > span {
+  text-align: center; }
+
+.katex .mfrac .frac-line {
+  display: inline-block;
+  width: 100%;
+  border-bottom-style: solid; }
+
+.katex .mfrac .frac-line,
+.katex .overline .overline-line,
+.katex .underline .underline-line,
+.katex .hline,
+.katex .hdashline,
+.katex .rule {
+  min-height: 1px; }
+
+.katex .mspace {
+  display: inline-block; }
+
+.katex .llap,
+.katex .rlap,
+.katex .clap {
+  width: 0;
+  position: relative; }
+
+.katex .llap > .inner,
+.katex .rlap > .inner,
+.katex .clap > .inner {
+  position: absolute; }
+
+.katex .llap > .fix,
+.katex .rlap > .fix,
+.katex .clap > .fix {
+  display: inline-block; }
+
+.katex .llap > .inner {
+  right: 0; }
+
+.katex .rlap > .inner,
+.katex .clap > .inner {
+  left: 0; }
+
+.katex .clap > .inner > span {
+  margin-left: -50%;
+  margin-right: 50%; }
+
+.katex .rule {
+  display: inline-block;
+  border: solid 0;
+  position: relative; }
+
+.katex .overline .overline-line,
+.katex .underline .underline-line,
+.katex .hline {
+  display: inline-block;
+  width: 100%;
+  border-bottom-style: solid; }
+
+.katex .hdashline {
+  display: inline-block;
+  width: 100%;
+  border-bottom-style: dashed; }
+
+.katex .sqrt > .root {
+  margin-left: 0.27777778em;
+  margin-right: -0.55555556em; }
+
+.katex .sizing,
+.katex .fontsize-ensurer {
+  display: inline-block; }
+
+.katex .sizing.reset-size1.size1,
+.katex .fontsize-ensurer.reset-size1.size1 {
+  font-size: 1em; }
+
+.katex .sizing.reset-size1.size2,
+.katex .fontsize-ensurer.reset-size1.size2 {
+  font-size: 1.2em; }
+
+.katex .sizing.reset-size1.size3,
+.katex .fontsize-ensurer.reset-size1.size3 {
+  font-size: 1.4em; }
+
+.katex .sizing.reset-size1.size4,
+.katex .fontsize-ensurer.reset-size1.size4 {
+  font-size: 1.6em; }
+
+.katex .sizing.reset-size1.size5,
+.katex .fontsize-ensurer.reset-size1.size5 {
+  font-size: 1.8em; }
+
+.katex .sizing.reset-size1.size6,
+.katex .fontsize-ensurer.reset-size1.size6 {
+  font-size: 2em; }
+
+.katex .sizing.reset-size1.size7,
+.katex .fontsize-ensurer.reset-size1.size7 {
+  font-size: 2.4em; }
+
+.katex .sizing.reset-size1.size8,
+.katex .fontsize-ensurer.reset-size1.size8 {
+  font-size: 2.88em; }
+
+.katex .sizing.reset-size1.size9,
+.katex .fontsize-ensurer.reset-size1.size9 {
+  font-size: 3.456em; }
+
+.katex .sizing.reset-size1.size10,
+.katex .fontsize-ensurer.reset-size1.size10 {
+  font-size: 4.148em; }
+
+.katex .sizing.reset-size1.size11,
+.katex .fontsize-ensurer.reset-size1.size11 {
+  font-size: 4.976em; }
+
+.katex .sizing.reset-size2.size1,
+.katex .fontsize-ensurer.reset-size2.size1 {
+  font-size: 0.83333333em; }
+
+.katex .sizing.reset-size2.size2,
+.katex .fontsize-ensurer.reset-size2.size2 {
+  font-size: 1em; }
+
+.katex .sizing.reset-size2.size3,
+.katex .fontsize-ensurer.reset-size2.size3 {
+  font-size: 1.16666667em; }
+
+.katex .sizing.reset-size2.size4,
+.katex .fontsize-ensurer.reset-size2.size4 {
+  font-size: 1.33333333em; }
+
+.katex .sizing.reset-size2.size5,
+.katex .fontsize-ensurer.reset-size2.size5 {
+  font-size: 1.5em; }
+
+.katex .sizing.reset-size2.size6,
+.katex .fontsize-ensurer.reset-size2.size6 {
+  font-size: 1.66666667em; }
+
+.katex .sizing.reset-size2.size7,
+.katex .fontsize-ensurer.reset-size2.size7 {
+  font-size: 2em; }
+
+.katex .sizing.reset-size2.size8,
+.katex .fontsize-ensurer.reset-size2.size8 {
+  font-size: 2.4em; }
+
+.katex .sizing.reset-size2.size9,
+.katex .fontsize-ensurer.reset-size2.size9 {
+  font-size: 2.88em; }
+
+.katex .sizing.reset-size2.size10,
+.katex .fontsize-ensurer.reset-size2.size10 {
+  font-size: 3.45666667em; }
+
+.katex .sizing.reset-size2.size11,
+.katex .fontsize-ensurer.reset-size2.size11 {
+  font-size: 4.14666667em; }
+
+.katex .sizing.reset-size3.size1,
+.katex .fontsize-ensurer.reset-size3.size1 {
+  font-size: 0.71428571em; }
+
+.katex .sizing.reset-size3.size2,
+.katex .fontsize-ensurer.reset-size3.size2 {
+  font-size: 0.85714286em; }
+
+.katex .sizing.reset-size3.size3,
+.katex .fontsize-ensurer.reset-size3.size3 {
+  font-size: 1em; }
+
+.katex .sizing.reset-size3.size4,
+.katex .fontsize-ensurer.reset-size3.size4 {
+  font-size: 1.14285714em; }
+
+.katex .sizing.reset-size3.size5,
+.katex .fontsize-ensurer.reset-size3.size5 {
+  font-size: 1.28571429em; }
+
+.katex .sizing.reset-size3.size6,
+.katex .fontsize-ensurer.reset-size3.size6 {
+  font-size: 1.42857143em; }
+
+.katex .sizing.reset-size3.size7,
+.katex .fontsize-ensurer.reset-size3.size7 {
+  font-size: 1.71428571em; }
+
+.katex .sizing.reset-size3.size8,
+.katex .fontsize-ensurer.reset-size3.size8 {
+  font-size: 2.05714286em; }
+
+.katex .sizing.reset-size3.size9,
+.katex .fontsize-ensurer.reset-size3.size9 {
+  font-size: 2.46857143em; }
+
+.katex .sizing.reset-size3.size10,
+.katex .fontsize-ensurer.reset-size3.size10 {
+  font-size: 2.96285714em; }
+
+.katex .sizing.reset-size3.size11,
+.katex .fontsize-ensurer.reset-size3.size11 {
+  font-size: 3.55428571em; }
+
+.katex .sizing.reset-size4.size1,
+.katex .fontsize-ensurer.reset-size4.size1 {
+  font-size: 0.625em; }
+
+.katex .sizing.reset-size4.size2,
+.katex .fontsize-ensurer.reset-size4.size2 {
+  font-size: 0.75em; }
+
+.katex .sizing.reset-size4.size3,
+.katex .fontsize-ensurer.reset-size4.size3 {
+  font-size: 0.875em; }
+
+.katex .sizing.reset-size4.size4,
+.katex .fontsize-ensurer.reset-size4.size4 {
+  font-size: 1em; }
+
+.katex .sizing.reset-size4.size5,
+.katex .fontsize-ensurer.reset-size4.size5 {
+  font-size: 1.125em; }
+
+.katex .sizing.reset-size4.size6,
+.katex .fontsize-ensurer.reset-size4.size6 {
+  font-size: 1.25em; }
+
+.katex .sizing.reset-size4.size7,
+.katex .fontsize-ensurer.reset-size4.size7 {
+  font-size: 1.5em; }
+
+.katex .sizing.reset-size4.size8,
+.katex .fontsize-ensurer.reset-size4.size8 {
+  font-size: 1.8em; }
+
+.katex .sizing.reset-size4.size9,
+.katex .fontsize-ensurer.reset-size4.size9 {
+  font-size: 2.16em; }
+
+.katex .sizing.reset-size4.size10,
+.katex .fontsize-ensurer.reset-size4.size10 {
+  font-size: 2.5925em; }
+
+.katex .sizing.reset-size4.size11,
+.katex .fontsize-ensurer.reset-size4.size11 {
+  font-size: 3.11em; }
+
+.katex .sizing.reset-size5.size1,
+.katex .fontsize-ensurer.reset-size5.size1 {
+  font-size: 0.55555556em; }
+
+.katex .sizing.reset-size5.size2,
+.katex .fontsize-ensurer.reset-size5.size2 {
+  font-size: 0.66666667em; }
+
+.katex .sizing.reset-size5.size3,
+.katex .fontsize-ensurer.reset-size5.size3 {
+  font-size: 0.77777778em; }
+
+.katex .sizing.reset-size5.size4,
+.katex .fontsize-ensurer.reset-size5.size4 {
+  font-size: 0.88888889em; }
+
+.katex .sizing.reset-size5.size5,
+.katex .fontsize-ensurer.reset-size5.size5 {
+  font-size: 1em; }
+
+.katex .sizing.reset-size5.size6,
+.katex .fontsize-ensurer.reset-size5.size6 {
+  font-size: 1.11111111em; }
+
+.katex .sizing.reset-size5.size7,
+.katex .fontsize-ensurer.reset-size5.size7 {
+  font-size: 1.33333333em; }
+
+.katex .sizing.reset-size5.size8,
+.katex .fontsize-ensurer.reset-size5.size8 {
+  font-size: 1.6em; }
+
+.katex .sizing.reset-size5.size9,
+.katex .fontsize-ensurer.reset-size5.size9 {
+  font-size: 1.92em; }
+
+.katex .sizing.reset-size5.size10,
+.katex .fontsize-ensurer.reset-size5.size10 {
+  font-size: 2.30444444em; }
+
+.katex .sizing.reset-size5.size11,
+.katex .fontsize-ensurer.reset-size5.size11 {
+  font-size: 2.76444444em; }
+
+.katex .sizing.reset-size6.size1,
+.katex .fontsize-ensurer.reset-size6.size1 {
+  font-size: 0.5em; }
+
+.katex .sizing.reset-size6.size2,
+.katex .fontsize-ensurer.reset-size6.size2 {
+  font-size: 0.6em; }
+
+.katex .sizing.reset-size6.size3,
+.katex .fontsize-ensurer.reset-size6.size3 {
+  font-size: 0.7em; }
+
+.katex .sizing.reset-size6.size4,
+.katex .fontsize-ensurer.reset-size6.size4 {
+  font-size: 0.8em; }
+
+.katex .sizing.reset-size6.size5,
+.katex .fontsize-ensurer.reset-size6.size5 {
+  font-size: 0.9em; }
+
+.katex .sizing.reset-size6.size6,
+.katex .fontsize-ensurer.reset-size6.size6 {
+  font-size: 1em; }
+
+.katex .sizing.reset-size6.size7,
+.katex .fontsize-ensurer.reset-size6.size7 {
+  font-size: 1.2em; }
+
+.katex .sizing.reset-size6.size8,
+.katex .fontsize-ensurer.reset-size6.size8 {
+  font-size: 1.44em; }
+
+.katex .sizing.reset-size6.size9,
+.katex .fontsize-ensurer.reset-size6.size9 {
+  font-size: 1.728em; }
+
+.katex .sizing.reset-size6.size10,
+.katex .fontsize-ensurer.reset-size6.size10 {
+  font-size: 2.074em; }
+
+.katex .sizing.reset-size6.size11,
+.katex .fontsize-ensurer.reset-size6.size11 {
+  font-size: 2.488em; }
+
+.katex .sizing.reset-size7.size1,
+.katex .fontsize-ensurer.reset-size7.size1 {
+  font-size: 0.41666667em; }
+
+.katex .sizing.reset-size7.size2,
+.katex .fontsize-ensurer.reset-size7.size2 {
+  font-size: 0.5em; }
+
+.katex .sizing.reset-size7.size3,
+.katex .fontsize-ensurer.reset-size7.size3 {
+  font-size: 0.58333333em; }
+
+.katex .sizing.reset-size7.size4,
+.katex .fontsize-ensurer.reset-size7.size4 {
+  font-size: 0.66666667em; }
+
+.katex .sizing.reset-size7.size5,
+.katex .fontsize-ensurer.reset-size7.size5 {
+  font-size: 0.75em; }
+
+.katex .sizing.reset-size7.size6,
+.katex .fontsize-ensurer.reset-size7.size6 {
+  font-size: 0.83333333em; }
+
+.katex .sizing.reset-size7.size7,
+.katex .fontsize-ensurer.reset-size7.size7 {
+  font-size: 1em; }
+
+.katex .sizing.reset-size7.size8,
+.katex .fontsize-ensurer.reset-size7.size8 {
+  font-size: 1.2em; }
+
+.katex .sizing.reset-size7.size9,
+.katex .fontsize-ensurer.reset-size7.size9 {
+  font-size: 1.44em; }
+
+.katex .sizing.reset-size7.size10,
+.katex .fontsize-ensurer.reset-size7.size10 {
+  font-size: 1.72833333em; }
+
+.katex .sizing.reset-size7.size11,
+.katex .fontsize-ensurer.reset-size7.size11 {
+  font-size: 2.07333333em; }
+
+.katex .sizing.reset-size8.size1,
+.katex .fontsize-ensurer.reset-size8.size1 {
+  font-size: 0.34722222em; }
+
+.katex .sizing.reset-size8.size2,
+.katex .fontsize-ensurer.reset-size8.size2 {
+  font-size: 0.41666667em; }
+
+.katex .sizing.reset-size8.size3,
+.katex .fontsize-ensurer.reset-size8.size3 {
+  font-size: 0.48611111em; }
+
+.katex .sizing.reset-size8.size4,
+.katex .fontsize-ensurer.reset-size8.size4 {
+  font-size: 0.55555556em; }
+
+.katex .sizing.reset-size8.size5,
+.katex .fontsize-ensurer.reset-size8.size5 {
+  font-size: 0.625em; }
+
+.katex .sizing.reset-size8.size6,
+.katex .fontsize-ensurer.reset-size8.size6 {
+  font-size: 0.69444444em; }
+
+.katex .sizing.reset-size8.size7,
+.katex .fontsize-ensurer.reset-size8.size7 {
+  font-size: 0.83333333em; }
+
+.katex .sizing.reset-size8.size8,
+.katex .fontsize-ensurer.reset-size8.size8 {
+  font-size: 1em; }
+
+.katex .sizing.reset-size8.size9,
+.katex .fontsize-ensurer.reset-size8.size9 {
+  font-size: 1.2em; }
+
+.katex .sizing.reset-size8.size10,
+.katex .fontsize-ensurer.reset-size8.size10 {
+  font-size: 1.44027778em; }
+
+.katex .sizing.reset-size8.size11,
+.katex .fontsize-ensurer.reset-size8.size11 {
+  font-size: 1.72777778em; }
+
+.katex .sizing.reset-size9.size1,
+.katex .fontsize-ensurer.reset-size9.size1 {
+  font-size: 0.28935185em; }
+
+.katex .sizing.reset-size9.size2,
+.katex .fontsize-ensurer.reset-size9.size2 {
+  font-size: 0.34722222em; }
+
+.katex .sizing.reset-size9.size3,
+.katex .fontsize-ensurer.reset-size9.size3 {
+  font-size: 0.40509259em; }
+
+.katex .sizing.reset-size9.size4,
+.katex .fontsize-ensurer.reset-size9.size4 {
+  font-size: 0.46296296em; }
+
+.katex .sizing.reset-size9.size5,
+.katex .fontsize-ensurer.reset-size9.size5 {
+  font-size: 0.52083333em; }
+
+.katex .sizing.reset-size9.size6,
+.katex .fontsize-ensurer.reset-size9.size6 {
+  font-size: 0.5787037em; }
+
+.katex .sizing.reset-size9.size7,
+.katex .fontsize-ensurer.reset-size9.size7 {
+  font-size: 0.69444444em; }
+
+.katex .sizing.reset-size9.size8,
+.katex .fontsize-ensurer.reset-size9.size8 {
+  font-size: 0.83333333em; }
+
+.katex .sizing.reset-size9.size9,
+.katex .fontsize-ensurer.reset-size9.size9 {
+  font-size: 1em; }
+
+.katex .sizing.reset-size9.size10,
+.katex .fontsize-ensurer.reset-size9.size10 {
+  font-size: 1.20023148em; }
+
+.katex .sizing.reset-size9.size11,
+.katex .fontsize-ensurer.reset-size9.size11 {
+  font-size: 1.43981481em; }
+
+.katex .sizing.reset-size10.size1,
+.katex .fontsize-ensurer.reset-size10.size1 {
+  font-size: 0.24108004em; }
+
+.katex .sizing.reset-size10.size2,
+.katex .fontsize-ensurer.reset-size10.size2 {
+  font-size: 0.28929605em; }
+
+.katex .sizing.reset-size10.size3,
+.katex .fontsize-ensurer.reset-size10.size3 {
+  font-size: 0.33751205em; }
+
+.katex .sizing.reset-size10.size4,
+.katex .fontsize-ensurer.reset-size10.size4 {
+  font-size: 0.38572806em; }
+
+.katex .sizing.reset-size10.size5,
+.katex .fontsize-ensurer.reset-size10.size5 {
+  font-size: 0.43394407em; }
+
+.katex .sizing.reset-size10.size6,
+.katex .fontsize-ensurer.reset-size10.size6 {
+  font-size: 0.48216008em; }
+
+.katex .sizing.reset-size10.size7,
+.katex .fontsize-ensurer.reset-size10.size7 {
+  font-size: 0.57859209em; }
+
+.katex .sizing.reset-size10.size8,
+.katex .fontsize-ensurer.reset-size10.size8 {
+  font-size: 0.69431051em; }
+
+.katex .sizing.reset-size10.size9,
+.katex .fontsize-ensurer.reset-size10.size9 {
+  font-size: 0.83317261em; }
+
+.katex .sizing.reset-size10.size10,
+.katex .fontsize-ensurer.reset-size10.size10 {
+  font-size: 1em; }
+
+.katex .sizing.reset-size10.size11,
+.katex .fontsize-ensurer.reset-size10.size11 {
+  font-size: 1.19961427em; }
+
+.katex .sizing.reset-size11.size1,
+.katex .fontsize-ensurer.reset-size11.size1 {
+  font-size: 0.20096463em; }
+
+.katex .sizing.reset-size11.size2,
+.katex .fontsize-ensurer.reset-size11.size2 {
+  font-size: 0.24115756em; }
+
+.katex .sizing.reset-size11.size3,
+.katex .fontsize-ensurer.reset-size11.size3 {
+  font-size: 0.28135048em; }
+
+.katex .sizing.reset-size11.size4,
+.katex .fontsize-ensurer.reset-size11.size4 {
+  font-size: 0.32154341em; }
+
+.katex .sizing.reset-size11.size5,
+.katex .fontsize-ensurer.reset-size11.size5 {
+  font-size: 0.36173633em; }
+
+.katex .sizing.reset-size11.size6,
+.katex .fontsize-ensurer.reset-size11.size6 {
+  font-size: 0.40192926em; }
+
+.katex .sizing.reset-size11.size7,
+.katex .fontsize-ensurer.reset-size11.size7 {
+  font-size: 0.48231511em; }
+
+.katex .sizing.reset-size11.size8,
+.katex .fontsize-ensurer.reset-size11.size8 {
+  font-size: 0.57877814em; }
+
+.katex .sizing.reset-size11.size9,
+.katex .fontsize-ensurer.reset-size11.size9 {
+  font-size: 0.69453376em; }
+
+.katex .sizing.reset-size11.size10,
+.katex .fontsize-ensurer.reset-size11.size10 {
+  font-size: 0.83360129em; }
+
+.katex .sizing.reset-size11.size11,
+.katex .fontsize-ensurer.reset-size11.size11 {
+  font-size: 1em; }
+
+.katex .delimsizing.size1 {
+  font-family: KaTeX_Size1; }
+
+.katex .delimsizing.size2 {
+  font-family: KaTeX_Size2; }
+
+.katex .delimsizing.size3 {
+  font-family: KaTeX_Size3; }
+
+.katex .delimsizing.size4 {
+  font-family: KaTeX_Size4; }
+
+.katex .delimsizing.mult .delim-size1 > span {
+  font-family: KaTeX_Size1; }
+
+.katex .delimsizing.mult .delim-size4 > span {
+  font-family: KaTeX_Size4; }
+
+.katex .nulldelimiter {
+  display: inline-block;
+  width: 0.12em; }
+
+.katex .delimcenter {
+  position: relative; }
+
+.katex .op-symbol {
+  position: relative; }
+
+.katex .op-symbol.small-op {
+  font-family: KaTeX_Size1; }
+
+.katex .op-symbol.large-op {
+  font-family: KaTeX_Size2; }
+
+.katex .op-limits > .vlist-t {
+  text-align: center; }
+
+.katex .accent > .vlist-t {
+  text-align: center; }
+
+.katex .accent .accent-body {
+  position: relative; }
+
+.katex .accent .accent-body:not(.accent-full) {
+  width: 0; }
+
+.katex .overlay {
+  display: block; }
+
+.katex .mtable .vertical-separator {
+  display: inline-block;
+  margin: 0 -0.025em;
+  border-right: 0.05em solid;
+  min-width: 1px; }
+
+.katex .mtable .vs-dashed {
+  border-right: 0.05em dashed; }
+
+.katex .mtable .arraycolsep {
+  display: inline-block; }
+
+.katex .mtable .col-align-c > .vlist-t {
+  text-align: center; }
+
+.katex .mtable .col-align-l > .vlist-t {
+  text-align: left; }
+
+.katex .mtable .col-align-r > .vlist-t {
+  text-align: right; }
+
+.katex .svg-align {
+  text-align: left; }
+
+.katex svg {
+  display: block;
+  position: absolute;
+  width: 100%;
+  height: inherit;
+  fill: currentColor;
+  stroke: currentColor;
+  fill-rule: nonzero;
+  fill-opacity: 1;
+  stroke-width: 1;
+  stroke-linecap: butt;
+  stroke-linejoin: miter;
+  stroke-miterlimit: 4;
+  stroke-dasharray: none;
+  stroke-dashoffset: 0;
+  stroke-opacity: 1; }
+
+.katex svg path {
+  stroke: none; }
+
+.katex img {
+  border-style: none;
+  min-width: 0;
+  min-height: 0;
+  max-width: none;
+  max-height: none; }
+
+.katex .stretchy {
+  width: 100%;
+  display: block;
+  position: relative;
+  overflow: hidden; }
+
+.katex .stretchy::before,
+.katex .stretchy::after {
+  content: ""; }
+
+.katex .hide-tail {
+  width: 100%;
+  position: relative;
+  overflow: hidden; }
+
+.katex .halfarrow-left {
+  position: absolute;
+  left: 0;
+  width: 50.2%;
+  overflow: hidden; }
+
+.katex .halfarrow-right {
+  position: absolute;
+  right: 0;
+  width: 50.2%;
+  overflow: hidden; }
+
+.katex .brace-left {
+  position: absolute;
+  left: 0;
+  width: 25.1%;
+  overflow: hidden; }
+
+.katex .brace-center {
+  position: absolute;
+  left: 25%;
+  width: 50%;
+  overflow: hidden; }
+
+.katex .brace-right {
+  position: absolute;
+  right: 0;
+  width: 25.1%;
+  overflow: hidden; }
+
+.katex .x-arrow-pad {
+  padding: 0 0.5em; }
+
+.katex .x-arrow,
+.katex .mover,
+.katex .munder {
+  text-align: center; }
+
+.katex .boxpad {
+  padding: 0 0.3em 0 0.3em; }
+
+.katex .fbox,
+.katex .fcolorbox {
+  box-sizing: border-box;
+  border: 0.04em solid; }
+
+.katex .cancel-pad {
+  padding: 0 0.2em 0 0.2em; }
+
+.katex .cancel-lap {
+  margin-left: -0.2em;
+  margin-right: -0.2em; }
+
+.katex .sout {
+  border-bottom-style: solid;
+  border-bottom-width: 0.08em; }
+
+.katex-display {
+  display: block;
+  margin: 1em 0;
+  text-align: center; }
+
+.katex-display > .katex {
+  display: block;
+  text-align: center;
+  white-space: nowrap; }
+
+.katex-display > .katex > .katex-html {
+  display: block;
+  position: relative; }
+
+.katex-display > .katex > .katex-html > .tag {
+  position: absolute;
+  right: 0; }
+
+.katex-display.leqno > .katex > .katex-html > .tag {
+  left: 0;
+  right: auto; }
+
+.katex-display.fleqn > .katex {
+  text-align: left; }
+
+[data-node-type='math-inline'] {
+  font-size: 0.9em;
+  display: inline-block;
+  vertical-align: middle;
+  max-width: 100%; }
+
+[data-node-type='math-block'] {
+  font-size: 20px;
+  display: block;
+  text-align: center;
+  max-width: 100%; }
+
+.editor {
+  /*! fileicon.css v0.1.1 | MIT License | github.com/picturepan2/fileicon.css */
+  /* fileicon.basic */
+  /* fileicons */
+  /* fileicon.types */
+  /* This clunky table, tableWrapper thing is because */
+  /* isReadOnly removes the wrapping div, so margins don't */
+  /* collapse as expected in all situations. */ }
+  .editor:focus {
+    outline: none !important; }
+  .editor .prosemirror-placeholder {
+    opacity: 0.5;
+    white-space: nowrap;
+    position: relative; }
+    .editor .prosemirror-placeholder:after {
+      position: absolute;
+      top: 0;
+      content: attr(data-content); }
+  .editor .ProseMirror-selectednode {
+    outline: 2px solid #bbbdc0; }
+  .editor.read-only .ProseMirror-selectednode {
+    outline: 0px solid #bbbdc0; }
+  .editor h1 a,
+  .editor h2 a,
+  .editor h3 a,
+  .editor h4 a,
+  .editor h5 a,
+  .editor h6 a {
+    text-decoration: none;
+    color: inherit; }
+  .editor span.footnote {
+    vertical-align: super;
+    font-size: 0.85em; }
+  .editor span.citation {
+    font-weight: bold; }
+  .editor table {
+    /* Prosemirror requires white-space: pre-wrap, but it's overriden by the quirks.css */
+    /* built-in that Firefox provides, breaking the editor. */
+    /* See https://github.com/ProseMirror/prosemirror/issues/651#issuecomment-313436150 */
+    white-space: pre-wrap !important; }
+  .editor .collab-cursor {
+    position: relative;
+    font-family: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans", "Helvetica Neue", sans-serif;
+    color: white;
+    user-select: none;
+    vertical-align: top; }
+    .editor .collab-cursor .inner-bar {
+      position: absolute;
+      height: calc(1em + 5px);
+      width: 2px;
+      background-color: #001996;
+      bottom: 0px;
+      left: 0; }
+      .editor .collab-cursor .inner-bar .inner-circle-small {
+        position: absolute;
+        height: 8px;
+        width: 8px;
+        border-radius: 8px;
+        background-color: #001996;
+        bottom: calc(100% + 0px);
+        left: -3px; }
+      .editor .collab-cursor .inner-bar .hover-wrapper {
+        transform: scale(0.4);
+        opacity: 0;
+        transform-origin: bottom left;
+        transition: .1s 0.3s linear transform, 0s 0.4s linear opacity;
+        display: block;
+        position: absolute;
+        bottom: 100%;
+        pointer-events: none;
+        z-index: 1; }
+        .editor .collab-cursor .inner-bar .hover-wrapper .inner-circle-big {
+          position: absolute;
+          height: 24px;
+          width: 24px;
+          border-radius: 24px;
+          background-color: #001996;
+          bottom: 0px;
+          left: -11px; }
+        .editor .collab-cursor .inner-bar .hover-wrapper .initials:after {
+          display: block;
+          position: absolute;
+          width: 20px;
+          height: 20px;
+          bottom: 2px;
+          left: -9px;
+          font-size: 12px;
+          font-weight: bold;
+          line-height: 20px;
+          text-align: center;
+          z-index: 4;
+          white-space: nowrap;
+          user-select: none; }
+        .editor .collab-cursor .inner-bar .hover-wrapper .name:after {
+          position: absolute;
+          display: block;
+          padding: 2px 12px;
+          border-radius: 2px;
+          color: white;
+          background-color: #777;
+          font-size: 12px;
+          line-height: 16px;
+          font-weight: 400;
+          bottom: 2px;
+          left: 6px;
+          white-space: nowrap;
+          z-index: 3;
+          user-select: none; }
+        .editor .collab-cursor .inner-bar .hover-wrapper .image:after {
+          position: absolute;
+          bottom: 2px;
+          left: -9px;
+          z-index: 5;
+          border-radius: 10px;
+          width: 20px;
+          height: 20px;
+          background-size: cover;
+          content: "";
+          max-width: none;
+          margin-top: 0px; }
+    .editor .collab-cursor:hover .hover-wrapper {
+      opacity: 1;
+      transform: scale(1);
+      transition: .1s linear transform, 0s 0s linear opacity; }
+  .editor figure {
+    text-align: center;
+    margin: 1em auto; }
+    .editor figure > * {
+      width: 100%;
+      pointer-events: none; }
+    .editor figure.ProseMirror-selectednode > * {
+      pointer-events: auto; }
+    .editor figure[data-align='left'] {
+      float: left;
+      margin: 0.5em 1.5em 0.5em 0em; }
+    .editor figure[data-align='right'] {
+      float: right;
+      margin: 0.5em 0em 0.5em 1.5em; }
+    .editor figure[data-size='1'] {
+      width: 1%; }
+    .editor figure[data-size='2'] {
+      width: 2%; }
+    .editor figure[data-size='3'] {
+      width: 3%; }
+    .editor figure[data-size='4'] {
+      width: 4%; }
+    .editor figure[data-size='5'] {
+      width: 5%; }
+    .editor figure[data-size='6'] {
+      width: 6%; }
+    .editor figure[data-size='7'] {
+      width: 7%; }
+    .editor figure[data-size='8'] {
+      width: 8%; }
+    .editor figure[data-size='9'] {
+      width: 9%; }
+    .editor figure[data-size='10'] {
+      width: 10%; }
+    .editor figure[data-size='11'] {
+      width: 11%; }
+    .editor figure[data-size='12'] {
+      width: 12%; }
+    .editor figure[data-size='13'] {
+      width: 13%; }
+    .editor figure[data-size='14'] {
+      width: 14%; }
+    .editor figure[data-size='15'] {
+      width: 15%; }
+    .editor figure[data-size='16'] {
+      width: 16%; }
+    .editor figure[data-size='17'] {
+      width: 17%; }
+    .editor figure[data-size='18'] {
+      width: 18%; }
+    .editor figure[data-size='19'] {
+      width: 19%; }
+    .editor figure[data-size='20'] {
+      width: 20%; }
+    .editor figure[data-size='21'] {
+      width: 21%; }
+    .editor figure[data-size='22'] {
+      width: 22%; }
+    .editor figure[data-size='23'] {
+      width: 23%; }
+    .editor figure[data-size='24'] {
+      width: 24%; }
+    .editor figure[data-size='25'] {
+      width: 25%; }
+    .editor figure[data-size='26'] {
+      width: 26%; }
+    .editor figure[data-size='27'] {
+      width: 27%; }
+    .editor figure[data-size='28'] {
+      width: 28%; }
+    .editor figure[data-size='29'] {
+      width: 29%; }
+    .editor figure[data-size='30'] {
+      width: 30%; }
+    .editor figure[data-size='31'] {
+      width: 31%; }
+    .editor figure[data-size='32'] {
+      width: 32%; }
+    .editor figure[data-size='33'] {
+      width: 33%; }
+    .editor figure[data-size='34'] {
+      width: 34%; }
+    .editor figure[data-size='35'] {
+      width: 35%; }
+    .editor figure[data-size='36'] {
+      width: 36%; }
+    .editor figure[data-size='37'] {
+      width: 37%; }
+    .editor figure[data-size='38'] {
+      width: 38%; }
+    .editor figure[data-size='39'] {
+      width: 39%; }
+    .editor figure[data-size='40'] {
+      width: 40%; }
+    .editor figure[data-size='41'] {
+      width: 41%; }
+    .editor figure[data-size='42'] {
+      width: 42%; }
+    .editor figure[data-size='43'] {
+      width: 43%; }
+    .editor figure[data-size='44'] {
+      width: 44%; }
+    .editor figure[data-size='45'] {
+      width: 45%; }
+    .editor figure[data-size='46'] {
+      width: 46%; }
+    .editor figure[data-size='47'] {
+      width: 47%; }
+    .editor figure[data-size='48'] {
+      width: 48%; }
+    .editor figure[data-size='49'] {
+      width: 49%; }
+    .editor figure[data-size='50'] {
+      width: 50%; }
+    .editor figure[data-size='51'] {
+      width: 51%; }
+    .editor figure[data-size='52'] {
+      width: 52%; }
+    .editor figure[data-size='53'] {
+      width: 53%; }
+    .editor figure[data-size='54'] {
+      width: 54%; }
+    .editor figure[data-size='55'] {
+      width: 55%; }
+    .editor figure[data-size='56'] {
+      width: 56%; }
+    .editor figure[data-size='57'] {
+      width: 57%; }
+    .editor figure[data-size='58'] {
+      width: 58%; }
+    .editor figure[data-size='59'] {
+      width: 59%; }
+    .editor figure[data-size='60'] {
+      width: 60%; }
+    .editor figure[data-size='61'] {
+      width: 61%; }
+    .editor figure[data-size='62'] {
+      width: 62%; }
+    .editor figure[data-size='63'] {
+      width: 63%; }
+    .editor figure[data-size='64'] {
+      width: 64%; }
+    .editor figure[data-size='65'] {
+      width: 65%; }
+    .editor figure[data-size='66'] {
+      width: 66%; }
+    .editor figure[data-size='67'] {
+      width: 67%; }
+    .editor figure[data-size='68'] {
+      width: 68%; }
+    .editor figure[data-size='69'] {
+      width: 69%; }
+    .editor figure[data-size='70'] {
+      width: 70%; }
+    .editor figure[data-size='71'] {
+      width: 71%; }
+    .editor figure[data-size='72'] {
+      width: 72%; }
+    .editor figure[data-size='73'] {
+      width: 73%; }
+    .editor figure[data-size='74'] {
+      width: 74%; }
+    .editor figure[data-size='75'] {
+      width: 75%; }
+    .editor figure[data-size='76'] {
+      width: 76%; }
+    .editor figure[data-size='77'] {
+      width: 77%; }
+    .editor figure[data-size='78'] {
+      width: 78%; }
+    .editor figure[data-size='79'] {
+      width: 79%; }
+    .editor figure[data-size='80'] {
+      width: 80%; }
+    .editor figure[data-size='81'] {
+      width: 81%; }
+    .editor figure[data-size='82'] {
+      width: 82%; }
+    .editor figure[data-size='83'] {
+      width: 83%; }
+    .editor figure[data-size='84'] {
+      width: 84%; }
+    .editor figure[data-size='85'] {
+      width: 85%; }
+    .editor figure[data-size='86'] {
+      width: 86%; }
+    .editor figure[data-size='87'] {
+      width: 87%; }
+    .editor figure[data-size='88'] {
+      width: 88%; }
+    .editor figure[data-size='89'] {
+      width: 89%; }
+    .editor figure[data-size='90'] {
+      width: 90%; }
+    .editor figure[data-size='91'] {
+      width: 91%; }
+    .editor figure[data-size='92'] {
+      width: 92%; }
+    .editor figure[data-size='93'] {
+      width: 93%; }
+    .editor figure[data-size='94'] {
+      width: 94%; }
+    .editor figure[data-size='95'] {
+      width: 95%; }
+    .editor figure[data-size='96'] {
+      width: 96%; }
+    .editor figure[data-size='97'] {
+      width: 97%; }
+    .editor figure[data-size='98'] {
+      width: 98%; }
+    .editor figure[data-size='99'] {
+      width: 99%; }
+    .editor figure[data-size='100'] {
+      width: 100%; }
+    .editor figure[data-align='full'] {
+      width: 100%; }
+    .editor figure figcaption {
+      opacity: 0.75;
+      padding: 2px 0px 5px; }
+  .editor .ProseMirror.read-only figure > * {
+    pointer-events: auto; }
+  .editor .file-icon {
+    font-family: Arial, Tahoma, sans-serif;
+    font-weight: 300;
+    display: inline-block;
+    width: 24px;
+    height: 32px;
+    background: #018fef;
+    position: relative;
+    border-radius: 2px;
+    text-align: left;
+    -webkit-font-smoothing: antialiased; }
+  .editor .file-icon::before {
+    display: block;
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 0;
+    height: 0;
+    border-bottom-left-radius: 2px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: #fff #fff rgba(255, 255, 255, 0.35) rgba(255, 255, 255, 0.35); }
+  .editor .file-icon::after {
+    display: block;
+    content: attr(data-type);
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    font-size: 10px;
+    color: #fff;
+    text-transform: lowercase;
+    width: 100%;
+    padding: 2px;
+    white-space: nowrap;
+    overflow: hidden; }
+  .editor .file-icon-xs {
+    width: 12px;
+    height: 16px;
+    border-radius: 2px; }
+  .editor .file-icon-xs::before {
+    border-bottom-left-radius: 1px;
+    border-width: 3px; }
+  .editor .file-icon-xs::after {
+    content: "";
+    border-bottom: 2px solid rgba(255, 255, 255, 0.45);
+    width: auto;
+    left: 2px;
+    right: 2px;
+    bottom: 3px; }
+  .editor .file-icon-sm {
+    width: 18px;
+    height: 24px;
+    border-radius: 2px; }
+  .editor .file-icon-sm::before {
+    border-bottom-left-radius: 2px;
+    border-width: 4px; }
+  .editor .file-icon-sm::after {
+    font-size: 7px;
+    padding: 2px; }
+  .editor .file-icon-lg {
+    width: 48px;
+    height: 64px;
+    border-radius: 3px; }
+  .editor .file-icon-lg::before {
+    border-bottom-left-radius: 2px;
+    border-width: 8px; }
+  .editor .file-icon-lg::after {
+    font-size: 16px;
+    padding: 4px 6px; }
+  .editor .file-icon-xl {
+    width: 96px;
+    height: 128px;
+    border-radius: 4px; }
+  .editor .file-icon-xl::before {
+    border-bottom-left-radius: 4px;
+    border-width: 16px; }
+  .editor .file-icon-xl::after {
+    font-size: 24px;
+    padding: 4px 10px; }
+  .editor .file-icon[data-type=zip],
+  .editor .file-icon[data-type=rar] {
+    background: #acacac; }
+  .editor .file-icon[data-type^=doc] {
+    background: #307cf1; }
+  .editor .file-icon[data-type^=xls] {
+    background: #0f9d58; }
+  .editor .file-icon[data-type^=ppt] {
+    background: #d24726; }
+  .editor .file-icon[data-type=pdf] {
+    background: #e13d34; }
+  .editor .file-icon[data-type=txt] {
+    background: #5eb533; }
+  .editor .file-icon[data-type=mp3],
+  .editor .file-icon[data-type=wma],
+  .editor .file-icon[data-type=m4a],
+  .editor .file-icon[data-type=flac] {
+    background: #8e44ad; }
+  .editor .file-icon[data-type=mp4],
+  .editor .file-icon[data-type=wmv],
+  .editor .file-icon[data-type=mov],
+  .editor .file-icon[data-type=avi],
+  .editor .file-icon[data-type=mkv] {
+    background: #7a3ce7; }
+  .editor .file-icon[data-type=bmp],
+  .editor .file-icon[data-type=jpg],
+  .editor .file-icon[data-type=jpeg],
+  .editor .file-icon[data-type=gif],
+  .editor .file-icon[data-type=png] {
+    background: #f48c00; }
+  .editor [data-node-type='file'] {
+    width: 65%; }
+    .editor [data-node-type='file'] .details {
+      display: flex;
+      align-items: center;
+      text-align: left; }
+      .editor [data-node-type='file'] .details .extension {
+        text-transform: uppercase;
+        font-family: 'Courier', monospace;
+        font-weight: 600;
+        font-size: 1.5em; }
+      .editor [data-node-type='file'] .details .file-name {
+        flex-grow: 1;
+        flex-shrink: 1;
+        margin: 0em 1em; }
+        .editor [data-node-type='file'] .details .file-name a {
+          color: inherit; }
+          .editor [data-node-type='file'] .details .file-name a:hover {
+            cursor: pointer;
+            text-decoration: underline !important; }
+      .editor [data-node-type='file'] .details .file-size {
+        margin: 0em 1em; }
+  .editor table {
+    margin: 0;
+    max-width: 100%; }
+  .editor th, .editor td {
+    min-width: 1em;
+    border: 1px solid #ddd;
+    padding: 3px 5px; }
+  .editor table {
+    margin: 1em 0; }
+  .editor .tableWrapper {
+    margin: 1em 0; }
+    .editor .tableWrapper table {
+      margin: 0em; }
+  .editor th {
+    font-weight: bold;
+    text-align: left;
+    background-color: #F0F0F4; }

--- a/workers/tasks/export/styles/printDocument.scss
+++ b/workers/tasks/export/styles/printDocument.scss
@@ -1,4 +1,6 @@
-@import '~@pubpub/editor/src/styles/base.scss';
+/* Editor Base Without Figures As Of 12/2019 */
+
+@import './editorBase.scss';
 
 @import 'styles/variables.scss';
 @import 'containers/Pub/PubDocument/pubBody.scss';


### PR DESCRIPTION
This temporarily switches to using a static pubpub-editor css file to avoid the pagedjs media query bug described here: https://gitlab.pagedmedia.org/tools/pagedjs-cli/issues/11

_Test plan_
1. Generate the PDF for a pub that uses sized images, ie: https://kfg.duqduq.org/pub/v7wsbips/
1. Repeat for float left, right, center and full
1. Repeat for videos