### PR TITLE
new: Google Scholar/Highwire metadata

### DIFF
--- a/server/editor/queries.js
+++ b/server/editor/queries.js
@@ -3,7 +3,7 @@ import Cite from 'citation-js';
 export const generateCiteHtmls = (inputVals, format = 'citation-apa') => {
 	const citeObjects = inputVals.map((input) => {
 		if (!input.structuredValue) {
-			return { ...input, html: '' };
+			return { ...input, html: '', json: '' };
 		}
 		try {
 			return Cite.async(input.structuredValue)
@@ -14,13 +14,19 @@ export const generateCiteHtmls = (inputVals, format = 'citation-apa') => {
 						style: format,
 						lang: 'en-US',
 					});
-					return { ...input, html: html };
+					const json = data.get({
+						format: 'real',
+						type: 'json',
+						style: 'csl',
+						lang: 'en-US',
+					});
+					return { ...input, html: html, json: json };
 				})
 				.catch(() => {
-					return { ...input, html: 'Error' };
+					return { ...input, html: 'Error', json: 'Error' };
 				});
 		} catch (err) {
-			return { ...input, html: 'Error' };
+			return { ...input, html: 'Error', json: 'Error' };
 		}
 	});
 	return Promise.all(citeObjects);

--- a/server/routes/pub.js
+++ b/server/routes/pub.js
@@ -4,7 +4,7 @@ import { Pub } from 'containers';
 
 import { getPubPageContextTitle } from 'shared/utils/pubPageTitle';
 import { getPubPublishedDate } from 'shared/pub/pubDates';
-import { getPDFDownload, getTextAbstract } from 'shared/pub/metadata';
+import { getPDFDownload, getTextAbstract, getGSNotes } from 'shared/pub/metadata';
 import { chooseCollectionForPub } from '../../client/utils/collections';
 import Html from '../Html';
 import app from '../server';
@@ -153,6 +153,7 @@ app.get(
 						collection: chooseCollectionForPub(pubData, initialData.locationData),
 						download: getPDFDownload(pubData),
 						textAbstract: pubData.initialDoc ? getTextAbstract(pubData.initialDoc) : '',
+						notes: getGSNotes(pubData.citations.concat(pubData.footnotes)),
 						// unlisted: isUnlistedDraft,
 					})}
 				>

--- a/server/routes/pub.js
+++ b/server/routes/pub.js
@@ -4,7 +4,7 @@ import { Pub } from 'containers';
 
 import { getPubPageContextTitle } from 'shared/utils/pubPageTitle';
 import { getPubPublishedDate } from 'shared/pub/pubDates';
-import { getPDFDownload, getTextAbstract, getGSNotes } from 'shared/pub/metadata';
+import { getPDFDownload, getTextAbstract, getGoogleScholarNotes } from 'shared/pub/metadata';
 import { chooseCollectionForPub } from '../../client/utils/collections';
 import Html from '../Html';
 import app from '../server';
@@ -153,7 +153,7 @@ app.get(
 						collection: chooseCollectionForPub(pubData, initialData.locationData),
 						download: getPDFDownload(pubData),
 						textAbstract: pubData.initialDoc ? getTextAbstract(pubData.initialDoc) : '',
-						notes: getGSNotes(pubData.citations.concat(pubData.footnotes)),
+						notes: getGoogleScholarNotes(pubData.citations.concat(pubData.footnotes)),
 						// unlisted: isUnlistedDraft,
 					})}
 				>

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -227,6 +227,7 @@ export const generateMetaComponents = ({
 	collection,
 	download,
 	textAbstract,
+	notes,
 }) => {
 	const siteName = initialData.communityData.title;
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
@@ -419,6 +420,14 @@ export const generateMetaComponents = ({
 		];
 	}
 
+	if (notes) {
+		const citationNoteTags = notes.map((note, i) => {
+			// https://github.com/yannickcr/eslint-plugin-react/issues/1123
+			// eslint-disable-next-line react/no-array-index-key
+			return <meta key={`n${i}`} name="citation_reference" content={note} />;
+		});
+		outputComponents = [...outputComponents, citationNoteTags];
+	}
 	if (unlisted) {
 		outputComponents = [
 			...outputComponents,

--- a/shared/pub/metadata.js
+++ b/shared/pub/metadata.js
@@ -50,43 +50,41 @@ export const getTextAbstract = (docJson) => {
 	return abstract;
 };
 
+const noteTypes = {
+	chapter: 'book',
+	book: 'book',
+	proceedings: 'conference',
+	'paper-conference': 'conference',
+};
+
 export const getGoogleScholarNotes = (notes) => {
 	return notes.reduce((unique, note) => {
 		const noteArray = [];
 		const noteType = note.json[0].type;
-		const noteTypes = {
-			chapter: 'book',
-			book: 'book',
-			proceedings: 'conference',
-			'paper-conference': 'conference',
-		};
 		const noteTypeString = noteTypes[noteType] || 'journal';
 
-		const noteArr = Object.entries(note.json[0]);
-		noteArr.forEach((entry) => {
-			switch (entry[0]) {
+		Object.entries(note.json[0]).forEach(([key, value]) => {
+			switch (key) {
 				case 'title':
-					noteArray.push(`citation_title=${entry[1]}`);
+					noteArray.push(`citation_title=${value}`);
 					break;
 				case 'author':
-					entry[1].forEach((author) => {
+					value.forEach((author) => {
 						noteArray.push(`citation_author=${author.given} ${author.family}`);
 					});
 					break;
 				case 'container-title':
-					noteArray.push(`citation_${noteTypeString}_title=${entry[1]}`);
+					noteArray.push(`citation_${noteTypeString}_title=${value}`);
 					break;
 				case 'issued':
-					noteArray.push(
-						`citation_publication_date=${entry[1]['date-parts'][0].join('/')}`,
-					);
+					noteArray.push(`citation_publication_date=${value['date-parts'][0].join('/')}`);
 					break;
 				case 'issue':
 				case 'volume':
 				case 'DOI':
 				case 'ISSN':
 				case 'ISBN':
-					noteArray.push(`citation_${entry[0]}=${entry[1]}`);
+					noteArray.push(`citation_${key}=${value}`);
 					break;
 				default:
 					break;

--- a/shared/pub/metadata.js
+++ b/shared/pub/metadata.js
@@ -49,3 +49,49 @@ export const getTextAbstract = (docJson) => {
 	}
 	return abstract;
 };
+
+export const getGSNotes = (notes) => {
+	return notes.reduce((unique, note) => {
+		const noteArray = [];
+		const noteType = note.json[0].type;
+		const noteTypes = {
+			chapter: 'book',
+			book: 'book',
+			proceedings: 'conference',
+			'paper-conference': 'conference',
+		};
+		const noteTypeString = noteTypes[noteType] || 'journal';
+
+		const noteArr = Object.entries(note.json[0]);
+		noteArr.forEach((entry) => {
+			switch (entry[0]) {
+				case 'title':
+					noteArray.push(`citation_title=${entry[1]}`);
+					break;
+				case 'author':
+					entry[1].forEach((author) => {
+						noteArray.push(`citation_author=${author.given} ${author.family}`);
+					});
+					break;
+				case 'container-title':
+					noteArray.push(`citation_${noteTypeString}_title=${entry[1]}`);
+					break;
+				case 'issued':
+					noteArray.push(
+						`citation_publication_date=${entry[1]['date-parts'][0].join('/')}`,
+					);
+					break;
+				case 'issue':
+				case 'volume':
+				case 'DOI':
+				case 'ISSN':
+				case 'ISBN':
+					noteArray.push(`citation_${entry[0]}=${entry[1]}`);
+					break;
+				default:
+					break;
+			}
+		});
+		return unique.includes(noteArray.join(';')) ? unique : [...unique, noteArray.join(';')];
+	}, []);
+};

--- a/shared/pub/metadata.js
+++ b/shared/pub/metadata.js
@@ -50,7 +50,7 @@ export const getTextAbstract = (docJson) => {
 	return abstract;
 };
 
-export const getGSNotes = (notes) => {
+export const getGoogleScholarNotes = (notes) => {
 	return notes.reduce((unique, note) => {
 		const noteArray = [];
 		const noteType = note.json[0].type;


### PR DESCRIPTION
This generates Google/Highwire meta tags for references on the frontend for pubs that use built-in footnotes or citations. It's a pretty naive generator; on the other hand, the tags themselves are [not well specified](https://citation.js.org/blog/?post=3781582023912504297). Eventually, we should probably write a CSL to produce these, but that seems like a multi-week project not particularly worth our time at the moment.

Features of this particular PR:
- De-duplicates among footnotes and tags
- Supports journal, conference, and book (defaulting to journal)
- Filters out unstructured inputs

_Test plan_
1. Visit pub with lots of citations and verify they are represented in meta tags 
2. Visit pub with duplicate tags (both within footnote/citation and across footnote/citation) and verify they are _not_ replicated in meta tags. (ex: https://hdsr.duqduq.org/pub/hx3pgxjc)
3. Visit pub with journal, book, and conference citations and verify they are represented properly with `citation_journal_title`, `citation_book_title`, and `citation_conference_title` respectively.
4. Create new pub. Publish with no references. Then add some references and publish. Make sure meta tags are not there before, there after, and that merging works as expected.