### PR TITLE
update: Set canonical URL for user profiles

### DIFF
--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -131,6 +131,7 @@ app.get(['/user/:slug', '/user/:slug/:mode'], (req, res, next) => {
 						title: `${userDataJson.fullName} · PubPub`,
 						description: userDataJson.bio,
 						image: userDataJson.avatar,
+						canonicalUrl: `https://www.pubpub.org/user/${userDataJson.slug}`,
 					})}
 				>
 					<UserContainer {...newInitialData} />

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -227,6 +227,7 @@ export const generateMetaComponents = ({
 	collection,
 	download,
 	textAbstract,
+	canonicalUrl,
 }) => {
 	const siteName = initialData.communityData.title;
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
@@ -424,6 +425,10 @@ export const generateMetaComponents = ({
 			...outputComponents,
 			<meta key="un1" name="robots" content="noindex,nofollow" />,
 		];
+	}
+
+	if (canonicalUrl) {
+		outputComponents = [...outputComponents, <link rel="canonical" href={canonicalUrl} />];
 	}
 
 	outputComponents = [


### PR DESCRIPTION
At the moment, search engines will index a user's profile on different communities as separate results. This leads to folks having 4 or 5 PubPub community profile pages in search engine results when entering their name. 

This PR proposes that we add a `<link rel="canonical">` tag to user profile meta tags that points to the default www.pubpub.org user profile. 