### PR TITLE
fix: Breaks URLs and other long strings in note popovers

### DIFF
--- a/client/components/PubNoteContent/pubNoteContent.scss
+++ b/client/components/PubNoteContent/pubNoteContent.scss
@@ -1,3 +1,3 @@
 .pub-note-content-component {
-	
+	word-break: break-word;
 }


### PR DESCRIPTION
To address #668 