### PR TITLE
fix: Wrap long affiliations in HTML/PDF exports.

### DIFF
--- a/workers/tasks/export/styles/printDocument.scss
+++ b/workers/tasks/export/styles/printDocument.scss
@@ -48,7 +48,7 @@ section.cover {
             margin: 0;
             margin-top: 0.5em;
             span.affiliation {
-                white-space: nowrap;
+                white-space: break-word;
                 display: inline-block;
                 margin-right: 0.2em;
             }


### PR DESCRIPTION
Fixes a small CSS issue in PDF exports where authors with super long affiliations had them cutoff on the cover page instead of wrapped.

Before:
<img width="621" alt="Screen Shot 2020-01-30 at 13 20 33" src="https://user-images.githubusercontent.com/639110/73478032-5085f100-4363-11ea-852b-1131caee8689.png">

After:
<img width="578" alt="Screen Shot 2020-01-30 at 13 19 38" src="https://user-images.githubusercontent.com/639110/73477986-3b10c700-4363-11ea-860f-9a9093280e45.png">

@idreyn: Let me know if there was a reason for setting nowrap here and if we should go instead with some kind of overflow setting higher up the tree.

_Test plan_
1. Create Pub with an author with a very long affiliation of at least 125 chars.
1. Export to PDF
1. Ensure that author name is not cutoff
1. Add a few more authors with long affiliations
1. Export PDF (requires updating the pub body)
1. Ensure that they all display properly and don't overlap