### PR TITLE
fix: Make sticky headers work when page size changes

### DIFF
--- a/client/containers/Pub/PubDocument/PubHeaderFormatting.js
+++ b/client/containers/Pub/PubDocument/PubHeaderFormatting.js
@@ -1,7 +1,7 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import stickybits from 'stickybits';
 
+import { useSticky } from 'utils/useSticky';
 import { FormattingBar, buttons } from 'components/FormattingBar';
 import PubHeaderCollaborators from './PubHeaderCollaborators';
 
@@ -14,18 +14,10 @@ const propTypes = {
 };
 
 const PubHeaderFormatting = (props) => {
-	const stickyInstanceRef = useRef(undefined);
-	useEffect(() => {
-		stickyInstanceRef.current = stickybits('.pub-draft-header-component', {
-			stickyBitStickyOffset: 37,
-			useStickyClasses: true,
-		});
-		return () => {
-			if (stickyInstanceRef.current) {
-				stickyInstanceRef.current.cleanup();
-			}
-		};
-	}, []);
+	useSticky({
+		selector: '.pub-draft-header-component',
+		offset: 37,
+	});
 
 	const { pubData, collabData } = props;
 	if (!pubData.canEditBranch) {

--- a/client/containers/Pub/PubHeader/PubHeader.js
+++ b/client/containers/Pub/PubHeader/PubHeader.js
@@ -1,11 +1,9 @@
 /* eslint-disable react/no-danger */
 import React, { useContext, useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
-import useWindowSize from 'react-use/lib/useWindowSize';
 // import dateFormat from 'dateformat';
 
 import classNames from 'classnames';
-import stickybits from 'stickybits';
 import { getJSON } from '@pubpub/editor';
 import { apiFetch, getResizedUrl } from 'utils';
 import {
@@ -19,9 +17,13 @@ import {
 	MenuDivider,
 	Popover,
 } from '@blueprintjs/core';
+
 import { GridWrapper, Overlay, Icon } from 'components';
 import { PageContext } from 'components/PageWrapper/PageWrapper';
+import { useSticky } from 'utils/useSticky';
+import { getAllPubContributors } from 'utils/pubContributors';
 import CitationsPreview from '../PubDocument/PubDetails/CitationsPreview';
+
 import PubToc from './PubToc';
 import Download from './Download';
 import Social from './Social';
@@ -30,7 +32,6 @@ import SharePanel from './SharePanel';
 import styleGenerator from './styleGenerator';
 import { generateHeaderBreadcrumbs, getTocHeadings } from './headerUtils';
 import CollectionsBar from './CollectionsBar';
-import { getAllPubContributors } from '../../../utils/pubContributors';
 
 require('./pubHeader.scss');
 
@@ -80,24 +81,15 @@ const PubHeader = (props) => {
 	const [isMounted, setIsMounted] = useState(false);
 	const [isEditingTitle, setIsEditingTitle] = useState(false);
 	const [isShareOpen, setIsShareOpen] = useState(false);
-	const { width: windowWidth } = useWindowSize();
 	const isDocMode = pubData.mode === 'document';
 
-	useEffect(() => {
-		if (!isDocMode) {
-			return () => {};
-		}
-		setIsMounted(true);
-		const nextOffsetHeight = headerRef.current.offsetHeight;
-		const stickyInstance = stickybits('.pub-header-component', {
-			stickyBitStickyOffset: 37 - nextOffsetHeight,
-			useStickyClasses: true,
-		});
+	useEffect(() => setIsMounted(true), []);
 
-		return () => {
-			stickyInstance.cleanup();
-		};
-	}, [pubData, windowWidth, isDocMode]);
+	useSticky({
+		isActive: isDocMode && headerRef.current,
+		selector: '.pub-header-component',
+		offset: headerRef.current ? 37 - headerRef.current.offsetHeight : 0,
+	});
 
 	const handleTitleSave = (newTitle) => {
 		return apiFetch('/api/pubs', {

--- a/client/utils/useSticky.js
+++ b/client/utils/useSticky.js
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+import stickybits from 'stickybits';
+
+const useOrFakeResizeObserver = (onResize) => {
+	const lastBodyHeight = useRef(null);
+	useEffect(() => {
+		if (typeof window !== 'undefined') {
+			if ('ResizeObserver' in window) {
+				const observer = new ResizeObserver(onResize);
+				observer.observe(document.body);
+				return () => observer.disconnect();
+			}
+			const interval = setInterval(() => {
+				const bodyHeight = document.body.offsetHeight;
+				if (bodyHeight !== lastBodyHeight.current) {
+					lastBodyHeight.current = bodyHeight;
+					onResize();
+				}
+			}, 100);
+			return () => clearInterval(interval);
+		}
+		return () => {};
+	}, [onResize]);
+};
+
+export const useSticky = ({ selector, offset = 0, isActive = true }) => {
+	const stickyInstanceRef = useRef(null);
+
+	useEffect(() => {
+		if (isActive) {
+			stickyInstanceRef.current = stickybits(selector, {
+				stickyBitStickyOffset: offset,
+				useStickyClasses: true,
+			});
+			return () => stickyInstanceRef.current.cleanup();
+		}
+		return () => {};
+	}, [isActive, offset, selector]);
+
+	useOrFakeResizeObserver(() => stickyInstanceRef.current.update());
+};


### PR DESCRIPTION
This addresses #678 and also Deepak's report that scrolling to the bottom of a Pub will sometimes cause large amounts of unpleasant jittering. Hoping to get a few pairs of eyes on this to verify that the problem is fixed, since I had some problem reproducing it to begin with.

_Technical mumbo-jumbo:_
It seems that Stickybits doesn't automatically recompute certain values when the total height of the page content changes, such as when a lot of text is added to a Pub — instead, you need to explicitly call the `update` method on the instance it provides. Here we observe changes using the `ResizeObserver` API where available, and using a timeout otherwise (in Safari and IE/legacy Edge). There are polyfills available for this API, but they appear not to work in this case. I factored the correct behavior into a `useSticky` hook that we should use from here on out.

_Test plan:_
Open a Pub and verify that the header works in read-only mode. Switch to an editable branch and add enough text that the total height of the page content is significantly increased, and verify that both the pub header and formatting bar stick as expected, and that there is no jitter when reaching the bottom of the page.