### PR TITLE
fix: Add a few additional redirects neeed by BAAS

### DIFF
--- a/server/routes/redirects.js
+++ b/server/routes/redirects.js
@@ -49,7 +49,9 @@ app.use((req, res, next) => {
 			'/news/lifetimes-of-astronomical-papers/': 'https://baas.aas.org/pub/2019i0207',
 			'/news-listing': 'https://baas.aas.org/news',
 			'/news/principles-of-editing/': 'https://baas.aas.org/pub/2019i0201',
+			'/obituaries/': 'https://baas.aas.org/obituaries',
 			'/obituaries-listing': 'https://baas.aas.org/obituaries',
+			'/obituaries-listing/': 'https://baas.aas.org/obituaries',
 		},
 	};
 


### PR DESCRIPTION
The Bulletin of the American Astronomical Society (BAAS) just replaced their old WordPress site with PubPub, and there are a few URLs out in the wild that we want to preserve by establishing redirects. A couple of the new entries that we need are because PubPub doesn't accept URLs with trailing slashes for its established names. One of them is for a URL slug that apparently got changed at some point.