### PR TITLE
new: Adds DMCA info without editing text of TOS

### DIFF
--- a/client/containers/Legal/Terms.js
+++ b/client/containers/Legal/Terms.js
@@ -385,8 +385,7 @@ const Terms = function(props) {
 				>
 					click here for more information
 				</Button>
-				<Dialog isOpen={isOpen} onClose={toggleOverlay}>
-					<p className={Classes.DIALOG_HEADER}>DMCA Agent Information</p>
+				<Dialog isOpen={isOpen} onClose={toggleOverlay} title="DMCA Agent Information">
 					<p className={Classes.DIALOG_BODY}>
 						PubPub DMCA Agent
 						<br />

--- a/client/containers/Legal/Terms.js
+++ b/client/containers/Legal/Terms.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Button, Dialog, Classes } from '@blueprintjs/core';
 import PropTypes from 'prop-types';
 
 const propTypes = {
@@ -6,6 +7,11 @@ const propTypes = {
 };
 
 const Terms = function(props) {
+	const [isOpen, setOpen] = useState(false);
+	const toggleOverlay = (e) => {
+		e.preventDefault();
+		setOpen(!isOpen);
+	};
 	return (
 		<div>
 			<h2>Terms of Service</h2>
@@ -365,9 +371,37 @@ const Terms = function(props) {
 				trademarks will inure to the exclusive benefit of the holder of such trademarks.
 			</p>
 			<p>
-				If you believe that any content on the Site infringes your copyright, please click
-				here for more information, including the email address for our DMCA agent, to whom
-				copyright infringement notifications should be sent. 
+				If you believe that any content on the Site infringes your copyright, please{' '}
+				<Button
+					minimal={true}
+					onClick={toggleOverlay}
+					style={{
+						margin: 0,
+						padding: 0,
+						textDecoration: 'underline',
+						verticalAlign: 'baseline',
+						minHeight: 'inherit',
+					}}
+				>
+					click here for more information
+				</Button>
+				<Dialog isOpen={isOpen} onClose={toggleOverlay}>
+					<p className={Classes.DIALOG_HEADER}>DMCA Agent Information</p>
+					<p className={Classes.DIALOG_BODY}>
+						PubPub DMCA Agent
+						<br />
+						c/o Yarn Labs, Inc.
+						<br />
+						245 Main street
+						<br />
+						Floor 2<br />
+						Cambridge, MA 02142
+						<br />
+						Email: <a href="mailto:dmca@pubpub.org">dmca@pubpub.org</a>
+					</p>
+				</Dialog>
+				, including the email address for our DMCA agent, to whom copyright infringement
+				notifications should be sent. 
 			</p>
 			<h3>Prohibited Uses of the Site</h3>
 			<p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2011,9 +2011,9 @@
 			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
 		},
 		"@pubpub/editor": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@pubpub/editor/-/editor-7.2.0.tgz",
-			"integrity": "sha512-EZrjIGwC0/pBpcJUQz4YNlCDKc/yqt1oTzoOSjF4hv7c9h8TB1yRoa6DX8hekfd71hIFRSUNjAPWkv8ZAeWudQ==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@pubpub/editor/-/editor-7.2.2.tgz",
+			"integrity": "sha512-DTyruoosSpLmViNr3RUHT/VAMyCO0KBM/g5Ksh9StMNHUuHueSiz2CEKx+IIntvqE3LR02G2aptpeaRpUhXA/Q==",
 			"requires": {
 				"camelcase-css": "^2.0.1",
 				"classnames": "^2.2.6",
@@ -14597,7 +14597,7 @@
 			}
 		},
 		"mathjax-full": {
-			"version": "git://github.com/mathjax/MathJax-src.git#bbd6eb4e4afb38c4e097bd8ea26cdec844204c47",
+			"version": "git://github.com/mathjax/MathJax-src.git#1e1a30f0a89e52fa7764dbb510763145a4da49f1",
 			"from": "git://github.com/mathjax/MathJax-src.git",
 			"requires": {
 				"esm": "^3.2.25",
@@ -17733,9 +17733,9 @@
 			}
 		},
 		"prosemirror-gapcursor": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.1.2.tgz",
-			"integrity": "sha512-Z+eqk6RysZVxidGWN5aWoSTbn5bTHf1XZ+nQJVwUSdwdBVkfQMFdTHgfrXA8W5MhHHdNg/EEEYG3z3Zi/vE2QQ==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.1.3.tgz",
+			"integrity": "sha512-/lgWvt2AdHjsM6oEsF65z0lhdQJGl6sQSfXSOX8/xjpd8ycfOolhgKZd4TPYpikwnh85JF4l5eIyiFZsl/RQQA==",
 			"requires": {
 				"prosemirror-keymap": "^1.0.0",
 				"prosemirror-model": "^1.0.0",
@@ -17855,9 +17855,9 @@
 			}
 		},
 		"prosemirror-view": {
-			"version": "1.13.7",
-			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.13.7.tgz",
-			"integrity": "sha512-P9Vrxe5/PJ68rJi/665NYAdj9hs9iXvvDo4OxD4G0rVmt4lna/n+H7BW1gT/ItDXdNR+LiU8c1mf/TX5RkJbxA==",
+			"version": "1.14.2",
+			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.14.2.tgz",
+			"integrity": "sha512-9yPVH6OLyaEraHjWHbSk2DB0R/1TsEE6AA1LI+vmCypXXA+zTzNrktUFzBhSJHehXDoEJcQfnl1Wdp5GPSh2+g==",
 			"requires": {
 				"prosemirror-model": "^1.1.0",
 				"prosemirror-state": "^1.0.0",


### PR DESCRIPTION
Pretty straightforward. Adds a dialog with DMCA information to the TOS that was missing in our initial push. Since this does not edit the TOS, I don't believe sending an update to users is required.

<img width="723" alt="Screen Shot 2020-03-06 at 12 06 37" src="https://user-images.githubusercontent.com/639110/76105443-f51ed280-5fa2-11ea-9b22-08b14bfa7540.png">

<img width="680" alt="Screen Shot 2020-03-06 at 12 06 42" src="https://user-images.githubusercontent.com/639110/76105458-fb14b380-5fa2-11ea-829a-e9ed2e99f24f.png">

Only weird-ish thing is I used a button, restyled to look like a link, because jsxa11y complained about using an anchor to launch the dialog.

_Test plan_
1. Visit Terms (/legal/terms)
2. Click "please click here for more information"
3. Verify that dialog opens when the line is clicked
4. Close dialog by clicking on the `x` in the header
5. Verify that dialog can be closed with escape and by clicking outside the dialog