### PR TITLE
new: Select copyright for Pub license

### DIFF
--- a/client/components/LicenseSelect/LicenseSelect.js
+++ b/client/components/LicenseSelect/LicenseSelect.js
@@ -1,10 +1,12 @@
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Icon, Popover, Menu, MenuItem } from '@blueprintjs/core';
+import dateFormat from 'dateformat';
 
 import { licenses, getLicenseBySlug } from 'shared/license';
 import { apiFetch } from 'utils';
 import { PageContext } from 'components/PageWrapper/PageWrapper';
+import { getPubPublishedDate } from 'shared/pub/pubDates';
 
 require('./licenseSelect.scss');
 
@@ -13,6 +15,8 @@ const propTypes = {
 	pubData: PropTypes.shape({
 		id: PropTypes.string,
 		licenseSlug: PropTypes.string,
+		collectionPubs: PropTypes.object,
+		activeBranch: PropTypes.object,
 	}).isRequired,
 	onSelect: PropTypes.func,
 	updateLocalData: PropTypes.func,
@@ -31,7 +35,15 @@ const LicenseSelect = (props) => {
 	const { communityData } = useContext(PageContext);
 
 	const currentLicense = getLicenseBySlug(pubData.licenseSlug);
-
+	const primaryCollectionPub = pubData.collectionPubs.find((cp) => cp.isPrimary);
+	let pubCopyrightDate = dateFormat(getPubPublishedDate(pubData, pubData.activeBranch), 'yyyy');
+	if (primaryCollectionPub && primaryCollectionPub.collection.metadata.copyrightYear) {
+		pubCopyrightDate = primaryCollectionPub.collection.metadata.copyrightYear;
+	}
+	let pubPublisher = communityData.title;
+	if (communityData.id === '78810858-8c4a-4435-a669-6bb176b61d40') {
+		pubPublisher = 'Massachusetts Institute of Technology';
+	}
 	const selectLicense = (license) => {
 		onSelect(license);
 		if (persistSelections) {
@@ -70,18 +82,28 @@ const LicenseSelect = (props) => {
 								<div>
 									<div className="title">
 										{license.short}{' '}
-										<a
-											href={license.link}
-											className="link"
-											onClick={(e) => e.stopPropagation()}
-											target="_blank"
-											rel="noopener noreferrer"
-										>
-											Learn more
-											<Icon iconSize={12} icon="share" />
-										</a>
+										{license.link && (
+											<a
+												href={license.link}
+												className="link"
+												onClick={(e) => e.stopPropagation()}
+												target="_blank"
+												rel="noopener noreferrer"
+											>
+												Learn more
+												<Icon iconSize={12} icon="share" />
+											</a>
+										)}
 									</div>
-									<div className="full">{license.full}</div>
+									{license.slug === 'copyright' && (
+										<div className="full">
+											Copyright © {pubCopyrightDate} {pubPublisher}. All
+											rights reserved.
+										</div>
+									)}
+									{license.slug !== 'copyright' && (
+										<div className="full">{license.full}</div>
+									)}
 								</div>
 							}
 							icon={renderIcon(license)}

--- a/client/components/LicenseSelect/LicenseSelect.js
+++ b/client/components/LicenseSelect/LicenseSelect.js
@@ -16,7 +16,6 @@ const propTypes = {
 		id: PropTypes.string,
 		licenseSlug: PropTypes.string,
 		collectionPubs: PropTypes.object,
-		activeBranch: PropTypes.object,
 	}).isRequired,
 	onSelect: PropTypes.func,
 	updateLocalData: PropTypes.func,
@@ -36,10 +35,13 @@ const LicenseSelect = (props) => {
 
 	const currentLicense = getLicenseBySlug(pubData.licenseSlug);
 	const primaryCollectionPub = pubData.collectionPubs.find((cp) => cp.isPrimary);
-	let pubCopyrightDate = dateFormat(getPubPublishedDate(pubData, pubData.activeBranch), 'yyyy');
-	if (primaryCollectionPub && primaryCollectionPub.collection.metadata.copyrightYear) {
-		pubCopyrightDate = primaryCollectionPub.collection.metadata.copyrightYear;
-	}
+	const collectionPubDate = primaryCollectionPub
+		? primaryCollectionPub.collection.metadata.copyrightYear ||
+		  primaryCollectionPub.collection.metadata.date ||
+		  primaryCollectionPub.collection.metadata.publicationDate
+		: null;
+	const pubCopyrightDate =
+		dateFormat(collectionPubDate, 'yyyy') || dateFormat(getPubPublishedDate(pubData), 'yyyy');
 	let pubPublisher = communityData.title;
 	if (communityData.id === '78810858-8c4a-4435-a669-6bb176b61d40') {
 		pubPublisher = 'Massachusetts Institute of Technology';

--- a/client/components/LicenseSelect/LicenseSelect.js
+++ b/client/components/LicenseSelect/LicenseSelect.js
@@ -44,6 +44,9 @@ const LicenseSelect = (props) => {
 	if (communityData.id === '78810858-8c4a-4435-a669-6bb176b61d40') {
 		pubPublisher = 'Massachusetts Institute of Technology';
 	}
+	if (currentLicense.slug === 'copyright') {
+		currentLicense.full = `Copyright © ${pubCopyrightDate} ${pubPublisher}. All rights reserved.`;
+	}
 	const selectLicense = (license) => {
 		onSelect(license);
 		if (persistSelections) {

--- a/client/containers/Pub/PubDocument/PubBottom/LicenseSection.js
+++ b/client/containers/Pub/PubDocument/PubBottom/LicenseSection.js
@@ -13,7 +13,6 @@ const propTypes = {
 		canManage: PropTypes.bool,
 		licenseSlug: PropTypes.string,
 		collectionPubs: PropTypes.object,
-		activeBranch: PropTypes.object,
 	}).isRequired,
 	updateLocalData: PropTypes.func.isRequired,
 };
@@ -23,10 +22,13 @@ const LicenseSection = (props) => {
 	const { communityData } = useContext(PageContext);
 	const { link, full, short, version, slug } = getLicenseBySlug(pubData.licenseSlug);
 	const primaryCollectionPub = pubData.collectionPubs.find((cp) => cp.isPrimary);
-	let pubCopyrightDate = dateFormat(getPubPublishedDate(pubData, pubData.activeBranch), 'yyyy');
-	if (primaryCollectionPub && primaryCollectionPub.collection.metadata.copyrightYear) {
-		pubCopyrightDate = primaryCollectionPub.collection.metadata.copyrightYear;
-	}
+	const collectionPubDate = primaryCollectionPub
+		? primaryCollectionPub.collection.metadata.copyrightYear ||
+		  primaryCollectionPub.collection.metadata.date ||
+		  primaryCollectionPub.collection.metadata.publicationDate
+		: null;
+	const pubCopyrightDate =
+		dateFormat(collectionPubDate, 'yyyy') || dateFormat(getPubPublishedDate(pubData), 'yyyy');
 	let pubPublisher = communityData.title;
 	if (communityData.id === '78810858-8c4a-4435-a669-6bb176b61d40') {
 		pubPublisher = 'Massachusetts Institute of Technology';

--- a/client/containers/Pub/PubDocument/PubBottom/LicenseSection.js
+++ b/client/containers/Pub/PubDocument/PubBottom/LicenseSection.js
@@ -3,13 +3,17 @@ import PropTypes from 'prop-types';
 import { LicenseSelect } from 'components';
 import { PageContext } from 'components/PageWrapper/PageWrapper';
 import { getLicenseBySlug } from 'shared/license';
+import dateFormat from 'dateformat';
 
+import { getPubPublishedDate } from 'shared/pub/pubDates';
 import PubBottomSection, { SectionBullets, AccentedIconButton } from './PubBottomSection';
 
 const propTypes = {
 	pubData: PropTypes.shape({
 		canManage: PropTypes.bool,
 		licenseSlug: PropTypes.string,
+		collectionPubs: PropTypes.object,
+		activeBranch: PropTypes.object,
 	}).isRequired,
 	updateLocalData: PropTypes.func.isRequired,
 };
@@ -17,7 +21,16 @@ const propTypes = {
 const LicenseSection = (props) => {
 	const { pubData, updateLocalData } = props;
 	const { communityData } = useContext(PageContext);
-	const { link, full, short, version } = getLicenseBySlug(pubData.licenseSlug);
+	const { link, full, short, version, slug } = getLicenseBySlug(pubData.licenseSlug);
+	const primaryCollectionPub = pubData.collectionPubs.find((cp) => cp.isPrimary);
+	let pubCopyrightDate = dateFormat(getPubPublishedDate(pubData, pubData.activeBranch), 'yyyy');
+	if (primaryCollectionPub && primaryCollectionPub.collection.metadata.copyrightYear) {
+		pubCopyrightDate = primaryCollectionPub.collection.metadata.copyrightYear;
+	}
+	let pubPublisher = communityData.title;
+	if (communityData.id === '78810858-8c4a-4435-a669-6bb176b61d40') {
+		pubPublisher = 'Massachusetts Institute of Technology';
+	}
 
 	return (
 		<PubBottomSection
@@ -26,11 +39,23 @@ const LicenseSection = (props) => {
 			className="pub-bottom-license"
 			title="License"
 			centerItems={
-				<SectionBullets>
-					<a target="_blank" rel="license noopener noreferrer" href={link}>
-						{`${full} (${short} ${version})`}
-					</a>
-				</SectionBullets>
+				<>
+					{slug === 'copyright' && (
+						<SectionBullets>
+							<span>
+								Copyright © {pubCopyrightDate} {pubPublisher}. (All rights
+								reserved.)
+							</span>
+						</SectionBullets>
+					)}
+					{slug !== 'copyright' && (
+						<SectionBullets>
+							<a target="_blank" rel="license noopener noreferrer" href={link}>
+								{`${full} (${short} ${version})`}
+							</a>
+						</SectionBullets>
+					)}
+				</>
 			}
 			iconItems={({ iconColor }) => {
 				if (pubData.canManage) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2011,9 +2011,9 @@
 			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
 		},
 		"@pubpub/editor": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@pubpub/editor/-/editor-7.2.2.tgz",
-			"integrity": "sha512-DTyruoosSpLmViNr3RUHT/VAMyCO0KBM/g5Ksh9StMNHUuHueSiz2CEKx+IIntvqE3LR02G2aptpeaRpUhXA/Q==",
+			"version": "7.3.0-beta.4",
+			"resolved": "https://registry.npmjs.org/@pubpub/editor/-/editor-7.3.0-beta.4.tgz",
+			"integrity": "sha512-PfHGdKc72PpWMcvbWZEnB0OoUl8x2PWfEKv2wb4C1zKrrW5PlF7V9dxnqJIJ30Olc81tLTLwWlt/tAYbsUn0cQ==",
 			"requires": {
 				"camelcase-css": "^2.0.1",
 				"classnames": "^2.2.6",
@@ -14614,7 +14614,7 @@
 			}
 		},
 		"mathjax-full": {
-			"version": "git://github.com/mathjax/MathJax-src.git#bbd6eb4e4afb38c4e097bd8ea26cdec844204c47",
+			"version": "git://github.com/mathjax/MathJax-src.git#1e1a30f0a89e52fa7764dbb510763145a4da49f1",
 			"from": "git://github.com/mathjax/MathJax-src.git",
 			"requires": {
 				"esm": "^3.2.25",
@@ -17769,9 +17769,9 @@
 			}
 		},
 		"prosemirror-gapcursor": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.1.3.tgz",
-			"integrity": "sha512-/lgWvt2AdHjsM6oEsF65z0lhdQJGl6sQSfXSOX8/xjpd8ycfOolhgKZd4TPYpikwnh85JF4l5eIyiFZsl/RQQA==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.1.4.tgz",
+			"integrity": "sha512-6WJRDcd5jeKDZfzM6nD8aLtA9y54aPgUzVD0rudNrirq8qWgugiN29BfvIVdiDzV0Q+/cwr2yNs5/ssSAvZ0Kw==",
 			"requires": {
 				"prosemirror-keymap": "^1.0.0",
 				"prosemirror-model": "^1.0.0",
@@ -17891,9 +17891,9 @@
 			}
 		},
 		"prosemirror-view": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.14.2.tgz",
-			"integrity": "sha512-9yPVH6OLyaEraHjWHbSk2DB0R/1TsEE6AA1LI+vmCypXXA+zTzNrktUFzBhSJHehXDoEJcQfnl1Wdp5GPSh2+g==",
+			"version": "1.14.5",
+			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.14.5.tgz",
+			"integrity": "sha512-kKxvECC0LuOh9IVIsb2EdXuJvD1o4VgVioCq9/g1nMPClrwzrHPDRSkj3fnoCNwu7mry28LvcRCSYvC2LI8ZZw==",
 			"requires": {
 				"prosemirror-model": "^1.1.0",
 				"prosemirror-state": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"@blueprintjs/core": "^3.17.1",
 		"@blueprintjs/icons": "^3.9.1",
 		"@blueprintjs/select": "^3.9.0",
-		"@pubpub/editor": "^7.2.2",
+		"@pubpub/editor": "^7.3.0-beta.4",
 		"@pubpub/prosemirror-pandoc": "^0.1.7",
 		"@sentry/browser": "^5.5.0",
 		"@sentry/node": "^5.5.0",

--- a/shared/license/licenses.js
+++ b/shared/license/licenses.js
@@ -37,6 +37,14 @@ export const licenses = [
 		link: 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
 		requiresPremium: true,
 	},
+	{
+		slug: 'copyright',
+		full: 'Copyright © All rights reserved.',
+		short: 'Copyright',
+		version: null,
+		link: null,
+		requiresPremium: true,
+	},
 ];
 
 export const getLicenseBySlug = (slug = 'cc-by') => {

--- a/static/license/copyright.svg
+++ b/static/license/copyright.svg
@@ -1,0 +1,17 @@
+<svg width="120" height="42" xmlns="http://www.w3.org/2000/svg">
+
+ <g>
+  <title>background</title>
+  <rect fill="none" id="canvas_background" height="44" width="122" y="-1" x="-1"/>
+ </g>
+ <g>
+  <title>Layer 1</title>
+  <g stroke="null" id="svg_7">
+   <circle stroke="null" id="svg_1" fill="black" r="20" cy="21" cx="60.000001"/>
+   <circle stroke="null" id="svg_2" fill="white" r="15.918368" cy="21" cx="60.000001"/>
+   <circle stroke="null" id="svg_3" fill="black" r="11.224489" cy="21" cx="60.000001"/>
+   <circle stroke="null" id="svg_4" fill="white" r="6.122449" cy="21" cx="60.000001"/>
+   <rect stroke="null" id="svg_5" fill="white" height="5.102041" width="9.183674" y="18.346939" x="63.469389"/>
+  </g>
+ </g>
+</svg>

--- a/stories/components/licenseSelectStories.js
+++ b/stories/components/licenseSelectStories.js
@@ -9,7 +9,7 @@ const LicenseSelectContainer = () => {
 	return (
 		<LicenseSelect
 			updateLocalData={(pubData) => setCurrentLicense(pubData.licenseSlug)}
-			pubData={{ id: '', licenseSlug: currentLicense }}
+			pubData={{ id: '', licenseSlug: currentLicense, collectionPubs: [] }}
 		>
 			{({ title, icon, loading }) => (
 				<Button icon={icon} text={title} rightIcon={loading && <Spinner size={5} />} />


### PR DESCRIPTION
This PR allows users in communities with `premiumLicense === true` to select copyright as one of the licenses. Copyright has some logic built in:

- By default, the copyright date is the year the pub was published (or created, for draft pubs), and the copyright holder is the name of the community.
- This is manually overwritten for the COVID community to be 'Massachusetts Institute of Technology'. In the future, we should add a copyright holder field for collections.
- If the pub is in a primary collection that has a publication date (or, in the case of a conference, date) set, that date is the copyright date.

_Test plan_
1. Visit a pub in a community without the license flag set (ie cursor). Verify that you cannot select copyright.
1. Visit a pub in a community with the license flag set (ie demo). Verify that you can select copyright.
1. Visit a pub with a primary collection set that has a publication date set (ie https://covid-19.mitpress.mit.edu/pub/84v5elhf/branch/2). Verify that the copyright date is the same as the collection publication date.
1. Visit a pub with multiple collections set. Verify that the copyright date is the same as the primary collection publication date.
1. Visit a pub with a collection that does not have a date set. Verify that the copyright date is the same as the year the pub was published (or, if in draft, created).
1. Visit a pub that's in multiple collections, with one primary with the publication date set. Verify that the publication date is the primary collection's publication date.