### PR TITLE
new: Heap tracking

### DIFF
--- a/client/containers/Legal/PrivacyPolicy.js
+++ b/client/containers/Legal/PrivacyPolicy.js
@@ -91,20 +91,22 @@ const PrivacyPolicy = function() {
 				users. Any such internal analytics will be conducted on an anonymized set of
 				user-generated content.
 			</p>
-			<h3>Keen</h3>
+			<h3>Keen & Heap</h3>
 			<p>
-				We use Keen software to perform Site usage analytics. Keen collects anonymous
-				information from users to help us track Site usage and referrals from other
-				websites. These data are used primarily to optimize the website experience for our
-				visitors, but we may use the data as well to assist us in our marketing of the Site.
+				We use Keen and Heap software to perform Site usage analytics. Keen and Heap collect
+				anonymous information from users to help us track Site usage and referrals from
+				other websites. These data are used primarily to optimize the website experience for
+				our visitors, but we may use the data as well to assist us in our marketing of the
+				Site.
 			</p>
 			<p>
-				Information collected and processed by Keen include the user’s IP address, network
-				location, and geographic location. Keen acquires all its information directly from
-				the user, by installing a cookie (see below) on JavaScribp3-enabled computers. The
-				Site does not share any information it collects with Keen, and Keen does not collect
-				any personal identifying information such as names, contact information, social
-				security numbers or financial information.
+				Information collected and processed by Keen and Heap include the user’s IP address,
+				network location, and geographic location. Keen and Heap acquires all its
+				information directly from the user, by installing a cookie (see below) on
+				JavaScript-enabled computers. The Site does not share any information it collects
+				with Keen and Heap, and Keen and Heap do not collect any personal identifying
+				information such as names, contact information, social security numbers or financial
+				information.
 			</p>
 			<h3>Cookies</h3>
 			<p>

--- a/client/utils/heap.js
+++ b/client/utils/heap.js
@@ -13,7 +13,6 @@ export const setupHeap = () => {
 		pubId: null,
 		branchId: null,
 	};
-	const customUserData = {};
 	if (communityData) {
 		customEventData.communityId = communityData.id;
 	}
@@ -25,8 +24,8 @@ export const setupHeap = () => {
 		customEventData.branchId = pubData.activeBranch.id;
 	}
 	if (hasGdprConsent && loginData.id) {
-		customUserData.userId = loginData.id;
+		customEventData.loggedIn = 'true';
+		window.heap.identify(loginData.id);
 	}
 	window.heap.addEventProperties(customEventData);
-	window.heap.addUserProperties(customUserData);
 };

--- a/client/utils/heap.js
+++ b/client/utils/heap.js
@@ -1,0 +1,32 @@
+import { isProd } from './isProd';
+import { getClientInitialData } from './initialData';
+import { getGdprConsentElection } from './legal/gdprConsent';
+
+export const setupHeap = () => {
+	const { communityData, collectionData, pubData, loginData } = getClientInitialData();
+	const hasGdprConsent = getGdprConsentElection(loginData);
+	const heapEnvironment = isProd() ? '422727431' : '3777990325';
+	window.heap.load(heapEnvironment);
+	const customEventData = {
+		communityId: null,
+		pageId: null,
+		pubId: null,
+		branchId: null,
+	};
+	const customUserData = {};
+	if (communityData) {
+		customEventData.communityId = communityData.id;
+	}
+	if (collectionData) {
+		customEventData.pageId = collectionData.id;
+	}
+	if (pubData) {
+		customEventData.pubId = pubData.id;
+		customEventData.branchId = pubData.activeBranch.id;
+	}
+	if (hasGdprConsent && loginData.id) {
+		customUserData.userId = loginData.id;
+	}
+	window.heap.addEventProperties(customEventData);
+	window.heap.addUserProperties(customUserData);
+};

--- a/client/utils/heap.js
+++ b/client/utils/heap.js
@@ -1,9 +1,8 @@
 import { isProd } from './isProd';
-import { getClientInitialData } from './initialData';
 import { getGdprConsentElection } from './legal/gdprConsent';
 
-export const setupHeap = () => {
-	const { communityData, collectionData, pubData, loginData } = getClientInitialData();
+export const setupHeap = (initialData) => {
+	const { communityData, collectionData, pubData, loginData } = initialData;
 	const hasGdprConsent = getGdprConsentElection(loginData);
 	const heapEnvironment = isProd() ? '422727431' : '3777990325';
 	// eslint-disable-next-line

--- a/client/utils/heap.js
+++ b/client/utils/heap.js
@@ -6,6 +6,8 @@ export const setupHeap = () => {
 	const { communityData, collectionData, pubData, loginData } = getClientInitialData();
 	const hasGdprConsent = getGdprConsentElection(loginData);
 	const heapEnvironment = isProd() ? '422727431' : '3777990325';
+	// eslint-disable-next-line
+	window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};
 	window.heap.load(heapEnvironment);
 	const customEventData = {
 		communityId: null,

--- a/client/utils/hydrateWrapper.js
+++ b/client/utils/hydrateWrapper.js
@@ -29,10 +29,9 @@ export const hydrateWrapper = (Component) => {
 		const initialData = getClientInitialData();
 		setIsProd(initialData.locationData.isPubPubProduction);
 
-		setupHeap();
-
 		if (!isLocalEnv(window)) {
 			setupKeen();
+			setupHeap();
 			window.sentryIsActive = true;
 			Sentry.init({ dsn: 'https://abe1c84bbb3045bd982f9fea7407efaa@sentry.io/1505439' });
 			Sentry.setUser({

--- a/client/utils/hydrateWrapper.js
+++ b/client/utils/hydrateWrapper.js
@@ -31,7 +31,7 @@ export const hydrateWrapper = (Component) => {
 
 		if (!isLocalEnv(window)) {
 			setupKeen();
-			setupHeap();
+			setupHeap(initialData);
 			window.sentryIsActive = true;
 			Sentry.init({ dsn: 'https://abe1c84bbb3045bd982f9fea7407efaa@sentry.io/1505439' });
 			Sentry.setUser({

--- a/client/utils/hydrateWrapper.js
+++ b/client/utils/hydrateWrapper.js
@@ -5,6 +5,7 @@ import { FocusStyleManager } from '@blueprintjs/core';
 
 import { getClientInitialData } from './initialData';
 import { setupKeen } from './keen';
+import { setupHeap } from './heap';
 import { setIsProd } from './isProd';
 
 const isStorybookEnv = (windowObj) =>
@@ -27,6 +28,8 @@ export const hydrateWrapper = (Component) => {
 
 		const initialData = getClientInitialData();
 		setIsProd(initialData.locationData.isPubPubProduction);
+
+		setupHeap();
 
 		if (!isLocalEnv(window)) {
 			setupKeen();

--- a/client/utils/hydrateWrapper.js
+++ b/client/utils/hydrateWrapper.js
@@ -29,9 +29,10 @@ export const hydrateWrapper = (Component) => {
 		const initialData = getClientInitialData();
 		setIsProd(initialData.locationData.isPubPubProduction);
 
+		setupHeap();
+
 		if (!isLocalEnv(window)) {
 			setupKeen();
-			setupHeap();
 			window.sentryIsActive = true;
 			Sentry.init({ dsn: 'https://abe1c84bbb3045bd982f9fea7407efaa@sentry.io/1505439' });
 			Sentry.setUser({

--- a/client/utils/legal/gdprConsent.js
+++ b/client/utils/legal/gdprConsent.js
@@ -7,7 +7,7 @@ import { getCookieOptions } from './cookieOptions';
 const cookieKey = 'gdpr-consent';
 const persistSignupCookieKey = 'gdpr-consent-survives-login';
 
-const odiousCookies = ['keen'];
+const odiousCookies = ['keen', 'heap'];
 const deleteOdiousCookies = () => odiousCookies.map((key) => Cookies.remove(key, { path: '' }));
 
 export const gdprCookiePersistsSignup = () => Cookies.get(persistSignupCookieKey) === 'yes';

--- a/client/utils/legal/gdprConsent.js
+++ b/client/utils/legal/gdprConsent.js
@@ -9,9 +9,9 @@ const persistSignupCookieKey = 'gdpr-consent-survives-login';
 
 const odiousCookies = ['keen', 'heap'];
 const deleteOdiousCookies = () => {
-	odiousCookies.map((key) => Cookies.remove(key, { path: '' }));
 	window.heap.resetIdentity();
 	window.heap.clearEventProperties();
+	odiousCookies.map((key) => Cookies.remove(key, { path: '' }));
 };
 
 export const gdprCookiePersistsSignup = () => Cookies.get(persistSignupCookieKey) === 'yes';
@@ -40,6 +40,9 @@ export const updateGdprConsent = (loginData, doesUserConsent) => {
 	Cookies.set(cookieKey, doesUserConsent ? 'accept' : 'decline', cookieOptions);
 	Cookies.set(persistSignupCookieKey, 'yes', cookieOptions);
 	if (!doesUserConsent) {
+		if (!loggedIn) {
+			window.heap.identify(Math.random());
+		}
 		deleteOdiousCookies();
 	}
 	if (loggedIn) {

--- a/client/utils/legal/gdprConsent.js
+++ b/client/utils/legal/gdprConsent.js
@@ -8,7 +8,11 @@ const cookieKey = 'gdpr-consent';
 const persistSignupCookieKey = 'gdpr-consent-survives-login';
 
 const odiousCookies = ['keen', 'heap'];
-const deleteOdiousCookies = () => odiousCookies.map((key) => Cookies.remove(key, { path: '' }));
+const deleteOdiousCookies = () => {
+	odiousCookies.map((key) => Cookies.remove(key, { path: '' }));
+	window.heap.resetIdentity();
+	window.heap.clearEventProperties();
+};
 
 export const gdprCookiePersistsSignup = () => Cookies.get(persistSignupCookieKey) === 'yes';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14618,8 +14618,8 @@
 			"from": "git://github.com/mathjax/MathJax-src.git",
 			"requires": {
 				"esm": "^3.2.25",
-				"mj-context-menu": "^0.2.0",
-				"speech-rule-engine": "^3.0.0-beta.6"
+				"mj-context-menu": "^0.2.2",
+				"speech-rule-engine": "^3.0.0-beta.8"
 			}
 		},
 		"md5.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14620,6 +14620,23 @@
 				"esm": "^3.2.25",
 				"mj-context-menu": "^0.2.2",
 				"speech-rule-engine": "^3.0.0-beta.8"
+			},
+			"dependencies": {
+				"mj-context-menu": {
+					"version": "0.2.2",
+					"resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.2.2.tgz",
+					"integrity": "sha512-OHlnKQqfFPEYZGdz2JWL0obrr82vVilha0WCUZslYfN+v+oz4VpmERnoHdTUWvOUVHNYjFkpOYnLEeHnt1BdsQ=="
+				},
+				"speech-rule-engine": {
+					"version": "3.0.0-beta.11",
+					"resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-3.0.0-beta.11.tgz",
+					"integrity": "sha512-ur+WhcEDfEnkTLQRxNt+ySGtXe8z8h42hAXYHu2C9QrofHSGrqeVPCFkRmfeNYEzT1V/xuAI/yaJZU+UcRkD3A==",
+					"requires": {
+						"commander": "*",
+						"wicked-good-xpath": "*",
+						"xmldom-sre": "^0.1.31"
+					}
+				}
 			}
 		},
 		"md5.js": {
@@ -15133,11 +15150,6 @@
 					"dev": true
 				}
 			}
-		},
-		"mj-context-menu": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.2.0.tgz",
-			"integrity": "sha512-yJxrWBHCjFZEHsZgfs7m5g9OSCNzsVYadW6f6lX3pgZL67vmodtSW/4zhsYmuDKweXfHs0M1kJge1uQIasWA+g=="
 		},
 		"mkdirp": {
 			"version": "0.5.1",
@@ -20491,16 +20503,6 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
-		},
-		"speech-rule-engine": {
-			"version": "3.0.0-beta.7",
-			"resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-3.0.0-beta.7.tgz",
-			"integrity": "sha512-sCXSQ1hovgrxLYVp+t+PAY05Wl7hDe006cmy8k89Ez5YKpI7OYlwS2UWJWO6DyVXR08quhmUqraxsVS0H2doaQ==",
-			"requires": {
-				"commander": "*",
-				"wicked-good-xpath": "*",
-				"xmldom-sre": "^0.1.31"
-			}
 		},
 		"split": {
 			"version": "1.0.1",

--- a/server/Html.js
+++ b/server/Html.js
@@ -72,6 +72,12 @@ const Html = (props) => {
 					title={props.initialData.communityData.title}
 					href="/opensearch.xml"
 				/>
+				<script
+					dangerouslySetInnerHTML={{
+						__html: `window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};
+	  heap.load("3777990325");`,
+					}}
+				/>
 			</head>
 			<body>
 				<div id="root">{props.children}</div>

--- a/server/Html.js
+++ b/server/Html.js
@@ -72,11 +72,6 @@ const Html = (props) => {
 					title={props.initialData.communityData.title}
 					href="/opensearch.xml"
 				/>
-				<script
-					dangerouslySetInnerHTML={{
-						__html: `window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};`,
-					}}
-				/>
 			</head>
 			<body>
 				<div id="root">{props.children}</div>

--- a/server/Html.js
+++ b/server/Html.js
@@ -74,8 +74,7 @@ const Html = (props) => {
 				/>
 				<script
 					dangerouslySetInnerHTML={{
-						__html: `window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};
-	  heap.load("3777990325");`,
+						__html: `window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=document.createElement("script");r.type="text/javascript",r.async=!0,r.src="https://cdn.heapanalytics.com/js/heap-"+e+".js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a);for(var n=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],o=0;o<p.length;o++)heap[p[o]]=n(p[o])};`,
 					}}
 				/>
 			</head>


### PR DESCRIPTION
Adds Heap tracking for both dev and prod, including the ability to opt out from tracking and small updates to the privacy policy.

The way Heap works is it assigns a relatively persistent anonymous `user_id` to every visitor. We can add an additional `identity` field from our side, and it will automatically merge sessions from the anonymous `user_id` when we supply an `identity` – useful for tracking logged in vs. logged out, and across devices. Also nice: we can strip or further anonymize the `identity` from downstream analytics in redshit etc. without losing the ability to match sessions.

So, this PR sets the PubPub user id as the Heap `identity` if a user is logged in and consents to tracking. 

Heap also allows you to set event properties. I've added an event property called `loggedIn` that shows true when users are logged in and consented and does not appear when users are logged out (or not consented), so we can differentiate across logged out and logged in events.

While logged in, opting out of tracking has the effect of removing the `identity` field and resetting your `user_id`, effectively breaking the tracking chain forever. 

When logged out, however, the anonymous `user_id` that Heap sets is hard to unset. So, if you're logged out and you opt out of tracking, I re-identify you with a number generated by Math.random and then tell Heap to unset that `identity`. This gives you a new anonymous `user_id`, breaking the tracking chain.

I've also included passing the same IDs (community, collection, pub, branch) we pass for Keen as event properties so we can eventually match to the product db in analytics tools.

_Test plan_
- Move `setupHeap();` from line 34 to line 31 in `client/utils/hydrateWrapper.js` to enable logging on local environments
- Load site in dev environment. View Define -> Live tracking on Heap for dev environment.
- Click around on dev and verify that Heap is tracking events
- Click into a pub and verify that communityId, pubId and branchId are set in events logged
- Click to the homepage and verify that pubId and branchId are unset
- Accept tracking cookies and login.
- Verify that logged in is set to true in the event. 
- Visit the Users tab and verify that a user with an identity that looks like a PubPub ID has visited.
- Visit `/legal/settings`
- Toggle settings to off.
- Refresh the page
- Heap live view should show a new, anonymous user id for subsequent refreshes. Logged in should not be set on the event.
- Toggle settings to on
- Refresh the page.
- Visit the Users tab and verify that the user with the same PubPub ID identity has now made more visits.
- Load in the production environment and verify that events are now logged on production.