### PR TITLE
update: Make searchSync and searchUtils work with new Member model

### DIFF
--- a/client/components/PubPreview/pubPreviewUtils.js
+++ b/client/components/PubPreview/pubPreviewUtils.js
@@ -41,9 +41,22 @@ export const generatePlainAuthorString = (pubData) => {
 	if (!pubData.attributions) {
 		return '';
 	}
-	const authors = pubData.attributions.filter((attribution) => {
-		return attribution.isAuthor;
-	});
+	const authors = pubData.attributions
+		.filter((attribution) => {
+			return attribution.isAuthor;
+		})
+		.map((attribution) => {
+			if (attribution.user) {
+				return attribution;
+			}
+			return {
+				...attribution,
+				user: {
+					id: attribution.id,
+					fullName: attribution.name,
+				},
+			};
+		});
 	return authors
 		.sort((foo, bar) => {
 			if (foo.order < bar.order) {

--- a/client/components/Thread/Thread.js
+++ b/client/components/Thread/Thread.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-// import { usePageContext } from 'utils/hooks';
-// import ReviewEvent from 'containers/Pub/PubReview/ReviewEvent';
 import ThreadComment from './ThreadComment';
 import ThreadEvent from './ThreadEvent';
 

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionInput.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionInput.js
@@ -108,6 +108,7 @@ const DiscussionInput = (props) => {
 				content: getJSON(changeObject.view),
 				text: getText(changeObject.view) || '',
 				initAnchorData: initAnchorData,
+				visibilityAccess: pubData.isRelease ? 'public' : 'members',
 			}),
 		});
 

--- a/client/containers/Pub/PubDocument/PubDiscussions/discussionUtils.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/discussionUtils.js
@@ -158,12 +158,6 @@ export const filterAndSortDiscussions = (
 		})
 		.filter((discussion) => !discussion.anchor || showAnchoredDiscussions)
 		.filter((discussion) => {
-			/* Some discussionsContentLive data coming from firebase has not been refactored. */
-			/* We should either delete all discussionContentLive on migration, or keep this */
-			/* filter indefinitely. */
-			return discussion.thread;
-		})
-		.filter((discussion) => {
 			if (filteredLabels.length === 0) {
 				return true;
 			}

--- a/client/containers/Pub/PubSyncManager.js
+++ b/client/containers/Pub/PubSyncManager.js
@@ -144,10 +144,6 @@ class PubSyncManager extends React.Component {
 						.on('child_changed', this.syncMetadata);
 
 					this.state.firebaseBranchRef
-						.child('discussionsContentLive')
-						.on('value', this.syncDiscussionsContent);
-
-					this.state.firebaseBranchRef
 						.child('cursors')
 						.on('value', this.syncRemoteCollabUsers);
 
@@ -166,11 +162,6 @@ class PubSyncManager extends React.Component {
 	componentWillUnmount() {
 		if (this.state.firebaseRootRef) {
 			this.state.firebaseRootRef.child('metadata').off('child_changed', this.syncMetadata);
-		}
-		if (this.state.firebaseBranchRef) {
-			this.state.firebaseBranchRef
-				.child('discussionsContentLive')
-				.off('child_changed', this.syncDiscussionsContent);
 		}
 	}
 

--- a/client/containers/Search/Search.js
+++ b/client/containers/Search/Search.js
@@ -47,8 +47,7 @@ const Search = (props) => {
 	const handleSearch = () => {
 		if (searchQuery) {
 			indexRef.current
-				.search({
-					query: searchQuery,
+				.search(searchQuery, {
 					page: page,
 				})
 				.then((results) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,121 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@algolia/cache-browser-local-storage": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.2.0.tgz",
+			"integrity": "sha512-uji5zxBxwNu8qKtyqghg9lUsN0OOZ58NfRKk0Il4IZCcCo78E0KfT3Uxr7XiYCJMRnqIsvbKWf0xA67tYNBSbA==",
+			"requires": {
+				"@algolia/cache-common": "4.2.0"
+			}
+		},
+		"@algolia/cache-common": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.2.0.tgz",
+			"integrity": "sha512-ATBQCBBLt4hPNKIKn06y5zqZPWQmI+PBF0287rFVj8BGmEr82BzoKMa5XIkvgpjtxwx6c5nSKxZaYkEFqtrxtQ=="
+		},
+		"@algolia/cache-in-memory": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.2.0.tgz",
+			"integrity": "sha512-NsVOR6ixK6jvurLW+1+h80/9N18QjU/AXdAZJoVeu4JXb2NPuej4Ld1zXFYvz/ypCFQE+dU8haaQnJIuTbD4vg==",
+			"requires": {
+				"@algolia/cache-common": "4.2.0"
+			}
+		},
+		"@algolia/client-account": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.2.0.tgz",
+			"integrity": "sha512-xz5OXU9DQ9pegABAgmTPV23f9tXmbUPO3w5J/b2QcP6jzfNnNfW3CkTwywgNLr16jIKLxmmClN5yqyJp6XmHBA==",
+			"requires": {
+				"@algolia/client-common": "4.2.0",
+				"@algolia/client-search": "4.2.0",
+				"@algolia/transporter": "4.2.0"
+			}
+		},
+		"@algolia/client-analytics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.2.0.tgz",
+			"integrity": "sha512-UNuZQOYuKPYl5fCgm1HZzoZ6Ewxtqrc4Cv5Dhdy5VatIV6lYEWOtdn+g+5qvWFGb6fv6688dg5EVJnXZNvVVZQ==",
+			"requires": {
+				"@algolia/client-common": "4.2.0",
+				"@algolia/client-search": "4.2.0",
+				"@algolia/requester-common": "4.2.0",
+				"@algolia/transporter": "4.2.0"
+			}
+		},
+		"@algolia/client-common": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.2.0.tgz",
+			"integrity": "sha512-KxZTWXf9FSl188iTAz9rhTMeBtbF/uaJcxw99jbWHxyK9KR87obZzTlTFYnIWLEBaTG1MmlgPSsDogAE4CHLOQ==",
+			"requires": {
+				"@algolia/requester-common": "4.2.0",
+				"@algolia/transporter": "4.2.0"
+			}
+		},
+		"@algolia/client-recommendation": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-recommendation/-/client-recommendation-4.2.0.tgz",
+			"integrity": "sha512-5QwvUJ5hpZVDz99o+EPgMg+z7maLWOZGUrUt5z8s+esl+taTb2h1PtyLpikAvC2d/BjYCEKyObTiRDYdzhqcoA==",
+			"requires": {
+				"@algolia/client-common": "4.2.0",
+				"@algolia/requester-common": "4.2.0",
+				"@algolia/transporter": "4.2.0"
+			}
+		},
+		"@algolia/client-search": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.2.0.tgz",
+			"integrity": "sha512-2SAz1/undr+RM7FNj3G0taWFG+8QEMQcYHxUhoOJKMIY9sPQN7UNCJRHYsulM+/g45oF67tXX09NSt14ewen0Q==",
+			"requires": {
+				"@algolia/client-common": "4.2.0",
+				"@algolia/requester-common": "4.2.0",
+				"@algolia/transporter": "4.2.0"
+			}
+		},
+		"@algolia/logger-common": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.2.0.tgz",
+			"integrity": "sha512-VQcJE5lr78oc+lbcGfPonCDTRwLNSxwtPrUP6Tj+CoDedsVHZhODAlHzLHhxc4vuyrU7xomvKJLqTUgfDNxzXQ=="
+		},
+		"@algolia/logger-console": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.2.0.tgz",
+			"integrity": "sha512-/1GE43jY0xKfJUi5ZGtEqq+oTyOzs+EgGKj7/zEHIpUc5NyxokIPWTqt3q6pzGSWFEkNbaA1gAVgXM1zCMVWYw==",
+			"requires": {
+				"@algolia/logger-common": "4.2.0"
+			}
+		},
+		"@algolia/requester-browser-xhr": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.2.0.tgz",
+			"integrity": "sha512-+PZKOe+UBdZYQg/h/8AbKQ2Ha4uDeoLnpZFv00IMr/elym0m2hl76xAeIBiIqGYsLCmGybGBFUF9n1imsKJUJQ==",
+			"requires": {
+				"@algolia/requester-common": "4.2.0"
+			}
+		},
+		"@algolia/requester-common": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.2.0.tgz",
+			"integrity": "sha512-SSKPRM/7UP54/dxyK6EYt4p6nTeJxYb1P6xVh/Ic6noBTCfqg5vBEKDa1DZD5MBtCvABoODd97UOfAo3ECG/jg=="
+		},
+		"@algolia/requester-node-http": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.2.0.tgz",
+			"integrity": "sha512-mRQgSM8qrMfjXaBnMjTmymR0NKwbr82Qwh1a5TgYyzMOBuRO5nRikawvTVgpNaEnQS0uesIiwd2ohOJ2gNu6oA==",
+			"requires": {
+				"@algolia/requester-common": "4.2.0"
+			}
+		},
+		"@algolia/transporter": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.2.0.tgz",
+			"integrity": "sha512-7CiwMYsEhrHySA8q70euIYOyhGtz/wz+MEC3nwGONBC82nGI6ntVqTFhCkpLIJqqbGbNlFgnCpwnLmSqLhRP3A==",
+			"requires": {
+				"@algolia/cache-common": "4.2.0",
+				"@algolia/logger-common": "4.2.0",
+				"@algolia/requester-common": "4.2.0"
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -4060,11 +4175,6 @@
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
 			"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
 		},
-		"agentkeepalive": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
-			"integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8="
-		},
 		"aggregate-error": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -4144,50 +4254,24 @@
 			"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
 		},
 		"algoliasearch": {
-			"version": "3.35.1",
-			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-3.35.1.tgz",
-			"integrity": "sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.2.0.tgz",
+			"integrity": "sha512-CgbyDBGMSzNISBFezPt68xAseknork+wNe/Oour1Hluk4OwbtobysRawFf93ZbLSQw/KbeGlVmVAvujeVIVdnQ==",
 			"requires": {
-				"agentkeepalive": "^2.2.0",
-				"debug": "^2.6.9",
-				"envify": "^4.0.0",
-				"es6-promise": "^4.1.0",
-				"events": "^1.1.0",
-				"foreach": "^2.0.5",
-				"global": "^4.3.2",
-				"inherits": "^2.0.1",
-				"isarray": "^2.0.1",
-				"load-script": "^1.0.0",
-				"object-keys": "^1.0.11",
-				"querystring-es3": "^0.2.1",
-				"reduce": "^1.0.1",
-				"semver": "^5.1.0",
-				"tunnel-agent": "^0.6.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"events": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-					"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-				},
-				"isarray": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-				}
+				"@algolia/cache-browser-local-storage": "4.2.0",
+				"@algolia/cache-common": "4.2.0",
+				"@algolia/cache-in-memory": "4.2.0",
+				"@algolia/client-account": "4.2.0",
+				"@algolia/client-analytics": "4.2.0",
+				"@algolia/client-common": "4.2.0",
+				"@algolia/client-recommendation": "4.2.0",
+				"@algolia/client-search": "4.2.0",
+				"@algolia/logger-common": "4.2.0",
+				"@algolia/logger-console": "4.2.0",
+				"@algolia/requester-browser-xhr": "4.2.0",
+				"@algolia/requester-common": "4.2.0",
+				"@algolia/requester-node-http": "4.2.0",
+				"@algolia/transporter": "4.2.0"
 			}
 		},
 		"amdefine": {
@@ -7946,15 +8030,6 @@
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
 			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
 		},
-		"envify": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/envify/-/envify-4.1.0.tgz",
-			"integrity": "sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==",
-			"requires": {
-				"esprima": "^4.0.0",
-				"through": "~2.3.4"
-			}
-		},
 		"enzyme": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
@@ -9470,7 +9545,8 @@
 		"foreach": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"optional": true
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -12506,11 +12582,6 @@
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
 				}
 			}
-		},
-		"load-script": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-			"integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
 		},
 		"loader-fs-cache": {
 			"version": "1.0.3",
@@ -17040,14 +17111,6 @@
 						"get-stdin": "^4.0.1"
 					}
 				}
-			}
-		},
-		"reduce": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/reduce/-/reduce-1.0.2.tgz",
-			"integrity": "sha512-xX7Fxke/oHO5IfZSk77lvPa/7bjMh9BuCk4OOoX5XTXrM7s0Z+MkPfSDfz0q7r91BhhGSs8gii/VEN/7zhCPpQ==",
-			"requires": {
-				"object-keys": "^1.1.0"
 			}
 		},
 		"reduce-css-calc": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"@storybook/addon-storyshots": "^5.0.11",
 		"@storybook/addon-viewport": "^5.0.11",
 		"@storybook/react": "^5.0.11",
-		"algoliasearch": "^3.32.1",
+		"algoliasearch": "^4.2.0",
 		"amqplib": "^0.5.3",
 		"autoprefixer": "^9.5.0",
 		"aws-sdk": "^2.444.0",

--- a/searchSync/searchSync.js
+++ b/searchSync/searchSync.js
@@ -15,14 +15,14 @@ let records = 0;
 const findAndIndexPubs = (pubIds) => {
 	return getPubSearchData(pubIds).then((pubSyncData) => {
 		records += pubSyncData.length;
-		return pubsIndex.addObjects(pubSyncData);
+		return pubsIndex.saveObjects(pubSyncData, { autoGenerateObjectIDIfNotExist: true });
 	});
 };
 
 const findAndIndexPages = (pageIds) => {
 	return getPageSearchData(pageIds).then((pageSyncData) => {
 		records += pageSyncData.length;
-		return pagesIndex.addObjects(pageSyncData);
+		return pagesIndex.saveObjects(pageSyncData, { autoGenerateObjectIDIfNotExist: true });
 	});
 };
 
@@ -32,7 +32,7 @@ new Promise((resolve) => {
 })
 	.then(() => {
 		return pubsIndex.setSettings({
-			unretrievableAttributes: ['branchAdminAccessId', 'branchAccessIds', 'branchContent'],
+			unretrievableAttributes: ['branchAccessIds', 'branchContent'],
 			searchableAttributes: [
 				'title',
 				'description',
@@ -49,14 +49,13 @@ new Promise((resolve) => {
 				'filterOnly(communityId)',
 				'filterOnly(branchIsPublic)',
 				'filterOnly(branchAccessIds)',
-				'filterOnly(branchAdminAccessId)',
 			],
 		});
 	})
 	.then(() => {
 		return Pub.findAll({
 			attributes: ['id'],
-			// limit: 100,
+			// limit: 10,
 			where: {
 				id: { [Op.ne]: '5dea7a72-330d-4fbf-8a88-c4723e201b39' },
 			},
@@ -78,7 +77,7 @@ new Promise((resolve) => {
 	})
 	.then(() => {
 		return pagesIndex.setSettings({
-			unretrievableAttributes: ['content'],
+			unretrievableAttributes: ['pageAccessIds', 'content'],
 			searchableAttributes: [
 				'title',
 				'description',
@@ -93,13 +92,14 @@ new Promise((resolve) => {
 				'filterOnly(isPublic)',
 				'filterOnly(pageId)',
 				'filterOnly(communityId)',
+				'filterOnly(pageAccessIds)',
 			],
 		});
 	})
 	.then(() => {
 		return Page.findAll({
 			attributes: ['id'],
-			// limit: 100,
+			// limit: 10,
 		});
 	})
 	.then((pageIds) => {

--- a/server/discussion/__tests__/api.test.js
+++ b/server/discussion/__tests__/api.test.js
@@ -1,4 +1,4 @@
-/* global it, expect, beforeAll, afterAll, beforeEach, afterEach */
+/* global it, expect, beforeAll, afterAll, afterEach */
 import uuid from 'uuid';
 
 import { setup, teardown, login, stub, modelize } from 'stubstub';
@@ -45,10 +45,6 @@ setup(beforeAll, async () => {
 	await models.resolve();
 });
 
-beforeEach(() => {
-	firebaseStub = stub(firebaseAdmin, 'updateFirebaseDiscussion');
-});
-
 afterEach(() => {
 	firebaseStub.restore();
 });
@@ -82,7 +78,6 @@ it('forbids logged-out visitors from making discussions on released pubs', async
 		.post('/api/discussions')
 		.send(makeDiscussion({ pub: releasePub, text: 'Hello world!' }))
 		.expect(403);
-	expect(firebaseStub.stubs.updateFirebaseDiscussion.called).toEqual(false);
 });
 
 it('forbids logged-in visitors from adding discussions to unreleased pubs', async () => {
@@ -92,7 +87,6 @@ it('forbids logged-in visitors from adding discussions to unreleased pubs', asyn
 		.post('/api/discussions')
 		.send(makeDiscussion({ pub: draftPub, text: 'Hello world!' }))
 		.expect(403);
-	expect(firebaseStub.stubs.updateFirebaseDiscussion.called).toEqual(false);
 });
 
 it('creates a database entry and updates Firebase', async () => {
@@ -112,7 +106,6 @@ it('creates a database entry and updates Firebase', async () => {
 		include: [{ model: ThreadComment, as: 'comments' }],
 	});
 
-	expect(firebaseStub.stubs.updateFirebaseDiscussion.called).toEqual(true);
 	expect(relatedThread.comments[0].text).toEqual('Hello world!');
 });
 

--- a/server/discussion/api.js
+++ b/server/discussion/api.js
@@ -11,6 +11,7 @@ const getRequestIds = (req) => {
 		pubId: req.body.pubId,
 		communityId: req.body.communityId,
 		accessHash: req.body.accessHash,
+		visibilityAccess: req.body.visibilityAccess,
 	};
 };
 

--- a/server/discussion/permissions.js
+++ b/server/discussion/permissions.js
@@ -3,7 +3,14 @@ import { DiscussionNew } from '../models';
 
 const userEditableFields = ['title', 'isClosed', 'labels'];
 
-export const getPermissions = async ({ discussionId, userId, pubId, communityId, accessHash }) => {
+export const getPermissions = async ({
+	discussionId,
+	userId,
+	pubId,
+	communityId,
+	accessHash,
+	visibilityAccess,
+}) => {
 	if (!userId) {
 		return {};
 	}
@@ -20,9 +27,8 @@ export const getPermissions = async ({ discussionId, userId, pubId, communityId,
 	});
 
 	const { canView, canAdmin, canCreateDiscussions } = scopeData.activePermissions;
-
 	return {
-		create: canView || canCreateDiscussions,
+		create: canView || (canCreateDiscussions && visibilityAccess !== 'members'),
 		update: canAdmin && discussionData && userEditableFields,
 	};
 };

--- a/server/discussion/queries.js
+++ b/server/discussion/queries.js
@@ -8,7 +8,6 @@ import {
 	ThreadEvent,
 	Visibility,
 } from '../models';
-import { updateFirebaseDiscussion } from '../utils/firebaseAdmin';
 
 const findDiscussionWithUser = (id) =>
 	DiscussionNew.findOne({
@@ -120,8 +119,9 @@ export const createDiscussion = async (inputValues, user) => {
 		userId: user.id,
 		threadId: newThread.id,
 	});
+
 	const newVisibility = await Visibility.create({
-		access: 'members',
+		access: inputValues.visibilityAccess,
 	});
 	const newDiscussion = await DiscussionNew.create({
 		id: inputValues.discussionId,
@@ -134,7 +134,6 @@ export const createDiscussion = async (inputValues, user) => {
 		pubId: inputValues.pubId,
 	});
 	const discussionWithUser = await findDiscussionWithUser(newDiscussion.id);
-	updateFirebaseDiscussion(discussionWithUser.toJSON(), inputValues.branchId);
 	return discussionWithUser;
 };
 
@@ -149,8 +148,6 @@ export const updateDiscussion = (inputValues, updatePermissions) => {
 	return DiscussionNew.update(filteredValues, {
 		where: { id: inputValues.discussionId },
 	}).then(async () => {
-		const discussionWithUser = await findDiscussionWithUser(inputValues.discussionId);
-		updateFirebaseDiscussion(discussionWithUser.toJSON(), inputValues.branchId);
 		return {
 			...filteredValues,
 			id: inputValues.discussionId,

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -1,73 +1,52 @@
-import Promise from 'bluebird';
 import React from 'react';
 import algoliasearch from 'algoliasearch';
 import Html from '../Html';
 import app from '../server';
 import { renderToNodeStream, getInitialData, handleErrors, generateMetaComponents } from '../utils';
-import { User, Community } from '../models';
 
 const client = algoliasearch(process.env.ALGOLIA_ID, process.env.ALGOLIA_KEY);
 const searchId = process.env.ALGOLIA_ID;
 const searchKey = process.env.ALGOLIA_SEARCH_KEY;
 
-app.get('/search', (req, res, next) => {
-	return getInitialData(req)
-		.then((initialData) => {
-			const findUser = User.findOne({
-				where: { id: initialData.loginData.id },
-				attributes: ['id'],
-				include: [
-					{
-						model: Community,
-						as: 'communities',
-						required: false,
-						attributes: ['id'],
-						through: { attributes: [] },
-					},
-				],
-			});
-			return Promise.all([initialData, findUser]);
-		})
-		.then(([initialData, userData]) => {
-			const userCommunities = (userData && userData.communities) || [];
-			const communityFilter = initialData.locationData.isBasePubPub
-				? ''
-				: `communityId:${initialData.communityData.id} AND `;
-			const pubCommunityAccessFilterString = userCommunities.reduce((prev, curr) => {
-				return `${prev} OR branchAdminAccessId:${curr.id}`;
-			}, '');
-			const pubUserFilterString = initialData.loginData.id
-				? ` OR branchAccessIds:${initialData.loginData.id}`
-				: '';
-			const pubSearchParams = {
-				filters: `${communityFilter}(branchIsPublic:true${pubCommunityAccessFilterString}${pubUserFilterString})`,
-			};
+app.get('/search', async (req, res, next) => {
+	try {
+		const initialData = await getInitialData(req);
+		const communityFilter = initialData.locationData.isBasePubPub
+			? ''
+			: `communityId:${initialData.communityData.id} AND `;
+		const pubUserFilterString = initialData.loginData.id
+			? ` OR branchAccessIds:${initialData.loginData.id}`
+			: '';
+		const pubSearchParams = {
+			filters: `${communityFilter}(branchIsPublic:true${pubUserFilterString})`,
+		};
 
-			const pageCommunityAccessFilterString = userCommunities.reduce((prev, curr) => {
-				return `${prev} OR communityId:${curr.id}`;
-			}, '');
-			const pageSearchParams = {
-				filters: `${communityFilter}(isPublic:true${pageCommunityAccessFilterString})`,
-			};
-			const searchData = {
-				searchId: searchId,
-				pubsSearchKey: client.generateSecuredApiKey(searchKey, pubSearchParams),
-				pagesSearchKey: client.generateSecuredApiKey(searchKey, pageSearchParams),
-			};
+		const pageUserFilterString = initialData.loginData.id
+			? ` OR pageAccessIds:${initialData.loginData.id}`
+			: '';
+		const pageSearchParams = {
+			filters: `${communityFilter}(isPublic:true${pageUserFilterString})`,
+		};
+		const searchData = {
+			searchId: searchId,
+			pubsSearchKey: client.generateSecuredApiKey(searchKey, pubSearchParams),
+			pagesSearchKey: client.generateSecuredApiKey(searchKey, pageSearchParams),
+		};
 
-			return renderToNodeStream(
-				res,
-				<Html
-					chunkName="Search"
-					initialData={initialData}
-					viewData={{ searchData: searchData }}
-					headerComponents={generateMetaComponents({
-						initialData: initialData,
-						title: `Search · ${initialData.communityData.title}`,
-						description: `Search for pubs in ${initialData.communityData.title}`,
-					})}
-				/>,
-			);
-		})
-		.catch(handleErrors(req, res, next));
+		return renderToNodeStream(
+			res,
+			<Html
+				chunkName="Search"
+				initialData={initialData}
+				viewData={{ searchData: searchData }}
+				headerComponents={generateMetaComponents({
+					initialData: initialData,
+					title: `Search · ${initialData.communityData.title}`,
+					description: `Search for pubs in ${initialData.communityData.title}`,
+				})}
+			/>,
+		);
+	} catch (err) {
+		return handleErrors(req, res, next)(err);
+	}
 });

--- a/server/utils/firebaseAdmin.js
+++ b/server/utils/firebaseAdmin.js
@@ -108,18 +108,3 @@ export const mergeFirebaseBranch = (pubId, sourceBranchId, destinationBranchId) 
 		return res;
 	});
 };
-
-export const updateFirebaseDiscussion = async (discussion, branchId) => {
-	const { pubId, id: discussionId } = discussion;
-	const branchKey = `pub-${pubId}/branch-${branchId}`;
-	const discussionsRef = database.ref(`${branchKey}/discussionsContentLive`);
-	const existingDiscussion = await discussionsRef
-		.orderByChild('id')
-		.equalTo(discussionId)
-		.once('value');
-	if (existingDiscussion.exists()) {
-		const childKey = Object.keys(existingDiscussion.val())[0];
-		return existingDiscussion.ref.child(childKey).update(discussion);
-	}
-	return discussionsRef.push(discussion);
-};

--- a/stubstub/stub.js
+++ b/stubstub/stub.js
@@ -54,15 +54,11 @@ export const stubFirebaseAdmin = () => {
 		const mergeFirebaseBranchStub = sinon
 			.stub(firebaseAdmin, 'mergeFirebaseBranch')
 			.returns({});
-		const updateFirebaseDiscussionStub = sinon
-			.stub(firebaseAdmin, 'updateFirebaseDiscussion')
-			.returns({});
 		stubs = [
 			getBranchDocStub,
 			getFirebaseTokenStub,
 			createFirebaseBranchStub,
 			mergeFirebaseBranchStub,
-			updateFirebaseDiscussionStub,
 		];
 	});
 

--- a/tools/dashboardMigrations/headerCols.js
+++ b/tools/dashboardMigrations/headerCols.js
@@ -17,7 +17,7 @@ export default async () => {
 			// migrate those pubs to the 'dark' header background color. If there's no background image,
 			// we default to the 'light' header that mimics the current vanilla pub style, with black
 			// text and an off-white background.
-			const headerBackgroundColor = hasHeaderImage ? 'dark' : 'light';
+			const headerBackgroundColor = hasHeaderImage && !hasBlocksStyle ? 'dark' : 'light';
 			// Keep any existing header styles, and pick 'light' or 'dark' otherwise to match with
 			// existing background images.
 			const headerStyle = hasBlocksStyle

--- a/workers/tasks/search.js
+++ b/workers/tasks/search.js
@@ -22,7 +22,7 @@ export const setPageSearchData = (pageId) => {
 			return getPageSearchData([pageId]);
 		})
 		.then((pageSyncData) => {
-			return pagesIndex.addObjects(pageSyncData);
+			return pagesIndex.saveObjects(pageSyncData, { autoGenerateObjectIDIfNotExist: true });
 		})
 		.catch((err) => {
 			console.error('Error setting Page search data: ', err);
@@ -45,7 +45,7 @@ export const setPubSearchData = (pubId) => {
 			return getPubSearchData([pubId]);
 		})
 		.then((pubSyncData) => {
-			return pubsIndex.addObjects(pubSyncData);
+			return pubsIndex.saveObjects(pubSyncData, { autoGenerateObjectIDIfNotExist: true });
 		})
 		.catch((err) => {
 			console.error('Error setting Pub search data: ', err);


### PR DESCRIPTION
This PR makes several changes to update our search permissioning based on the new Members model. The Members model simplifies the handling of private data by simply including an `accessIds` array on each algolia object which is filtered against. 

This does not yet account for Pubs who have their draft set to be publicly visible, as the PublicPermissions model is still in development.