### PR TITLE
fix: Discussion Visibility and syncing bugs

### DIFF
--- a/client/components/Thread/Thread.js
+++ b/client/components/Thread/Thread.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-// import { usePageContext } from 'utils/hooks';
-// import ReviewEvent from 'containers/Pub/PubReview/ReviewEvent';
 import ThreadComment from './ThreadComment';
 import ThreadEvent from './ThreadEvent';
 

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionInput.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionInput.js
@@ -108,6 +108,7 @@ const DiscussionInput = (props) => {
 				content: getJSON(changeObject.view),
 				text: getText(changeObject.view) || '',
 				initAnchorData: initAnchorData,
+				visibilityAccess: pubData.isRelease ? 'public' : 'members',
 			}),
 		});
 

--- a/client/containers/Pub/PubDocument/PubDiscussions/discussionUtils.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/discussionUtils.js
@@ -158,12 +158,6 @@ export const filterAndSortDiscussions = (
 		})
 		.filter((discussion) => !discussion.anchor || showAnchoredDiscussions)
 		.filter((discussion) => {
-			/* Some discussionsContentLive data coming from firebase has not been refactored. */
-			/* We should either delete all discussionContentLive on migration, or keep this */
-			/* filter indefinitely. */
-			return discussion.thread;
-		})
-		.filter((discussion) => {
 			if (filteredLabels.length === 0) {
 				return true;
 			}

--- a/client/containers/Pub/PubSyncManager.js
+++ b/client/containers/Pub/PubSyncManager.js
@@ -143,11 +143,6 @@ class PubSyncManager extends React.Component {
 						.child('metadata')
 						.on('child_changed', this.syncMetadata);
 
-					/* Disabled for initial dashboard launch */
-					// this.state.firebaseBranchRef
-					// 	.child('discussionsContentLive')
-					// 	.on('value', this.syncDiscussionsContent);
-
 					this.state.firebaseBranchRef
 						.child('cursors')
 						.on('value', this.syncRemoteCollabUsers);
@@ -168,12 +163,6 @@ class PubSyncManager extends React.Component {
 		if (this.state.firebaseRootRef) {
 			this.state.firebaseRootRef.child('metadata').off('child_changed', this.syncMetadata);
 		}
-		/* Disabled for initial dashboard launch */
-		// if (this.state.firebaseBranchRef) {
-		// 	this.state.firebaseBranchRef
-		// 		.child('discussionsContentLive')
-		// 		.off('child_changed', this.syncDiscussionsContent);
-		// }
 	}
 
 	syncMetadata(snapshot) {

--- a/client/containers/Pub/PubSyncManager.js
+++ b/client/containers/Pub/PubSyncManager.js
@@ -143,9 +143,10 @@ class PubSyncManager extends React.Component {
 						.child('metadata')
 						.on('child_changed', this.syncMetadata);
 
-					this.state.firebaseBranchRef
-						.child('discussionsContentLive')
-						.on('value', this.syncDiscussionsContent);
+					/* Disabled for initial dashboard launch */
+					// this.state.firebaseBranchRef
+					// 	.child('discussionsContentLive')
+					// 	.on('value', this.syncDiscussionsContent);
 
 					this.state.firebaseBranchRef
 						.child('cursors')
@@ -167,11 +168,12 @@ class PubSyncManager extends React.Component {
 		if (this.state.firebaseRootRef) {
 			this.state.firebaseRootRef.child('metadata').off('child_changed', this.syncMetadata);
 		}
-		if (this.state.firebaseBranchRef) {
-			this.state.firebaseBranchRef
-				.child('discussionsContentLive')
-				.off('child_changed', this.syncDiscussionsContent);
-		}
+		/* Disabled for initial dashboard launch */
+		// if (this.state.firebaseBranchRef) {
+		// 	this.state.firebaseBranchRef
+		// 		.child('discussionsContentLive')
+		// 		.off('child_changed', this.syncDiscussionsContent);
+		// }
 	}
 
 	syncMetadata(snapshot) {

--- a/server/discussion/__tests__/api.test.js
+++ b/server/discussion/__tests__/api.test.js
@@ -1,4 +1,4 @@
-/* global it, expect, beforeAll, afterAll, beforeEach, afterEach */
+/* global it, expect, beforeAll, afterAll, afterEach */
 import uuid from 'uuid';
 
 import { setup, teardown, login, stub, modelize } from 'stubstub';
@@ -45,10 +45,6 @@ setup(beforeAll, async () => {
 	await models.resolve();
 });
 
-beforeEach(() => {
-	firebaseStub = stub(firebaseAdmin, 'updateFirebaseDiscussion');
-});
-
 afterEach(() => {
 	firebaseStub.restore();
 });
@@ -82,7 +78,6 @@ it('forbids logged-out visitors from making discussions on released pubs', async
 		.post('/api/discussions')
 		.send(makeDiscussion({ pub: releasePub, text: 'Hello world!' }))
 		.expect(403);
-	expect(firebaseStub.stubs.updateFirebaseDiscussion.called).toEqual(false);
 });
 
 it('forbids logged-in visitors from adding discussions to unreleased pubs', async () => {
@@ -92,7 +87,6 @@ it('forbids logged-in visitors from adding discussions to unreleased pubs', asyn
 		.post('/api/discussions')
 		.send(makeDiscussion({ pub: draftPub, text: 'Hello world!' }))
 		.expect(403);
-	expect(firebaseStub.stubs.updateFirebaseDiscussion.called).toEqual(false);
 });
 
 it('creates a database entry and updates Firebase', async () => {
@@ -112,7 +106,6 @@ it('creates a database entry and updates Firebase', async () => {
 		include: [{ model: ThreadComment, as: 'comments' }],
 	});
 
-	expect(firebaseStub.stubs.updateFirebaseDiscussion.called).toEqual(true);
 	expect(relatedThread.comments[0].text).toEqual('Hello world!');
 });
 

--- a/server/discussion/api.js
+++ b/server/discussion/api.js
@@ -11,6 +11,7 @@ const getRequestIds = (req) => {
 		pubId: req.body.pubId,
 		communityId: req.body.communityId,
 		accessHash: req.body.accessHash,
+		visibilityAccess: req.body.visibilityAccess,
 	};
 };
 

--- a/server/discussion/permissions.js
+++ b/server/discussion/permissions.js
@@ -3,7 +3,14 @@ import { DiscussionNew } from '../models';
 
 const userEditableFields = ['title', 'isClosed', 'labels'];
 
-export const getPermissions = async ({ discussionId, userId, pubId, communityId, accessHash }) => {
+export const getPermissions = async ({
+	discussionId,
+	userId,
+	pubId,
+	communityId,
+	accessHash,
+	visibilityAccess,
+}) => {
 	if (!userId) {
 		return {};
 	}
@@ -20,9 +27,8 @@ export const getPermissions = async ({ discussionId, userId, pubId, communityId,
 	});
 
 	const { canView, canAdmin, canCreateDiscussions } = scopeData.activePermissions;
-
 	return {
-		create: canView || canCreateDiscussions,
+		create: canView || (canCreateDiscussions && visibilityAccess !== 'members'),
 		update: canAdmin && discussionData && userEditableFields,
 	};
 };

--- a/server/discussion/queries.js
+++ b/server/discussion/queries.js
@@ -7,7 +7,6 @@ import {
 	ThreadComment,
 	ThreadEvent,
 	Visibility,
-	Branch,
 } from '../models';
 
 const findDiscussionWithUser = (id) =>
@@ -121,12 +120,8 @@ export const createDiscussion = async (inputValues, user) => {
 		threadId: newThread.id,
 	});
 
-	const branchData = await Branch.findOne({
-		where: { id: inputValues.branchId || null },
-		attributes: ['id', 'title'],
-	});
 	const newVisibility = await Visibility.create({
-		access: (branchData || {}).title === 'public' ? 'public' : 'members',
+		access: inputValues.visibilityAccess,
 	});
 	const newDiscussion = await DiscussionNew.create({
 		id: inputValues.discussionId,

--- a/server/discussion/queries.js
+++ b/server/discussion/queries.js
@@ -9,7 +9,6 @@ import {
 	Visibility,
 	Branch,
 } from '../models';
-import { updateFirebaseDiscussion } from '../utils/firebaseAdmin';
 
 const findDiscussionWithUser = (id) =>
 	DiscussionNew.findOne({
@@ -140,7 +139,6 @@ export const createDiscussion = async (inputValues, user) => {
 		pubId: inputValues.pubId,
 	});
 	const discussionWithUser = await findDiscussionWithUser(newDiscussion.id);
-	updateFirebaseDiscussion(discussionWithUser.toJSON(), inputValues.branchId);
 	return discussionWithUser;
 };
 
@@ -155,8 +153,6 @@ export const updateDiscussion = (inputValues, updatePermissions) => {
 	return DiscussionNew.update(filteredValues, {
 		where: { id: inputValues.discussionId },
 	}).then(async () => {
-		const discussionWithUser = await findDiscussionWithUser(inputValues.discussionId);
-		updateFirebaseDiscussion(discussionWithUser.toJSON(), inputValues.branchId);
 		return {
 			...filteredValues,
 			id: inputValues.discussionId,

--- a/server/discussion/queries.js
+++ b/server/discussion/queries.js
@@ -7,6 +7,7 @@ import {
 	ThreadComment,
 	ThreadEvent,
 	Visibility,
+	Branch,
 } from '../models';
 import { updateFirebaseDiscussion } from '../utils/firebaseAdmin';
 
@@ -120,8 +121,13 @@ export const createDiscussion = async (inputValues, user) => {
 		userId: user.id,
 		threadId: newThread.id,
 	});
+
+	const branchData = await Branch.findOne({
+		where: { id: inputValues.branchId || null },
+		attributes: ['id', 'title'],
+	});
 	const newVisibility = await Visibility.create({
-		access: 'members',
+		access: (branchData || {}).title === 'public' ? 'public' : 'members',
 	});
 	const newDiscussion = await DiscussionNew.create({
 		id: inputValues.discussionId,

--- a/server/utils/firebaseAdmin.js
+++ b/server/utils/firebaseAdmin.js
@@ -108,22 +108,3 @@ export const mergeFirebaseBranch = (pubId, sourceBranchId, destinationBranchId) 
 		return res;
 	});
 };
-
-export const updateFirebaseDiscussion = async () => {
-	return null;
-};
-/* Disabled for initial dashboard launch */
-// export const updateFirebaseDiscussion = async (discussion, branchId) => {
-// 	const { pubId, id: discussionId } = discussion;
-// 	const branchKey = `pub-${pubId}/branch-${branchId}`;
-// 	const discussionsRef = database.ref(`${branchKey}/discussionsContentLive`);
-// 	const existingDiscussion = await discussionsRef
-// 		.orderByChild('id')
-// 		.equalTo(discussionId)
-// 		.once('value');
-// 	if (existingDiscussion.exists()) {
-// 		const childKey = Object.keys(existingDiscussion.val())[0];
-// 		return existingDiscussion.ref.child(childKey).update(discussion);
-// 	}
-// 	return discussionsRef.push(discussion);
-// };

--- a/server/utils/firebaseAdmin.js
+++ b/server/utils/firebaseAdmin.js
@@ -109,17 +109,21 @@ export const mergeFirebaseBranch = (pubId, sourceBranchId, destinationBranchId) 
 	});
 };
 
-export const updateFirebaseDiscussion = async (discussion, branchId) => {
-	const { pubId, id: discussionId } = discussion;
-	const branchKey = `pub-${pubId}/branch-${branchId}`;
-	const discussionsRef = database.ref(`${branchKey}/discussionsContentLive`);
-	const existingDiscussion = await discussionsRef
-		.orderByChild('id')
-		.equalTo(discussionId)
-		.once('value');
-	if (existingDiscussion.exists()) {
-		const childKey = Object.keys(existingDiscussion.val())[0];
-		return existingDiscussion.ref.child(childKey).update(discussion);
-	}
-	return discussionsRef.push(discussion);
+export const updateFirebaseDiscussion = async () => {
+	return null;
 };
+/* Disabled for initial dashboard launch */
+// export const updateFirebaseDiscussion = async (discussion, branchId) => {
+// 	const { pubId, id: discussionId } = discussion;
+// 	const branchKey = `pub-${pubId}/branch-${branchId}`;
+// 	const discussionsRef = database.ref(`${branchKey}/discussionsContentLive`);
+// 	const existingDiscussion = await discussionsRef
+// 		.orderByChild('id')
+// 		.equalTo(discussionId)
+// 		.once('value');
+// 	if (existingDiscussion.exists()) {
+// 		const childKey = Object.keys(existingDiscussion.val())[0];
+// 		return existingDiscussion.ref.child(childKey).update(discussion);
+// 	}
+// 	return discussionsRef.push(discussion);
+// };

--- a/stubstub/stub.js
+++ b/stubstub/stub.js
@@ -54,15 +54,11 @@ export const stubFirebaseAdmin = () => {
 		const mergeFirebaseBranchStub = sinon
 			.stub(firebaseAdmin, 'mergeFirebaseBranch')
 			.returns({});
-		const updateFirebaseDiscussionStub = sinon
-			.stub(firebaseAdmin, 'updateFirebaseDiscussion')
-			.returns({});
 		stubs = [
 			getBranchDocStub,
 			getFirebaseTokenStub,
 			createFirebaseBranchStub,
 			mergeFirebaseBranchStub,
-			updateFirebaseDiscussionStub,
 		];
 	});
 


### PR DESCRIPTION
This PR sets the Visibility of new Discussion objects based on their branch of origin. If created on a 'public' branch (i.e. a Release), the Visibility is set to 'public'. In all other cases, the Visibility is set to 'members'.

This PR also disables the live syncing of discussion objects over the discussionsContentLive object on firebase. A new live-syncing approach will be implemented shortly.