### PR TITLE
fix: Include release model in RSS query

### DIFF
--- a/server/rss/queries.js
+++ b/server/rss/queries.js
@@ -1,6 +1,6 @@
 import RSS from 'rss';
 import { getPubPublishedDate } from 'shared/pub/pubDates';
-import { Community, Pub, User, PubAttribution, Branch, Release } from '../models';
+import { Community, Pub, User, PubAttribution, Release } from '../models';
 
 export const getCommunityRss = (hostname) => {
 	const whereQuery =
@@ -51,10 +51,6 @@ export const getCommunityRss = (hostname) => {
 						],
 					},
 					{
-						model: Branch,
-						as: 'branches',
-					},
-					{
 						model: Release,
 						as: 'releases',
 					},
@@ -79,7 +75,6 @@ export const getCommunityRss = (hostname) => {
 			pubDate: new Date(),
 			ttl: '60',
 		});
-		console.log(communityData.pubs[0]);
 		communityData.pubs
 			.map((pub) => {
 				const pubJSON = pub.toJSON();

--- a/server/rss/queries.js
+++ b/server/rss/queries.js
@@ -1,6 +1,6 @@
 import RSS from 'rss';
 import { getPubPublishedDate } from 'shared/pub/pubDates';
-import { Community, Pub, User, PubAttribution, Branch } from '../models';
+import { Community, Pub, User, PubAttribution, Branch, Release } from '../models';
 
 export const getCommunityRss = (hostname) => {
 	const whereQuery =
@@ -54,6 +54,10 @@ export const getCommunityRss = (hostname) => {
 						model: Branch,
 						as: 'branches',
 					},
+					{
+						model: Release,
+						as: 'releases',
+					},
 				],
 			},
 		],
@@ -75,7 +79,7 @@ export const getCommunityRss = (hostname) => {
 			pubDate: new Date(),
 			ttl: '60',
 		});
-
+		console.log(communityData.pubs[0]);
 		communityData.pubs
 			.map((pub) => {
 				const pubJSON = pub.toJSON();


### PR DESCRIPTION
I wasn't 100% sure if branches could be stripped out or not in the query, but it seems to work.

_Test Plan_
- visit `/rss.xml` and make sure it generates XML.
- Copy output and [validate](https://validator.w3.org/feed/check.cgi)