### PR TITLE
fixes: pub discussions touch-up

### DIFF
--- a/client/components/Thread/ThreadComment.js
+++ b/client/components/Thread/ThreadComment.js
@@ -13,7 +13,8 @@ const propTypes = {
 };
 
 const ThreadComment = (props) => {
-	const { author, content, createdAt } = props.commentData;
+	const { commentData } = props;
+	const { author, content, createdAt } = commentData;
 
 	/* The classname thread-comment2 can have the number removed once */
 	/* Discussions/ThreadComment is deprecated */
@@ -27,7 +28,6 @@ const ThreadComment = (props) => {
 					</a>{' '}
 					said <TimeAgo {...timeAgoBaseProps} date={createdAt} />
 				</div>
-				{/* <div>Options</div> */}
 			</div>
 			<div className="content">
 				<Editor initialContent={content} isReadOnly={true} />

--- a/client/containers/Pub/PubDocument/PubBody.js
+++ b/client/containers/Pub/PubDocument/PubBody.js
@@ -300,9 +300,7 @@ const PubBody = (props) => {
 							<Discussion
 								key={embedId}
 								pubData={pubData}
-								collabData={collabData}
 								historyData={historyData}
-								firebaseBranchRef={firebaseBranchRef}
 								discussionData={activeDiscussion}
 								updateLocalData={updateLocalData}
 								canPreview={true}

--- a/client/containers/Pub/PubDocument/PubBottom/Discussions/DiscussionsSection.js
+++ b/client/containers/Pub/PubDocument/PubBottom/Discussions/DiscussionsSection.js
@@ -20,20 +20,13 @@ const propTypes = {
 		canManage: PropTypes.bool,
 		canDiscussBranch: PropTypes.bool,
 	}).isRequired,
-	collabData: PropTypes.object.isRequired,
-	historyData: PropTypes.object.isRequired,
-	firebaseBranchRef: PropTypes.object,
 	updateLocalData: PropTypes.func.isRequired,
 	sideContentRef: PropTypes.object.isRequired,
 	mainContentRef: PropTypes.object.isRequired,
 };
 
-const defaultProps = {
-	firebaseBranchRef: undefined,
-};
-
 const DiscussionsSection = (props) => {
-	const { pubData, updateLocalData } = props;
+	const { pubData, updateLocalData, sideContentRef, mainContentRef } = props;
 	const { discussions } = pubData;
 	const { communityData, scopeData } = usePageContext();
 	const { canView, canManage, canCreateDiscussions } = scopeData.activePermissions;
@@ -136,7 +129,9 @@ const DiscussionsSection = (props) => {
 		>
 			{({ searchTerm, isSearching }) => (
 				<PubDiscussions
-					{...props}
+					sideContentRef={sideContentRef}
+					mainContentRef={mainContentRef}
+					pubData={pubData}
 					filterDiscussions={createDiscussionFilter(searchTerm)}
 					searchTerm={searchTerm}
 					showBottomInput={
@@ -149,5 +144,4 @@ const DiscussionsSection = (props) => {
 };
 
 DiscussionsSection.propTypes = propTypes;
-DiscussionsSection.defaultProps = defaultProps;
 export default DiscussionsSection;

--- a/client/containers/Pub/PubDocument/PubBottom/PubBottom.js
+++ b/client/containers/Pub/PubDocument/PubBottom/PubBottom.js
@@ -17,8 +17,6 @@ const propTypes = {
 		footnotes: PropTypes.arrayOf(notePropType).isRequired,
 	}).isRequired,
 	collabData: PropTypes.object.isRequired,
-	historyData: PropTypes.object.isRequired,
-	firebaseBranchRef: PropTypes.object,
 	updateLocalData: PropTypes.func.isRequired,
 	sideContentRef: PropTypes.object.isRequired,
 	mainContentRef: PropTypes.object.isRequired,
@@ -26,7 +24,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-	firebaseBranchRef: undefined,
 	showDiscussions: true,
 };
 
@@ -36,6 +33,8 @@ const PubBottom = (props) => {
 		pubData,
 		showDiscussions,
 		updateLocalData,
+		sideContentRef,
+		mainContentRef,
 	} = props;
 
 	const { citations = [], footnotes = [] } = pubData;
@@ -73,7 +72,14 @@ const PubBottom = (props) => {
 							/>
 						)}
 						<LicenseSection pubData={pubData} updateLocalData={updateLocalData} />
-						{showDiscussions && <DiscussionsSection {...props} />}
+						{showDiscussions && (
+							<DiscussionsSection
+								pubData={pubData}
+								updateLocalData={updateLocalData}
+								sideContentRef={sideContentRef}
+								mainContentRef={mainContentRef}
+							/>
+						)}
 					</div>
 				</div>
 			)}

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/Discussion.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/Discussion.js
@@ -192,7 +192,6 @@ const Discussion = (props) => {
 				<>
 					{showManageTools && (
 						<ManageTools
-							isDiscussionAuthor={isDiscussionAuthor}
 							pubData={pubData}
 							discussionData={discussionData}
 							onUpdateDiscussion={handleUpdateDiscussion}

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/Discussion.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/Discussion.js
@@ -1,23 +1,22 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Button, Tooltip } from '@blueprintjs/core';
+import { Button } from '@blueprintjs/core';
+
 import { Icon } from 'components';
 import { apiFetch } from 'utils';
 import { usePageContext } from 'utils/hooks';
-import ThreadComment from './ThreadComment';
+
+import { discussionMatchesSearchTerm } from '../discussionUtils';
 import DiscussionInput from './DiscussionInput';
 import LabelList from './LabelList';
-import LabelSelect from './LabelSelect';
-import DiscussionReanchor from './DiscussionReanchor';
-import { discussionMatchesSearchTerm } from '../discussionUtils';
+import ManageTools from './ManageTools';
+import ThreadComment from './ThreadComment';
 
 require('./discussion.scss');
 
 const propTypes = {
 	pubData: PropTypes.object.isRequired,
-	collabData: PropTypes.object.isRequired,
-	firebaseBranchRef: PropTypes.object,
 	discussionData: PropTypes.object.isRequired,
 	updateLocalData: PropTypes.func.isRequired,
 	canPreview: PropTypes.bool,
@@ -25,26 +24,19 @@ const propTypes = {
 };
 
 const defaultProps = {
-	firebaseBranchRef: undefined,
 	canPreview: false,
 	searchTerm: null,
 };
 
 const Discussion = (props) => {
-	const {
-		pubData,
-		discussionData,
-		canPreview,
-		searchTerm,
-		updateLocalData,
-		collabData,
-		firebaseBranchRef,
-	} = props;
-	const { communityData, scopeData, loginData, locationData } = usePageContext();
-	const { canAdmin, canView, canCreateDiscussions } = scopeData.activePermissions;
+	const { pubData, discussionData, canPreview, searchTerm, updateLocalData } = props;
+	const { communityData, scopeData, locationData, loginData } = usePageContext();
+	const { canView, canCreateDiscussions, canAdmin } = scopeData.activePermissions;
 	const [previewExpanded, setPreviewExpanded] = useState(false);
-	const [isLoadingArchive, setIsLoadingArchive] = useState(false);
 	const isPreview = canPreview && !previewExpanded;
+	const canReply = canView || canCreateDiscussions;
+	const isDiscussionAuthor = loginData.id === discussionData.userId;
+	const showManageTools = canAdmin || (isDiscussionAuthor && !discussionData.isClosed);
 
 	const renderPreviewDiscussionsAndOverflow = (threadComments, minShown) => {
 		let shownDiscussionsCount = 0;
@@ -74,10 +66,11 @@ const Discussion = (props) => {
 				elements.push(
 					<ThreadComment
 						key={threadComment.id}
-						threadCommentData={threadComment}
+						discussionData={discussionData}
 						isPreview={isPreviewDiscussion}
-						// isRootThread={isRootThread}
-						{...props}
+						updateLocalData={updateLocalData}
+						threadCommentData={threadComment}
+						pubData={pubData}
 					/>,
 				);
 			} else {
@@ -89,25 +82,7 @@ const Discussion = (props) => {
 		return elements;
 	};
 
-	const renderDiscussions = () => {
-		// const filteredDiscussions = threadData.filter((discussion) => discussion.threadNumber);
-		const filteredThreadComments = discussionData.thread.comments;
-		if (isPreview) {
-			return renderPreviewDiscussionsAndOverflow(filteredThreadComments, 2);
-		}
-		return filteredThreadComments.map((item) => {
-			return (
-				<ThreadComment
-					key={item.id}
-					threadCommentData={item}
-					isPreview={isPreview}
-					// isRootThread={index === 0}
-					{...props}
-				/>
-			);
-		});
-	};
-	const handlePutDiscussion = (discussionUpdates) => {
+	const handleUpdateDiscussion = (discussionUpdates) => {
 		return apiFetch('/api/discussions', {
 			method: 'PUT',
 			body: JSON.stringify({
@@ -132,7 +107,55 @@ const Discussion = (props) => {
 			});
 		});
 	};
-	const isDiscussionAuthor = loginData.id === discussionData.userId;
+
+	const renderAnchorText = () => {
+		const { anchor } = discussionData;
+		if (anchor) {
+			const { prefix, suffix, exact } = anchor;
+			return (
+				<div className="anchor-text">
+					{prefix}
+					<span className="exact">{exact}</span>
+					{suffix}
+				</div>
+			);
+		}
+		return null;
+	};
+
+	const renderDiscussions = () => {
+		const filteredThreadComments = discussionData.thread.comments;
+		if (isPreview) {
+			return renderPreviewDiscussionsAndOverflow(filteredThreadComments, 2);
+		}
+		return filteredThreadComments.map((item) => {
+			return (
+				<ThreadComment
+					key={item.id}
+					discussionData={discussionData}
+					updateLocalData={updateLocalData}
+					threadCommentData={item}
+					isPreview={isPreview}
+					pubData={pubData}
+				/>
+			);
+		});
+	};
+
+	const renderInput = () => {
+		if (!canReply) {
+			return null;
+		}
+		return (
+			<DiscussionInput
+				key={discussionData.thread.comments.length}
+				pubData={pubData}
+				updateLocalData={updateLocalData}
+				discussionData={discussionData}
+			/>
+		);
+	};
+
 	return (
 		<div
 			tabIndex={-1}
@@ -141,6 +164,7 @@ const Discussion = (props) => {
 				'discussion-component',
 				isPreview && 'preview',
 				previewExpanded && 'expanded-preview',
+				showManageTools && 'has-manage-tools',
 			)}
 			onClick={() => {
 				if (isPreview) {
@@ -153,6 +177,7 @@ const Discussion = (props) => {
 					minimal
 					small
 					className="collapse-button"
+					onClick={() => setPreviewExpanded(false)}
 					icon={
 						<Icon
 							icon="collapse-all"
@@ -160,64 +185,24 @@ const Discussion = (props) => {
 							color={communityData.accentColorDark}
 						/>
 					}
-					onClick={() => {
-						setPreviewExpanded(false);
-					}}
 				/>
 			)}
 			<LabelList pubData={pubData} discussionData={discussionData} />
-			{!isPreview && discussionData.anchor && (
-				<div className="anchor-text">
-					{discussionData.anchor.prefix}
-					<span className="exact">{discussionData.anchor.exact}</span>
-					{discussionData.anchor.suffix}
-				</div>
-			)}
-			{!isPreview &&
-				canAdmin &&
-				firebaseBranchRef &&
-				loginData.id === 'b242f616-7aaa-479c-8ee5-3933dcf70859' && (
-					<DiscussionReanchor
-						discussionData={discussionData}
-						collabData={collabData}
-						firebaseBranchRef={firebaseBranchRef}
-					/>
-				)}
-			{!isPreview && (isDiscussionAuthor || canAdmin) && (
-				<React.Fragment>
-					<LabelSelect
-						availableLabels={pubData.labels || []}
-						labelsData={discussionData.labels || []}
-						onPutDiscussion={handlePutDiscussion}
-						canManagePub={canAdmin}
-						canManageThread={isDiscussionAuthor}
-					/>
-					<Tooltip content={discussionData.isClosed ? 'Unarchive' : 'Archive'}>
-						<Button
-							icon={
-								<Icon
-									icon={discussionData.isClosed ? 'export' : 'import'}
-									iconSize={12}
-								/>
-							}
-							minimal={true}
-							small={true}
-							loading={isLoadingArchive}
-							alt={discussionData.isClosed ? 'Unarchive' : 'Archive'}
-							onClick={() => {
-								setIsLoadingArchive(true);
-								handlePutDiscussion({
-									isClosed: !discussionData.isClosed,
-								});
-							}}
+			{!isPreview && (
+				<>
+					{showManageTools && (
+						<ManageTools
+							isDiscussionAuthor={isDiscussionAuthor}
+							pubData={pubData}
+							discussionData={discussionData}
+							onUpdateDiscussion={handleUpdateDiscussion}
 						/>
-					</Tooltip>
-				</React.Fragment>
+					)}
+					{renderAnchorText()}
+				</>
 			)}
 			{renderDiscussions()}
-			{!isPreview && (canView || canCreateDiscussions) && (
-				<DiscussionInput key={discussionData.thread.comments.length} {...props} />
-			)}
+			{!isPreview && renderInput()}
 		</div>
 	);
 };

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionInput.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionInput.js
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { AnchorButton, Button, Intent } from '@blueprintjs/core';
+
 import Editor, {
 	getText,
 	getJSON,
@@ -7,24 +9,20 @@ import Editor, {
 	convertLocalHighlightToDiscussion,
 	getLocalHighlightText,
 } from 'components/Editor';
-import { AnchorButton, Button, Intent } from '@blueprintjs/core';
 import { Avatar } from 'components';
-import { usePageContext } from 'utils/hooks';
-import FormattingBarLegacy from 'components/FormattingBarLegacy/FormattingBar';
 import { apiFetch } from 'utils';
+import { usePageContext } from 'utils/hooks';
+import { usePubContext } from 'containers/Pub/pubHooks';
+import FormattingBarLegacy from 'components/FormattingBarLegacy/FormattingBar';
 
 const propTypes = {
 	pubData: PropTypes.object.isRequired,
-	collabData: PropTypes.object.isRequired,
-	firebaseBranchRef: PropTypes.object,
-	discussionData: PropTypes.object.isRequired,
 	updateLocalData: PropTypes.func.isRequired,
+	discussionData: PropTypes.object.isRequired,
 	isPubBottomInput: PropTypes.bool,
-	historyData: PropTypes.object.isRequired,
 };
 
 const defaultProps = {
-	firebaseBranchRef: undefined,
 	isPubBottomInput: false,
 };
 
@@ -36,14 +34,8 @@ const getPlaceholderText = (isNewThread, isPubBottomInput) => {
 };
 
 const DiscussionInput = (props) => {
-	const {
-		pubData,
-		collabData,
-		updateLocalData,
-		discussionData,
-		isPubBottomInput,
-		historyData,
-	} = props;
+	const { discussionData, isPubBottomInput, pubData, updateLocalData } = props;
+	const { historyData, collabData, firebaseBranchRef } = usePubContext();
 	const { loginData, locationData, communityData } = usePageContext();
 	const pubView = collabData.editorChangeObject.view;
 	const [changeObject, setChangeObject] = useState({});
@@ -112,14 +104,6 @@ const DiscussionInput = (props) => {
 			}),
 		});
 
-		if (props.firebaseBranchRef) {
-			await convertLocalHighlightToDiscussion(
-				pubView,
-				discussionData.id,
-				props.firebaseBranchRef,
-			);
-		}
-
 		updateLocalData('pub', {
 			discussions: [...pubData.discussions, outputData],
 		});
@@ -127,6 +111,8 @@ const DiscussionInput = (props) => {
 		if (isPubBottomInput) {
 			setIsLoading(false);
 			setEditorKey(Date.now());
+		} else if (firebaseBranchRef) {
+			await convertLocalHighlightToDiscussion(pubView, discussionData.id, firebaseBranchRef);
 		}
 	};
 

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionReanchor.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionReanchor.js
@@ -18,7 +18,7 @@ const DiscussionReanchor = (props) => {
 	const [isActive, setIsActive] = useState(false);
 
 	const { selection } = collabData.editorChangeObject;
-	const { anchor = {} } = discussionData;
+	const { anchor } = discussionData;
 
 	const handleReanchor = () => {
 		const { view } = collabData.editorChangeObject;
@@ -41,11 +41,13 @@ const DiscussionReanchor = (props) => {
 				ReactDOM.createPortal(
 					<Card className="discussion-reanchor-component">
 						<p>Make a highlight in the document and then click "Re-anchor".</p>
-						<p>
-							{anchor.prefix}
-							<em style={{ fontWeight: 'bold' }}>{anchor.exact}</em>
-							{anchor.suffix}
-						</p>
+						{anchor && (
+							<p>
+								{anchor.prefix}
+								<em style={{ fontWeight: 'bold' }}>{anchor.exact}</em>
+								{anchor.suffix}
+							</p>
+						)}
 						<ButtonGroup>
 							<Button onClick={() => setIsActive(false)} style={{ marginRight: 10 }}>
 								Cancel

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionReanchor.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionReanchor.js
@@ -1,37 +1,42 @@
 import React, { useState } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import { reanchorDiscussion } from 'components/Editor';
 import { Button, ButtonGroup, Card, Icon } from '@blueprintjs/core';
+
+import { reanchorDiscussion } from 'components/Editor';
+import { usePubContext } from 'containers/Pub/pubHooks';
 
 require('./discussionReanchor.scss');
 
 const propTypes = {
 	discussionData: PropTypes.object.isRequired,
-	collabData: PropTypes.object.isRequired,
-	firebaseBranchRef: PropTypes.object.isRequired,
 };
 
 const DiscussionReanchor = (props) => {
-	const { collabData, discussionData, firebaseBranchRef } = props;
+	const { discussionData } = props;
+	const { collabData, firebaseBranchRef } = usePubContext();
 	const [isActive, setIsActive] = useState(false);
+
 	const { selection } = collabData.editorChangeObject;
-	const onReanchor = () => {
+	const { anchor = {} } = discussionData;
+
+	const handleReanchor = () => {
 		const { view } = collabData.editorChangeObject;
 		reanchorDiscussion(view, firebaseBranchRef, discussionData.id);
 		setIsActive(false);
 	};
 
-	const anchor = discussionData.anchor || {};
 	return (
-		<React.Fragment>
+		<>
 			<Button
 				small
 				minimal
 				disabled={isActive}
 				onClick={() => setIsActive(true)}
 				icon={<Icon icon="text-highlight" iconSize={12} />}
-			/>
+			>
+				Re-anchor
+			</Button>
 			{isActive &&
 				ReactDOM.createPortal(
 					<Card className="discussion-reanchor-component">
@@ -46,7 +51,7 @@ const DiscussionReanchor = (props) => {
 								Cancel
 							</Button>
 							<Button
-								onClick={onReanchor}
+								onClick={handleReanchor}
 								disabled={!selection || selection.empty}
 								intent="primary"
 							>
@@ -56,7 +61,7 @@ const DiscussionReanchor = (props) => {
 					</Card>,
 					document.querySelector('body'),
 				)}
-		</React.Fragment>
+		</>
 	);
 };
 

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/LabelSelect.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/LabelSelect.js
@@ -10,7 +10,6 @@ const propTypes = {
 	labelsData: PropTypes.array.isRequired,
 	onPutDiscussion: PropTypes.func.isRequired,
 	canAdminPub: PropTypes.bool.isRequired,
-	canManageThread: PropTypes.bool.isRequired,
 };
 
 class LabelSelect extends Component {
@@ -63,94 +62,91 @@ class LabelSelect extends Component {
 			return this.props.canAdminPub || label.publicApply;
 		});
 
+		if (availableLabels.length === 0) {
+			return null;
+		}
+
 		return (
-			<span className="label-select-component">
-				{this.props.canManageThread && !!availableLabels.length && (
-					<Popover
-						content={
-							<Menu>
-								<Button
-									fill
-									text="Save"
-									onClick={this.handleSave}
-									loading={this.state.isSaving}
-									disabled={!this.state.labelsDataChanged}
-								/>
-								{availableLabels
-									.sort((foo, bar) => {
-										if (foo.title < bar.title) {
-											return -1;
+			<Popover
+				popoverClassName="label-select-component"
+				content={
+					<Menu>
+						<Button
+							fill
+							className="save-button"
+							text="Save"
+							onClick={this.handleSave}
+							loading={this.state.isSaving}
+							disabled={!this.state.labelsDataChanged}
+						/>
+						{availableLabels
+							.sort((foo, bar) => {
+								if (foo.title < bar.title) {
+									return -1;
+								}
+								if (foo.title > bar.title) {
+									return 1;
+								}
+								return 0;
+							})
+							.map((label) => {
+								const isActive = this.state.labelsData.indexOf(label.id) > -1;
+								return (
+									<MenuItem
+										key={label.id}
+										shouldDismissPopover={false}
+										onClick={() => {
+											if (isActive) {
+												return this.removeLabel(label.id);
+											}
+											return this.applyLabel(label.id);
+										}}
+										icon={
+											<div
+												className="color"
+												style={{ backgroundColor: label.color }}
+											>
+												{isActive && <Icon icon="tick" iconSize={14} />}
+											</div>
 										}
-										if (foo.title > bar.title) {
-											return 1;
-										}
-										return 0;
-									})
-									.map((label) => {
-										const isActive =
-											this.state.labelsData.indexOf(label.id) > -1;
-										return (
-											<MenuItem
-												key={label.id}
-												shouldDismissPopover={false}
-												onClick={() => {
-													if (isActive) {
-														return this.removeLabel(label.id);
+										text={label.title}
+										labelElement={
+											this.props.canAdminPub && (
+												<Tooltip
+													content={
+														label.publicApply
+															? 'All discussion authors can apply this label.'
+															: 'Only managers can apply this label.'
 													}
-													return this.applyLabel(label.id);
-												}}
-												icon={
-													<div
-														className="color"
-														style={{ backgroundColor: label.color }}
-													>
-														{isActive && (
-															<Icon icon="tick" iconSize={14} />
-														)}
-													</div>
-												}
-												text={label.title}
-												labelElement={
-													this.props.canAdminPub && (
-														<Tooltip
-															content={
-																label.publicApply
-																	? 'All discussion authors can apply this label.'
-																	: 'Only managers can apply this label.'
-															}
-														>
-															<Icon
-																icon="endorsed"
-																className={
-																	label.publicApply
-																		? ''
-																		: 'active'
-																}
-															/>
-														</Tooltip>
-													)
-												}
-											/>
-										);
-									})}
-							</Menu>
-						}
-						position={Position.BOTTOM_RIGHT}
-						transitionDuration={-1}
-						usePortal={false}
-						target={
-							<Button
-								minimal
-								small
-								onClick={this.toggleEditMode}
-								icon={<Icon icon="tag2" iconSize={12} />}
-							>
-								Labels
-							</Button>
-						}
-					/>
-				)}
-			</span>
+												>
+													<Icon
+														icon="endorsed"
+														className={
+															label.publicApply ? '' : 'active'
+														}
+													/>
+												</Tooltip>
+											)
+										}
+									/>
+								);
+							})}
+					</Menu>
+				}
+				position={Position.BOTTOM_RIGHT}
+				transitionDuration={-1}
+				minimal
+				target={
+					<Button
+						minimal
+						small
+						onClick={this.toggleEditMode}
+						icon={<Icon icon="tag2" iconSize={12} />}
+					>
+						Labels
+					</Button>
+				}
+			/>
 		);
 	}
 }

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/LabelSelect.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/LabelSelect.js
@@ -9,7 +9,7 @@ const propTypes = {
 	availableLabels: PropTypes.array.isRequired,
 	labelsData: PropTypes.array.isRequired,
 	onPutDiscussion: PropTypes.func.isRequired,
-	canManagePub: PropTypes.bool.isRequired,
+	canAdminPub: PropTypes.bool.isRequired,
 	canManageThread: PropTypes.bool.isRequired,
 };
 
@@ -60,7 +60,7 @@ class LabelSelect extends Component {
 		});
 
 		const availableLabels = this.props.availableLabels.filter((label) => {
-			return this.props.canManagePub || label.publicApply;
+			return this.props.canAdminPub || label.publicApply;
 		});
 
 		return (
@@ -111,7 +111,7 @@ class LabelSelect extends Component {
 												}
 												text={label.title}
 												labelElement={
-													this.props.canManagePub && (
+													this.props.canAdminPub && (
 														<Tooltip
 															content={
 																label.publicApply
@@ -144,7 +144,9 @@ class LabelSelect extends Component {
 								small
 								onClick={this.toggleEditMode}
 								icon={<Icon icon="tag2" iconSize={12} />}
-							/>
+							>
+								Labels
+							</Button>
 						}
 					/>
 				)}

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ManageTools.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ManageTools.js
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '@blueprintjs/core';
+
+import { Icon, ConfirmDialog } from 'components';
+import { usePageContext } from 'utils/hooks';
+
+import LabelSelect from './LabelSelect';
+import DiscussionReanchor from './DiscussionReanchor';
+
+const propTypes = {
+	isDiscussionAuthor: PropTypes.bool.isRequired,
+	pubData: PropTypes.shape({ labels: PropTypes.array }).isRequired,
+	discussionData: PropTypes.shape({
+		isClosed: PropTypes.bool,
+		labels: PropTypes.array,
+		userId: PropTypes.string,
+	}).isRequired,
+	onUpdateDiscussion: PropTypes.func.isRequired,
+};
+
+const ManageTools = (props) => {
+	const { pubData, discussionData, onUpdateDiscussion, isDiscussionAuthor } = props;
+	const { scopeData } = usePageContext();
+	const { canAdmin, isSuperAdmin } = scopeData.activePermissions;
+	const { isClosed } = discussionData;
+	const [isArchiving, setIsArchiving] = useState(false);
+
+	const handleToggleArchive = () => {
+		setIsArchiving(true);
+		onUpdateDiscussion({ isClosed: !isClosed });
+	};
+
+	const renderArchiveButton = () => {
+		if (discussionData.isClosed && !canAdmin) {
+			return null;
+		}
+
+		const verb = isClosed ? 'Unarchive' : 'Archive';
+		return (
+			<ConfirmDialog
+				onConfirm={handleToggleArchive}
+				confirmLabel="Archive"
+				text={`Are you sure you want to ${verb.toLowerCase()} this discussion?`}
+			>
+				{({ open }) => (
+					<Button
+						icon={<Icon icon={isClosed ? 'export' : 'import'} iconSize={12} />}
+						minimal={true}
+						small={true}
+						loading={isArchiving}
+						onClick={open}
+					>
+						{verb}
+					</Button>
+				)}
+			</ConfirmDialog>
+		);
+	};
+
+	return (
+		<div className="manage-tools-component">
+			<LabelSelect
+				availableLabels={pubData.labels || []}
+				labelsData={discussionData.labels || []}
+				onPutDiscussion={onUpdateDiscussion}
+				canAdminPub={canAdmin}
+				canManageThread={canAdmin || isDiscussionAuthor}
+			/>
+			{renderArchiveButton()}
+			{isSuperAdmin && <DiscussionReanchor discussionData={discussionData} />}
+		</div>
+	);
+};
+
+ManageTools.propTypes = propTypes;
+export default ManageTools;

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ManageTools.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ManageTools.js
@@ -9,7 +9,6 @@ import LabelSelect from './LabelSelect';
 import DiscussionReanchor from './DiscussionReanchor';
 
 const propTypes = {
-	isDiscussionAuthor: PropTypes.bool.isRequired,
 	pubData: PropTypes.shape({ labels: PropTypes.array }).isRequired,
 	discussionData: PropTypes.shape({
 		isClosed: PropTypes.bool,
@@ -20,7 +19,7 @@ const propTypes = {
 };
 
 const ManageTools = (props) => {
-	const { pubData, discussionData, onUpdateDiscussion, isDiscussionAuthor } = props;
+	const { pubData, discussionData, onUpdateDiscussion } = props;
 	const { scopeData } = usePageContext();
 	const { canAdmin, isSuperAdmin } = scopeData.activePermissions;
 	const { isClosed } = discussionData;
@@ -65,7 +64,6 @@ const ManageTools = (props) => {
 				labelsData={discussionData.labels || []}
 				onPutDiscussion={onUpdateDiscussion}
 				canAdminPub={canAdmin}
-				canManageThread={canAdmin || isDiscussionAuthor}
 			/>
 			{renderArchiveButton()}
 			{isSuperAdmin && <DiscussionReanchor discussionData={discussionData} />}

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ManageTools.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ManageTools.js
@@ -40,7 +40,7 @@ const ManageTools = (props) => {
 		return (
 			<ConfirmDialog
 				onConfirm={handleToggleArchive}
-				confirmLabel="Archive"
+				confirmLabel={verb}
 				text={`Are you sure you want to ${verb.toLowerCase()} this discussion?`}
 			>
 				{({ open }) => (

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.js
@@ -16,7 +16,6 @@ const propTypes = {
 	threadCommentData: PropTypes.object.isRequired,
 	pubData: PropTypes.object.isRequired,
 	updateLocalData: PropTypes.func.isRequired,
-
 	isPreview: PropTypes.bool,
 };
 

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/discussion.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/discussion.scss
@@ -13,6 +13,10 @@
 			transform: rotate(45deg);
 		}
 	}
+	.manage-tools-component {
+		display: flex;
+		margin-bottom: 1em;
+	}
 	.anchor-text {
 		padding: 0.25em;
 		background: #f0f0f7;

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/labelSelect.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/labelSelect.scss
@@ -1,4 +1,7 @@
 .label-select-component {
+	.save-button {
+		margin-bottom: 4px;
+	}
 	.color {
 		height: 18px;
 		width: 18px;

--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionGroup/DiscussionGroup.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionGroup/DiscussionGroup.js
@@ -8,9 +8,7 @@ require('./discussionGroup.scss');
 
 const propTypes = {
 	pubData: PropTypes.object.isRequired,
-	collabData: PropTypes.object.isRequired,
 	historyData: PropTypes.object.isRequired,
-	firebaseBranchRef: PropTypes.object.isRequired,
 	discussions: PropTypes.array.isRequired,
 	mountClassName: PropTypes.string.isRequired,
 	updateLocalData: PropTypes.func.isRequired,
@@ -23,9 +21,7 @@ const propTypes = {
 const DiscussionGroup = (props) => {
 	const {
 		pubData,
-		collabData,
 		historyData,
-		firebaseBranchRef,
 		updateLocalData,
 		discussions,
 		sideContentRef,
@@ -116,9 +112,7 @@ const DiscussionGroup = (props) => {
 			{activeDiscussionData && (
 				<Discussion
 					pubData={pubData}
-					collabData={collabData}
 					historyData={historyData}
-					firebaseBranchRef={firebaseBranchRef}
 					discussionData={activeDiscussionData}
 					updateLocalData={updateLocalData}
 				/>

--- a/client/containers/Pub/PubDocument/PubDiscussions/discussionUtils.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/discussionUtils.js
@@ -162,7 +162,7 @@ export const filterAndSortDiscussions = (
 				return true;
 			}
 			const hasNecessaryLabel = filteredLabels.reduce((prev, curr) => {
-				if (discussion.labels && discussion.labels.indexOf(curr) === -1) {
+				if (!discussion.labels || discussion.labels.indexOf(curr) === -1) {
 					return false;
 				}
 				return prev;

--- a/client/containers/Pub/PubDocument/PubDiscussions/discussionUtils.js
+++ b/client/containers/Pub/PubDocument/PubDiscussions/discussionUtils.js
@@ -162,7 +162,7 @@ export const filterAndSortDiscussions = (
 				return true;
 			}
 			const hasNecessaryLabel = filteredLabels.reduce((prev, curr) => {
-				if (discussion.labels.indexOf(curr) === -1) {
+				if (discussion.labels && discussion.labels.indexOf(curr) === -1) {
 					return false;
 				}
 				return prev;

--- a/client/containers/Pub/PubDocument/PubDiscussions/pubDiscussions.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/pubDiscussions.scss
@@ -11,6 +11,9 @@
 			&:not(:last-child) {
 				border-bottom: 0px solid transparent;
 			}
+			&.has-manage-tools {
+				padding: 1em;
+			}
 			&.preview {
 				padding: 1em;
 				cursor: pointer;

--- a/client/containers/Pub/PubDocument/PubDocument.js
+++ b/client/containers/Pub/PubDocument/PubDocument.js
@@ -117,8 +117,6 @@ const PubDocument = (props) => {
 			<PubBottom
 				pubData={pubData}
 				collabData={collabData}
-				historyData={historyData}
-				firebaseBranchRef={firebaseBranchRef}
 				updateLocalData={updateLocalData}
 				sideContentRef={sideContentRef}
 				mainContentRef={mainContentRef}

--- a/client/containers/Pub/PubSyncManager.js
+++ b/client/containers/Pub/PubSyncManager.js
@@ -9,7 +9,7 @@ import { getPubPageTitle } from 'shared/utils/pubPageTitle';
 
 export const PubContext = React.createContext({
 	pubData: {},
-	collabData: {},
+	collabData: { editorChangeObject: {} },
 	historyData: {},
 	firebaseBranchRef: null,
 	updateLocalData: null,

--- a/server/discussion/api.js
+++ b/server/discussion/api.js
@@ -1,5 +1,5 @@
 import app, { wrap } from '../server';
-import { getPermissions } from './permissions';
+import { getCreatePermission, getUpdatePermissions } from './permissions';
 import { createDiscussion, updateDiscussion } from './queries';
 import { ForbiddenError } from '../errors';
 
@@ -19,8 +19,8 @@ app.post(
 	'/api/discussions',
 	wrap(async (req, res) => {
 		const requestIds = getRequestIds(req);
-		const permissions = await getPermissions(requestIds);
-		if (!permissions.create) {
+		const canCreate = await getCreatePermission(requestIds);
+		if (!canCreate) {
 			throw new ForbiddenError();
 		}
 		const newDiscussion = await createDiscussion(req.body, req.user);
@@ -32,11 +32,8 @@ app.put(
 	'/api/discussions',
 	wrap(async (req, res) => {
 		const requestIds = getRequestIds(req);
-		const permissions = await getPermissions(requestIds);
-		if (!permissions.update) {
-			throw new ForbiddenError();
-		}
-		const updatedValues = await updateDiscussion(req.body, permissions.update);
+		const permissions = await getUpdatePermissions(requestIds);
+		const updatedValues = await updateDiscussion(req.body, permissions);
 		return res.status(200).json(updatedValues);
 	}),
 );

--- a/server/discussion/queries.js
+++ b/server/discussion/queries.js
@@ -175,7 +175,8 @@ export const updateDiscussion = async (values, permissions) => {
 
 	if ('labels' in values) {
 		const labels = [];
-		const hasRemovedManagedLabels = discussion.labels.some((labelId) => {
+		const existingLabels = discussion.labels || [];
+		const hasRemovedManagedLabels = existingLabels.some((labelId) => {
 			const labelDefinition = pub.labels.find((label) => label.id === labelId);
 			const missingFromUpdate = !values.labels.includes(labelId);
 			return labelDefinition && !labelDefinition.publicApply && missingFromUpdate;
@@ -184,7 +185,7 @@ export const updateDiscussion = async (values, permissions) => {
 			throw new ForbiddenError();
 		}
 		for (const labelId of values.labels) {
-			const isExistingLabel = discussion.labels.includes(labelId);
+			const isExistingLabel = existingLabels.includes(labelId);
 			const labelDefinition = pub.labels.find((label) => label.id === labelId);
 			if (labelDefinition) {
 				const { publicApply } = labelDefinition;

--- a/server/discussion/queries.js
+++ b/server/discussion/queries.js
@@ -1,4 +1,6 @@
-import { attributesPublicUser } from '../utils/attributesPublicUser';
+/* eslint-disable no-restricted-syntax */
+import { ForbiddenError } from 'server/errors';
+import { attributesPublicUser } from 'server/utils/attributesPublicUser';
 import {
 	User,
 	DiscussionNew,
@@ -6,8 +8,9 @@ import {
 	Thread,
 	ThreadComment,
 	ThreadEvent,
+	Pub,
 	Visibility,
-} from '../models';
+} from 'server/models';
 
 const findDiscussionWithUser = (id) =>
 	DiscussionNew.findOne({
@@ -137,20 +140,65 @@ export const createDiscussion = async (inputValues, user) => {
 	return discussionWithUser;
 };
 
-export const updateDiscussion = (inputValues, updatePermissions) => {
-	// Filter to only allow certain fields to be updated
-	const filteredValues = {};
-	Object.keys(inputValues).forEach((key) => {
-		if (updatePermissions.includes(key)) {
-			filteredValues[key] = inputValues[key];
+export const updateDiscussion = async (values, permissions) => {
+	const { discussionId, pubId } = values;
+	const {
+		canTitle,
+		canApplyPublicLabels,
+		canApplyManagedLabels,
+		canClose,
+		canReopen,
+	} = permissions;
+	const updatedValues = {};
+
+	const [discussion, pub] = await Promise.all([
+		DiscussionNew.findOne({ where: { id: discussionId } }),
+		Pub.findOne({ where: { id: pubId }, attributes: ['id', 'labels'] }),
+	]);
+
+	if ('title' in values) {
+		if (canTitle) {
+			updatedValues.title = values.title;
+		} else {
+			throw new ForbiddenError();
 		}
-	});
-	return DiscussionNew.update(filteredValues, {
-		where: { id: inputValues.discussionId },
-	}).then(async () => {
-		return {
-			...filteredValues,
-			id: inputValues.discussionId,
-		};
-	});
+	}
+
+	if ('isClosed' in values) {
+		const canModifyClosed = values.isClosed ? canClose : canReopen;
+		if (canModifyClosed) {
+			updatedValues.isClosed = values.isClosed;
+		} else {
+			throw new ForbiddenError();
+		}
+	}
+
+	if ('labels' in values) {
+		const labels = [];
+		const hasRemovedManagedLabels = discussion.labels.some((labelId) => {
+			const labelDefinition = pub.labels.find((label) => label.id === labelId);
+			const missingFromUpdate = !values.labels.includes(labelId);
+			return labelDefinition && !labelDefinition.publicApply && missingFromUpdate;
+		});
+		if (hasRemovedManagedLabels && !canApplyManagedLabels) {
+			throw new ForbiddenError();
+		}
+		for (const labelId of values.labels) {
+			const isExistingLabel = discussion.labels.includes(labelId);
+			const labelDefinition = pub.labels.find((label) => label.id === labelId);
+			if (labelDefinition) {
+				const { publicApply } = labelDefinition;
+				const canLabel = publicApply ? canApplyPublicLabels : canApplyManagedLabels;
+				if (isExistingLabel || canLabel) {
+					labels.push(labelId);
+				} else {
+					throw new ForbiddenError();
+				}
+			}
+		}
+		updatedValues.labels = labels;
+	}
+
+	await discussion.update(updatedValues);
+	return discussion;
 };

--- a/server/utils/queryHelpers/scopeGet.js
+++ b/server/utils/queryHelpers/scopeGet.js
@@ -261,6 +261,7 @@ getActivePermissions = async (
 	};
 
 	const initialOptions = {
+		isSuperAdmin: isSuperAdmin,
 		canCreateForks: null,
 		canCreateReviews: null,
 		canCreateDiscussions: true,

--- a/stories/containers/Pub/PubDiscussions/discussionThreadStories.js
+++ b/stories/containers/Pub/PubDiscussions/discussionThreadStories.js
@@ -6,9 +6,5 @@ import { pubData, discussionsData } from 'data';
 const [singleDiscussion] = discussionsData;
 
 storiesOf('containers/Pub/PubDiscussions/Discussion', module).add('default', () => (
-	<Discussion
-		discussionData={singleDiscussion}
-		pubData={pubData}
-		collabData={{ editorChangeObject: {} }}
-	/>
+	<Discussion discussionData={singleDiscussion} pubData={pubData} />
 ));


### PR DESCRIPTION
After the Dashboard migration, there's some stuff we can clean up around discussions:

- Re-enabling discussion labels with some permissions tweaks
- Applying a modicum of styling to the discussion management buttons
- Some props cleanup — it is not necessary to be passing `firebaseRef` and `collabData` deep into the discussions render tree.

Here is a discussion with the new buttons layout — I think the text labels improve the buttons:
<img width="317" alt="image" src="https://user-images.githubusercontent.com/2208769/80768340-2259ae00-8b18-11ea-993a-d08ba6df7416.png">

_Test plan:_
- Create a discussion from both the pub bottom and the pub document
- Edit a ThreadComment
- Archive a discussion
- As an admin, un-archive a discussion
- Re-anchor a discussion
- As an admin, create a label
- As an admin, apply a label to a discussion
- As an author, apply a label to a discussion
- Run `npm run test server/discussion/`
