### PR TITLE
update: Change shadow author last name assumption

### DIFF
--- a/server/collectionAttribution/queries.js
+++ b/server/collectionAttribution/queries.js
@@ -1,3 +1,4 @@
+import ensureUserForAttribution from 'shared/utils/ensureUserForAttribution';
 import { CollectionAttribution, User } from '../models';
 import { attributesPublicUser } from '../utils/attributesPublicUser';
 
@@ -18,24 +19,12 @@ export const createCollectionAttribution = (inputValues) => {
 			});
 		})
 		.then((populatedCollectionAttribution) => {
+			const populatedCollectionAttributionJson = populatedCollectionAttribution.toJSON();
 			if (populatedCollectionAttribution.user) {
-				return populatedCollectionAttribution.toJSON();
+				return populatedCollectionAttributionJson;
 			}
-			return {
-				...populatedCollectionAttribution.toJSON(),
-				user: {
-					id: populatedCollectionAttribution.id,
-					initials: populatedCollectionAttribution.name[0],
-					fullName: populatedCollectionAttribution.name,
-					firstName: populatedCollectionAttribution.name.split(' ')[0],
-					lastName: populatedCollectionAttribution.name
-						.split(' ')
-						.slice(1, populatedCollectionAttribution.name.split(' ').length)
-						.join(' '),
-					avatar: populatedCollectionAttribution.avatar,
-					title: populatedCollectionAttribution.title,
-				},
-			};
+
+			return ensureUserForAttribution(populatedCollectionAttributionJson);
 		});
 };
 

--- a/server/pubAttribution/queries.js
+++ b/server/pubAttribution/queries.js
@@ -1,3 +1,4 @@
+import ensureUserForAttribution from 'shared/utils/ensureUserForAttribution';
 import { PubAttribution, User } from '../models';
 import { attributesPublicUser } from '../utils/attributesPublicUser';
 
@@ -18,24 +19,11 @@ export const createPubAttribution = (inputValues) => {
 			});
 		})
 		.then((populatedPubAttribution) => {
+			const populatedPubAttributionJson = populatedPubAttribution.toJSON();
 			if (populatedPubAttribution.user) {
-				return populatedPubAttribution.toJSON();
+				return populatedPubAttributionJson;
 			}
-			return {
-				...populatedPubAttribution.toJSON(),
-				user: {
-					id: populatedPubAttribution.id,
-					initials: populatedPubAttribution.name[0],
-					fullName: populatedPubAttribution.name,
-					firstName: populatedPubAttribution.name.split(' ')[0],
-					lastName: populatedPubAttribution.name
-						.split(' ')
-						.slice(1, populatedPubAttribution.name.split(' ').length)
-						.join(' '),
-					avatar: populatedPubAttribution.avatar,
-					title: populatedPubAttribution.title,
-				},
-			};
+			return ensureUserForAttribution(populatedPubAttributionJson);
 		});
 };
 

--- a/server/rss/queries.js
+++ b/server/rss/queries.js
@@ -1,5 +1,6 @@
 import RSS from 'rss';
 import { getPubPublishedDate } from 'shared/pub/pubDates';
+import ensureUserForAttribution from 'shared/utils/ensureUserForAttribution';
 import { Community, Pub, User, PubAttribution, Release } from '../models';
 
 export const getCommunityRss = (hostname) => {
@@ -102,21 +103,7 @@ export const getCommunityRss = (hostname) => {
 						if (attribution.user) {
 							return attribution;
 						}
-						return {
-							...attribution,
-							user: {
-								id: attribution.id,
-								initials: attribution.name[0],
-								fullName: attribution.name,
-								firstName: attribution.name.split(' ')[0],
-								lastName: attribution.name
-									.split(' ')
-									.slice(1, attribution.name.split(' ').length)
-									.join(' '),
-								avatar: attribution.avatar,
-								title: attribution.title,
-							},
-						};
+						return ensureUserForAttribution(attribution);
 					})
 					.filter((item) => {
 						return item.isAuthor;

--- a/server/utils/citations.js
+++ b/server/utils/citations.js
@@ -67,7 +67,6 @@ export const generateCitationHTML = async (pubData, communityData) => {
 	};
 	const pubCiteObject = await Cite.async({
 		...commonData,
-		id: pubData.id,
 		DOI: pubData.doi,
 		ISSN: pubData.doi ? communityData.issn : null,
 		issued: pubIssuedDate && [getDatePartsObject(pubIssuedDate)],

--- a/server/utils/collectionQueries.js
+++ b/server/utils/collectionQueries.js
@@ -1,3 +1,4 @@
+import ensureUserForAttribution from 'shared/utils/ensureUserForAttribution';
 import { User, CollectionAttribution, CollectionPub } from '../models';
 
 export const getCollectionAttributions = (collectionId) =>
@@ -22,24 +23,11 @@ export const getCollectionAttributions = (collectionId) =>
 		],
 	}).then((attributions) => {
 		return attributions.map((attribution) => {
+			const attributionJson = attribution.toJSON();
 			if (attribution.user) {
-				return attribution;
+				return attributionJson;
 			}
-			return {
-				...attribution.toJSON(),
-				user: {
-					id: attribution.id,
-					initials: attribution.name[0],
-					fullName: attribution.name,
-					firstName: attribution.name.split(' ')[0],
-					lastName: attribution.name
-						.split(' ')
-						.slice(1, attribution.name.split(' ').length)
-						.join(' '),
-					avatar: attribution.avatar,
-					title: attribution.title,
-				},
-			};
+			return ensureUserForAttribution(attributionJson);
 		});
 	});
 

--- a/shared/utils/ensureUserForAttribution.js
+++ b/shared/utils/ensureUserForAttribution.js
@@ -5,22 +5,22 @@
  */
 export default (attribution) => {
 	if (!attribution.user || attribution.user.id === attribution.id) {
-		// eslint-disable-next-line no-param-reassign
+		const { id, name, avatar, title, orcid } = attribution;
 		return {
 			...attribution,
 			user: {
 				isShadowUser: true,
-				id: attribution.id,
-				initials: attribution.name[0],
-				fullName: attribution.name,
-				firstName: attribution.name.split(' ')[0],
-				lastName: attribution.name
+				id: id,
+				initials: name[0],
+				fullName: name,
+				firstName: name
 					.split(' ')
-					.slice(1, attribution.name.split(' ').length)
+					.slice(0, -1)
 					.join(' '),
-				avatar: attribution.avatar,
-				title: attribution.title,
-				orcid: attribution.orcid,
+				lastName: name.split(' ').pop(),
+				avatar: avatar,
+				title: title,
+				orcid: orcid,
 			},
 		};
 	}


### PR DESCRIPTION
This pull request implments the temporary fix suggested in #784. For shadow authors, the assumption for last name parsing (as used to generate citation data) is that everything after the final space is the last name. 

A bit of cleanup to use the `ensureUserForAttribution` everywhere is also included.

Finally, the `id` field has been removed from the citation data in `server/utils/citations.js` as it was causing strange caching behavior. APA and Harvard citations weren't being updated to reflect new author information. Cite must keep a working cache in memory that is references with the `id` field. 
