### PR TITLE
fix: Strip leading numbers from TOC

### DIFF
--- a/client/components/Editor/plugins/headerIds.js
+++ b/client/components/Editor/plugins/headerIds.js
@@ -11,6 +11,7 @@ export default () => {
 				if (node.type.name === 'heading') {
 					const newId = node.textContent
 						.replace(/[^a-zA-Z0-9-\s]/gi, '')
+						.replace(/^\d+\W+/gi, '')
 						.replace(/\s+/gi, ' ')
 						.trim()
 						.toLowerCase()

--- a/client/containers/Pub/PubHeader/headerUtils.js
+++ b/client/containers/Pub/PubHeader/headerUtils.js
@@ -79,6 +79,7 @@ export const getTocHeadings = (docJson) => {
 					textContent &&
 					textContent
 						.replace(/[^a-zA-Z0-9-\s]/gi, '')
+						.replace(/^\d+\W+/gi, '')
 						.replace(/\s+/gi, ' ')
 						.trim()
 						.toLowerCase()


### PR DESCRIPTION
This PR addresses #780. Article headers with leading numbers were not properly linking in the ToC. The HTML generated for the headers was formatted (by Prosemirror I believe) to be compliant with HTML standards that say you're not allowed to start a tag `id` with a number. In both the editor plugin and ToC generator, our regex was skipping this part, but because ProseMirror handled it for us in HTML, the ToC and HTML content became out of sync.

The fix is to add a regex that strips leading numbers from header ids in both the Editor plugin and the ToC generator.