### PR TITLE
update: Use consistent ToC placement

### DIFF
--- a/client/containers/Pub/PubHeader/DraftReleaseButtons.js
+++ b/client/containers/Pub/PubHeader/DraftReleaseButtons.js
@@ -9,7 +9,6 @@ import { pubUrl } from 'shared/utils/canonicalUrls';
 import { formatDate } from 'shared/utils/dates';
 
 import ResponsiveHeaderButton from './ResponsiveHeaderButton';
-import PubToc from './PubToc';
 
 const propTypes = {
 	pubData: PropTypes.shape({
@@ -22,12 +21,6 @@ const propTypes = {
 	historyData: PropTypes.object.isRequired,
 	updatePubData: PropTypes.func.isRequired,
 	updateHistoryData: PropTypes.func.isRequired,
-	pubHeadings: PropTypes.array.isRequired,
-	showTocButton: PropTypes.bool,
-};
-
-const defaultProps = {
-	showTocButton: false,
 };
 
 const getHistoryButtonLabelForTimestamp = (timestamp, label, noTimestampLabel) => {
@@ -47,14 +40,7 @@ const getHistoryButtonLabelForTimestamp = (timestamp, label, noTimestampLabel) =
 };
 
 const DraftReleaseButtons = (props) => {
-	const {
-		historyData,
-		pubData,
-		pubHeadings,
-		updateHistoryData,
-		updatePubData,
-		showTocButton,
-	} = props;
+	const { historyData, pubData, updateHistoryData, updatePubData } = props;
 	const {
 		communityData,
 		scopeData,
@@ -64,27 +50,11 @@ const DraftReleaseButtons = (props) => {
 	const { isRelease } = pubData;
 	const canRequestReview = !canAdmin && !!userId;
 
-	const renderTocButton = () => {
-		if (pubHeadings.length > 0 && showTocButton) {
-			return (
-				<PubToc headings={pubHeadings} placement="bottom-start">
-					<ResponsiveHeaderButton
-						outerLabel="Contents"
-						simpleLabel="Contents"
-						labelPosition="right"
-						icon="toc"
-					/>
-				</PubToc>
-			);
-		}
-		return null;
-	};
-
 	const renderForRelease = () => {
 		const { releases, releaseNumber } = pubData;
 		const latestReleaseTimestamp = new Date(releases[releases.length - 1].createdAt).valueOf();
 		return (
-			<>
+			<React.Fragment>
 				{(canView || canViewDraft) && (
 					<ResponsiveHeaderButton
 						icon="edit"
@@ -121,8 +91,7 @@ const DraftReleaseButtons = (props) => {
 						))
 						.reverse()}
 				</Menu>
-				{renderTocButton()}
-			</>
+			</React.Fragment>
 		);
 	};
 
@@ -136,7 +105,7 @@ const DraftReleaseButtons = (props) => {
 			typeof latestRelease.sourceBranchKey !== 'number' ||
 			latestRelease.sourceBranchKey < latestKey;
 		return (
-			<>
+			<React.Fragment>
 				<ResponsiveHeaderButton
 					icon="history"
 					className="draft-history-button"
@@ -210,8 +179,7 @@ const DraftReleaseButtons = (props) => {
 						)}
 					</DialogLauncher>
 				)}
-				{renderTocButton()}
-			</>
+			</React.Fragment>
 		);
 	};
 
@@ -223,5 +191,4 @@ const DraftReleaseButtons = (props) => {
 };
 
 DraftReleaseButtons.propTypes = propTypes;
-DraftReleaseButtons.defaultProps = defaultProps;
 export default DraftReleaseButtons;

--- a/client/containers/Pub/PubHeader/PubHeaderContent.js
+++ b/client/containers/Pub/PubHeader/PubHeaderContent.js
@@ -16,9 +16,8 @@ const propTypes = {
 	historyData: PropTypes.object.isRequired,
 	onShowHeaderDetails: PropTypes.func.isRequired,
 	pubData: PropTypes.shape({
-		doi: PropTypes.string,
-		isRelease: PropTypes.bool,
 		id: PropTypes.string.isRequired,
+		doi: PropTypes.string,
 	}).isRequired,
 	pubHeadings: PropTypes.array.isRequired,
 	updateLocalData: PropTypes.func.isRequired,
@@ -26,7 +25,7 @@ const propTypes = {
 
 const PubHeaderContent = (props) => {
 	const { historyData, onShowHeaderDetails, pubData, pubHeadings, updateLocalData } = props;
-	const { doi, isRelease } = pubData;
+	const { doi } = pubData;
 	const { communityData } = usePageContext();
 	const publishedDate = getPubPublishedDate(pubData);
 
@@ -89,7 +88,6 @@ const PubHeaderContent = (props) => {
 				pubData={pubData}
 				updatePubData={updateAndSavePubData}
 				pubHeadings={pubHeadings}
-				showTocButton={!isRelease}
 				onShowHeaderDetails={onShowHeaderDetails}
 			/>
 			<DraftReleaseButtons
@@ -97,8 +95,6 @@ const PubHeaderContent = (props) => {
 				historyData={historyData}
 				updatePubData={updatePubData}
 				updateHistoryData={updateHistoryData}
-				pubHeadings={pubHeadings}
-				showTocButton={isRelease}
 			/>
 		</div>
 	);

--- a/client/containers/Pub/PubHeader/UtilityButtons.js
+++ b/client/containers/Pub/PubHeader/UtilityButtons.js
@@ -21,15 +21,10 @@ const propTypes = {
 	}).isRequired,
 	pubHeadings: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
 	updatePubData: PropTypes.func.isRequired,
-	showTocButton: PropTypes.bool,
-};
-
-const defaultProps = {
-	showTocButton: true,
 };
 
 const UtilityButtons = (props) => {
-	const { onShowHeaderDetails, pubData, pubHeadings, showTocButton, updatePubData } = props;
+	const { onShowHeaderDetails, pubData, pubHeadings, updatePubData } = props;
 	const { membersData, isRelease } = pubData;
 	const { communityData, scopeData } = usePageContext();
 	const { canManage } = scopeData.activePermissions;
@@ -97,7 +92,7 @@ const UtilityButtons = (props) => {
 			<Download pubData={pubData}>
 				<SmallHeaderButton label="Download" labelPosition="left" icon="download2" />
 			</Download>
-			{pubHeadings.length > 0 && showTocButton && (
+			{pubHeadings.length > 0 && (
 				<PubToc headings={pubHeadings}>
 					<SmallHeaderButton label="Contents" labelPosition="left" icon="toc" />
 				</PubToc>
@@ -107,5 +102,4 @@ const UtilityButtons = (props) => {
 };
 
 UtilityButtons.propTypes = propTypes;
-UtilityButtons.defaultProps = defaultProps;
 export default UtilityButtons;


### PR DESCRIPTION
This PR addresses #794. It sets the contents button to consistently render in the right-hand list for all cases: Release, Draft, and mobile on both.

![Screen Shot 2020-05-06 at 2 55 52 PM](https://user-images.githubusercontent.com/1000455/81187721-4f8cdd00-8fac-11ea-8f46-4aa81228bd36.png)
