### PR TITLE
fix: header-block chrome overflow bug

### DIFF
--- a/client/containers/Pub/PubHeader/pubHeader.scss
+++ b/client/containers/Pub/PubHeader/pubHeader.scss
@@ -123,6 +123,9 @@ $mobile-bottom-buttons-spacing: 10px;
     @include in-blocks-theme {
         .pub-header-content-component {
             column-gap: 20px;
+            .title-group-component {
+                margin-right: 20px;
+            }
         }
     }
 


### PR DESCRIPTION
This PR addresses #783. The issue seems to be a difference in how chrome renders `box-decoration-break`. Adding an additional margin equal to the column-gap makes ensures that Chrome breaks each line in time to avoid overlap.