### PR TITLE
fix: Add releaseNumber check

### DIFF
--- a/server/routes/pubDocument.js
+++ b/server/routes/pubDocument.js
@@ -77,7 +77,7 @@ app.get('/pub/:pubSlug/release/:releaseNumber', async (req, res, next) => {
 		const { releaseNumber: releaseNumberString, pubSlug } = req.params;
 		const initialData = await getInitialData(req);
 		const releaseNumber = parseInt(releaseNumberString, 10);
-		if (Number.isNaN(releaseNumber)) {
+		if (Number.isNaN(releaseNumber) || releaseNumber < 1) {
 			throw new NotFoundError();
 		}
 

--- a/server/utils/queryHelpers/pubSanitize.js
+++ b/server/utils/queryHelpers/pubSanitize.js
@@ -48,7 +48,10 @@ export default (pubData, initialData, releaseNumber) => {
 		return null;
 	}
 
-	const isRelease = !!(releaseNumber || releaseNumber === 0);
+	const isRelease = !!releaseNumber;
+	if (isRelease && pubData.releases.length < releaseNumber) {
+		return null;
+	}
 
 	// TODO(ian): completely unsure why we can't just the `order` parameter within the `include`
 	// object for the query made above, but it doesn't seem to work.


### PR DESCRIPTION
This PR adds a couple checks to resolve a couple bugs related to `/pub/release` route handling.