### PR TITLE
fix: Prevent Menu component flipping

### DIFF
--- a/client/components/Menu/Menu.js
+++ b/client/components/Menu/Menu.js
@@ -51,6 +51,7 @@ export const Menu = React.forwardRef((props, ref) => {
 		placement: placement,
 		gutter: gutter,
 		unstable_preventOverflow: false,
+		unstable_flip: false,
 	});
 
 	const handleDismiss = () => {


### PR DESCRIPTION
This PR fixes a popover Menu flipping bug that was showing up on the MemberPermissionPicker component. 

![Screen Shot 2020-05-06 at 3 58 29 PM](https://user-images.githubusercontent.com/1000455/81192708-72ba8b00-8fb2-11ea-8743-0bc892ce1023.png)
