### PR TITLE
GitHub gist embed

### DIFF
--- a/client/components/FormattingBar/media/Media.js
+++ b/client/components/FormattingBar/media/Media.js
@@ -13,6 +13,7 @@ import MediaYoutube from './MediaYoutube';
 import MediaCodepen from './MediaCodepen';
 import MediaVimeo from './MediaVimeo';
 import MediaSoundcloud from './MediaSoundcloud';
+import MediaGithub from './MediaGithub';
 
 require('./media.scss');
 
@@ -50,6 +51,7 @@ class Media extends Component {
 			{ text: 'Codepen', icon: 'codepen' },
 			{ text: 'Vimeo', icon: 'vimeo' },
 			{ text: 'SoundCloud', icon: 'soundcloud' },
+			{ text: 'GitHub Gist', icon: 'github' },
 		];
 		const activeItem = this.state.activeItem;
 		const componentProps = {
@@ -105,6 +107,7 @@ class Media extends Component {
 				{activeItem === 'Codepen' && <MediaCodepen {...componentProps} />}
 				{activeItem === 'Vimeo' && <MediaVimeo {...componentProps} />}
 				{activeItem === 'SoundCloud' && <MediaSoundcloud {...componentProps} />}
+				{activeItem === 'GitHub Gist' && <MediaGithub {...componentProps} />}
 			</div>
 		);
 	}

--- a/client/components/FormattingBar/media/MediaGithub.js
+++ b/client/components/FormattingBar/media/MediaGithub.js
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { InputGroup, Button, Intent, NonIdealState } from '@blueprintjs/core';
+import { isHttpsUri } from 'valid-url';
+import { apiFetch, getIframeSrc, getEmbedType } from 'utils';
+import Icon from 'components/Icon/Icon';
+
+const propTypes = {
+	onInsert: PropTypes.func.isRequired,
+	// isSmall: PropTypes.bool.isRequired,
+};
+
+class MediaGithub extends Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			isValid: false,
+			input: '',
+			embedUrl: '',
+			embedTitle: '',
+		};
+		this.handleInput = this.handleInput.bind(this);
+		this.handleInsert = this.handleInsert.bind(this);
+	}
+
+	handleInput(url) {
+		const input = getIframeSrc(url) || url;
+		const isValid = isHttpsUri(input) && getEmbedType(input) === 'github';
+		this.setState(
+			{
+				input: input,
+				isValid: isValid,
+			},
+			() => {
+				if (!this.state.isValid) {
+					return this.setState({ embedUrl: '', embedTitle: '' });
+				}
+
+				const queryParams = `?type=${getEmbedType(input)}&input=${input}`;
+				return apiFetch(`/api/editor/embed${queryParams}`).then((result) => {
+					this.setState({
+						embedUrl: `data:text/html;charset=utf-8,${result.html}`,
+						embedTitle: result.title,
+					});
+				});
+			},
+		);
+	}
+
+	handleInsert() {
+		this.props.onInsert('iframe', {
+			url: this.state.embedUrl,
+			caption: this.state.embedTitle,
+			align: 'full',
+			height: 800,
+		});
+	}
+
+	render() {
+		return (
+			<div className="formatting-bar_media-component-content">
+				<InputGroup
+					className="top-input"
+					fill={true}
+					placeholder="Enter GitHub Gist URL"
+					large={true}
+					value={this.state.input}
+					onChange={(evt) => {
+						this.handleInput(evt.target.value);
+					}}
+					rightElement={
+						<Button
+							text="Insert"
+							intent={Intent.PRIMARY}
+							disabled={!this.state.embedUrl}
+							large={true}
+							onClick={this.handleInsert}
+						/>
+					}
+				/>
+				{this.state.isValid && (
+					<div className="preview-wrapper">
+						<iframe frameBorder="none" src={this.state.embedUrl} title="URL preview" />
+					</div>
+				)}
+				{!this.state.isValid && (
+					<div className="preview-wrapper">
+						<NonIdealState
+							title="Paste a GitHub Gist URL above"
+							icon={<Icon icon="github" iconSize={60} useColor={true} />}
+							action={
+								<Button
+									text="Load Sample URL"
+									onClick={() => {
+										this.handleInput(
+											'https://gist.github.com/gabestein/16fd6244f88625c0ea02e044a22d4ac5',
+										);
+									}}
+								/>
+							}
+						/>
+					</div>
+				)}
+			</div>
+		);
+	}
+}
+
+MediaGithub.propTypes = propTypes;
+export default MediaGithub;

--- a/client/components/FormattingBar/media/MediaYoutube.js
+++ b/client/components/FormattingBar/media/MediaYoutube.js
@@ -92,7 +92,7 @@ class MediaYoutube extends Component {
 									text="Load Sample URL"
 									onClick={() => {
 										this.handleInput(
-											'https://www.youtube.com/watch?v=UA4QLH_Llv0',
+											'https://www.youtube.com/watch?v=k5Q6-hh49mU',
 										);
 									}}
 								/>

--- a/client/utils/index.js
+++ b/client/utils/index.js
@@ -485,6 +485,7 @@ export const getEmbedType = (input) => {
 		codepen: ['https://codepen.io'],
 		vimeo: ['https://vimeo.com', 'https://player.vimeo.com'],
 		soundcloud: ['https://soundcloud.com'],
+		github: ['https://gist.github.com'],
 	};
 
 	return Object.keys(urls).reduce((prev, curr) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13753,7 +13753,7 @@
 			"requires": {
 				"esm": "^3.2.25",
 				"mj-context-menu": "^0.2.2",
-				"speech-rule-engine": "^3.0.0-beta.10"
+				"speech-rule-engine": "^3.0.0-beta.8"
 			}
 		},
 		"md5.js": {

--- a/server/editor/api.js
+++ b/server/editor/api.js
@@ -37,6 +37,25 @@ app.get('/api/editor/embed', (req, res) => {
 	const oembedUrl = oembedUrls[type];
 
 	if (!oembedUrl) {
+		if (type === 'github') {
+			const githubParts = input.split('/');
+			// GitHub API requests require a user agent: https://developer.github.com/v3/#user-agent-required
+			return request(`https://api.github.com/gists/${githubParts[githubParts.length - 1]}`, {
+				json: true,
+				headers: {
+					'User-Agent': 'pubpub',
+				},
+			})
+				.then((result) => {
+					return res.status(200).json({
+						html: `<html><head></head><body><style type="text/css">.gist-file .gist-data {max-height: 730px;}</style><script src="${result.html_url}.js"></script></body></html>`,
+					});
+				})
+				.catch((err) => {
+					console.warn(err);
+					return res.status(500).json(err);
+				});
+		}
 		return res.status(400).json('Type not supported');
 	}
 

--- a/server/editor/api.js
+++ b/server/editor/api.js
@@ -48,6 +48,7 @@ app.get('/api/editor/embed', (req, res) => {
 			})
 				.then((result) => {
 					return res.status(200).json({
+						title: `${result.description}`,
 						html: `<html><head></head><body><style type="text/css">.gist-file .gist-data {max-height: 730px;}</style><script src="${result.html_url}.js"></script></body></html>`,
 					});
 				})


### PR DESCRIPTION
Got a number of requests for Gists and/or syntax highlighting for code blocks recently from folks coming over from Medium.

This PR allows users to embed Gists via the media bar. Unfortunately, GitHub no longer maintains oembed URLs. So, this pings the GitHub API to verify that the Gist exists, and if so, reconstructs the script tag embed tag and adds it to the iframe src as a data url, along with some styling.

This approach looks basically native for single-file gists, has few security implications, fits well into our existing embed model, and avoids having to build a new block in the editor for Gists. 

But there are two downsides: for multi-file gists, there's an additional scrollbar that's a little wonky (see screenshot). And because we use a data url for the iframe source, changing the source field isn't as straightforward as for other types of iFrames (although other "apps" have a similar problem since they use links from oembed endpoints, not the main site that a user would type in).

I think it's worth it to support some kind of syntax-highlighted code as people are looking at us for those purposes. Ultimately, I think we could improve gist support and build in native syntax highlighting for our code blocks.

_Test plan_
1. Go to a pub
1. Add a gist from a gist url (e.g. `https://gist.github.com/youruser/12345`)
1. Make sure it loads
1. Try something that's not a gist and make sure it does not load
1. Try a malicious URL with some js in it (ie `http://hacker/"%20+%20document.cookie;`) and make sure it doesn't load.

<img width="936" alt="Screen Shot 2020-05-08 at 12 17 02" src="https://user-images.githubusercontent.com/639110/81425698-1aa49580-9126-11ea-9cbf-0b78ad0f048b.png">
<img width="687" alt="Screen Shot 2020-05-08 at 12 18 49" src="https://user-images.githubusercontent.com/639110/81425701-1b3d2c00-9126-11ea-8d5e-a8bda46cf3d5.png">
