### PR TITLE
fix: Create Member on new pub creation

### DIFF
--- a/server/pub/queries.js
+++ b/server/pub/queries.js
@@ -1,4 +1,4 @@
-import { Pub, PubAttribution, CollectionPub, Branch } from '../models';
+import { Pub, PubAttribution, CollectionPub, Branch, Member } from '../models';
 import { generateHash, slugifyString } from '../utils/strings';
 import { setPubSearchData, deletePubSearchData } from '../utils/search';
 
@@ -23,14 +23,19 @@ export const createPub = async (
 		...restArgs,
 	});
 
-	const createPubAttribution =
-		userId &&
-		PubAttribution.create({
-			userId: userId,
-			pubId: newPub.id,
-			isAuthor: true,
-			order: 0.5,
-		});
+	const createPubAttribution = PubAttribution.create({
+		userId: userId,
+		pubId: newPub.id,
+		isAuthor: true,
+		order: 0.5,
+	});
+
+	const createMember = Member.create({
+		userId: userId,
+		pubId: newPub.id,
+		permissions: 'manage',
+		isOwner: true /* TODO: I don't believe isOwner is fully implemented yet, so we should not rely on it. */,
+	});
 
 	const createPublicBranch = Branch.create({
 		shortId: 1,
@@ -58,6 +63,7 @@ export const createPub = async (
 		createCollectionPubs,
 		createPublicBranch,
 		createDraftBranch,
+		createMember,
 	]);
 
 	setPubSearchData(newPub.id);

--- a/stubstub/modelize/builders.js
+++ b/stubstub/modelize/builders.js
@@ -55,7 +55,8 @@ builders.Community = async (args = {}) => {
 };
 
 builders.Pub = async (args) => {
-	const { id: pubId } = await createPub(args);
+	const pubCreator = await builders.User();
+	const { id: pubId } = await createPub(args, pubCreator.id);
 	return Pub.findOne({ where: { id: pubId }, include: [{ model: Branch, as: 'branches' }] });
 };
 


### PR DESCRIPTION
This PR fixes a bug that was causing new pubs to be inaccessible to their creator because no Member object was created. Additionally, it adds a default userId to Pub modelize builder as createPub should never be called without a creating User.

_Test Plan:_
- Log into a community with an account that is not a community-level admin or manager.
- Click any public 'New Pub' button
- Verify that you are redirected to a pub you can access, and not a 404 page.