### PR TITLE
fix: Add appropriate empty state for Pub header with no contributors

### DIFF
--- a/client/components/AttributionEditor/AttributionEditor.js
+++ b/client/components/AttributionEditor/AttributionEditor.js
@@ -190,8 +190,8 @@ class AttributionEditor extends Component {
 									hasEmptyState && (
 										<NonIdealState
 											icon="person"
-											title="No attribution yet!"
-											description="Start typing a person's name above to add attribution."
+											title="No contributors yet!"
+											description="Start typing a person's name above to add a contributor."
 										/>
 									)
 								}

--- a/client/components/Byline/Byline.js
+++ b/client/components/Byline/Byline.js
@@ -4,71 +4,77 @@ import PropTypes from 'prop-types';
 import { getAllPubContributors } from 'utils/pubContributors';
 
 const propTypes = {
-	emptyState: PropTypes.node,
 	pubData: PropTypes.shape({}).isRequired,
 	bylinePrefix: PropTypes.string,
 	hideAuthors: PropTypes.bool,
 	hideContributors: PropTypes.bool,
 	linkToUsers: PropTypes.bool,
+	renderEmptyState: PropTypes.func,
 	renderSuffix: PropTypes.func,
 };
 
 const defaultProps = {
-	emptyState: null,
 	bylinePrefix: 'by',
 	hideAuthors: false,
 	hideContributors: true,
 	linkToUsers: true,
+	renderEmptyState: () => null,
 	renderSuffix: () => null,
 };
 
 const Byline = (props) => {
 	const {
 		pubData,
-		emptyState,
 		bylinePrefix,
 		hideAuthors,
 		hideContributors,
 		linkToUsers,
+		renderEmptyState,
 		renderSuffix,
 	} = props;
 	const authors = getAllPubContributors(pubData, hideAuthors, hideContributors);
 
-	if (authors.length > 0) {
+	const renderContent = () => {
 		return (
-			<div className="byline-component byline">
-				<span className="text-wrapper">
-					{bylinePrefix && <span>{bylinePrefix} </span>}
-					{authors.map((author, index) => {
-						const separator =
-							index === authors.length - 1 || authors.length === 2 ? '' : ', ';
-						const prefix = index === authors.length - 1 && index !== 0 ? ' and ' : '';
-						const user = author.user;
-						if (user.slug && linkToUsers) {
-							return (
-								<span key={`author-${user.id}`}>
-									{prefix}
-									<a href={`/user/${user.slug}`} className="hoverline">
-										{user.fullName}
-									</a>
-									{separator}
-								</span>
-							);
-						}
+			<>
+				{bylinePrefix && <span>{bylinePrefix} </span>}
+				{authors.map((author, index) => {
+					const separator =
+						index === authors.length - 1 || authors.length === 2 ? '' : ', ';
+					const prefix = index === authors.length - 1 && index !== 0 ? ' and ' : '';
+					const user = author.user;
+					if (user.slug && linkToUsers) {
 						return (
 							<span key={`author-${user.id}`}>
 								{prefix}
-								{user.fullName}
+								<a href={`/user/${user.slug}`} className="hoverline">
+									{user.fullName}
+								</a>
 								{separator}
 							</span>
 						);
-					})}
-					{renderSuffix && renderSuffix()}
-				</span>
-			</div>
+					}
+					return (
+						<span key={`author-${user.id}`}>
+							{prefix}
+							{user.fullName}
+							{separator}
+						</span>
+					);
+				})}
+				{renderSuffix && renderSuffix()}
+			</>
 		);
-	}
-	return emptyState;
+	};
+
+	return (
+		<div className="byline-component byline">
+			<span className="text-wrapper">
+				{authors.length > 0 && renderContent()}
+				{authors.length === 0 && renderEmptyState()}
+			</span>
+		</div>
+	);
 };
 
 Byline.propTypes = propTypes;

--- a/client/components/PubAttributionEditor/PubAttributionDialog.js
+++ b/client/components/PubAttributionEditor/PubAttributionDialog.js
@@ -16,7 +16,7 @@ const PubAttributionDialog = (props) => {
 	return (
 		<Dialog
 			className="pub-attribution-dialog-component"
-			title="Edit Pub attribution"
+			title="Edit Pub contributors"
 			isOpen={isOpen}
 			onClose={onClose}
 		>

--- a/client/containers/Pub/PubHeader/BylineEditButton.js
+++ b/client/containers/Pub/PubHeader/BylineEditButton.js
@@ -13,11 +13,10 @@ const propTypes = {
 const BylineEditButton = (props) => {
 	const { onClick } = props;
 	return (
-		<Button className="byline-edit-button-component" onClick={onClick}>
-			<div className="box-style pub-header-themed-box pub-header-themed-box-hover-target">
+		<Button className="byline-edit-button-component" onClick={onClick} aria-label="Edit byline">
+			<div className="icon-box pub-header-themed-box pub-header-themed-box-hover-target">
 				<Icon icon="edit2" iconSize={14} />
 			</div>
-			<div className="inline-style">{' • '} Edit</div>
 		</Button>
 	);
 };

--- a/client/containers/Pub/PubHeader/TitleGroup.js
+++ b/client/containers/Pub/PubHeader/TitleGroup.js
@@ -53,6 +53,18 @@ const TitleGroup = (props) => {
 		);
 	};
 
+	const renderBylineEmptyState = () => {
+		if (isRelease || !canManage) {
+			return null;
+		}
+		return (
+			<>
+				<span className="pub-header-themed-secondary">Edit byline</span>
+				{renderBylineEditor()}
+			</>
+		);
+	};
+
 	return (
 		<div className="title-group-component">
 			<EditableHeaderText
@@ -72,7 +84,11 @@ const TitleGroup = (props) => {
 					placeholder="Add a description for this Pub"
 				/>
 			)}
-			<Byline pubData={pubData} renderSuffix={() => !isRelease && renderBylineEditor()} />
+			<Byline
+				pubData={pubData}
+				renderSuffix={() => !isRelease && renderBylineEditor()}
+				renderEmptyState={renderBylineEmptyState}
+			/>
 			{publishedDate && (
 				<div className="published-date">
 					<span className="pub-header-themed-secondary">Published on</span>

--- a/client/containers/Pub/PubHeader/bylineEditButton.scss
+++ b/client/containers/Pub/PubHeader/bylineEditButton.scss
@@ -3,7 +3,11 @@
 .byline-edit-button-component {
     @include base-button;
     margin-left: 4px;
-    .box-style {
+    vertical-align: bottom;
+    @include mobile {
+        vertical-align: middle;
+    }
+    .icon-box {
         padding: 4px 10px;
         border-radius: 25px;
         font-style: normal;
@@ -14,21 +18,9 @@
 .pub-header-theme-black-blocks,
 .pub-header-theme-white-blocks {
     .byline-edit-button-component {
-        .box-style {
-            display: none;
-        }
-    }
-}
-
-.pub-header-theme-dark,
-.pub-header-theme-light {
-    .byline-edit-button-component {
-        vertical-align: top;
-        @include mobile {
-            vertical-align: middle;
-        }
-        .inline-style {
-            display: none;
+        vertical-align: middle;
+        .icon-box {
+            padding: 0;
         }
     }
 }

--- a/client/containers/Pub/PubHeader/details/PubDetails.js
+++ b/client/containers/Pub/PubHeader/details/PubDetails.js
@@ -28,10 +28,6 @@ const PubDetails = (props) => {
 	const { scopeData } = usePageContext();
 	const { canView } = scopeData.activePermissions;
 
-	if (!contributors.length && !pubData.doi) {
-		return null;
-	}
-
 	const createdAt = getPubCreatedDate(pubData);
 	const publishedAt = getPubPublishedDate(pubData);
 	const updatedAt = getPubUpdatedDate({ pub: pubData, branch: pubData.activeBranch });


### PR DESCRIPTION
Some fixes in response to issues that Deepak identified when there are no byline contributors:

- The byline editor button is still accessible from the Pub header via an empty state
- The Pub details pane no longer goes blank
- I changed the language in the empty state of the `PubAttributionsDialog` to talk about "contributors" rather than "attribution" as an abstract, mass noun.

_Test plan:_
- Ensure the byline editor button is visible whether or not there are byline contributors
- Ensure the pub details pane is visible whether or not there are contributors
- Check the byline editor button against all header styles and a range of viewport widths

_Screenshots:_

Light/dark theme:
<img width="1036" alt="Screen Shot 2020-05-14 at 11 51 08 AM" src="https://user-images.githubusercontent.com/2208769/81957851-26d39b80-95db-11ea-9943-8f8880cedb72.png">

Blocks theme:
<img width="1036" alt="Screen Shot 2020-05-14 at 11 51 20 AM" src="https://user-images.githubusercontent.com/2208769/81957859-2804c880-95db-11ea-87f1-fe8346efdeb2.png">

New language in attributions modal:
<img width="1019" alt="Screen Shot 2020-05-14 at 11 52 44 AM" src="https://user-images.githubusercontent.com/2208769/81957862-289d5f00-95db-11ea-81a1-ffb1004a9f4b.png">
