### PR TITLE
fix: bullet and header size

### DIFF
--- a/client/containers/Pub/PubDocument/pubBody.scss
+++ b/client/containers/Pub/PubDocument/pubBody.scss
@@ -177,20 +177,6 @@
 	// }
 }
 
-@media print {
-	.pub-body-component {
-		font-size: 14px;
-		h1,
-		h2,
-		h3,
-		h4,
-		h5,
-		h6 {
-			page-break-after: avoid;
-		}
-	}
-}
-
 .pub-body-alert {
 	.error-time {
 		font-weight: bold;

--- a/workers/tasks/export/styles/printDocument.scss
+++ b/workers/tasks/export/styles/printDocument.scss
@@ -117,11 +117,33 @@ section.cover {
         }
     }
 
+    // Manually resize main text elements to make them more palatable for print
+    $print-body-text-size: 14px;
+    .pub-body-component .editor.Prosemirror {
+        p, li, li p {
+            font-size: $print-body-text-size;
+        }
+        h1 {
+            font-size: $print-body-text-size * 1.4;
+        }
+        h2 {
+            font-size: $print-body-text-size * 1.3;
+        }
+        h3 {
+            font-size: $print-body-text-size * 1.2;
+        }
+        h4, h5, h6, [data-node-type='math-block'] {
+            font-size: $print-body-text-size * 1.1;
+        }
+    }
+
     /* Avoid being the last element on the page */
     h1,
     h2,
     h3,
-    h4 {
+    h4,
+    h5,
+    h6 {
         break-after: avoid;
     }
 
@@ -186,7 +208,6 @@ section.cover {
     }
 
     [data-node-type='math-block'] {
-        font-size: 16px;
         break-inside: avoid;
     }
 


### PR DESCRIPTION
- Moves errant print declarations out of `pubBody.scss` into `printDocument.scss` (side note: at some point we should see what happens if we use `printDocument.scss` as a print stylesheet when people try to just cmd/ctrl-p a pub)
- Manually sizes down a bunch of elements for print version to a base size of 14px, including headers, which a few folks have said are too big for PDFs.

_Test_
Export a PDF? Here's an attached one that shows all the new sizing.

[74b345af-c3e9-4062-8cdd-1f8d8e865f6e (5).pdf](https://github.com/pubpub/pubpub/files/4652785/74b345af-c3e9-4062-8cdd-1f8d8e865f6e.5.pdf)

<img width="564" alt="Screen Shot 2020-05-19 at 15 51 52" src="https://user-images.githubusercontent.com/639110/82371723-a94bc900-99e8-11ea-8606-25cc3acc2864.png">
