### PR TITLE
dev: Update sentry to use release info

### DIFF
--- a/client/utils/hydrateWrapper.js
+++ b/client/utils/hydrateWrapper.js
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/browser';
 import { hydrate } from 'react-dom';
 import { FocusStyleManager } from '@blueprintjs/core';
 
-import { setEnvironment } from 'shared/utils/environment';
+import { setEnvironment, setRelease } from 'shared/utils/environment';
 import { getClientInitialData } from './initialData';
 import { setupKeen } from './keen';
 import { setupHeap } from './heap';
@@ -16,8 +16,9 @@ const isLocalEnv = (windowObj) => windowObj.location.origin.indexOf('localhost:'
 export const hydrateWrapper = (Component) => {
 	if (typeof window !== 'undefined' && !isStorybookEnv(window)) {
 		const initialData = getClientInitialData();
-		const { isProd, isDuqDuq } = initialData.locationData;
+		const { isProd, isDuqDuq, release } = initialData.locationData;
 		setEnvironment(isProd, isDuqDuq);
+		setRelease(release);
 
 		FocusStyleManager.onlyShowFocusOnTabs();
 
@@ -41,6 +42,7 @@ export const hydrateWrapper = (Component) => {
 			Sentry.init({
 				dsn: 'https://abe1c84bbb3045bd982f9fea7407efaa@sentry.io/1505439',
 				environment: isProd ? 'prod' : 'dev',
+				release: release,
 			});
 			Sentry.setUser({
 				id: initialData.loginData.id,

--- a/client/utils/hydrateWrapper.js
+++ b/client/utils/hydrateWrapper.js
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/browser';
 import { hydrate } from 'react-dom';
 import { FocusStyleManager } from '@blueprintjs/core';
 
-import { setEnvironment, setRelease } from 'shared/utils/environment';
+import { setEnvironment, setAppCommit } from 'shared/utils/environment';
 import { getClientInitialData } from './initialData';
 import { setupKeen } from './keen';
 import { setupHeap } from './heap';
@@ -16,9 +16,9 @@ const isLocalEnv = (windowObj) => windowObj.location.origin.indexOf('localhost:'
 export const hydrateWrapper = (Component) => {
 	if (typeof window !== 'undefined' && !isStorybookEnv(window)) {
 		const initialData = getClientInitialData();
-		const { isProd, isDuqDuq, release } = initialData.locationData;
+		const { isProd, isDuqDuq, appCommit } = initialData.locationData;
 		setEnvironment(isProd, isDuqDuq);
-		setRelease(release);
+		setAppCommit(appCommit);
 
 		FocusStyleManager.onlyShowFocusOnTabs();
 
@@ -42,7 +42,7 @@ export const hydrateWrapper = (Component) => {
 			Sentry.init({
 				dsn: 'https://abe1c84bbb3045bd982f9fea7407efaa@sentry.io/1505439',
 				environment: isProd ? 'prod' : 'dev',
-				release: release,
+				release: appCommit,
 			});
 			Sentry.setUser({
 				id: initialData.loginData.id,

--- a/server/server.js
+++ b/server/server.js
@@ -8,12 +8,13 @@ import noSlash from 'no-slash';
 import passport from 'passport';
 import * as Sentry from '@sentry/node';
 
-import { setEnvironment } from 'shared/utils/environment';
+import { setEnvironment, setRelease, isProd, getRelease } from 'shared/utils/environment';
 
 import { sequelize, User } from './models';
 import { HTTPStatusError } from './errors';
 
 setEnvironment(process.env.PUBPUB_PRODUCTION, process.env.IS_DUQDUQ);
+setRelease(process.env.HEROKU_SLUG_COMMIT);
 require('shared/utils/serverModuleOverwrite');
 
 // Wrapper for app.METHOD() handlers. Though we need this to properly catch errors in handlers that
@@ -39,7 +40,11 @@ export default app;
 
 if (process.env.NODE_ENV === 'production') {
 	// The Sentry request handler must be the first middleware on the app
-	Sentry.init({ dsn: 'https://abe1c84bbb3045bd982f9fea7407efaa@sentry.io/1505439' });
+	Sentry.init({
+		dsn: 'https://abe1c84bbb3045bd982f9fea7407efaa@sentry.io/1505439',
+		environment: isProd() ? 'prod' : 'dev',
+		release: getRelease(),
+	});
 	app.use(Sentry.Handlers.requestHandler({ user: ['id', 'slug'] }));
 	app.use(enforce.HTTPS({ trustProtoHeader: true }));
 }

--- a/server/server.js
+++ b/server/server.js
@@ -8,13 +8,13 @@ import noSlash from 'no-slash';
 import passport from 'passport';
 import * as Sentry from '@sentry/node';
 
-import { setEnvironment, setRelease, isProd, getRelease } from 'shared/utils/environment';
+import { setEnvironment, setAppCommit, isProd, getAppCommit } from 'shared/utils/environment';
 
 import { sequelize, User } from './models';
 import { HTTPStatusError } from './errors';
 
 setEnvironment(process.env.PUBPUB_PRODUCTION, process.env.IS_DUQDUQ);
-setRelease(process.env.HEROKU_SLUG_COMMIT);
+setAppCommit(process.env.HEROKU_SLUG_COMMIT);
 require('shared/utils/serverModuleOverwrite');
 
 // Wrapper for app.METHOD() handlers. Though we need this to properly catch errors in handlers that
@@ -43,7 +43,7 @@ if (process.env.NODE_ENV === 'production') {
 	Sentry.init({
 		dsn: 'https://abe1c84bbb3045bd982f9fea7407efaa@sentry.io/1505439',
 		environment: isProd() ? 'prod' : 'dev',
-		release: getRelease(),
+		release: getAppCommit(),
 	});
 	app.use(Sentry.Handlers.requestHandler({ user: ['id', 'slug'] }));
 	app.use(enforce.HTTPS({ trustProtoHeader: true }));

--- a/server/utils/initData.js
+++ b/server/utils/initData.js
@@ -1,6 +1,6 @@
 import queryString from 'query-string';
 
-import { isProd, isDuqDuq, getRelease } from 'shared/utils/environment';
+import { isProd, isDuqDuq, getAppCommit } from 'shared/utils/environment';
 
 import { getScope, getCommunity, sanitizeCommunity } from './queryHelpers';
 
@@ -31,7 +31,7 @@ export const getInitialData = async (req, isDashboard) => {
 		isBasePubPub: hostname === 'www.pubpub.org',
 		isProd: isProd(),
 		isDuqDuq: isDuqDuq(),
-		release: getRelease(),
+		release: getAppCommit(),
 	};
 
 	/* If basePubPub - return fixed data */

--- a/server/utils/initData.js
+++ b/server/utils/initData.js
@@ -1,6 +1,6 @@
 import queryString from 'query-string';
 
-import { isProd, isDuqDuq } from 'shared/utils/environment';
+import { isProd, isDuqDuq, getRelease } from 'shared/utils/environment';
 
 import { getScope, getCommunity, sanitizeCommunity } from './queryHelpers';
 
@@ -31,6 +31,7 @@ export const getInitialData = async (req, isDashboard) => {
 		isBasePubPub: hostname === 'www.pubpub.org',
 		isProd: isProd(),
 		isDuqDuq: isDuqDuq(),
+		release: getRelease(),
 	};
 
 	/* If basePubPub - return fixed data */

--- a/shared/utils/environment.js
+++ b/shared/utils/environment.js
@@ -1,5 +1,5 @@
 let environment;
-let release;
+let appCommit;
 
 const PRODUCTION = 'production';
 const DUQDUQ = 'duqduq';
@@ -27,9 +27,9 @@ export const isDevelopment = () => {
 	return environment === DEVELOPMENT;
 };
 
-export const setRelease = (releaseHash) => {
-	release = releaseHash;
+export const setAppCommit = (appCommitHash) => {
+	appCommit = appCommitHash;
 };
-export const getRelease = () => {
-	return release;
+export const getAppCommit = () => {
+	return appCommit;
 };

--- a/shared/utils/environment.js
+++ b/shared/utils/environment.js
@@ -1,4 +1,5 @@
 let environment;
+let release;
 
 const PRODUCTION = 'production';
 const DUQDUQ = 'duqduq';
@@ -24,4 +25,11 @@ export const isDuqDuq = () => {
 
 export const isDevelopment = () => {
 	return environment === DEVELOPMENT;
+};
+
+export const setRelease = (releaseHash) => {
+	release = releaseHash;
+};
+export const getRelease = () => {
+	return release;
 };

--- a/workers/environment.js
+++ b/workers/environment.js
@@ -13,7 +13,7 @@ Module.prototype.require = function(...args) {
 
 require('@babel/register');
 
-const { setEnvironment, setRelease } = require('../shared/utils/environment');
+const { setEnvironment, setAppCommit } = require('../shared/utils/environment');
 
 setEnvironment(process.env.PUBPUB_PRODUCTION, process.env.IS_DUQDUQ);
-setRelease(process.env.HEROKU_SLUG_COMMIT);
+setAppCommit(process.env.HEROKU_SLUG_COMMIT);

--- a/workers/environment.js
+++ b/workers/environment.js
@@ -13,6 +13,7 @@ Module.prototype.require = function(...args) {
 
 require('@babel/register');
 
-const { setEnvironment } = require('../shared/utils/environment');
+const { setEnvironment, setRelease } = require('../shared/utils/environment');
 
 setEnvironment(process.env.PUBPUB_PRODUCTION, process.env.IS_DUQDUQ);
+setRelease(process.env.HEROKU_SLUG_COMMIT);

--- a/workers/queue.js
+++ b/workers/queue.js
@@ -6,7 +6,7 @@ import { Worker } from 'worker_threads';
 import amqplib from 'amqplib';
 import * as Sentry from '@sentry/node';
 
-import { isProd, getRelease } from '../shared/utils/environment';
+import { isProd, getAppCommit } from '../shared/utils/environment';
 import { WorkerTask } from '../server/models';
 
 const maxWorkerTimeSeconds = 120;
@@ -20,7 +20,7 @@ if (process.env.NODE_ENV === 'production') {
 	Sentry.init({
 		dsn: 'https://abe1c84bbb3045bd982f9fea7407efaa@sentry.io/1505439',
 		environment: isProd() ? 'prod' : 'dev',
-		release: getRelease(),
+		release: getAppCommit(),
 	});
 }
 

--- a/workers/queue.js
+++ b/workers/queue.js
@@ -6,6 +6,7 @@ import { Worker } from 'worker_threads';
 import amqplib from 'amqplib';
 import * as Sentry from '@sentry/node';
 
+import { isProd, getRelease } from '../shared/utils/environment';
 import { WorkerTask } from '../server/models';
 
 const maxWorkerTimeSeconds = 120;
@@ -14,6 +15,13 @@ let currentWorkerThreads = 0;
 
 if (process.env.NODE_ENV !== 'production') {
 	require('../server/config.js');
+}
+if (process.env.NODE_ENV === 'production') {
+	Sentry.init({
+		dsn: 'https://abe1c84bbb3045bd982f9fea7407efaa@sentry.io/1505439',
+		environment: isProd() ? 'prod' : 'dev',
+		release: getRelease(),
+	});
 }
 
 // Every worker task should be run exactly once, but we keep an attemptCount field in the database


### PR DESCRIPTION
This PR adds release information to our `Sentry.init` configuration, thanks to the recently discovered [Dyno Metadata lab option](https://devcenter.heroku.com/articles/dyno-metadata). I've set this flag for both `pubpub-v6-dev` and `pubpub-v6-prod`.

I also added a Sentry initialization to `workers/queue.js` which (from what I can tell) was missing altogether.