### PR TITLE
fix: Add draft to Sharing URLs

### DIFF
--- a/client/components/PubShareDialog/PubShareDialog.js
+++ b/client/components/PubShareDialog/PubShareDialog.js
@@ -46,7 +46,7 @@ const AccessHashOptions = (props) => {
 	const { viewHash, editHash } = pubData;
 
 	const renderHashRow = (label, hash) => {
-		const url = pubUrl(communityData, pubData, { accessHash: hash });
+		const url = pubUrl(communityData, pubData, { accessHash: hash, isDraft: true });
 		return (
 			<ControlGroup className="hash-row">
 				<ClickToCopyButton minimal={false} copyString={url}>
@@ -92,7 +92,7 @@ const MembersOptions = (props) => {
 	const localMembers = membersByType[activeTargetType];
 
 	return (
-		<>
+		<React.Fragment>
 			<p>{getHelperText(activeTargetName, activeTargetType, canManage)}</p>
 			{canManage && (
 				<ControlGroup className="add-member-controls">
@@ -126,7 +126,7 @@ const MembersOptions = (props) => {
 			{!!membersByType.organization.length && activeTargetType !== 'organization' && (
 				<InheritedMembersBlock members={membersByType.organization} scope="Organization" />
 			)}
-		</>
+		</React.Fragment>
 	);
 };
 
@@ -145,7 +145,7 @@ const PubShareDialog = (props) => {
 
 	const renderInner = () => {
 		return (
-			<>
+			<React.Fragment>
 				<div className="pane">
 					<h6 className="pane-title">Members</h6>
 					<div className="pane-content">
@@ -153,15 +153,15 @@ const PubShareDialog = (props) => {
 					</div>
 				</div>
 				{hasHash && (
-					<>
+					<React.Fragment>
 						<Divider />
 						<div className="pane">
 							<h6 className="pane-title">Share a URL</h6>
 							<AccessHashOptions pubData={pubData} />
 						</div>
-					</>
+					</React.Fragment>
 				)}
-			</>
+			</React.Fragment>
 		);
 	};
 

--- a/client/components/PubShareDialog/PubShareDialog.js
+++ b/client/components/PubShareDialog/PubShareDialog.js
@@ -22,6 +22,7 @@ const propTypes = {
 	pubData: PropTypes.shape({
 		editHash: PropTypes.string,
 		viewHash: PropTypes.string,
+		isRelease: PropTypes.bool,
 		membersData: PropTypes.shape({
 			members: PropTypes.arrayOf(PropTypes.shape({})),
 		}),
@@ -43,10 +44,13 @@ const getHelperText = (activeTargetName, activeTargetType, canModifyMembers) => 
 const AccessHashOptions = (props) => {
 	const { pubData } = props;
 	const { communityData } = usePageContext();
-	const { viewHash, editHash } = pubData;
+	const { viewHash, editHash, isRelease } = pubData;
 
 	const renderHashRow = (label, hash) => {
-		const url = pubUrl(communityData, pubData, { accessHash: hash, isDraft: true });
+		const url = pubUrl(communityData, pubData, {
+			accessHash: hash,
+			isDraft: !isRelease,
+		});
 		return (
 			<ControlGroup className="hash-row">
 				<ClickToCopyButton minimal={false} copyString={url}>
@@ -73,6 +77,7 @@ AccessHashOptions.propTypes = {
 	pubData: PropTypes.shape({
 		editHash: PropTypes.string,
 		viewHash: PropTypes.string,
+		isRelease: PropTypes.bool,
 	}).isRequired,
 };
 


### PR DESCRIPTION
This PR resolves #814. Sharing URLs now include `/draft` to avoid unwanted redirection to a Release (if it exists).

![Screen Shot 2020-06-02 at 3 10 13 PM](https://user-images.githubusercontent.com/1000455/83530105-301d9d00-a4e3-11ea-9a77-2a3c709f76ea.png)
