### PR TITLE
fix: always update search results after user stops typing

### DIFF
--- a/client/containers/Search/Search.js
+++ b/client/containers/Search/Search.js
@@ -8,7 +8,7 @@ import { Icon } from 'components';
 import { getResizedUrl } from 'utils/images';
 import { generatePageBackground } from 'utils/pages';
 import { generatePubBackground } from 'utils/pubs';
-import { usePageContext, useEffectThrottled } from 'utils/hooks';
+import { usePageContext, useThrottled } from 'utils/hooks';
 
 require('./search.scss');
 
@@ -46,21 +46,21 @@ const Search = (props) => {
 		}
 	};
 
-	const handleSearch = (searchQuery, page, mode) => {
-		if (!searchQuery) {
-			return;
-		}
-
-		indexRef.current.search(searchQuery, {
-			page
-		}).then((results) => {
-			setIsLoading(false);
-			setSearchResults(results.hits);
-			numPagesSetter(Math.min(results.nbPages, 10));
-		});
+	const handleSearch = () => {
+		indexRef.current
+			.search(throttledSearchQuery, {
+				page: page,
+			})
+			.then((results) => {
+				setIsLoading(false);
+				setSearchResults(results.hits);
+				numPagesSetter(Math.min(results.nbPages, 10));
+			});
 	};
 
-	useEffectThrottled(handleSearch, 1000, { leading: false }, [searchQuery, page, mode]);
+	const throttledSearchQuery = useThrottled(searchQuery, 1000, { leading: false });
+
+	useEffect(handleSearch, [throttledSearchQuery]);
 
 	useEffect(() => {
 		setClient();

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
 		"keen-analysis": "^3.3.1",
 		"keen-tracking": "^4.4.0",
 		"keyboardjs": "^2.5.1",
+		"lodash.throttle": "^4.1.1",
 		"mailgun.js": "^2.0.1",
 		"mini-css-extract-plugin": "^0.7.0",
 		"mudder": "^1.0.4",

--- a/utils/hooks.js
+++ b/utils/hooks.js
@@ -1,4 +1,5 @@
-import React, { useContext } from 'react';
+import React, { useContext, useCallback, useEffect } from 'react';
+import throttle from "lodash.throttle";
 
 export const PageContext = React.createContext({});
 
@@ -13,4 +14,12 @@ export const usePageContext = (previewContextObject) => {
 
 export const usePendingChanges = () => {
 	return useContext(PendingChanges);
+};
+
+export const useCallbackThrottled = (fn, timeout, throttleOptions, deps = []) => 
+	useCallback(throttle(fn, timeout, throttleOptions), deps);
+
+export const useEffectThrottled = (fn, timeout, throttleOptions, args = []) => {
+	const execute = useCallbackThrottled(fn, 1000, throttleOptions);
+	useEffect(() => execute(...args), [execute, ...args]);
 };

--- a/utils/hooks.js
+++ b/utils/hooks.js
@@ -16,17 +16,16 @@ export const usePendingChanges = () => {
 	return useContext(PendingChanges);
 };
 
-export const useThrottled = (value, timeout, throttleOptions) => {
-	const { leading, trailing } = throttleOptions;
+export const useThrottled = (value, timeout, { leading, trailing } = {}) => {
 	const [throttledValue, setThrottledValue] = useState(value);
 	const throttledSetState = useMemo(
-		() => throttle(setThrottledValue, timeout, throttleOptions),
-		[timeout, leading, trailing]
+		() => throttle(setThrottledValue, timeout, { leading: leading, trailing: trailing }),
+		[timeout, leading, trailing],
 	);
 
 	useEffect(() => {
 		throttledSetState(value);
-	}, [value]);
+	}, [throttledSetState, value]);
 
 	return throttledValue;
 };

--- a/utils/hooks.js
+++ b/utils/hooks.js
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback, useEffect } from 'react';
+import React, { useContext, useEffect, useState, useMemo } from 'react';
 import throttle from 'lodash.throttle';
 
 export const PageContext = React.createContext({});
@@ -16,11 +16,17 @@ export const usePendingChanges = () => {
 	return useContext(PendingChanges);
 };
 
+export const useThrottled = (value, timeout, throttleOptions) => {
+	const { leading, trailing } = throttleOptions;
+	const [throttledValue, setThrottledValue] = useState(value);
+	const throttledSetState = useMemo(
+		() => throttle(setThrottledValue, timeout, throttleOptions),
+		[timeout, leading, trailing]
+	);
 
-export const useCallbackThrottled = (fn, timeout, throttleOptions, deps = []) => 
-	useCallback(throttle(fn, timeout, throttleOptions), deps);
+	useEffect(() => {
+		throttledSetState(value);
+	}, [value]);
 
-export const useEffectThrottled = (fn, timeout, throttleOptions, args = []) => {
-	const execute = useCallbackThrottled(fn, timeout, throttleOptions);
-	useEffect(() => execute(...args), [execute, ...args]);
+	return throttledValue;
 };

--- a/utils/hooks.js
+++ b/utils/hooks.js
@@ -1,5 +1,5 @@
 import React, { useContext, useCallback, useEffect } from 'react';
-import throttle from "lodash.throttle";
+import throttle from 'lodash.throttle';
 
 export const PageContext = React.createContext({});
 
@@ -16,10 +16,11 @@ export const usePendingChanges = () => {
 	return useContext(PendingChanges);
 };
 
+
 export const useCallbackThrottled = (fn, timeout, throttleOptions, deps = []) => 
 	useCallback(throttle(fn, timeout, throttleOptions), deps);
 
 export const useEffectThrottled = (fn, timeout, throttleOptions, args = []) => {
-	const execute = useCallbackThrottled(fn, 1000, throttleOptions);
+	const execute = useCallbackThrottled(fn, timeout, throttleOptions);
 	useEffect(() => execute(...args), [execute, ...args]);
 };


### PR DESCRIPTION
This PR resolves #819. A search will now execute at the tail end of user input into the search text box.

<img src="https://user-images.githubusercontent.com/6402908/85608731-5a1a3900-b623-11ea-9629-e11caacb4bfe.gif" width=400 />
