### PR TITLE
fix: use positional args in useThrottled and provide boolean defaults for leading/trailing options

### DIFF
--- a/client/containers/Search/Search.js
+++ b/client/containers/Search/Search.js
@@ -27,7 +27,7 @@ const Search = (props) => {
 	);
 	const [numPages, numPagesSetter] = useState(0);
 	const [mode, modeSetter] = useState(locationData.query.mode || 'pubs');
-	const throttledSearchQuery = useThrottled(searchQuery, 1000, { leading: false });
+	const throttledSearchQuery = useThrottled(searchQuery, 1000, false);
 	const inputRef = useRef(null);
 	const clientRef = useRef(undefined);
 	const indexRef = useRef(undefined);

--- a/utils/hooks.js
+++ b/utils/hooks.js
@@ -16,7 +16,7 @@ export const usePendingChanges = () => {
 	return useContext(PendingChanges);
 };
 
-export const useThrottled = (value, timeout, { leading, trailing } = {}) => {
+export const useThrottled = (value, timeout, leading = true, trailing = true) => {
 	const [throttledValue, setThrottledValue] = useState(value);
 	const throttledSetState = useMemo(
 		() => throttle(setThrottledValue, timeout, { leading: leading, trailing: trailing }),


### PR DESCRIPTION
Follow-up PR to #866 that splits options object for `useThrottled` into two boolean args, `leading` and `trailing`. This simplifies the code a bit and fixes an issue where the throttling would not behave as expected when either option was undefined.