### PR TITLE
update: Improve metadata imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2551,9 +2551,9 @@
 			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
 		},
 		"@pubpub/prosemirror-pandoc": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@pubpub/prosemirror-pandoc/-/prosemirror-pandoc-0.4.0.tgz",
-			"integrity": "sha512-OkUDtkgsoJVhXxvvVptWtSZYq0ReHFDgM4+BsBmjSZF8DRlFQ8QytC490/gGVwBPOcYbWAnAm2hFzd9uxRC/iA==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@pubpub/prosemirror-pandoc/-/prosemirror-pandoc-0.5.0.tgz",
+			"integrity": "sha512-zOaU0MidS5Rd8ZayPU35mtqLRd00YSyYYQtyQG5EqIoNNhH3lYjAf8vgylXHhs4lFyBCRNV0zsFAx5aGHAqOvg==",
 			"requires": {
 				"collections": "^5.1.9"
 			}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"@blueprintjs/core": "^3.24.0",
 		"@blueprintjs/icons": "^3.14.0",
 		"@blueprintjs/select": "^3.12.0",
-		"@pubpub/prosemirror-pandoc": "^0.4.0",
+		"@pubpub/prosemirror-pandoc": "^0.5.0",
 		"@sentry/browser": "^5.5.0",
 		"@sentry/node": "^5.5.0",
 		"@storybook/addon-storyshots": "^5.0.11",

--- a/server/pub/model.js
+++ b/server/pub/model.js
@@ -34,6 +34,7 @@ export default (sequelize, dataTypes) => {
 			doi: { type: dataTypes.TEXT },
 			labels: { type: dataTypes.JSONB },
 			downloads: { type: dataTypes.JSONB },
+			metadata: { type: dataTypes.JSONB },
 			licenseSlug: { type: dataTypes.TEXT, defaultValue: 'cc-by' },
 			citationStyle: { type: dataTypes.TEXT, defaultValue: 'apa' },
 			citationInlineStyle: { type: dataTypes.TEXT, defaultValue: 'count' },

--- a/tools/index.js
+++ b/tools/index.js
@@ -20,9 +20,11 @@ const commandFiles = {
 	migrateDash: './dashboardMigrations/runMigrations.js',
 	migrationsDeprecated: './migrationsDeprecated.js',
 	migration2020_05_06: './migration2020_05_06.js',
+	migration2020_06_24: './migration2020_06_24.js',
 	searchSync: './searchSync.js',
 	switchBranchOrders: './switchBranchOrders.js',
 	syncDevFirebase: './syncFirebase.js',
+	syncDbSchema: './syncDbSchema.js',
 };
 
 const activeCommandFile = commandFiles[command];

--- a/tools/migration2020_06_24.js
+++ b/tools/migration2020_06_24.js
@@ -1,0 +1,13 @@
+import { Sequelize } from 'sequelize';
+import { sequelize } from 'server/models';
+
+console.info('Beginning Migration');
+sequelize.queryInterface
+	.addColumn('Pubs', 'metadata', { type: Sequelize.JSONB })
+	.catch((err) => {
+		console.info('Error with Migration', err);
+	})
+	.finally(() => {
+		console.info('Ending Migration');
+		process.exit();
+	});

--- a/workers/tasks/import/bulk/README.md
+++ b/workers/tasks/import/bulk/README.md
@@ -374,6 +374,8 @@ This can be helpful for mocking out some complicated TeX commands that Pandoc do
 
 **`pandocMetadata: object`**: an arbitrary object that will be written as YAML to a separate file and given to the Pandoc import process as a metadata block.
 
+**`extractMetadataFromDocument: boolean`**: extract metadata from delimited YAML metadata block in _any_ document, even if it isn't a Markdown file.
+
 **`importerFlags: string[]`**: flags passed to the importer (the same ones available from the `Meta+/` "nerd mode" menu in the single-Pub importer).
 
 **`macros: {

--- a/workers/tasks/import/bulk/directives/pub.js
+++ b/workers/tasks/import/bulk/directives/pub.js
@@ -245,7 +245,7 @@ const createPandocMetadataFile = async (directive, extractedPandocYamlString) =>
 	const yamlString = pandocMetadata ? YAML.stringify(pandocMetadata) : extractedPandocYamlString;
 	if (yamlString) {
 		const { path: tmpPath } = await tmp.file({ postfix: '.yaml' });
-		fs.writeFileSync(tmpPath, yamlString);
+		await fs.writeFile(tmpPath, yamlString);
 		return { tmpPath: tmpPath, label: 'metadata' };
 	}
 	return null;


### PR DESCRIPTION
This PR makes two changes to support upcoming bulk imports:

- Adds a `metadata` field to the `Pub` model that can support a JSON blob of arbitrary metadata, to hold onto later. I'm open to calling this something else.
- Provides the ability to extract metadata from YAML document headers in non-Markdown documents, which Pandoc doesn't seem to support without some kludges.

_Test plan:_

Colocate these two files in the same directory:

test.html:
```html
---
title: This Pub Has a Title
subtitle: It really does, wow
authors:
  - Travis Rich
  - Mystery Author
  - Gabriel Stein
# slug: this-pub-has-a-slug
date: 2019-05-25
pubMetadata:
  hi: hello
  yes: it works
---
<h1>Hello!</h1>
<p>This is a test.</p>
```

config.pubpub.yaml

```yaml
type: community
subdomain: test

children:
  test.html:
    type: pub
    extractMetadataFromDocument: true
    matchSlugsToAttributions: ['gabriel-stein', 'travis-rich']
```

Then run:

```
npm run tools bulkimport -- --actor=pubpub-team --directory path/to/your/files --receipt anywhere/receipt.json
```

Verify that a Pub on test.duqduq.org is created and all the fields in the HTML file header block are correctly inferred and applied to the Pub, as shown below. Check that `pubMetadata` appears in the Pub's database entry as `metadata`.

<img width="1188" alt="image" src="https://user-images.githubusercontent.com/2208769/85640168-0a566480-b659-11ea-85a0-f8510e86ee88.png">



