### PR TITLE
fix: maintain aspect ratio of footer logo

### DIFF
--- a/client/components/Footer/footer.scss
+++ b/client/components/Footer/footer.scss
@@ -6,6 +6,7 @@
 	.col-12 {
 		display: flex;
 		justify-content: space-between;
+		align-items: center;
 	}
 	.bp3-input-group {
 		margin-top: 0.25em;
@@ -38,12 +39,12 @@
 		.footer-image {
 			max-height: 75px;
 			max-width: 250px;
-			width: 100%;
 		}
 	}
 	.right {
 		text-align: right;
 		flex: 1 1 auto;
+		width: 100%;
 		max-width: 500px;
 		.footer-title {
 			font-size: 18px;


### PR DESCRIPTION
This PR resolves #828 by removing the `width: 100%` rule from the footer logo element. The image will retain its original aspect ratio, and will not scale up to a larger width or height than the source image's base dimensions.

In addition, this PR fixes the alignment of the footer left/right elements in smaller viewports (around tablet dimensions).

Before:
<img width="50%" alt="Screen Shot 2020-06-25 at 2 19 17 PM" src="https://user-images.githubusercontent.com/6402908/85776687-f2c9bb00-b6ee-11ea-82bc-0a8c8050f012.png">

After:
<img width="50%" alt="Screen Shot 2020-06-25 at 2 19 47 PM" src="https://user-images.githubusercontent.com/6402908/85776708-f65d4200-b6ee-11ea-9220-47873c9996d6.png">
