### PR TITLE
refactor: refactor search and fix issues with pagination and mode transitions

### DIFF
--- a/client/containers/Search/Search.js
+++ b/client/containers/Search/Search.js
@@ -44,23 +44,22 @@ const Search = (props) => {
 	const clientRef = useRef(undefined);
 	const indexRef = useRef(undefined);
 
-	const setClient = (nextMode) => {
+	const setClient = () => {
 		const allowedModes = ['pubs', 'pages'];
-		if (allowedModes.indexOf(nextMode) > -1) {
+		if (allowedModes.indexOf(mode) > -1) {
 			let key;
-			if (nextMode === 'pubs') {
+			if (mode === 'pubs') {
 				key = searchData.pubsSearchKey;
 			}
-			if (nextMode === 'pages') {
+			if (mode === 'pages') {
 				key = searchData.pagesSearchKey;
 			}
 			clientRef.current = algoliasearch(searchData.searchId, key);
-			indexRef.current = clientRef.current.initIndex(nextMode);
+			indexRef.current = clientRef.current.initIndex(mode);
 		}
 	};
 
 	useEffect(() => {
-		setClient(mode);
 		inputRef.current.focus();
 		/* This inputRef manipulation is to ensure that the cursor starts */
 		/* at the end of the text in the search input */
@@ -69,10 +68,12 @@ const Search = (props) => {
 		inputRef.current.value = val;
 	}, []); /* eslint-disable-line react-hooks/exhaustive-deps */
 
+	// Update search client when mode changes
+	useEffect(setClient, [mode]);
+
 	useEffect(() => {
 		// Execute search when search text (throttled), page, or mode changes
 		if (throttledSearchQuery.length > 0) {
-			setSearchResults([]);
 			setIsLoading(true);
 
 			indexRef.current
@@ -97,12 +98,13 @@ const Search = (props) => {
 	const handleSetPage = (pageIndex) => {
 		setPage(pageIndex);
 		window.scrollTo(0, 0);
+		setSearchResults([]);
 	};
 
 	const handleModeChange = (nextMode) => {
 		setMode(nextMode);
 		setPage(0);
-		setClient(nextMode);
+		setSearchResults([]);
 	};
 
 	const pages = new Array(numPages).fill('');

--- a/client/containers/Search/Search.js
+++ b/client/containers/Search/Search.js
@@ -17,11 +17,23 @@ const propTypes = {
 };
 
 const getSearchPath = (query, page, mode) => {
-	const queryString = query ? `?q=${query}` : '';
-	const pageString = page ? `&page=${page + 1}` : '';
-	const modeString = mode !== 'pubs' ? `${queryString ? '&' : '?'}mode=${mode}` : '';
+	const params = new URLSearchParams();
 
-	return `/search${queryString}${pageString}${modeString}`;
+	if (query) {
+		params.append('q', query);
+	}
+
+	if (page) {
+		params.append('page', page + 1);
+	}
+
+	if (mode !== 'pubs') {
+		params.append('mode', mode);
+	}
+
+	const queryString = params.toString();
+
+	return `/search${queryString.length > 0 ? `?${queryString}` : ''}`;
 };
 
 const updateHistory = (query, page, mode) => {

--- a/server/Html.js
+++ b/server/Html.js
@@ -29,6 +29,7 @@ const polyfills = [
 	'requestIdleCallback',
 	'String.prototype.includes',
 	'URL',
+	'URLSearchParams',
 ].join(',');
 
 const Html = (props) => {


### PR DESCRIPTION
This PR fixes a couple of issues on the Search page with pagination and mode transitions that I suspect are the same issues outlined in #853, specifically the second and third bullet points:

> Sometimes an initial search (under "Pubs") produces results; then clicking on the "Pages" tab produces similar results, and then clicking on the "Pubs" tab no longer shows results (but results continue to appear under "Pages").

and

> In either case above, in the "Pages" results-view, search results include pubs, but the URL of each result is missing "/pub/", and so does not resolve (generating a "Page Not Found" error). Adding "/pub/" back in makes them resolve as expected.

I believe these two points are caused by the same issue - that pubs would still appear in the results when the user attempted to filter by page. Then, re-selecting the "Pubs" filter would yield and empty set of results.

I'm not 100% sure about the first bullet point in #853 related to Pubs not loading. I haven't witnessed this behavior first-hand, but I do think that this refactor will improve the reliability of the search page in general.

**Test Plan:**

1) Visit the search page
2) Type in a search query, e.g. "Untitled". Take a mental note of the results.
3) Toggle the filter to "Pages". You should observe the results changing, and the pubs from the prior filter should no longer be visible
4) Toggle the filter back to "Pubs". You should see the original results in step 1
5) Type in a query that results in more than one page of results
6) Go to page two of the results. Take a mental note of the results.
7) Reload the page. You should see the original results in step 6