### PR TITLE
feature(?): Make it possible to "release" draft discussions with Release

### DIFF
--- a/client/components/Editor/utils/branches.js
+++ b/client/components/Editor/utils/branches.js
@@ -59,6 +59,8 @@ export const mergeBranch = (sourceFirebaseRef, destinationFirebaseRef) => {
 				.child('merges')
 				.child(nextMergeKey)
 				.set(Object.values(changesSnapshotVal));
-			return Promise.all([setLastMergeKey, appendMerge]);
+			return Promise.all([setLastMergeKey, appendMerge]).then(() => {
+				return { mergeKey: nextMergeKey };
+			});
 		});
 };

--- a/client/components/Editor/utils/discussions.js
+++ b/client/components/Editor/utils/discussions.js
@@ -1,0 +1,38 @@
+import { uncompressSelectionJSON, compressSelectionJSON } from 'prosemirror-compress-pubpub';
+
+// For every discussion in sourceBranch.discussions, assumes that the anchoring information
+// (head, anchor, type) is valid on the destination branch document, but needs to be mapped to the
+// destination branch's latest key information.
+export const copyDiscussionMapsToBranch = async (
+	sourceBranchRef,
+	destinationBranchRef,
+	destinationBranchCurrentKey,
+	idFilter = () => true,
+) => {
+	const sourceDiscussionsSnapshot = await sourceBranchRef.child('discussions').once('value');
+	const sourceDiscussions = sourceDiscussionsSnapshot.val();
+	if (sourceDiscussions) {
+		await Object.entries(sourceDiscussions).map(async (entry) => {
+			const [discussionId, discussionInfo] = entry;
+			if (!idFilter(discussionId)) {
+				return;
+			}
+			const { selection: compressedSelection } = discussionInfo;
+			const { anchor, head, type } = uncompressSelectionJSON(compressedSelection);
+			const destinationBranchDiscussion = {
+				initAnchor: anchor,
+				initHead: head,
+				initKey: destinationBranchCurrentKey,
+				currentKey: destinationBranchCurrentKey,
+				selection: compressSelectionJSON({
+					anchor: anchor,
+					head: head,
+					type: type,
+				}),
+			};
+			await destinationBranchRef
+				.child(`discussions/${discussionId}`)
+				.set(destinationBranchDiscussion);
+		});
+	}
+};

--- a/client/components/PubReleaseDialog/PubReleaseDialog.js
+++ b/client/components/PubReleaseDialog/PubReleaseDialog.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { AnchorButton, Button, Callout, Classes, Dialog, Icon } from '@blueprintjs/core';
+import { AnchorButton, Button, Callout, Classes, Dialog, Icon, Checkbox } from '@blueprintjs/core';
 
 import { MinimalEditor } from 'components';
 import { usePageContext } from 'utils/hooks';
@@ -23,7 +23,14 @@ const propTypes = {
 
 const defaultProps = {};
 
-const createRelease = ({ draftKey, pubId, communityId, noteContent, noteText }) =>
+const createRelease = ({
+	draftKey,
+	pubId,
+	communityId,
+	noteContent,
+	noteText,
+	makeDraftDiscussionsPublic,
+}) =>
 	apiFetch('/api/releases', {
 		method: 'POST',
 		body: JSON.stringify({
@@ -32,6 +39,7 @@ const createRelease = ({ draftKey, pubId, communityId, noteContent, noteText }) 
 			noteContent: noteContent,
 			noteText: noteText,
 			draftKey: draftKey,
+			makeDraftDiscussionsPublic: makeDraftDiscussionsPublic,
 		}),
 	});
 
@@ -39,6 +47,7 @@ const PubReleaseDialog = (props) => {
 	const { isOpen, onClose, historyData, pubData, updatePubData } = props;
 	const { communityData } = usePageContext();
 	const [noteData, setNoteData] = useState({});
+	const [makeDraftDiscussionsPublic, setMakeDraftDiscussionsPublic] = useState(false);
 	const [isCreatingRelease, setIsCreatingRelease] = useState(false);
 	const [createdRelease, setCreatedRelease] = useState(false);
 	const [releaseError, setReleleaseError] = useState(null);
@@ -52,6 +61,7 @@ const PubReleaseDialog = (props) => {
 			noteContent: noteData.content,
 			noteText: noteData.text,
 			draftKey: historyData.latestKey,
+			makeDraftDiscussionsPublic: makeDraftDiscussionsPublic,
 		})
 			.then(({ release }) => {
 				setReleleaseError(null);
@@ -147,6 +157,13 @@ const PubReleaseDialog = (props) => {
 							}}
 							focusOnLoad={true}
 							placeholder="Add a (publicly-visible) note describing this release."
+						/>
+						<Checkbox
+							checked={makeDraftDiscussionsPublic}
+							onChange={() =>
+								setMakeDraftDiscussionsPublic(!makeDraftDiscussionsPublic)
+							}
+							label="Make all discussions on the draft visible to the public"
 						/>
 					</React.Fragment>
 				)}

--- a/client/components/PubReleaseDialog/PubReleaseDialog.js
+++ b/client/components/PubReleaseDialog/PubReleaseDialog.js
@@ -45,7 +45,12 @@ const createRelease = ({
 
 const PubReleaseDialog = (props) => {
 	const { isOpen, onClose, historyData, pubData, updatePubData } = props;
-	const { communityData } = usePageContext();
+	const {
+		communityData,
+		scopeData: {
+			activePermissions: { isSuperAdmin },
+		},
+	} = usePageContext();
 	const [noteData, setNoteData] = useState({});
 	const [makeDraftDiscussionsPublic, setMakeDraftDiscussionsPublic] = useState(false);
 	const [isCreatingRelease, setIsCreatingRelease] = useState(false);
@@ -158,13 +163,15 @@ const PubReleaseDialog = (props) => {
 							focusOnLoad={true}
 							placeholder="Add a (publicly-visible) note describing this release."
 						/>
-						<Checkbox
-							checked={makeDraftDiscussionsPublic}
-							onChange={() =>
-								setMakeDraftDiscussionsPublic(!makeDraftDiscussionsPublic)
-							}
-							label="Make all discussions on the draft visible to the public"
-						/>
+						{isSuperAdmin && (
+							<Checkbox
+								checked={makeDraftDiscussionsPublic}
+								onChange={() =>
+									setMakeDraftDiscussionsPublic(!makeDraftDiscussionsPublic)
+								}
+								label="Make all discussions on the draft visible to the public"
+							/>
+						)}
 					</React.Fragment>
 				)}
 				{renderReleaseResult()}

--- a/client/components/PubReleaseDialog/pubReleaseDialog.scss
+++ b/client/components/PubReleaseDialog/pubReleaseDialog.scss
@@ -2,6 +2,7 @@
     .minimal-editor-component {
         height: 150px;
         overflow: auto;
+        margin-bottom: 10px;
         .editor-wrapper {
             min-height: 100%;
         }

--- a/server/discussion/queries.js
+++ b/server/discussion/queries.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-syntax */
+import { Op } from 'sequelize';
 import { ForbiddenError } from 'server/utils/errors';
 import { attributesPublicUser } from 'server/utils/attributesPublicUser';
 import {
@@ -202,4 +203,10 @@ export const updateDiscussion = async (values, permissions) => {
 
 	await discussion.update(updatedValues);
 	return discussion;
+};
+
+export const updateVisibilityForDiscussions = async (discussionsWhereQuery, visibilityUpdate) => {
+	const discussions = await DiscussionNew.findAll({ where: discussionsWhereQuery });
+	const visibilityIds = discussions.map((d) => d.visibilityId);
+	await Visibility.update(visibilityUpdate, { where: { id: { [Op.in]: visibilityIds } } });
 };

--- a/server/release/api.js
+++ b/server/release/api.js
@@ -4,9 +4,16 @@ import { ForbiddenError } from 'server/utils/errors';
 import { getPermissions } from './permissions';
 import { createRelease } from './queries';
 
-const getRequestIds = (req) => {
+const getRequestValues = (req) => {
 	const user = req.user || {};
-	const { communityId, pubId, draftKey, noteText, noteContent } = req.body;
+	const {
+		communityId,
+		pubId,
+		draftKey,
+		noteText,
+		noteContent,
+		makeDraftDiscussionsPublic,
+	} = req.body;
 	return {
 		userId: user.id,
 		communityId: communityId,
@@ -14,13 +21,22 @@ const getRequestIds = (req) => {
 		draftKey: draftKey,
 		noteText: noteText,
 		noteContent: noteContent,
+		makeDraftDiscussionsPublic: makeDraftDiscussionsPublic,
 	};
 };
 
 app.post(
 	'/api/releases',
 	wrap(async (req, res) => {
-		const { userId, communityId, pubId, draftKey, noteText, noteContent } = getRequestIds(req);
+		const {
+			userId,
+			communityId,
+			pubId,
+			draftKey,
+			noteText,
+			noteContent,
+			makeDraftDiscussionsPublic,
+		} = getRequestValues(req);
 		const permissions = await getPermissions({
 			userId: userId,
 			pubId: pubId,
@@ -37,6 +53,7 @@ app.post(
 			draftKey: draftKey,
 			noteText: noteText,
 			noteContent: noteContent,
+			makeDraftDiscussionsPublic: makeDraftDiscussionsPublic,
 		});
 
 		return res.status(201).json({ release: release });

--- a/server/utils/firebaseAdmin.js
+++ b/server/utils/firebaseAdmin.js
@@ -11,6 +11,7 @@ import {
 } from 'components/Editor';
 import discussionSchema from 'utils/editor/discussionSchema';
 import { getFirebaseConfig } from 'utils/editor/firebaseConfig';
+import { copyDiscussionMapsToBranch } from '../../client/components/Editor/utils/discussions';
 
 const getFirebaseApp = () => {
 	if (firebaseAdmin.apps.length > 0) {
@@ -104,11 +105,20 @@ export const createFirebaseBranch = (pubId, baseBranchId, newBranchId) => {
 	return createBranch(baseFirebaseRef, newFirebaseRef);
 };
 
-export const mergeFirebaseBranch = (pubId, sourceBranchId, destinationBranchId) => {
+export const mergeFirebaseBranch = (
+	pubId,
+	sourceBranchId,
+	destinationBranchId,
+	copyDiscussionMaps = false,
+) => {
 	const sourceFirebaseRef = getBranchRef(pubId, sourceBranchId);
 	const destinationFirebaseRef = getBranchRef(pubId, destinationBranchId);
-	return mergeBranch(sourceFirebaseRef, destinationFirebaseRef).then(async (res) => {
+	return mergeBranch(sourceFirebaseRef, destinationFirebaseRef).then(async (mergeResult) => {
+		const { mergeKey } = mergeResult;
 		await restoreDiscussionMaps(destinationFirebaseRef, editorSchema, true);
-		return res;
+		if (copyDiscussionMaps) {
+			await copyDiscussionMapsToBranch(sourceFirebaseRef, destinationFirebaseRef, mergeKey);
+		}
+		return mergeResult;
 	});
 };


### PR DESCRIPTION
We have a Commonplace piece with a draft containing lots of annotations that need to carry over to the Release. In other words, we need to do the following:

- Batch-update the `Visibility` of every discussion in the Pub draft to set `access = public`
- Update the Release branch in Firebase with the correct discussion anchor information

I have wrapped these two things into a new checkbox in the Release modal, as seen here:

![image](https://user-images.githubusercontent.com/2208769/86175836-0495ce80-baf2-11ea-9189-ee57e588f720.png)

This solves our immediate problem, but my question is, do we want to give everyone the ability to do this? Without a more robust toolkit for managing discussion visibility it feels like this is a potentially dangerous thing to give to users. So I've made it accessible only to the superadmin account for the time being.

_Test plan:_
- I created a discussion on the draft of a Pub and then released the Pub with this new box checked and observed that it anchored the discussion in the correct place on the Release, and that it is visible when logged out.
- I repeated this process with a second Release of the same Pub, but did not check the box, and saw that the discussion was not visible when logged out, and not anchored.
- I made a discussion on the Release and then verified that this process does not clobber it.