### PR TITLE
fix: Create checkpoints on branch merge

### DIFF
--- a/client/components/Editor/plugins/collaborative/document.js
+++ b/client/components/Editor/plugins/collaborative/document.js
@@ -82,7 +82,7 @@ export default (schema, props, collabDocPluginKey, localClientId) => {
 					/* If multiple of saveEveryNSteps, update checkpoint */
 					const saveEveryNSteps = 100;
 					if (snapshot.key && snapshot.key % saveEveryNSteps === 0) {
-						storeCheckpoint(ref, newState.doc, snapshot.key);
+						storeCheckpoint(ref, newState.doc.toJSON(), snapshot.key);
 					}
 				}
 				/* eslint-disable-next-line no-use-before-define */

--- a/client/components/Editor/utils/branches.js
+++ b/client/components/Editor/utils/branches.js
@@ -26,50 +26,43 @@ export const createBranch = (baseFirebaseRef, newFirebaseRef, versionNumber) => 
 	});
 };
 
-export const mergeBranch = (sourceFirebaseRef, destinationFirebaseRef, prosemirrorSchema) => {
-	/* TODO-BRANCH At the moment, this merge simply appends new changes in a merge */
-	/* It does not properly handle 'commonAncestor' or any similar */
-	/* concept which would be needed for multi-direction merging */
-	/* or multi-branch merge trees */
-	return destinationFirebaseRef
+export const mergeBranch = async (sourceFirebaseRef, destinationFirebaseRef, prosemirrorSchema) => {
+	const mergesSnapshot = await destinationFirebaseRef
 		.child('merges')
 		.orderByKey()
 		.startAt(String(0))
-		.once('value')
-		.then((mergesSnapshot) => {
-			const mergesSnapshotVal = mergesSnapshot.val() || {};
-			const numKeyables = Object.values(mergesSnapshotVal).reduce((prev, curr) => {
-				return prev + curr.length;
-			}, 0);
-			const nextMergeKey = Object.values(mergesSnapshotVal).length;
-			const getSourceChanges = sourceFirebaseRef
-				.child('changes')
-				.orderByKey()
-				.startAt(String(numKeyables))
-				.once('value');
-			return Promise.all([getSourceChanges, nextMergeKey]);
-		})
-		.then(async ([changesSnapshot, nextMergeKey]) => {
-			const changesSnapshotVal = changesSnapshot.val() || {};
-			if (!Object.values(changesSnapshotVal).length) {
-				/* If there are no new changes to add into a merge, simply return */
-				return null;
-			}
-			const setLastMergeKey = destinationFirebaseRef.child('lastMergeKey').set(nextMergeKey);
-			const appendMerge = destinationFirebaseRef
-				.child('merges')
-				.child(nextMergeKey)
-				.set(Object.values(changesSnapshotVal));
+		.once('value');
 
-			await Promise.all([setLastMergeKey, appendMerge]);
+	const mergesSnapshotVal = mergesSnapshot.val() || {};
+	const numKeyables = Object.values(mergesSnapshotVal).reduce(
+		(count, merge) => count + merge.length,
+		0,
+	);
+	const nextMergeKey = Object.values(mergesSnapshotVal).length;
+	const changesSnapshot = await sourceFirebaseRef
+		.child('changes')
+		.orderByKey()
+		.startAt(String(numKeyables))
+		.once('value');
+	const changesSnapshotVal = changesSnapshot.val();
 
-			const { doc } = await getFirebaseDoc(
-				destinationFirebaseRef,
-				prosemirrorSchema,
-				nextMergeKey,
-			);
-			await storeCheckpoint(destinationFirebaseRef, doc, nextMergeKey);
+	const hasChanges = changesSnapshotVal && Object.values(changesSnapshotVal).length;
+	if (!hasChanges) {
+		return null;
+	}
 
-			return { mergeKey: nextMergeKey };
-		});
+	const setLastMergeKey = destinationFirebaseRef.child('lastMergeKey').set(nextMergeKey);
+	const appendMerge = destinationFirebaseRef
+		.child('merges')
+		.child(nextMergeKey)
+		.set(Object.values(changesSnapshotVal));
+	await Promise.all([setLastMergeKey, appendMerge]);
+
+	const sourceKey = Object.keys(changesSnapshotVal)
+		.map((key) => parseInt(key, 10))
+		.reduce((a, b) => Math.max(a, b), -1);
+	const { doc } = await getFirebaseDoc(sourceFirebaseRef, prosemirrorSchema, sourceKey);
+	await storeCheckpoint(destinationFirebaseRef, doc, nextMergeKey);
+
+	return { mergeKey: nextMergeKey };
 };

--- a/client/components/Editor/utils/firebase.js
+++ b/client/components/Editor/utils/firebase.js
@@ -3,15 +3,15 @@ import { compressStateJSON, compressStepJSON } from 'prosemirror-compress-pubpub
 
 export const firebaseTimestamp = { '.sv': 'timestamp' };
 
-export const storeCheckpoint = async (firebaseRef, docNode, keyNumber) => {
+export const storeCheckpoint = async (firebaseRef, docJson, keyNumber) => {
 	const checkpoint = {
-		d: compressStateJSON({ doc: docNode.toJSON() }).d,
+		d: compressStateJSON({ doc: docJson }).d,
 		k: keyNumber,
 		t: firebaseTimestamp,
 	};
 	await Promise.all([
-		firebaseRef.child('checkpoint').set(checkpoint),
 		firebaseRef.child(`checkpoints/${keyNumber}`).set(checkpoint),
+		firebaseRef.child('checkpoint').set(checkpoint),
 		firebaseRef.child(`checkpointMap/${keyNumber}`).set(firebaseTimestamp),
 	]);
 };

--- a/client/containers/Pub/PubSyncManager.js
+++ b/client/containers/Pub/PubSyncManager.js
@@ -128,6 +128,10 @@ class PubSyncManager extends React.Component {
 		this.updatePubData = this.updatePubData.bind(this);
 		this.updateCollabData = this.updateCollabData.bind(this);
 		this.updateLocalData = this.updateLocalData.bind(this);
+		if (typeof window !== 'undefined') {
+			// eslint-disable-next-line no-underscore-dangle
+			window.__pubId__ = this.props.pubData.id;
+		}
 	}
 
 	componentDidMount() {

--- a/server/utils/firebaseAdmin.js
+++ b/server/utils/firebaseAdmin.js
@@ -67,7 +67,7 @@ export const getBranchDoc = async (pubId, branchId, historyKey, createMissingChe
 		{ timestamp: firstTimestamp, key: firstKey },
 		{ timestamp: latestTimestamp, key: latestKey },
 	] = await Promise.all([
-		getFirebaseDoc(branchRef, editorSchema, historyKey, createMissingCheckpoints),
+		getFirebaseDoc(branchRef, editorSchema, historyKey),
 		getFirstKeyAndTimestamp(branchRef),
 		getLatestKeyAndTimestamp(branchRef),
 	]);


### PR DESCRIPTION
A failure mode I encountered recently that was causing an uptick in timeouts:

- Someone creates a very long Pub (30k firebase changes)
- They can load the draft just fine because of incremental checkpoints
- They create a Release, which bunches all of the changes into a merge, but doesn't create a checkpoint
- Loading that Release is slow because it has to reassemble the doc from changes 0 to 30k, causing timeouts/OOM

To solve this I have added functionality to create a checkpoint when two branches are merged, e.g. when a Release is created. It will only be a bit of extra work to arrive at one of these more stable solutions:

- drop Release branches entirely and read Release content from `(draftBranchId, key)` pairs
- just store Release docs in Postgres and load them from there

...but this is a good interim solution.

_Test plan:_

I observed the three ways a checkpoint can be created:

- Created a new Pub and started typing
- Refreshed the page at `key=57` and noted that a checkpoint was created there.
- Typed past `key=100`, `key=200`, etc. and noticed that checkpoints were created there.
- Created a release of the Pub and observed that on the release/public branch, a checkpoint was created at `key=0` (representing the merge).