### PR TITLE
update: Add one-line explanations to the top of most dashboard pages

### DIFF
--- a/client/containers/DashboardImpact/DashboardImpact.js
+++ b/client/containers/DashboardImpact/DashboardImpact.js
@@ -24,7 +24,7 @@ const DashboardImpact = (props) => {
 	const { baseToken, benchmarkToken } = impactData;
 	const { scopeData } = usePageContext();
 	const {
-		elements: { activeTargetType, activeTargetName, activeTarget},
+		elements: { activeTargetType, activeTargetName, activeTarget },
 		activePermissions: { canView },
 	} = scopeData;
 	const displayDataWarning = activeTarget.createdAt < '2020-04-29';

--- a/client/containers/DashboardImpact/DashboardImpact.js
+++ b/client/containers/DashboardImpact/DashboardImpact.js
@@ -11,6 +11,8 @@ import {
 } from '@blueprintjs/core';
 import IframeResizer from 'iframe-resizer-react';
 
+import { DashboardFrame } from 'components';
+
 require('./dashboardImpact.scss');
 
 const propTypes = {
@@ -22,7 +24,7 @@ const DashboardImpact = (props) => {
 	const { baseToken, benchmarkToken } = impactData;
 	const { scopeData } = usePageContext();
 	const {
-		elements: { activeTargetType, activeTarget },
+		elements: { activeTargetType, activeTargetName, activeTarget},
 		activePermissions: { canView },
 	} = scopeData;
 	const displayDataWarning = activeTarget.createdAt < '2020-04-29';
@@ -34,8 +36,11 @@ const DashboardImpact = (props) => {
 		return width < 960 ? 45 : 61;
 	};
 	return (
-		<div className="dashboard-impact-container">
-			<h2 className="dashboard-content-header">Impact</h2>
+		<DashboardFrame
+			title="Impact"
+			className="dashboard-impact-container"
+			details={`Learn more about who your ${activeTargetName} is reaching.`}
+		>
 			<section>
 				<h3 id="historical_benchmark" className="absolute-header">
 					Analytics
@@ -141,7 +146,7 @@ const DashboardImpact = (props) => {
 					</React.Fragment>
 				)}
 			</section>
-		</div>
+		</DashboardFrame>
 	);
 };
 

--- a/client/containers/DashboardMembers/DashboardMembers.js
+++ b/client/containers/DashboardMembers/DashboardMembers.js
@@ -25,7 +25,7 @@ const DashboardMembers = (props) => {
 	});
 	const { scopeData } = usePageContext();
 	const {
-		elements: { activeTargetType },
+		elements: { activeTargetType, activeTargetName },
 		activePermissions: { canManage },
 	} = scopeData;
 
@@ -38,7 +38,11 @@ const DashboardMembers = (props) => {
 		(membersByType.organization.length && activeTargetType !== 'organization');
 
 	return (
-		<DashboardFrame className="dashboard-members-container" title="Members">
+		<DashboardFrame
+			className="dashboard-members-container"
+			title="Members"
+			details={`Invite and manage collaborators on this ${activeTargetName}.`}
+		>
 			{canManage && (
 				<SettingsSection title="Add Member">
 					<ControlGroup className="add-member-controls">

--- a/client/containers/DashboardPages/DashboardPages.js
+++ b/client/containers/DashboardPages/DashboardPages.js
@@ -69,6 +69,7 @@ const DashboardPages = () => {
 		<DashboardFrame
 			className="dashboard-pages-container"
 			title="Pages"
+			details="Create and manage Pages to give stucture to your Community."
 			controls={renderControls()}
 		>
 			<DashboardRowListing>

--- a/client/containers/DashboardReviews/DashboardReviews.js
+++ b/client/containers/DashboardReviews/DashboardReviews.js
@@ -28,7 +28,11 @@ const DashboardReviews = (props) => {
 		return pub.reviews.length;
 	});
 	return (
-		<DashboardFrame className="dashboard-reviews-container" title="Reviews">
+		<DashboardFrame
+			className="dashboard-reviews-container"
+			title="Reviews"
+			details="Reviews allow members of your Community to request feedback on their Pubs and release them to the world."
+		>
 			{!pubsWithReviews.length && (
 				<Menu className="list-content">
 					<NonIdealState title="No Reviews Yet" icon="social-media" />


### PR DESCRIPTION
While working on the dashboard tab for Pub edges, I realized that the `details` prop of the `DashboardFrame` is criminally underused, and could be employed to give brief explanations about what each Dashboard tab does. I've taken a stab at the copy here, feel free to poke holes in it or just tell me that this is a silly idea.

Here's what it looks like when text is rendered into `details`:
![image](https://user-images.githubusercontent.com/2208769/86837851-81cebf80-c06d-11ea-8c3a-b95c2a9473f2.png)
