### PR TITLE
feature: resolve data from doi.org URLs in pubEdgeProposal endpoint

### DIFF
--- a/server/pubEdgeProposal/api.js
+++ b/server/pubEdgeProposal/api.js
@@ -1,6 +1,6 @@
 import app, { wrap } from 'server/server';
 import { parseUrl } from 'utils/urls';
-import { isDoi, extractDoiFromOrgUrl } from 'utils/crossref/isDoi';
+import { isDoi, extractDoiFromOrgUrl } from 'utils/crossref/parseDoi';
 
 import { getPubDataFromUrl, createPubEdgeProposalFromCrossrefDoi } from './queries';
 

--- a/utils/crossref/isDoi.js
+++ b/utils/crossref/isDoi.js
@@ -1,3 +1,24 @@
-const PATTERN = /\b10\.(?:97[89]\.\d{2,8}\/\d{1,7}|\d{4,9}\/\S+)/;
+export const DOI_PATTERN = /\b10\.(?:97[89]\.\d{2,8}\/\d{1,7}|\d{4,9}\/\S+)/;
+export const DOI_ORG_PATTERN = /doi\.org$/;
 
-export const isDoi = (value) => typeof value === 'string' && PATTERN.test(value);
+export const isDoi = (value) => typeof value === 'string' && DOI_PATTERN.test(value);
+
+export const extractDoi = (value) => {
+	const matches = value.match(DOI_PATTERN);
+
+	if (!matches) {
+		return;
+	}
+
+	return matches[0];
+};
+
+export const extractDoiFromOrgUrl = (url) => {
+	const { hostname, pathname } = url;
+
+	if (!DOI_ORG_PATTERN.test(hostname)) {
+		return null;
+	}
+
+	return extractDoi(pathname) || null;
+};

--- a/utils/crossref/parseDoi.js
+++ b/utils/crossref/parseDoi.js
@@ -7,7 +7,7 @@ export const extractDoi = (value) => {
 	const matches = value.match(DOI_PATTERN);
 
 	if (!matches) {
-		return;
+		return null;
 	}
 
 	return matches[0];
@@ -20,5 +20,5 @@ export const extractDoiFromOrgUrl = (url) => {
 		return null;
 	}
 
-	return extractDoi(pathname) || null;
+	return extractDoi(pathname);
 };


### PR DESCRIPTION
This PR adds support for resolving DOIs from doi.org URLs.

**Test Plan:**

* Run:
```sh
curl http://localhost:9876/api/pubEdgeProposal\?object=http%3A%2F%2Fdx.doi.org%2F10.1155%2F2014%2F413629
```
* Review the response: it should have an `externalPublication` field that conforms to the `ExternalPublication` shape.