### PR TITLE
fix: support citiation_ tags and fix error on crossref 404

### DIFF
--- a/server/pubEdgeProposal/api.js
+++ b/server/pubEdgeProposal/api.js
@@ -13,6 +13,7 @@ app.get(
 	wrap(async (req, res) => {
 		const { object } = req.query;
 		const url = parseUrl(object);
+
 		let edge = null;
 
 		if (url) {


### PR DESCRIPTION
This PR fixes an error that would occur if the crossref REST API returned a 404 for a (probably invalid) DOI. In addition, it adds support for Highwire/Google Scholoar `citation_*` meta tags, and adds some clarifying/structural comments to the scraper module.