### PR TITLE
fix: improve pub edge styling; use anchor instead of clickable div

### DIFF
--- a/client/components/PubEdge/PubEdge.js
+++ b/client/components/PubEdge/PubEdge.js
@@ -109,41 +109,52 @@ const PubEdge = (props) => {
 		onKeyDown: handleClick,
 		role: 'link',
 		tabIndex: '0',
+		alt: title,
 	};
 
 	const maybeLink = (element, restProps = {}) => {
 		if (actsLikeLink) {
-			return element;
+			return (
+				<span {...restProps} className={classNames(restProps.className, 'link')}>
+					{element}
+				</span>
+			);
 		}
-		return (
-			<a href={url} {...restProps}>
-				{element}
-			</a>
-		);
+
+		return <a href={url}>{element}</a>;
 	};
 
-	return (
+	const maybeWrapWithLink = (element, restProps = {}) => {
+		if (actsLikeLink) {
+			return (
+				<a href={url} {...restProps}>
+					{element}
+				</a>
+			);
+		}
+
+		return <div {...restProps}>{element}</div>;
+	};
+
+	return maybeWrapWithLink(
 		<PubEdgeLayout
-			outerElementProps={linkLikeProps || {}}
-			className={classNames('pub-edge-component', actsLikeLink && 'acts-like-link')}
 			topLeftElement={avatar && maybeLink(<img src={avatar} alt="" />, { tabIndex: '-1' })}
-			titleElement={maybeLink(title)}
+			titleElement={maybeLink(title, linkLikeProps)}
 			bylineElement={<Byline contributors={contributors} />}
 			metadataElements={[
 				description && (
 					<Button
-						as="a"
+						as={actsLikeLink ? 'span' : 'a'}
 						onClick={handleToggleDescriptionClick}
 						onKeyDown={handleToggleDescriptionClick}
 						tabIndex="0"
+						className="link"
 					>
 						{open ? 'Hide Description' : 'Show Description'}
 					</Button>
 				),
 				<>Published on {publishedAt}</>,
-				<a href={url} alt={title} tabIndex="0">
-					{url}
-				</a>,
+				maybeLink(url, linkLikeProps),
 			]}
 			detailsElement={
 				<details open={open}>
@@ -152,7 +163,8 @@ const PubEdge = (props) => {
 					<p>{description}</p>
 				</details>
 			}
-		/>
+		/>,
+		{ className: classNames('pub-edge-component', actsLikeLink && 'acts-like-link') },
 	);
 };
 

--- a/client/components/PubEdge/pubEdge.scss
+++ b/client/components/PubEdge/pubEdge.scss
@@ -9,7 +9,7 @@
 	max-width: 1200px;
 
 	.title-container {
-		font-size: 1.6em;
+		font-size: 18px;
 		font-weight: 400;
 		letter-spacing: 1px;
 		margin-bottom: 8px;
@@ -76,15 +76,15 @@
 		display: flex;
 		flex-wrap: wrap;
 		list-style-type: none;
-		margin: 0;
+		margin: 5px 0 0 0;
 		padding: 0;
 
 		li {
 			display: flex;
 			align-items: center;
 			flex: 0 0 auto;
-			font-family: $base-font;
-			font-size: 0.8em;
+			font-family: $header-font;
+			font-size: 12px;
 			font-weight: 300;
 		}
 
@@ -129,6 +129,24 @@
 }
 
 .pub-edge-component {
+	display: flex;
+
+	text-decoration: none;
+
+	&:hover,
+	&:focus {
+		text-decoration: none;
+	}
+
+	.link {
+		text-decoration: none;
+
+		&:hover,
+		&:focus {
+			text-decoration: underline;
+		}
+	}
+
 	&.acts-like-link {
 		cursor: pointer;
 		&:hover,
@@ -146,7 +164,7 @@
 	}
 
 	.title-container {
-		line-height: 21px;
+		line-height: 24px;
 	}
 
 	details {

--- a/client/components/PubEdgeListing/PubEdgeListingCard.js
+++ b/client/components/PubEdgeListing/PubEdgeListingCard.js
@@ -1,6 +1,6 @@
 import { Icon } from '@blueprintjs/core';
 import classNames from 'classnames';
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import { PubEdge } from 'components';
@@ -61,6 +61,10 @@ const PubEdgeListingCard = (props) => {
 	} = props;
 	const { communityData } = usePageContext();
 	const viewingFromTarget = getIsViewingFromTarget(pubEdge, viewingFromSibling, isInboundEdge);
+	const [hover, setHover] = useState(false);
+	const handleMouseEnter = useCallback(() => setHover(true), []);
+	const handleMouseLeave = useCallback(() => setHover(false), []);
+	const style = hover ? { borderColor: accentColor || communityData.accentColorDark } : {};
 
 	const renderRelation = () => {
 		const { relationType, pubIsParent } = pubEdge;
@@ -103,7 +107,11 @@ const PubEdgeListingCard = (props) => {
 	return (
 		<div
 			className={classNames('pub-edge-listing-card-component', inPubBody && 'in-pub-body')}
-			style={{ borderColor: accentColor || communityData.accentColorDark }}
+			style={style}
+			onMouseEnter={handleMouseEnter}
+			onMouseLeave={handleMouseLeave}
+			onFocus={handleMouseEnter}
+			onBlur={handleMouseLeave}
 		>
 			{children && <div className="controls">{children}</div>}
 			<div className={classNames('relation', showIcon && 'show-icon')}>

--- a/client/components/PubEdgeListing/pubEdgeListingCard.scss
+++ b/client/components/PubEdgeListing/pubEdgeListingCard.scss
@@ -5,18 +5,25 @@
 	border-width: 1px;
 	margin-bottom: 24px;
 	position: relative;
-	transition: filter 100ms linear;
+	transition: all 100ms linear;
 
 	&.in-pub-body {
-		filter: grayscale(100%);
+		> * {
+			filter: grayscale(100%);
+		}
+
 		&:hover,
 		&:active,
 		&:focus {
-			filter: grayscale(0%);
+			> * {
+				filter: grayscale(0%);
+			}
 		}
+
 		> .controls {
 			right: 4px;
 		}
+
 		&:last-child {
 			margin-bottom: 0;
 		}
@@ -39,6 +46,7 @@
 
 	> .relation {
 		left: calc(24px - 8px);
+		filter: grayscale(0%);
 
 		.relation-name {
 			border-bottom: 1px dotted;
@@ -52,7 +60,7 @@
 		.drop-return {
 			margin-right: 4px;
 			position: relative;
-			bottom: 3px;
+			bottom: px;
 			transform: rotateY(180deg);
 		}
 	}

--- a/client/components/PubEdgeListing/pubEdgeListingCard.scss
+++ b/client/components/PubEdgeListing/pubEdgeListingCard.scss
@@ -49,7 +49,6 @@
 		filter: grayscale(0%);
 
 		.relation-name {
-			border-bottom: 1px dotted;
 			font-weight: 600;
 		}
 

--- a/server/pubEdgeProposal/queries.js
+++ b/server/pubEdgeProposal/queries.js
@@ -19,16 +19,6 @@ const ensureFullUrlForExternalPublication = (externalPublication, responseUrl) =
 	return externalPublication;
 };
 
-export const createPubEdgeProposalFromCrossrefDoi = async (doi) => {
-	const externalPublication = await createExternalPublicationFromCrossrefDoi(doi);
-
-	return externalPublication
-		? {
-				externalPublication: externalPublication,
-		  }
-		: null;
-};
-
 export const createExternalPublicationFromCrossrefDoi = async (doi) => {
 	const response = await fetch(`https://api.crossref.org/works/${doi}`);
 
@@ -65,6 +55,16 @@ export const createExternalPublicationFromCrossrefDoi = async (doi) => {
 		title: Array.isArray(title) ? title[0] : title,
 		url: URL,
 	};
+};
+
+export const createPubEdgeProposalFromCrossrefDoi = async (doi) => {
+	const externalPublication = await createExternalPublicationFromCrossrefDoi(doi);
+
+	return externalPublication
+		? {
+				externalPublication: externalPublication,
+		  }
+		: null;
 };
 
 export const createExternalPublicationFromMicrodata = ($) => {


### PR DESCRIPTION
This PR addresses the following feedback:

1. `.pub-edge-component .title-container` : change font-size to 18px and line-height to 24px (using px instead of em for specificity)
2. `.pub-edge-listing-card-component>.relation .drop-return`: change bottom to 1px (for better alignment with adjacent text layer's baseline)
3. Use multidisplay font for metadata.
4. Use 12px font size for metadata.
5. Use lighter border when PubEdge card is inactive/not hovered. This was accomplished using `mouseenter`/`mouseleave` events.
6. Drop return icon now has accent color before and after hovering.