### PR TITLE
Pub Connection Tweaks

### DIFF
--- a/client/components/PubEdge/PubEdge.js
+++ b/client/components/PubEdge/PubEdge.js
@@ -109,13 +109,12 @@ const PubEdge = (props) => {
 		onKeyDown: handleClick,
 		role: 'link',
 		tabIndex: '0',
-		alt: title,
 	};
 
 	const maybeLink = (element, restProps = {}) => {
 		if (actsLikeLink) {
 			return (
-				<span {...restProps} className={classNames(restProps.className, 'link')}>
+				<span {...restProps} className="link">
 					{element}
 				</span>
 			);

--- a/client/components/PubEdgeListing/PubEdgeListing.js
+++ b/client/components/PubEdgeListing/PubEdgeListing.js
@@ -154,6 +154,7 @@ const PubEdgeListing = (props) => {
 		[],
 	);
 
+	const disableCarouselControls = filteredPubEdgeValues.length === 1;
 	const showControls =
 		collatedPubEdgeValues.length > 1 && (!isolated || filteredPubEdgeValues.length > 1);
 
@@ -162,14 +163,15 @@ const PubEdgeListing = (props) => {
 			<PubEdgeListingCounter index={index} count={length} />
 			<PubEdgeListingControls
 				accentColor={accentColor}
+				carouselControlsDisabled={disableCarouselControls}
 				filters={filters}
 				mode={mode}
-				showFilterMenu={!isolated}
-				onBackClick={back}
-				onNextClick={next}
-				onFilterToggle={onFilterToggle}
 				onAllFilterToggle={onAllFilterToggle}
+				onBackClick={back}
+				onFilterToggle={onFilterToggle}
 				onModeChange={setMode}
+				onNextClick={next}
+				showFilterMenu={!isolated}
 			/>
 		</>
 	);

--- a/client/components/PubEdgeListing/PubEdgeListingControls.js
+++ b/client/components/PubEdgeListing/PubEdgeListingControls.js
@@ -18,15 +18,18 @@ const propTypes = {
 	onModeChange: PropTypes.func.isRequired,
 	onFilterToggle: PropTypes.func.isRequired,
 	onAllFilterToggle: PropTypes.func.isRequired,
+	carouselControlsDisabled: PropTypes.bool,
 };
 
 const defaultProps = {
 	showFilterMenu: false,
+	carouselControlsDisabled: false,
 };
 
 const PubEdgeListingControls = (props) => {
 	const {
 		accentColor,
+		carouselControlsDisabled,
 		filters,
 		mode,
 		showFilterMenu,
@@ -75,6 +78,8 @@ const PubEdgeListingControls = (props) => {
 		</div>
 	);
 
+	const carouselControlColor = carouselControlsDisabled ? '#a1a1a1' : accentColor;
+
 	return (
 		<nav className="pub-edge-listing-controls-component">
 			<span className="filters">
@@ -83,11 +88,21 @@ const PubEdgeListingControls = (props) => {
 			<ButtonGroup minimal>
 				{mode === Mode.Carousel && (
 					<>
-						<Button onClick={onBackClick} minimal small>
-							<Icon icon="circle-arrow-left" color={accentColor} />
+						<Button
+							onClick={onBackClick}
+							minimal
+							small
+							disabled={carouselControlsDisabled}
+						>
+							<Icon icon="circle-arrow-left" color={carouselControlColor} />
 						</Button>
-						<Button onClick={onNextClick} minimal small>
-							<Icon icon="circle-arrow-right" color={accentColor} />
+						<Button
+							onClick={onNextClick}
+							minimal
+							small
+							disabled={carouselControlsDisabled}
+						>
+							<Icon icon="circle-arrow-right" color={carouselControlColor} />
 						</Button>
 					</>
 				)}

--- a/client/components/PubEdgeListing/pubEdgeListingCard.scss
+++ b/client/components/PubEdgeListing/pubEdgeListingCard.scss
@@ -5,7 +5,7 @@
 	border-width: 1px;
 	margin-bottom: 24px;
 	position: relative;
-	transition: filter 100ms linear;
+	transition: all 100ms linear;
 
 	&.in-pub-body {
 		> * {

--- a/client/components/PubEdgeListing/pubEdgeListingCard.scss
+++ b/client/components/PubEdgeListing/pubEdgeListingCard.scss
@@ -5,7 +5,7 @@
 	border-width: 1px;
 	margin-bottom: 24px;
 	position: relative;
-	transition: all 100ms linear;
+	transition: filter 100ms linear;
 
 	&.in-pub-body {
 		> * {

--- a/client/containers/DashboardEdges/NewEdgeInput.js
+++ b/client/containers/DashboardEdges/NewEdgeInput.js
@@ -130,7 +130,7 @@ const NewEdgeInput = (props) => {
 			items={suggestedItems}
 			inputProps={{
 				large: true,
-				placeholder: 'Search to add Pubs from this Community, or enter a URL',
+				placeholder: 'Search to add Pubs from this Community, or enter a URL or DOI',
 			}}
 			inputValueRenderer={renderInputValue}
 			onQueryChange={(query) => setQueryValue(query.trim())}

--- a/server/pubEdgeProposal/queries.js
+++ b/server/pubEdgeProposal/queries.js
@@ -9,14 +9,15 @@ import { getOptionsForIncludedPub } from 'server/utils/queryHelpers/pubEdgeOptio
 import { pubEdgeQueries, runQueries } from 'server/utils/scrape';
 
 const ensureFullUrlForExternalPublication = (externalPublication, responseUrl) => {
+	const { origin } = parseUrl(responseUrl);
+
 	if (externalPublication.url && /^\//.test(externalPublication.url)) {
-		const { origin } = parseUrl(responseUrl);
 		const url = new URL(externalPublication.url, origin);
 
 		return { ...externalPublication, url: url };
+	} else {
+		return { ...externalPublication, url: responseUrl.toString() };
 	}
-
-	return externalPublication;
 };
 
 export const createExternalPublicationFromCrossrefDoi = async (doi) => {

--- a/server/utils/scrape.js
+++ b/server/utils/scrape.js
@@ -59,8 +59,8 @@ const queryDocument = (config, $) => {
 export const pubEdgeQueries = {
 	avatar: [
 		// OGP
-		'meta[property*="og:image:secure_url" i]',
-		'meta[property*="og:image" i]',
+		'meta[property="og:image:secure_url"]',
+		'meta[property="og:image"]',
 		// Twitter
 		'meta[name*="twitter:image" i]',
 		// Best guess
@@ -73,14 +73,14 @@ export const pubEdgeQueries = {
 			multiple: true,
 		},
 		// Highwire/Google Scholar
-		{ selector: 'meta[name*="citation_author" i]', multiple: true },
+		{ selector: 'meta[name="citation_author"]', multiple: true },
 		// OGP
-		{ selector: 'meta[property*="article:author" i]', multiple: true },
+		{ selector: 'meta[property="article:author"]', multiple: true },
 		// Web standard
-		{ selector: 'meta[name*="author" i]', multiple: true },
+		{ selector: 'meta[name="author"]', multiple: true },
 		// Best guess
 		{
-			selector: '[rel*="author" i], .author',
+			selector: '[rel="author"], .author',
 			multiple: true,
 		},
 	],
@@ -88,17 +88,17 @@ export const pubEdgeQueries = {
 		// DC
 		{ selector: 'meta[name*="dc.identifier" i]', process: doiProcessor },
 		// Highwire/Google Scholar
-		{ selector: 'meta[name*="citation_doi" i]', process: doiProcessor },
+		{ selector: 'meta[name="citation_doi"]', process: doiProcessor },
 		// Prism
-		{ selector: 'meta[name*="prism.doi" i]', process: doiProcessor },
+		{ selector: 'meta[name="prism.doi"]', process: doiProcessor },
 		// Web standard
-		{ selector: 'meta[name*="doi" i]', process: doiProcessor },
+		{ selector: 'meta[name="doi"]', process: doiProcessor },
 	],
 	url: [
 		// Highwire/Google Scholar
-		'meta[name*="citation_public_url" i]',
+		'meta[name="citation_public_url"]',
 		// OG
-		'meta[property*="og:url" i]',
+		'meta[property="og:url"]',
 		// Web standard
 		{ selector: 'link[rel="canonical"]', process: ($el) => $el.attr('href') },
 	],
@@ -106,12 +106,12 @@ export const pubEdgeQueries = {
 		// DC
 		{ selector: 'meta[name*="dc.date" i]', process: dateProcessor },
 		// Highwire/Google Scholar
-		{ selector: 'meta[name*="citation_publication_date" i]', process: dateProcessor },
+		{ selector: 'meta[name="citation_publication_date"]', process: dateProcessor },
 		// OGP
-		{ selector: 'meta[property*="article:published_time" i]', process: dateProcessor },
+		{ selector: 'meta[property="article:published_time"]', process: dateProcessor },
 		// Prism
 		{
-			selector: 'meta[name*="prism.publicationDate" i]',
+			selector: 'meta[name="prism.publicationDate"]',
 			process: dateProcessor,
 		},
 		// Best guess
@@ -124,21 +124,21 @@ export const pubEdgeQueries = {
 		// DC
 		'meta[name*="dc.title" i]',
 		// Highwire/Google Scholar
-		'meta[name*="citation_title" i]',
+		'meta[name="citation_title"]',
 		// OGP
-		'meta[property*="og:title" i]',
+		'meta[property="og:title"]',
 		// Web standard
 		'title',
 	],
 	description: [
 		// Break our convention here a little by searching for an abstract first
-		'meta[name*="citation_abstract" i]',
+		'meta[name="citation_abstract"]',
 		// DC
 		'meta[name*="dc.description" i]',
 		// OGP
-		'meta[property*="og:description" i]',
+		'meta[property="og:description"]',
 		// Web standard
-		'meta[name*="description" i]',
+		'meta[name="description"]',
 	],
 };
 


### PR DESCRIPTION
This PR is a fast-follow to #905 that addresses PR feedback and fixes some additional feedback from team including:

- Author email and ORCID information showing up in contributors from Medrxiv pub edge proposal
- "or DOI" missing from pub connection search/fuzzy finder
- Carousel controls remaining active when only item existed in filtered array of connections