### PR TITLE
feature: add deposit preview endpoint

### DIFF
--- a/client/containers/DashboardSettings/CollectionSettings/CollectionMetadataEditor.js
+++ b/client/containers/DashboardSettings/CollectionSettings/CollectionMetadataEditor.js
@@ -63,9 +63,10 @@ class CollectionMetadataEditor extends React.Component {
 	handleGetDoiClick() {
 		const { communityData, collection, onUpdateCollection } = this.props;
 		this.setState({ isGettingDoi: true });
-		return apiFetch('/api/doi/collection', {
+		return apiFetch('/api/doi', {
 			method: 'POST',
 			body: JSON.stringify({
+				target: 'collection',
 				collectionId: collection.id,
 				communityId: communityData.id,
 			}),

--- a/client/containers/DashboardSettings/PubSettings/Doi.js
+++ b/client/containers/DashboardSettings/PubSettings/Doi.js
@@ -27,9 +27,10 @@ class Doi extends Component {
 	handleAssignDoi() {
 		const { communityData, pubData, updatePubData } = this.props;
 		this.setState({ isLoading: true });
-		return apiFetch('/api/doi/pub', {
+		return apiFetch('/api/doi', {
 			method: 'POST',
 			body: JSON.stringify({
+				target: 'pub',
 				pubId: pubData.id,
 				communityId: communityData.id,
 			}),

--- a/server/doi/__tests__/api.test.js
+++ b/server/doi/__tests__/api.test.js
@@ -66,12 +66,16 @@ it('does not let anyone who is not a community admin create a DOI', async () => 
 		haplessUsers.map(async (user) => {
 			const agent = await login(user);
 			await agent
-				.post('/api/doi/pub')
-				.send({ pubId: pub.id, communityId: community.id })
+				.post('/api/doi')
+				.send({ target: 'pub', pubId: pub.id, communityId: community.id })
 				.expect(403);
 			await agent
-				.post('/api/doi/collection')
-				.send({ collectionId: collection.id, communityId: community.id })
+				.post('/api/doi')
+				.send({
+					target: 'collection',
+					collectionId: collection.id,
+					communityId: community.id,
+				})
 				.expect(403);
 			await agent
 				.get('/api/doiPreview')
@@ -85,12 +89,12 @@ it('forbids issuing a DOI to a Pub without a release', async () => {
 	const { communityAdmin, community, draftOnlyPub } = models;
 	const agent = await login(communityAdmin);
 	await agent
-		.post('/api/doi/pub')
-		.send({ pubId: draftOnlyPub.id, communityId: community.id })
+		.post('/api/doi')
+		.send({ target: 'pub', pubId: draftOnlyPub.id, communityId: community.id })
 		.expect(403);
 	await agent
 		.get('/api/doiPreview')
-		.query({ pubId: draftOnlyPub.id, communityId: community.id, target: 'pub' })
+		.query({ target: 'pub', pubId: draftOnlyPub.id, communityId: community.id })
 		.expect(403);
 });
 
@@ -101,21 +105,28 @@ it('lets community admins create a DOI for pubs in their community', async () =>
 	const {
 		body: { dois },
 	} = await agent
-		.post('/api/doi/pub')
-		.send({ pubId: pub.id, communityId: community.id })
+		.post('/api/doi')
+		.send({ target: 'pub', pubId: pub.id, communityId: community.id })
 		.expect(201);
+
+	expect(dois.pub).toEqual(expectedPubDoi);
+	expect(doiStub.called).toEqual(true);
+});
+
+it('lets community admins preview a DOI for pubs in their community', async () => {
+	const { communityAdmin, community, pub } = models;
+	const expectedPubDoi = `10.21428/${community.id.slice(0, 8)}.${pub.id.slice(0, 8)}`;
+	const agent = await login(communityAdmin);
 	const {
 		body: {
 			depositJson: { dois: previewDois },
 		},
 	} = await agent
 		.get('/api/doiPreview')
-		.query({ pubId: pub.id, communityId: community.id, target: 'pub' })
+		.query({ target: 'pub', pubId: pub.id, communityId: community.id })
 		.expect(201);
 
 	expect(previewDois.pub).toEqual(expectedPubDoi);
-	expect(dois.pub).toEqual(expectedPubDoi);
-	expect(doiStub.called).toEqual(true);
 });
 
 it('lets community admins create a DOI for collections in their community', async () => {
@@ -128,21 +139,31 @@ it('lets community admins create a DOI for collections in their community', asyn
 	const {
 		body: { dois },
 	} = await agent
-		.post('/api/doi/collection')
-		.send({ collectionId: collection.id, communityId: community.id })
+		.post('/api/doi')
+		.send({ target: 'collection', collectionId: collection.id, communityId: community.id })
 		.expect(201);
+
+	expect(dois.collection).toEqual(expectedCollectionDoi);
+	expect(doiStub.called).toEqual(true);
+});
+
+it('lets community admins preview a DOI for collections in their community', async () => {
+	const { communityAdmin, community, collection } = models;
+	const expectedCollectionDoi = `10.21428/${community.id.slice(0, 8)}.${collection.id.slice(
+		0,
+		8,
+	)}`;
+	const agent = await login(communityAdmin);
 	const {
 		body: {
 			depositJson: { dois: previewDois },
 		},
 	} = await agent
 		.get('/api/doiPreview')
-		.query({ collectionId: collection.id, communityId: community.id, target: 'collection' })
+		.query({ target: 'collection', collectionId: collection.id, communityId: community.id })
 		.expect(201);
 
 	expect(previewDois.collection).toEqual(expectedCollectionDoi);
-	expect(dois.collection).toEqual(expectedCollectionDoi);
-	expect(doiStub.called).toEqual(true);
 });
 
 teardown(afterAll);

--- a/server/doi/__tests__/api.test.js
+++ b/server/doi/__tests__/api.test.js
@@ -73,6 +73,10 @@ it('does not let anyone who is not a community admin create a DOI', async () => 
 				.post('/api/doi/collection')
 				.send({ collectionId: collection.id, communityId: community.id })
 				.expect(403);
+			await agent
+				.get('/api/doiPreview')
+				.query({ pubId: pub.id, communityId: community.id, target: 'pub' })
+				.expect(403);
 		}),
 	);
 });
@@ -84,10 +88,15 @@ it('forbids issuing a DOI to a Pub without a release', async () => {
 		.post('/api/doi/pub')
 		.send({ pubId: draftOnlyPub.id, communityId: community.id })
 		.expect(403);
+	await agent
+		.get('/api/doiPreview')
+		.query({ pubId: draftOnlyPub.id, communityId: community.id, target: 'pub' })
+		.expect(403);
 });
 
 it('lets community admins create a DOI for pubs in their community', async () => {
 	const { communityAdmin, community, pub } = models;
+	const expectedPubDoi = `10.21428/${community.id.slice(0, 8)}.${pub.id.slice(0, 8)}`;
 	const agent = await login(communityAdmin);
 	const {
 		body: { dois },
@@ -95,12 +104,26 @@ it('lets community admins create a DOI for pubs in their community', async () =>
 		.post('/api/doi/pub')
 		.send({ pubId: pub.id, communityId: community.id })
 		.expect(201);
-	expect(dois.pub).toEqual(`10.21428/${community.id.slice(0, 8)}.${pub.id.slice(0, 8)}`);
+	const {
+		body: {
+			depositJson: { dois: previewDois },
+		},
+	} = await agent
+		.get('/api/doiPreview')
+		.query({ pubId: pub.id, communityId: community.id, target: 'pub' })
+		.expect(201);
+	console.log(previewDois);
+	expect(previewDois.pub).toEqual(expectedPubDoi);
+	expect(dois.pub).toEqual(expectedPubDoi);
 	expect(doiStub.called).toEqual(true);
 });
 
 it('lets community admins create a DOI for collections in their community', async () => {
 	const { communityAdmin, community, collection } = models;
+	const expectedCollectionDoi = `10.21428/${community.id.slice(0, 8)}.${collection.id.slice(
+		0,
+		8,
+	)}`;
 	const agent = await login(communityAdmin);
 	const {
 		body: { dois },
@@ -108,9 +131,16 @@ it('lets community admins create a DOI for collections in their community', asyn
 		.post('/api/doi/collection')
 		.send({ collectionId: collection.id, communityId: community.id })
 		.expect(201);
-	expect(dois.collection).toEqual(
-		`10.21428/${community.id.slice(0, 8)}.${collection.id.slice(0, 8)}`,
-	);
+	const {
+		body: {
+			depositJson: { dois: previewDois },
+		},
+	} = await agent
+		.get('/api/doiPreview')
+		.query({ collectionId: collection.id, communityId: community.id, target: 'collection' })
+		.expect(201);
+	expect(previewDois.collection).toEqual(expectedCollectionDoi);
+	expect(dois.collection).toEqual(expectedCollectionDoi);
 	expect(doiStub.called).toEqual(true);
 });
 

--- a/server/doi/__tests__/api.test.js
+++ b/server/doi/__tests__/api.test.js
@@ -112,7 +112,7 @@ it('lets community admins create a DOI for pubs in their community', async () =>
 		.get('/api/doiPreview')
 		.query({ pubId: pub.id, communityId: community.id, target: 'pub' })
 		.expect(201);
-	console.log(previewDois);
+
 	expect(previewDois.pub).toEqual(expectedPubDoi);
 	expect(dois.pub).toEqual(expectedPubDoi);
 	expect(doiStub.called).toEqual(true);
@@ -139,6 +139,7 @@ it('lets community admins create a DOI for collections in their community', asyn
 		.get('/api/doiPreview')
 		.query({ collectionId: collection.id, communityId: community.id, target: 'collection' })
 		.expect(201);
+
 	expect(previewDois.collection).toEqual(expectedCollectionDoi);
 	expect(dois.collection).toEqual(expectedCollectionDoi);
 	expect(doiStub.called).toEqual(true);


### PR DESCRIPTION
This PR adds a new endpoint `GET /api/doiPreview` that essentially does the same thing as the `POST /api/doi` endpoint without submitting the deposit to Crossref.

The endpoint has the same authN rules as the `POST` endpoint, and returns an object with both the raw JSON and compiled XML forms of the deposit. The JSON is provided in case we want to show tabs for both XML and JSON representations of the deposit in the dashboard in the future. I'm also using the JSON payload in the API tests.

**Test Plan:**

* Set `PUBPUB_LOCAL_COMMUNITY` to `'test'`
* Start PubPub and log in
* Visit http://localhost:9876/api/doiPreview?pubId=4f54941a-bdaa-446d-bf8b-72aced92e028&communityId=df04b703-65a6-4b8d-8c58-ebdf76c94c4a&target=pub
