### PR TITLE
fix: pub connection styling fixes and placeholder thumbnails

### DIFF
--- a/client/components/PubEdge/PubEdge.js
+++ b/client/components/PubEdge/PubEdge.js
@@ -23,7 +23,7 @@ export const propTypes = {
 };
 
 const defaultProps = {
-	accentColor: '#dddddd',
+	accentColor: '#ddd',
 	actsLikeLink: false,
 	viewingFromTarget: false,
 };

--- a/client/components/PubEdge/PubEdge.js
+++ b/client/components/PubEdge/PubEdge.js
@@ -142,7 +142,7 @@ const PubEdge = (props) => {
 		<PubEdgeLayout
 			topLeftElement={maybeLink(
 				avatar ? (
-					<img src={avatar} alt="" />
+					<img src={avatar} alt={title} />
 				) : (
 					<PubEdgePlaceholderThumbnail
 						color={accentColor}

--- a/client/components/PubEdge/PubEdge.js
+++ b/client/components/PubEdge/PubEdge.js
@@ -48,7 +48,6 @@ const getValuesFromPubEdge = (pubEdge, communityData, viewingFromTarget) => {
 			avatar: avatar,
 			contributors: attributions,
 			description: description,
-			isExternal: false,
 			publicationDate: getPubPublishedDate(displayedPub),
 			title: title,
 			url: url,
@@ -67,7 +66,6 @@ const getValuesFromPubEdge = (pubEdge, communityData, viewingFromTarget) => {
 			avatar: avatar,
 			contributors: contributors,
 			description: description,
-			isExternal: true,
 			publicationDate: publicationDate,
 			title: title,
 			url: url,
@@ -77,10 +75,10 @@ const getValuesFromPubEdge = (pubEdge, communityData, viewingFromTarget) => {
 };
 
 const PubEdge = (props) => {
-	const { accentColor, actsLikeLink, isExternal, pubEdge, viewingFromTarget } = props;
+	const { accentColor, actsLikeLink, pubEdge, viewingFromTarget } = props;
 	const [open, setOpen] = useState(false);
 	const { communityData } = usePageContext();
-
+	const hasExternalPublication = Boolean(pubEdge.externalPublication);
 	const { avatar, contributors, description, publicationDate, title, url } = getValuesFromPubEdge(
 		pubEdge,
 		communityData,
@@ -146,7 +144,10 @@ const PubEdge = (props) => {
 				avatar ? (
 					<img src={avatar} alt="" />
 				) : (
-					<PubEdgePlaceholderThumbnail color={accentColor} external={isExternal} />
+					<PubEdgePlaceholderThumbnail
+						color={accentColor}
+						external={hasExternalPublication}
+					/>
 				),
 				{ tabIndex: '-1' },
 			)}

--- a/client/components/PubEdge/PubEdge.js
+++ b/client/components/PubEdge/PubEdge.js
@@ -11,16 +11,19 @@ import { getPubPublishedDate } from 'utils/pub/pubDates';
 
 import { pubEdgeType } from './constants';
 import PubEdgeLayout from './PubEdgeLayout';
+import PubEdgePlaceholderThumbnail from './PubEdgePlaceholderThumbnail';
 
 require('./pubEdge.scss');
 
 export const propTypes = {
+	accentColor: PropTypes.string,
 	actsLikeLink: PropTypes.bool,
 	pubEdge: pubEdgeType.isRequired,
 	viewingFromTarget: PropTypes.bool,
 };
 
 const defaultProps = {
+	accentColor: '#dddddd',
 	actsLikeLink: false,
 	viewingFromTarget: false,
 };
@@ -42,11 +45,12 @@ const getValuesFromPubEdge = (pubEdge, communityData, viewingFromTarget) => {
 		const { title, description, attributions, avatar } = displayedPub;
 		const url = getUrlForPub(displayedPub, communityData);
 		return {
-			contributors: attributions,
-			title: title,
-			description: description,
 			avatar: avatar,
+			contributors: attributions,
+			description: description,
+			isExternal: false,
 			publicationDate: getPubPublishedDate(displayedPub),
+			title: title,
 			url: url,
 		};
 	}
@@ -60,19 +64,20 @@ const getValuesFromPubEdge = (pubEdge, communityData, viewingFromTarget) => {
 			publicationDate,
 		} = externalPublication;
 		return {
-			title: title,
-			description: description,
-			contributors: contributors,
 			avatar: avatar,
-			url: url,
+			contributors: contributors,
+			description: description,
+			isExternal: true,
 			publicationDate: publicationDate,
+			title: title,
+			url: url,
 		};
 	}
 	return {};
 };
 
 const PubEdge = (props) => {
-	const { actsLikeLink, pubEdge, viewingFromTarget } = props;
+	const { accentColor, actsLikeLink, isExternal, pubEdge, viewingFromTarget } = props;
 	const [open, setOpen] = useState(false);
 	const { communityData } = usePageContext();
 
@@ -137,7 +142,14 @@ const PubEdge = (props) => {
 
 	return maybeWrapWithLink(
 		<PubEdgeLayout
-			topLeftElement={avatar && maybeLink(<img src={avatar} alt="" />, { tabIndex: '-1' })}
+			topLeftElement={maybeLink(
+				avatar ? (
+					<img src={avatar} alt="" />
+				) : (
+					<PubEdgePlaceholderThumbnail color={accentColor} external={isExternal} />
+				),
+				{ tabIndex: '-1' },
+			)}
 			titleElement={maybeLink(title, linkLikeProps)}
 			bylineElement={<Byline contributors={contributors} />}
 			metadataElements={[

--- a/client/components/PubEdge/PubEdgeEditor.js
+++ b/client/components/PubEdge/PubEdgeEditor.js
@@ -4,8 +4,11 @@ import { EditableText, TagInput, InputGroup } from '@blueprintjs/core';
 import { Button as RKButton } from 'reakit/Button';
 import dateFormat from 'dateformat';
 
+import { usePageContext } from 'utils/hooks';
+
 import { externalPublicationType } from './constants';
 import PubEdgeLayout from './PubEdgeLayout';
+import PubEdgePlaceholderThumbnail from './PubEdgePlaceholderThumbnail';
 
 require('./pubEdge.scss');
 
@@ -69,7 +72,13 @@ const PubEdgeEditor = (props) => {
 	return (
 		<PubEdgeLayout
 			className="pub-edge-editor-component"
-			topLeftElement={avatar && <img src={avatar} alt="" />}
+			topLeftElement={
+				avatar ? (
+					<img src={avatar} alt="" />
+				) : (
+					<PubEdgePlaceholderThumbnail color="#ccc" external />
+				)
+			}
 			titleElement={
 				<EditableText
 					placeholder="Add a title for this publication"

--- a/client/components/PubEdge/PubEdgePlaceholderThumbnail.js
+++ b/client/components/PubEdge/PubEdgePlaceholderThumbnail.js
@@ -1,0 +1,29 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+
+import { Icon } from 'components';
+
+require('./pubEdgePlaceholderThumbnail.scss');
+
+const propTypes = {
+	color: PropTypes.string.isRequired,
+	external: PropTypes.bool,
+};
+
+const defaultProps = {
+	external: false,
+};
+
+function PubEdgePlaceholderThumbnail(props) {
+	const style = useMemo(() => ({ backgroundColor: props.color }), [props.color]);
+
+	return (
+		<div className="pub-edge-placeholder-thumbnail-component" style={style}>
+			<Icon icon={props.external ? 'link' : 'pubDoc'} color="#ffffff" />
+		</div>
+	);
+}
+
+PubEdgePlaceholderThumbnail.propTypes = propTypes;
+PubEdgePlaceholderThumbnail.defaultProps = defaultProps;
+export default PubEdgePlaceholderThumbnail;

--- a/client/components/PubEdge/pubEdgePlaceholderThumbnail.scss
+++ b/client/components/PubEdge/pubEdgePlaceholderThumbnail.scss
@@ -5,4 +5,5 @@
 	justify-content: center;
 	transition: all 75ms linear;
 	width: 120px;
+	border-radius: 3px;
 }

--- a/client/components/PubEdge/pubEdgePlaceholderThumbnail.scss
+++ b/client/components/PubEdge/pubEdgePlaceholderThumbnail.scss
@@ -1,0 +1,8 @@
+.pub-edge-placeholder-thumbnail-component {
+	align-items: center;
+	display: flex;
+	height: 90px;
+	justify-content: center;
+	transition: all 75ms linear;
+	width: 120px;
+}

--- a/client/components/PubEdge/pubEdgeStories.js
+++ b/client/components/PubEdge/pubEdgeStories.js
@@ -19,6 +19,14 @@ const pubEdge = {
 	pubIsParent: true,
 };
 
+const pubEdgeWithoutAvatar = {
+	...pubEdge,
+	externalPublication: {
+		...pubEdge.externalPublication,
+		avatar: null,
+	},
+};
+
 const StatefulPreviewWrapper = () => {
 	const [externalPublication, setExternalPublication] = useState(pubEdge.externalPublication);
 	return (
@@ -33,6 +41,11 @@ const StatefulPreviewWrapper = () => {
 
 storiesOf('components/PubEdge', module)
 	.add('default', () => <PubEdge pubEdge={pubEdge} />)
-	.add('actsLikeLink', () => <PubEdge pubEdge={pubEdge} actsLikeLink={true} />);
+	.add('actsLikeLink', () => <PubEdge pubEdge={pubEdge} actsLikeLink={true} />)
+	.add('no avatar', () => (
+		<>
+			<PubEdge pubEdge={pubEdgeWithoutAvatar} />
+		</>
+	));
 
 storiesOf('components/PubEdgeEditor', module).add('default', () => <StatefulPreviewWrapper />);

--- a/client/components/PubEdgeListing/PubEdgeListingCard.js
+++ b/client/components/PubEdgeListing/PubEdgeListingCard.js
@@ -51,6 +51,7 @@ const getIsViewingFromTarget = (pubEdge, viewingFromSibling, isInboundEdge) => {
 };
 
 const PubEdgeListingCard = (props) => {
+	const { communityData } = usePageContext();
 	const {
 		accentColor = communityData.accentColorDark,
 		children,
@@ -62,12 +63,11 @@ const PubEdgeListingCard = (props) => {
 		showIcon,
 		viewingFromSibling,
 	} = props;
-	const { communityData } = usePageContext();
 	const viewingFromTarget = getIsViewingFromTarget(pubEdge, viewingFromSibling, isInboundEdge);
 	const [hover, setHover] = useState(false);
 	const handleMouseEnter = useCallback(() => setHover(true), []);
 	const handleMouseLeave = useCallback(() => setHover(false), []);
-	const hoverAccentColor = hover ? accentColor : '#dddddd';
+	const hoverAccentColor = hover ? accentColor : '#ddd';
 	const style = { borderColor: hoverAccentColor };
 
 	const renderRelation = () => {

--- a/client/components/PubEdgeListing/PubEdgeListingCard.js
+++ b/client/components/PubEdgeListing/PubEdgeListingCard.js
@@ -52,7 +52,7 @@ const getIsViewingFromTarget = (pubEdge, viewingFromSibling, isInboundEdge) => {
 
 const PubEdgeListingCard = (props) => {
 	const {
-		accentColor,
+		accentColor = communityData.accentColorDark,
 		children,
 		inPubBody,
 		isInboundEdge,
@@ -67,7 +67,8 @@ const PubEdgeListingCard = (props) => {
 	const [hover, setHover] = useState(false);
 	const handleMouseEnter = useCallback(() => setHover(true), []);
 	const handleMouseLeave = useCallback(() => setHover(false), []);
-	const style = hover ? { borderColor: accentColor || communityData.accentColorDark } : {};
+	const hoverAccentColor = hover ? accentColor : '#dddddd';
+	const style = { borderColor: hoverAccentColor };
 
 	const renderRelation = () => {
 		const { relationType, pubIsParent } = pubEdge;
@@ -139,9 +140,10 @@ const PubEdgeListingCard = (props) => {
 			</div>
 			{pubEdgeElement || (
 				<PubEdge
+					accentColor={hoverAccentColor}
+					actsLikeLink={inPubBody}
 					pubEdge={pubEdge}
 					viewingFromTarget={viewingFromTarget}
-					actsLikeLink={inPubBody}
 				/>
 			)}
 		</div>

--- a/client/components/PubEdgeListing/pubEdgeListing.scss
+++ b/client/components/PubEdgeListing/pubEdgeListing.scss
@@ -1,7 +1,6 @@
 .pub-edge-listing-component {
 	display: flex;
 	flex-direction: column;
-	padding: 20px 0;
 
 	> .top {
 		align-items: center;

--- a/client/components/PubEdgeListing/pubEdgeListing.scss
+++ b/client/components/PubEdgeListing/pubEdgeListing.scss
@@ -1,6 +1,7 @@
 .pub-edge-listing-component {
 	display: flex;
 	flex-direction: column;
+	padding: 20px 0;
 
 	> .top {
 		align-items: center;
@@ -14,9 +15,9 @@
 		}
 	}
 
-    @media screen and (max-width: 720px) {
-        font-size: 12px;
-    }
+	@media screen and (max-width: 720px) {
+		font-size: 12px;
+	}
 }
 
 .pub-edge-listing-counter-component {

--- a/client/components/PubEdgeListing/pubEdgeListingCard.scss
+++ b/client/components/PubEdgeListing/pubEdgeListingCard.scss
@@ -3,13 +3,13 @@
 	border-radius: 3px;
 	border-style: solid;
 	border-width: 1px;
-	margin-bottom: 24px;
+	margin-bottom: 30px;
 	position: relative;
-	transition: all 100ms linear;
-
+	transition: all 60ms linear;
 	&.in-pub-body {
 		> * {
 			filter: grayscale(100%);
+			transition: all 60ms linear;
 		}
 
 		&:hover,

--- a/client/components/PubEdgeListing/pubEdgeListingStories.js
+++ b/client/components/PubEdgeListing/pubEdgeListingStories.js
@@ -9,7 +9,7 @@ import { Filter } from './constants';
 
 const somePub = {
 	title: 'Scripture as Interface. A Hermeneutical Reflection on a Concept based in Media Theory',
-	avatar: 'https://assets.pubpub.org/nlgqoo6x/51572618306498.png',
+	avatar: null,
 	releases: [
 		{
 			id: '52ebe6a2-ff74-4537-8ce8-c7999f1fbd55',
@@ -74,7 +74,7 @@ const outboundEdges = [
 		externalPublication: {
 			title: 'Wunden verbinden',
 			contributors: ['Hildegund Keul'],
-			avatar: 'https://assets.pubpub.org/qsjyoz1y/61586620971745.png',
+			avatar: null,
 			url: 'https://cursor.pubpub.org/pub/keul-wunden/release/2',
 			publicationDate: Date.now(),
 			description:

--- a/client/containers/Pub/PubDocument/pubDocument.scss
+++ b/client/containers/Pub/PubDocument/pubDocument.scss
@@ -10,6 +10,11 @@
 		margin-bottom: 30px;
 	}
 
+	.bottom-pub-edges {
+		padding-top: 30px;
+		padding-bottom: 30px;
+	}
+
 	.discussions {
 		background-color: #f8f8f8;
 		line-height: 1.6;


### PR DESCRIPTION
Based on feedback from @djagdish, this PR:
* Changes the un-hovered border color to `#dddddd`
* `.pub-edge-listing-card-component` -- increases margin-bottom to 30px to add a bit more breathing space between cards when viewed in list format
* `.pub-edge-listing-component` -- adds padding-top and padding-bottom of 20px to add a bit more space between Pub body and the related pubs.
* Adds placeholder thumbnails when a connected pub or external publication doesn't resolve with an avatar.

**Without hover state:**

<img width="740" alt="Screen Shot 2020-07-17 at 12 44 45 PM" src="https://user-images.githubusercontent.com/6402908/87810685-5bf2a900-c82b-11ea-8ff4-0f186298adb2.png">

**With hover state:**

<img width="741" alt="Screen Shot 2020-07-17 at 12 44 27 PM" src="https://user-images.githubusercontent.com/6402908/87810718-6a40c500-c82b-11ea-8c0e-17dc176b834a.png">