### PR TITLE
Export bullet font size fix

### DIFF
--- a/workers/tasks/export/styles/printDocument.scss
+++ b/workers/tasks/export/styles/printDocument.scss
@@ -29,7 +29,7 @@ https://gitlab.pagedmedia.org/tools/pagedjs-cli/issues/11 */
 
 .pub-body-component {
     // override bullet sizing for PDFs
-    .editor.ProseMirror li p {
+    .editor.ProseMirror li p, .editor.ProseMirror ul > li > p {
             font-size: inherit;
         }
     .editor.ProseMirror .pub-notes ol > li {
@@ -116,11 +116,13 @@ section.cover {
             content: counter(page);
         }
     }
-
+    /* These never actually took effect because I didn't capitalize prosemirror
+    And I can't test it now because for some reason the dev queue isn't working.
+    So commenting out for now until I can test them.
     // Manually resize main text elements to make them more palatable for print
     $print-body-text-size: 14px;
-    .pub-body-component .editor.Prosemirror {
-        p, li, li p {
+    .pub-body-component .editor.ProseMirror {
+        p, li, li p, ul > li > p {
             font-size: $print-body-text-size;
         }
         h1 {
@@ -136,7 +138,7 @@ section.cover {
             font-size: $print-body-text-size * 1.1;
         }
     }
-
+    */
     /* Avoid being the last element on the page */
     h1,
     h2,


### PR DESCRIPTION
Very quick fix to make bullets in exports the same size as everything else. Previously, they were much larger. I also commented out some CSS that I had added but realized didn't actually take effect yet because I didn't capitalized Mirror in ProseMirror. I intend to go back and make these changes eventually

<img width="559" alt="Screen Shot 2020-07-17 at 16 03 08" src="https://user-images.githubusercontent.com/639110/87826682-50ad7680-c847-11ea-82ee-d8d918226769.png">

<img width="585" alt="Screen Shot 2020-07-17 at 16 05 00" src="https://user-images.githubusercontent.com/639110/87826662-45f2e180-c847-11ea-99ab-b296bb3d3f5e.png">

_Test Plan_
1. Export a PDF with a paragraph, an unordered list, and an ordered list (ie: https://demo.pubpub.org/pub/md4wb7lk/draft). Make sure it's all the same size.