### PR TITLE
fix: improve keyboard/mouse a11y of pub edge card

### DIFF
--- a/client/components/PubEdge/PubEdge.js
+++ b/client/components/PubEdge/PubEdge.js
@@ -95,18 +95,18 @@ const PubEdge = (props) => {
 		[open],
 	);
 
-	const handleClick = useCallback(
+	const handleLinkClick = useCallback(
 		(e) => {
 			if (e.type === 'click' || e.key === 'Enter') {
-				window.open(url, '_top');
+				window.open(url, e.metaKey ? '_blank' : '_self');
 			}
 		},
 		[url],
 	);
 
 	const linkLikeProps = actsLikeLink && {
-		onClick: handleClick,
-		onKeyDown: handleClick,
+		onClick: handleLinkClick,
+		onKeyDown: handleLinkClick,
 		role: 'link',
 		tabIndex: '0',
 	};
@@ -142,15 +142,15 @@ const PubEdge = (props) => {
 			bylineElement={<Byline contributors={contributors} />}
 			metadataElements={[
 				description && (
-					<Button
-						as={actsLikeLink ? 'span' : 'a'}
+					<span
 						onClick={handleToggleDescriptionClick}
 						onKeyDown={handleToggleDescriptionClick}
 						tabIndex="0"
 						className="link"
+						role="button"
 					>
 						{open ? 'Hide Description' : 'Show Description'}
-					</Button>
+					</span>
 				),
 				<>Published on {publishedAt}</>,
 				maybeLink(url, linkLikeProps),

--- a/client/components/PubEdge/pubEdge.scss
+++ b/client/components/PubEdge/pubEdge.scss
@@ -138,6 +138,7 @@
 	}
 
 	.link {
+		cursor: pointer;
 		text-decoration: none;
 
 		&:hover,


### PR DESCRIPTION
This PR improves the meta key + click and keyboard enter behavior of the PubEdge element. cmd+clicking the parent (when `actsLikeLike==true`, as well as cmd+clicking internal links (except for description toggle) will now consistently open the target URL in a new tab.