### PR TITLE
Some Release fixes

### DIFF
--- a/client/components/PubReleaseDialog/PubReleaseDialog.js
+++ b/client/components/PubReleaseDialog/PubReleaseDialog.js
@@ -68,7 +68,7 @@ const PubReleaseDialog = (props) => {
 			draftKey: historyData.latestKey,
 			makeDraftDiscussionsPublic: makeDraftDiscussionsPublic,
 		})
-			.then(({ release }) => {
+			.then((release) => {
 				setReleleaseError(null);
 				setCreatedRelease(release);
 				setIsCreatingRelease(false);

--- a/client/containers/DashboardEdges/NewEdgeInput.js
+++ b/client/containers/DashboardEdges/NewEdgeInput.js
@@ -42,6 +42,7 @@ const indeterminateMenuItem = (
 		isSkeleton={true}
 		showImage={true}
 		disabled={true}
+		onClick={() => {}}
 	/>
 );
 

--- a/client/containers/Pub/PubHeader/DraftReleaseButtons.js
+++ b/client/containers/Pub/PubHeader/DraftReleaseButtons.js
@@ -39,6 +39,14 @@ const getHistoryButtonLabelForTimestamp = (timestamp, label, noTimestampLabel) =
 	};
 };
 
+const getCanCreateRelease = (latestRelease, latestKey) => {
+	if (latestRelease) {
+		const { sourceBranchKey } = latestRelease;
+		return typeof sourceBranchKey !== 'number' || sourceBranchKey < latestKey;
+	}
+	return latestKey !== -1;
+};
+
 const DraftReleaseButtons = (props) => {
 	const { historyData, pubData, updateHistoryData, updatePubData } = props;
 	const { communityData, scopeData } = usePageContext();
@@ -95,10 +103,7 @@ const DraftReleaseButtons = (props) => {
 		const { latestKey, timestamps } = historyData;
 		const latestRelease = releases[releases.length - 1];
 		const latestTimestamp = timestamps[latestKey];
-		const canRelease =
-			!latestRelease ||
-			typeof latestRelease.sourceBranchKey !== 'number' ||
-			latestRelease.sourceBranchKey < latestKey;
+		const canRelease = getCanCreateRelease(latestRelease, latestKey);
 		return (
 			<React.Fragment>
 				<ResponsiveHeaderButton

--- a/server/release/__tests__/api.test.js
+++ b/server/release/__tests__/api.test.js
@@ -1,0 +1,150 @@
+/* global it, expect, beforeAll, afterAll, afterEach */
+import { setup, teardown, login, stubOut, modelize } from 'stubstub';
+
+import { Export, Release } from 'server/models';
+import { getExportFormats } from 'utils/export/formats';
+
+const models = modelize`
+	Community community {
+		Pub pub {
+			Member {
+				permissions: "manage"
+				User pubManager {}
+            }
+            Member {
+                permissions: "admin"
+                User pubAdmin {}
+            }
+		}
+		Pub exportablePub {
+			Member {
+				permissions: "admin"
+				user: pubAdmin
+			}
+		}
+	}
+`;
+
+setup(beforeAll, async () => {
+	await models.resolve();
+});
+
+afterEach(async () => {
+	const { pub } = models;
+	await Release.destroy({ where: { pubId: pub.id } });
+});
+
+teardown(afterAll);
+
+stubOut('server/utils/firebaseAdmin', {
+	mergeFirebaseBranch: () => ({ mergeKey: 0 }),
+	getLatestKey: () => 0,
+	getBranchDoc: () => {
+		return {
+			historyData: { latestKey: 0 },
+		};
+	},
+});
+
+const createReleaseRequest = ({ community, pub, ...rest }) => ({
+	communityId: community.id,
+	pubId: pub.id,
+	noteText: '',
+	noteContent: {},
+	...rest,
+});
+
+it('refuses to create a Release for non-admins of a Pub', async () => {
+	const { community, pub, pubManager } = models;
+	const agent = await login(pubManager);
+	await agent
+		.post('/api/releases')
+		.send(
+			createReleaseRequest({
+				community: community,
+				pub: pub,
+				draftKey: 0,
+				createExports: false,
+			}),
+		)
+		.expect(403);
+});
+
+it('will create a Release for admins of a Pub', async () => {
+	const { community, pub, pubAdmin } = models;
+	const agent = await login(pubAdmin);
+	const { body: release } = await agent
+		.post('/api/releases')
+		.send(
+			createReleaseRequest({
+				community: community,
+				pub: pub,
+				draftKey: 0,
+				createExports: false,
+			}),
+		)
+		.expect(201);
+	expect(release.sourceBranchKey).toEqual(0);
+});
+
+it('will create a Release for admins of a Pub', async () => {
+	const { community, pub, pubAdmin } = models;
+	const agent = await login(pubAdmin);
+	const { body: release } = await agent
+		.post('/api/releases')
+		.send(
+			createReleaseRequest({
+				community: community,
+				pub: pub,
+				draftKey: 0,
+				createExports: false,
+			}),
+		)
+		.expect(201);
+	expect(release.sourceBranchKey).toEqual(0);
+});
+
+it('will not create duplicate Releases for the same draft-key of a Pub', async () => {
+	const { community, pub, pubAdmin } = models;
+	const agent = await login(pubAdmin);
+	await agent
+		.post('/api/releases')
+		.send(
+			createReleaseRequest({
+				community: community,
+				pub: pub,
+				draftKey: 0,
+				createExports: false,
+			}),
+		)
+		.expect(201);
+	await agent
+		.post('/api/releases')
+		.send(
+			createReleaseRequest({
+				community: community,
+				pub: pub,
+				draftKey: 0,
+				createExports: false,
+			}),
+		)
+		.expect(500);
+});
+
+it('will export the Pub to every supported export format upon release', async () => {
+	const { community, exportablePub, pubAdmin } = models;
+	const agent = await login(pubAdmin);
+	await agent
+		.post('/api/releases')
+		.send(
+			createReleaseRequest({
+				community: community,
+				pub: exportablePub,
+				draftKey: 0,
+				createExports: false,
+			}),
+		)
+		.expect(201);
+	const createdExports = await Export.findAll({ where: { pubId: exportablePub.id } });
+	expect(getExportFormats().every((fmt) => createdExports.some((exp) => exp.format === fmt)));
+});

--- a/server/release/api.js
+++ b/server/release/api.js
@@ -30,7 +30,6 @@ app.post(
 	wrap(async (req, res) => {
 		const {
 			communityId,
-			createExports,
 			draftKey,
 			makeDraftDiscussionsPublic,
 			noteContent,
@@ -55,7 +54,6 @@ app.post(
 			noteText: noteText,
 			noteContent: noteContent,
 			makeDraftDiscussionsPublic: makeDraftDiscussionsPublic,
-			createExports: createExports,
 		});
 
 		return res.status(201).json(release);

--- a/server/release/api.js
+++ b/server/release/api.js
@@ -8,20 +8,20 @@ const getRequestValues = (req) => {
 	const user = req.user || {};
 	const {
 		communityId,
-		pubId,
 		draftKey,
-		noteText,
-		noteContent,
 		makeDraftDiscussionsPublic,
+		noteContent,
+		noteText,
+		pubId,
 	} = req.body;
 	return {
-		userId: user.id,
 		communityId: communityId,
-		pubId: pubId,
 		draftKey: draftKey,
-		noteText: noteText,
-		noteContent: noteContent,
 		makeDraftDiscussionsPublic: makeDraftDiscussionsPublic,
+		noteContent: noteContent,
+		noteText: noteText,
+		pubId: pubId,
+		userId: user.id,
 	};
 };
 
@@ -29,13 +29,14 @@ app.post(
 	'/api/releases',
 	wrap(async (req, res) => {
 		const {
-			userId,
 			communityId,
-			pubId,
+			createExports,
 			draftKey,
-			noteText,
-			noteContent,
 			makeDraftDiscussionsPublic,
+			noteContent,
+			noteText,
+			pubId,
+			userId,
 		} = getRequestValues(req);
 		const permissions = await getPermissions({
 			userId: userId,
@@ -54,8 +55,9 @@ app.post(
 			noteText: noteText,
 			noteContent: noteContent,
 			makeDraftDiscussionsPublic: makeDraftDiscussionsPublic,
+			createExports: createExports,
 		});
 
-		return res.status(201).json({ release: release });
+		return res.status(201).json(release);
 	}),
 );

--- a/workers/tasks/import/bulk/README.md
+++ b/workers/tasks/import/bulk/README.md
@@ -63,6 +63,8 @@ Any Communities, Collections, and Pubs created will be immediately visible onlin
 npm run tools bulkimport -- --actor=pubpub-user-slug --receipt /path/to/receipt --publish
 ```
 
+You can choose whether to create Pub exports (which you may not want during testing) using the `--create-exports` flag, which defaults to `true`.
+
 If you want to discard all _created_ objects (preserving those that were targeted by directives but not created by them), then run:
 
 ```
@@ -156,7 +158,7 @@ slug: this-one-already-exists
 type: community
 create: true
 title: My New Community
-description: Pretty cool, no? # optional
+description: "Pretty cool, no?" # optional
 subdomain: my-new-community # optional
 ```
 
@@ -711,7 +713,7 @@ We could simply accept the fact that `cruft.tex` will create a Pub, or we could 
 children:
     chapters/chapter-one.tex:
         type: pub
-        title: Chapter One: The Way Things Are
+        title: "Chapter One: The Way Things Are"
         resolve:
             - ../footnote-definitions.tex:
                 as: _.tex
@@ -720,7 +722,7 @@ children:
             \newcommand{\emc2}{$E = mc^2$}
     chapters/chapter-two.tex:
         type: pub
-        title: Chapter One: The Way Things Ought to Be
+        title: "Chapter Two: The Way Things Ought to Be"
         resolve:
             - ../footnote-definitions.tex:
                 as: _.tex

--- a/workers/tasks/import/bulk/cli.js
+++ b/workers/tasks/import/bulk/cli.js
@@ -45,6 +45,11 @@ const {
 	.option('yes', {
 		description: 'Skip confirmation prompts (at your own peril)',
 		type: 'boolean',
+	})
+	.options('create-exports', {
+		description: 'Create Pub exports during the publish stage',
+		type: 'boolen',
+		default: true,
 	});
 
 export const getActor = async (userSlug) => {
@@ -72,7 +77,16 @@ const writePlanToFile = async (path, plan) => {
 };
 
 const main = async () => {
-	const { actor: actorSlug, community, yes, dryRun, discard, publish, receipt } = args;
+	const {
+		actor: actorSlug,
+		community,
+		createExports,
+		discard,
+		dryRun,
+		publish,
+		receipt,
+		yes,
+	} = args;
 	const actor = await getActor(actorSlug);
 	const shouldImport = !discard && !publish;
 	if (shouldImport) {
@@ -115,7 +129,13 @@ const main = async () => {
 			);
 		}
 		const plan = await readPlanFromFile(receipt);
-		await publishBulkImportPlan({ plan: plan, yes: yes, dryRun: dryRun, actor: actor });
+		await publishBulkImportPlan({
+			plan: plan,
+			yes: yes,
+			dryRun: dryRun,
+			actor: actor,
+			createExports: createExports,
+		});
 	}
 };
 

--- a/workers/tasks/import/bulk/publish.js
+++ b/workers/tasks/import/bulk/publish.js
@@ -4,7 +4,7 @@ import { createRelease } from 'server/release/queries';
 import { printImportPlan, getCreatedItemsFromPlan } from './plan';
 import { promptOkay } from './prompt';
 
-export const publishBulkImportPlan = async ({ plan, yes, actor, dryRun }) => {
+export const publishBulkImportPlan = async ({ plan, yes, actor, dryRun, createExports }) => {
 	printImportPlan(plan, { verb: 'publish' });
 	if (dryRun) {
 		return;
@@ -15,7 +15,9 @@ export const publishBulkImportPlan = async ({ plan, yes, actor, dryRun }) => {
 	});
 	const { collections, pubs } = getCreatedItemsFromPlan(plan);
 	await Promise.all([
-		...pubs.map((pub) => createRelease({ userId: actor.id, pubId: pub.id })),
+		...pubs.map((pub) =>
+			createRelease({ userId: actor.id, pubId: pub.id, createExports: createExports }),
+		),
 		...collections.map((collection) =>
 			Collection.update({ isPublic: true }, { where: { id: collection.id } }),
 		),


### PR DESCRIPTION
This PR includes a bundle of fixes related to Releases that have been piling up:

- There is a UI bug that appears to let you create a Release from an empty Pub, which is something we need to continue to disallow for the time being due to technical debt in our Firebase infra (cc @metasj)
- Last week we had a conversation the possibility of Releases created from bulk import clogging up the worker queue. I dug into it and it turns out this is behavior we _should_ be seeing, but aren't — the dashboard-adjacent migration from branch-merges to Releases didn't carry over the desired behavior of kicking off exports at publish time. So not only do we need to restore that, we also need a flag to selectively disable the newly-restored behavior during bulk import!
- Sort of central to all of this, the Release API doesn't have any tests. Releasing is a complicated enough process to justify a much more comprehensive test suite than I have here, but this is a start — and I sort of hope the process will be simpler by the time we get to writing any more.

Anyway, this PR addresses all of that. I'll try to add some elucidation inline, because this is a lot.

_Test plan:_
- Make sure you can actually create a release through the UI on your devserver
- Run `npm run test server/release`