### PR TITLE
feat: deposit preview for journals, conferences, books

### DIFF
--- a/client/components/AssignDoi/AssignDoi.js
+++ b/client/components/AssignDoi/AssignDoi.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useReducer, useEffect } from 'react';
+import React, { useCallback, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import { Button } from '@blueprintjs/core';
 
@@ -109,6 +109,8 @@ export function reducer(state, action) {
 				result: null,
 				error: action.payload,
 			};
+		default:
+			return state;
 	}
 }
 
@@ -156,14 +158,14 @@ function AssignDoi(props) {
 				method: 'POST',
 				body: body,
 			});
-			const doi = response.dois[target];
+			const targetDoi = response.dois[target];
 
 			dispatch({
 				type: AssignDoiActionType.FetchDepositSuccess,
-				payload: doi,
+				payload: targetDoi,
 			});
 
-			onDeposit(doi);
+			onDeposit(targetDoi);
 		} catch (error) {
 			dispatch({ type: AssignDoiActionType.Error, payload: error.message });
 			onError(error);

--- a/client/components/AssignDoi/AssignDoi.js
+++ b/client/components/AssignDoi/AssignDoi.js
@@ -1,0 +1,205 @@
+import React, { useCallback, useReducer, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '@blueprintjs/core';
+
+import { apiFetch } from 'client/utils/apiFetch';
+
+import AssignDoiPreview from './AssignDoiPreview';
+
+require('./assignDoi.scss');
+
+const noop = () => {};
+
+const propTypes = {
+	communityData: PropTypes.object.isRequired,
+	disabled: PropTypes.bool,
+	pubData: PropTypes.object.isRequired,
+	doi: PropTypes.string,
+	target: PropTypes.string.isRequired,
+	onDeposit: PropTypes.func,
+	onPreview: PropTypes.func,
+	onError: PropTypes.func,
+};
+
+const defaultProps = {
+	disabled: false,
+	doi: null,
+	onPreview: noop,
+	onDeposit: noop,
+	onError: noop,
+};
+
+const AssignDoiState = {
+	Initial: 'initial',
+	Previewing: 'previewing',
+	Previewed: 'previewed',
+	Depositing: 'depositing',
+	Deposited: 'deposited',
+};
+
+const AssignDoiActionType = {
+	FetchPreview: 'fetch_preview',
+	FetchPreviewSuccess: 'fetch_preview_success',
+	FetchDeposit: 'fetch_deposit',
+	FetchDepositSuccess: 'fetch_deposit_success',
+	Error: 'error',
+};
+
+const buttonTextByState = {
+	[AssignDoiState.Initial]: 'Assign DOI',
+	[AssignDoiState.Previewing]: 'Getting Preview',
+	[AssignDoiState.Previewed]: 'Submit Deposit',
+	[AssignDoiState.Depositing]: 'Depositing',
+	[AssignDoiState.Deposited]: 'DOI Deposited',
+};
+
+const getButtonText = (state, doi) => {
+	if (state === AssignDoiState.Initial && doi) {
+		return 'Resubmit DOI deposit';
+	}
+
+	return buttonTextByState[state];
+};
+
+export function reducer(state, action) {
+	switch (action.type) {
+		case AssignDoiActionType.FetchPreview:
+			if (!(state.state === AssignDoiState.Initial || state.state === AssignDoiState.Error)) {
+				return state;
+			}
+
+			return {
+				state: AssignDoiState.Previewing,
+				result: null,
+				error: null,
+			};
+		case AssignDoiActionType.FetchPreviewSuccess:
+			if (state.state !== AssignDoiState.Previewing) {
+				return state;
+			}
+
+			return {
+				state: AssignDoiState.Previewed,
+				result: action.payload,
+				error: null,
+			};
+		case AssignDoiActionType.FetchDeposit:
+			if (state.state !== AssignDoiState.Previewed) {
+				return state;
+			}
+
+			return {
+				state: AssignDoiState.Depositing,
+				result: null,
+				error: null,
+			};
+		case AssignDoiActionType.FetchDepositSuccess:
+			if (state.state !== AssignDoiState.Depositing) {
+				return state;
+			}
+
+			return {
+				state: AssignDoiState.Deposited,
+				result: action.payload,
+				error: null,
+			};
+		case AssignDoiActionType.Error:
+			return {
+				state: AssignDoiState.Initial,
+				result: null,
+				error: action.payload,
+			};
+	}
+}
+
+const initialState = {
+	state: AssignDoiState.Initial,
+	preview: null,
+	result: null,
+};
+
+function AssignDoi(props) {
+	const { communityData, disabled, doi, pubData, onPreview, onDeposit, onError, target } = props;
+	const [{ state, result }, dispatch] = useReducer(reducer, initialState);
+	const fetchPreview = useCallback(async () => {
+		dispatch({ type: AssignDoiActionType.FetchPreview });
+
+		try {
+			const params = new URLSearchParams({
+				target: target,
+				pubId: pubData.id,
+				communityId: communityData.id,
+			});
+			const preview = await apiFetch(`/api/doiPreview?${params.toString()}`);
+
+			onPreview(preview);
+
+			dispatch({
+				type: AssignDoiActionType.FetchPreviewSuccess,
+				payload: preview,
+			});
+		} catch (error) {
+			dispatch({ type: AssignDoiActionType.Error, payload: error.message });
+			onError(error);
+		}
+	}, [communityData, pubData, target, onPreview, onError]);
+	const fetchDeposit = useCallback(async () => {
+		dispatch({ type: AssignDoiActionType.FetchDeposit });
+
+		try {
+			const body = JSON.stringify({
+				target: target,
+				pubId: pubData.id,
+				communityId: communityData.id,
+			});
+			const response = await apiFetch('/api/doi', {
+				method: 'POST',
+				body: body,
+			});
+			const doi = response.dois[target];
+
+			dispatch({
+				type: AssignDoiActionType.FetchDepositSuccess,
+				payload: doi,
+			});
+
+			onDeposit(doi);
+		} catch (error) {
+			dispatch({ type: AssignDoiActionType.Error, payload: error.message });
+			onError(error);
+		}
+	}, [communityData, pubData, target, onDeposit, onError]);
+
+	let action;
+
+	if (state === AssignDoiState.Initial) {
+		action = fetchPreview;
+	} else if (state === AssignDoiState.Previewed) {
+		action = fetchDeposit;
+	}
+
+	return (
+		<div className="assign-doi-component">
+			<Button
+				disabled={disabled || !action}
+				text={getButtonText(state, doi)}
+				loading={state === AssignDoiState.Previewing || state === AssignDoiState.Depositing}
+				onClick={action}
+				icon={state === AssignDoiState.Deposited && 'tick'}
+			/>
+			{state === AssignDoiState.Previewed && (
+				<>
+					<p>
+						Review the information below, then use the button above to submit the
+						deposit to Crossref.
+					</p>
+					<AssignDoiPreview {...result} />
+				</>
+			)}
+		</div>
+	);
+}
+
+AssignDoi.propTypes = propTypes;
+AssignDoi.defaultProps = defaultProps;
+export default AssignDoi;

--- a/client/components/AssignDoi/AssignDoiPreview.js
+++ b/client/components/AssignDoi/AssignDoiPreview.js
@@ -1,0 +1,215 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Tab, Tabs } from '@blueprintjs/core';
+
+import { formatDate } from 'utils/dates';
+
+require('./assignDoiPreview.scss');
+
+const propTypes = {
+	depositJson: PropTypes.object.isRequired,
+	depositXml: PropTypes.string.isRequired,
+};
+const defaultProps = {};
+
+const isBook = (doiBatch) => 'book' in doiBatch.body;
+const isJournal = (doiBatch) => 'journal' in doiBatch.body;
+const isConference = (doiBatch) => 'conference' in doiBatch.body;
+
+const renderTitles = (titles) => {
+	return (
+		<>
+			<dt>Title</dt>
+			<dd>{titles.title}</dd>
+		</>
+	);
+};
+
+const renderPublisher = (publisher) => {
+	return (
+		<>
+			<dt>Publisher</dt>
+			<dd>{publisher.publisher_name}</dd>
+		</>
+	);
+};
+
+const renderPublicationDate = (publication_date) => {
+	const { day, month, year } = publication_date;
+
+	return (
+		<>
+			<dt>Publication Date</dt>
+			<dd>{formatDate(new Date([month, day, year]))}</dd>
+		</>
+	);
+};
+
+const renderContributors = (contributors) => {
+	const contributorNames = contributors.person_name.map(
+		(contributor) =>
+			`${contributor.given_name} ${contributor.surname} (${contributor['@contributor_role']})`,
+	);
+
+	return (
+		<>
+			<dt>Contributors</dt>
+			<dd>
+				<ul>{contributorNames}</ul>
+			</dd>
+		</>
+	);
+};
+
+const renderArticlePreview = (doi_batch) => {
+	const {
+		body: {
+			journal: {
+				journal_article: { titles, publication_date, contributors },
+				journal_metadata: {
+					full_title: journalFullTitle,
+					doi_data: { doi: journalDoi },
+				},
+			},
+		},
+	} = doi_batch;
+
+	return (
+		<>
+			<h6>Journal Article</h6>
+			<dl>
+				{renderTitles(titles)}
+				{renderPublicationDate(publication_date)}
+				{renderContributors(contributors)}
+			</dl>
+			<h6>Journal Metadata</h6>
+			<dl>
+				<dt>Title</dt>
+				<dd>{journalFullTitle}</dd>
+				<dt>DOI</dt>
+				<dd>{journalDoi}</dd>
+			</dl>
+		</>
+	);
+};
+
+const renderBookPreview = (doi_batch) => {
+	const {
+		body: {
+			book: {
+				book_metadata: {
+					titles: bookTitles,
+					edition_number,
+					publisher,
+					publication_date: bookPublicationDate,
+				},
+				content_item: {
+					titles: contentTitles,
+					contributors,
+					publication_date: contentPublicationDate,
+				},
+			},
+		},
+	} = doi_batch;
+
+	return (
+		<>
+			<h6>Book Metadata</h6>
+			<dl>
+				{renderTitles(bookTitles)}
+				<dt>Edition Number</dt>
+				<dd>{edition_number}</dd>
+				{renderPublisher(publisher)}
+				{renderPublicationDate(bookPublicationDate)}
+			</dl>
+			<h6>Content</h6>
+			<dl>
+				{renderTitles(contentTitles)}
+				{renderContributors(contributors)}
+				{renderPublicationDate(contentPublicationDate)}
+			</dl>
+		</>
+	);
+};
+
+const renderConferencePreview = (doi_batch) => {
+	const {
+		body: {
+			conference: {
+				conference_paper: { contributors, titles: paperTitles },
+				event_metadata: {
+					conference_name,
+					conference_date: { '#text': conferenceDate },
+				},
+				proceedings_metadata: { proceedings_title, publication_date, publisher },
+			},
+		},
+	} = doi_batch;
+
+	return (
+		<>
+			<h6>Conference Paper</h6>
+			<dl>
+				{renderTitles(paperTitles)}
+				{renderContributors(contributors)}
+			</dl>
+			<h6>Event Metadata</h6>
+			<dl>
+				<dt>Conference Name</dt>
+				<dd>{conference_name}</dd>
+			</dl>
+			<dl>
+				<dt>Conference Date</dt>
+				<dd>{formatDate(new Date(conferenceDate))}</dd>
+			</dl>
+			<h6>Proceedings Metadata</h6>
+			<dl>
+				<dt>Proceedings Title</dt>
+				<dd>{proceedings_title}</dd>
+				{renderPublicationDate(publication_date)}
+				{renderPublisher(publisher)}
+			</dl>
+		</>
+	);
+};
+
+function AssignDoiPreview(props) {
+	const [selectedTab, setSelectedTab] = useState('preview');
+	const {
+		deposit: { doi_batch },
+		dois: { community: communityDoi, pub: pubDoi },
+	} = props.depositJson;
+
+	const renderPreviewTab = () => {
+		return (
+			<>
+				<h6>DOIs</h6>
+				<dl>
+					<dt>Community</dt>
+					<dd>{communityDoi}</dd>
+					<dt>Pub</dt>
+					<dd>{pubDoi}</dd>
+				</dl>
+				{isJournal(doi_batch) && renderArticlePreview(doi_batch)}
+				{isBook(doi_batch) && renderBookPreview(doi_batch)}
+				{isConference(doi_batch) && renderConferencePreview(doi_batch)}
+			</>
+		);
+	};
+
+	return (
+		<Tabs
+			onChange={setSelectedTab}
+			selectedTabId={selectedTab}
+			className="assign-doi-preview-component"
+		>
+			<Tab id="preview" title="Preview" panel={renderPreviewTab()} />
+			<Tab id="xml" title="XML" panel={<pre>{props.depositXml}</pre>} />
+		</Tabs>
+	);
+}
+
+AssignDoiPreview.propTypes = propTypes;
+AssignDoiPreview.defaultProps = defaultProps;
+
+export default AssignDoiPreview;

--- a/client/components/AssignDoi/AssignDoiPreview.js
+++ b/client/components/AssignDoi/AssignDoiPreview.js
@@ -157,8 +157,6 @@ const renderConferencePreview = (doi_batch) => {
 			<dl>
 				<dt>Conference Name</dt>
 				<dd>{conference_name}</dd>
-			</dl>
-			<dl>
 				<dt>Conference Date</dt>
 				<dd>{formatDate(new Date(conferenceDate))}</dd>
 			</dl>

--- a/client/components/AssignDoi/assignDoi.scss
+++ b/client/components/AssignDoi/assignDoi.scss
@@ -1,0 +1,5 @@
+.assign-doi-component {
+	> p {
+		margin: 12px 0;
+	}
+}

--- a/client/components/AssignDoi/assignDoiPreview.scss
+++ b/client/components/AssignDoi/assignDoiPreview.scss
@@ -1,0 +1,44 @@
+.assign-doi-preview-component {
+	margin: 12px 0;
+	padding: 12px;
+	border: 1px dashed #ccc;
+	border-radius: 3px;
+	font-size: 0.9em;
+
+	dl {
+		display: inline-grid;
+		grid-template-columns: auto auto;
+		margin: 0;
+
+		&:not(:last-child) {
+			margin: 0 0 18px 0;
+		}
+
+		> dt {
+			padding: 4px;
+			word-break: break-word;
+			color: #666;
+		}
+
+		> dd {
+			padding: 4px;
+			margin: 0;
+
+			ul {
+				margin: 0;
+				padding: 0;
+				list-style-type: none;
+			}
+		}
+	}
+
+	pre {
+		font-family: 'Courier', monospace;
+		max-height: 200px;
+		overflow: auto;
+		font-size: inherit;
+		background-color: #f1f1f1;
+		padding: 8px 12px;
+		margin: 0;
+	}
+}

--- a/client/components/AssignDoi/assignDoiPreview.scss
+++ b/client/components/AssignDoi/assignDoiPreview.scss
@@ -17,7 +17,8 @@
 		> dt {
 			padding: 4px;
 			word-break: break-word;
-			color: #666;
+			color: #777;
+			text-align: right;
 		}
 
 		> dd {

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -1,4 +1,5 @@
 export { default as AccentStyle } from './AccentStyle/AccentStyle';
+export { default as AssignDoi } from './AssignDoi/AssignDoi';
 export { default as AttributionEditor } from './AttributionEditor/AttributionEditor';
 export { default as Avatar } from './Avatar/Avatar';
 export { default as Byline } from './Byline/Byline';

--- a/client/containers/DashboardSettings/PubSettings/Doi.js
+++ b/client/containers/DashboardSettings/PubSettings/Doi.js
@@ -5,6 +5,8 @@ import { Button, FormGroup } from '@blueprintjs/core';
 import { getSchemaForKind } from 'utils/collections/schemas';
 import { apiFetch } from 'client/utils/apiFetch';
 
+import { AssignDoi } from 'components';
+
 require('./doi.scss');
 
 const propTypes = {
@@ -18,30 +20,15 @@ class Doi extends Component {
 	constructor(props) {
 		super(props);
 		this.state = {
-			isLoading: false,
 			justSetDoi: false,
 		};
-		this.handleAssignDoi = this.handleAssignDoi.bind(this);
+		this.handleDeposit = this.handleDeposit.bind(this);
 	}
 
-	handleAssignDoi() {
-		const { communityData, pubData, updatePubData } = this.props;
-		this.setState({ isLoading: true });
-		return apiFetch('/api/doi', {
-			method: 'POST',
-			body: JSON.stringify({
-				target: 'pub',
-				pubId: pubData.id,
-				communityId: communityData.id,
-			}),
-		})
-			.then(({ dois: { pub: pubDoi } }) => {
-				updatePubData({ doi: pubDoi });
-				this.setState({ isLoading: false, justSetDoi: true });
-			})
-			.catch(() => {
-				this.setState({ isLoading: false });
-			});
+	handleDeposit(doi) {
+		const { updatePubData } = this.props;
+		this.setState({ justSetDoi: true });
+		updatePubData({ doi: doi });
 	}
 
 	renderCollectionContextMessage() {
@@ -106,12 +93,14 @@ class Doi extends Component {
 			pubData: { doi },
 			canIssueDoi,
 		} = this.props;
-		const { isLoading, justSetDoi } = this.state;
+		const { justSetDoi } = this.state;
+
 		return (
 			<div className="pub-settings-container_doi-component">
 				{this.renderStatusMessage()}
 				{this.renderCollectionContextMessage()}
 				{this.renderDoi()}
+
 				<FormGroup
 					helperText={
 						doi &&
@@ -124,14 +113,13 @@ class Doi extends Component {
 						)
 					}
 				>
-					<Button
-						text={
-							justSetDoi ? 'Submitted!' : doi ? 'Resubmit DOI deposit' : 'Assign DOI'
-						}
-						loading={isLoading}
-						onClick={this.handleAssignDoi}
-						disabled={!canIssueDoi || justSetDoi}
-						icon={justSetDoi && 'tick'}
+					<AssignDoi
+						communityData={this.props.communityData}
+						disabled={!canIssueDoi}
+						onDeposit={this.handleDeposit}
+						pubData={this.props.pubData}
+						doi={doi}
+						target="pub"
 					/>
 				</FormGroup>
 			</div>

--- a/client/containers/DashboardSettings/PubSettings/Doi.js
+++ b/client/containers/DashboardSettings/PubSettings/Doi.js
@@ -1,9 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Button, FormGroup } from '@blueprintjs/core';
+import { FormGroup } from '@blueprintjs/core';
 
 import { getSchemaForKind } from 'utils/collections/schemas';
-import { apiFetch } from 'client/utils/apiFetch';
 
 import { AssignDoi } from 'components';
 


### PR DESCRIPTION
This PR adds a new component `AssignDoi` which handles previewing and submission of DOI deposits to Crossref. Existing deposit submission logic was removed from the `<Doi>` component used in Pub settings and replaced with `<AssignDoi>`. The deposit preview has both a human-readable view of the deposit and the raw XML that will be sent to Crossref. Previews are supported for journal articles, conferences, and books.

### Screen capture

<img width="468" src="https://user-images.githubusercontent.com/6402908/88077151-eea38880-cb48-11ea-9e83-df1ab7cc668b.gif">

### Journal Article
<img width="468" alt="Screen Shot 2020-07-21 at 11 57 43 AM" src="https://user-images.githubusercontent.com/6402908/88077558-670a4980-cb49-11ea-819e-d753c5d3fdb4.png">

### Book Chapter
<img width="468" alt="Screen Shot 2020-07-21 at 11 56 50 AM" src="https://user-images.githubusercontent.com/6402908/88077470-4f32c580-cb49-11ea-9760-157128a9e8f1.png">

### Conference Paper
<img width="468" alt="Screen Shot 2020-07-21 at 11 55 51 AM" src="https://user-images.githubusercontent.com/6402908/88077313-24487180-cb49-11ea-8976-ca0acaf6cd31.png">

Resolves #908