### PR TITLE
feature: persist deposit record for deposited pubs and collections

### DIFF
--- a/server/collection/model.js
+++ b/server/collection/model.js
@@ -38,9 +38,10 @@ export default (sequelize, dataTypes) => {
 					const {
 						Collection,
 						CollectionAttribution,
-						Page,
 						CollectionPub,
+						CrossrefDepositRecord,
 						Member,
+						Page,
 					} = models;
 					Collection.hasMany(CollectionAttribution, {
 						onDelete: 'CASCADE',
@@ -56,6 +57,11 @@ export default (sequelize, dataTypes) => {
 						foreignKey: 'collectionId',
 					});
 					Collection.belongsTo(Page, { as: 'page', foreignKey: 'pageId' });
+					Collection.belongsTo(CrossrefDepositRecord, {
+						onDelete: 'CASCADE',
+						as: 'crossrefDepositRecord',
+						foreignKey: 'crossrefDepositRecordId',
+					});
 				},
 			},
 		},

--- a/server/crossrefDepositRecord/model.js
+++ b/server/crossrefDepositRecord/model.js
@@ -1,0 +1,6 @@
+export default (sequelize, dataTypes) => {
+	return sequelize.define('CrossrefDepositRecord', {
+		id: sequelize.idType,
+		depositJson: dataTypes.JSONB,
+	});
+};

--- a/server/crossrefDepositRecord/queries.js
+++ b/server/crossrefDepositRecord/queries.js
@@ -1,0 +1,13 @@
+import { CrossrefDepositRecord } from 'server/models';
+
+export const createCrossrefDepositRecord = ({ depositJson }) => {
+	return CrossrefDepositRecord.create({
+		depositJson,
+	});
+};
+
+export const updateCrossrefDepositRecord = ({ crossrefDepositRecordId, ...values }) => {
+	return CrossrefDepositRecord.update(values, {
+		where: { id: crossrefDepositRecordId },
+	});
+};

--- a/server/doi/api.js
+++ b/server/doi/api.js
@@ -24,7 +24,7 @@ const previewOrDepositDoi = async (req, options = { deposit: false }) => {
 		throw new ForbiddenError();
 	}
 
-	const doiJson = await (deposit ? setDoiData : getDoiData)(
+	const depositJson = await (deposit ? setDoiData : getDoiData)(
 		{
 			communityId: communityId,
 			collectionId: collectionId,
@@ -33,26 +33,26 @@ const previewOrDepositDoi = async (req, options = { deposit: false }) => {
 		target,
 	);
 
-	return doiJson;
+	return depositJson;
 };
 
 app.post(
 	'/api/doi',
 	wrap(async (req, res) => {
-		const doiJson = await previewOrDepositDoi(req, { deposit: true });
+		const depositJson = await previewOrDepositDoi(req, { deposit: true });
 
-		return res.status(201).json(doiJson);
+		return res.status(201).json(depositJson);
 	}),
 );
 
 app.get(
 	'/api/doiPreview',
 	wrap(async (req, res) => {
-		const doiJson = await previewOrDepositDoi(req);
-		const depositXml = xmlbuilder.create(doiJson, { headless: true }).end({ pretty: true });
+		const depositJson = await previewOrDepositDoi(req);
+		const depositXml = xmlbuilder.create(depositJson, { headless: true }).end({ pretty: true });
 
 		return res.status(201).json({
-			depositJson: doiJson,
+			depositJson: depositJson,
 			depositXml: depositXml,
 		});
 	}),

--- a/server/models.js
+++ b/server/models.js
@@ -41,6 +41,7 @@ export const CollectionAttribution = sequelize.import('./collectionAttribution/m
 export const CollectionPub = sequelize.import('./collectionPub/model.js');
 export const Community = sequelize.import('./community/model.js');
 export const CommunityAdmin = sequelize.import('./communityAdmin/model.js');
+export const CrossrefDepositRecord = sequelize.import('./crossrefDepositRecord/model.js');
 export const Discussion = sequelize.import('./discussion/model.js');
 export const Doc = sequelize.import('./doc/model.js');
 export const Export = sequelize.import('./export/model.js');

--- a/server/pub/model.js
+++ b/server/pub/model.js
@@ -52,18 +52,19 @@ export default (sequelize, dataTypes) => {
 			classMethods: {
 				associate: (models) => {
 					const {
+						Branch,
+						CollectionPub,
+						Community,
+						CrossrefDepositRecord,
+						DiscussionNew,
+						Fork,
+						Member,
 						Pub,
 						PubAttribution,
 						PubEdge,
-						CollectionPub,
-						Community,
-						Branch,
 						PubVersion,
 						Release,
-						DiscussionNew,
-						Fork,
 						ReviewNew,
-						Member,
 					} = models;
 					Pub.hasMany(PubAttribution, {
 						onDelete: 'CASCADE',
@@ -124,6 +125,11 @@ export default (sequelize, dataTypes) => {
 						onDelete: 'CASCADE',
 						as: 'inboundEdges',
 						foreignKey: 'targetPubId',
+					});
+					Pub.belongsTo(CrossrefDepositRecord, {
+						onDelete: 'CASCADE',
+						as: 'crossrefDepositRecord',
+						foreignKey: 'crossrefDepositRecordId',
 					});
 				},
 			},

--- a/tools/migrations/2020_07_22_addCrossrefDepositRecord.js
+++ b/tools/migrations/2020_07_22_addCrossrefDepositRecord.js
@@ -1,0 +1,20 @@
+module.exports = async ({ Sequelize, sequelize }) => {
+	await sequelize.queryInterface.addColumn('Pubs', 'crossrefDepositRecordId', {
+		type: Sequelize.UUID,
+		allowNull: true,
+		references: {
+			model: 'CrossrefDepositRecords',
+			key: 'id',
+		},
+		onDelete: 'CASCADE',
+	});
+	await sequelize.queryInterface.addColumn('Collections', 'crossrefDepositRecordId', {
+		type: Sequelize.UUID,
+		allowNull: true,
+		references: {
+			model: 'CrossrefDepositRecords',
+			key: 'id',
+		},
+		onDelete: 'CASCADE',
+	});
+};


### PR DESCRIPTION
This PR adds a new model, `CrossrefDepositRecord`, which is upserted each time a Collection or Pub is deposited in Crossref (via `setDoiData`). The presence or absence of this property on a Pub will determine whether or not that Pub's DOI is editable in a future PR.