### PR TITLE
fix: use PubByline for connected pubs to ensure same order of attributions

### DIFF
--- a/client/components/PubEdge/PubEdge.js
+++ b/client/components/PubEdge/PubEdge.js
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { Byline } from 'components';
+import { Byline, PubByline } from 'components';
 import { usePageContext } from 'utils/hooks';
 import { formatDate } from 'utils/dates';
 import { pubUrl, pubShortUrl } from 'utils/canonicalUrls';
@@ -86,6 +86,7 @@ const PubEdge = (props) => {
 	const { accentColor, actsLikeLink, pubEdge, viewingFromTarget } = props;
 	const [open, setOpen] = useState(false);
 	const { communityData } = usePageContext();
+	const displayedPub = viewingFromTarget ? pubEdge.pub : pubEdge.targetPub;
 	const hasExternalPublication = Boolean(pubEdge.externalPublication);
 	const { avatar, contributors, description, publicationDate, title, url } = getValuesFromPubEdge(
 		pubEdge,
@@ -160,7 +161,14 @@ const PubEdge = (props) => {
 				{ tabIndex: '-1' },
 			)}
 			titleElement={maybeLink(title, linkLikeProps)}
-			bylineElement={contributors.length > 0 && <Byline contributors={contributors} />}
+			bylineElement={
+				contributors.length > 0 &&
+				(displayedPub ? (
+					<PubByline pubData={displayedPub} />
+				) : (
+					<Byline contributors={contributors} />
+				))
+			}
 			metadataElements={[
 				description && (
 					<span

--- a/client/components/PubMenuItem/PubMenuItem.js
+++ b/client/components/PubMenuItem/PubMenuItem.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Button } from 'reakit/Button';
 
-import { Byline, PreviewImage } from 'components';
+import { Byline, PreviewImage, PubByline } from 'components';
 
 require('./pubMenuItem.scss');
 
@@ -16,6 +16,7 @@ const propTypes = {
 	onClick: PropTypes.func.isRequired,
 	showImage: PropTypes.bool,
 	title: PropTypes.string.isRequired,
+	pubData: PropTypes.object,
 };
 
 const defaultProps = {
@@ -24,10 +25,21 @@ const defaultProps = {
 	image: null,
 	isSkeleton: false,
 	showImage: false,
+	pubData: false,
 };
 
 const PubMenuItem = React.forwardRef((props, ref) => {
-	const { active, contributors, disabled, image, isSkeleton, onClick, showImage, title } = props;
+	const {
+		active,
+		contributors,
+		disabled,
+		image,
+		isSkeleton,
+		onClick,
+		showImage,
+		title,
+		pubData,
+	} = props;
 	const skeletonClass = classNames(isSkeleton && 'bp3-skeleton');
 	return (
 		<Button
@@ -46,7 +58,11 @@ const PubMenuItem = React.forwardRef((props, ref) => {
 			<div className="inner">
 				<div className={classNames('title', skeletonClass)}>{title}</div>
 				<div className={classNames('subtitle', skeletonClass)}>
-					<Byline contributors={contributors} linkToUsers={false} />
+					{pubData ? (
+						<PubByline pubData={pubData} linkToUsers={false} />
+					) : (
+						<Byline contributors={contributors} linkToUsers={false} />
+					)}
 				</div>
 			</div>
 		</Button>

--- a/client/containers/DashboardEdges/NewEdgeInput.js
+++ b/client/containers/DashboardEdges/NewEdgeInput.js
@@ -96,6 +96,7 @@ const NewEdgeInput = (props) => {
 					active={modifiers.active}
 					onClick={handleClick}
 					showImage={true}
+					pubData={targetPub}
 				/>
 			);
 		}


### PR DESCRIPTION
This PR uses the `<PubByline>` component within the PubEdge and PubMenuItem components to guarantee the ordering of attributions is the same as what is displayed on the target pub.

Fixes #935