### PR TITLE
fix: Some cleaner markup in PubEdge-related components

### DIFF
--- a/client/components/PubEdge/PubEdge.js
+++ b/client/components/PubEdge/PubEdge.js
@@ -93,6 +93,7 @@ const PubEdge = (props) => {
 		viewingFromTarget,
 	);
 
+	const detailsElementId = `edge-details-${pubEdge.id}`;
 	const publishedAt = formatDate(publicationDate);
 
 	const handleToggleDescriptionClick = useCallback(
@@ -106,32 +107,20 @@ const PubEdge = (props) => {
 		[open],
 	);
 
-	const handleLinkClick = useCallback(
-		(e) => {
-			if (e.type === 'click' || e.key === 'Enter') {
-				window.open(url, e.metaKey ? '_blank' : '_self');
-			}
-		},
-		[url],
-	);
-
-	const linkLikeProps = actsLikeLink && {
-		onClick: handleLinkClick,
-		onKeyDown: handleLinkClick,
-		role: 'link',
-		tabIndex: '0',
-	};
-
 	const maybeLink = (element, restProps = {}) => {
 		if (actsLikeLink) {
 			return (
-				<span {...restProps} className="link">
+				<span className="link" {...restProps}>
 					{element}
 				</span>
 			);
 		}
 
-		return <a href={url}>{element}</a>;
+		return (
+			<a href={url} {...restProps}>
+				{element}
+			</a>
+		);
 	};
 
 	const maybeWrapWithLink = (element, restProps = {}) => {
@@ -142,7 +131,6 @@ const PubEdge = (props) => {
 				</a>
 			);
 		}
-
 		return <div {...restProps}>{element}</div>;
 	};
 
@@ -159,7 +147,7 @@ const PubEdge = (props) => {
 				),
 				{ tabIndex: '-1' },
 			)}
-			titleElement={maybeLink(title, linkLikeProps)}
+			titleElement={maybeLink(title)}
 			bylineElement={contributors.length > 0 && <Byline contributors={contributors} />}
 			metadataElements={[
 				description && (
@@ -167,17 +155,19 @@ const PubEdge = (props) => {
 						onClick={handleToggleDescriptionClick}
 						onKeyDown={handleToggleDescriptionClick}
 						tabIndex="0"
-						className="link"
+						className="link description-toggle"
 						role="button"
+						aria-controls={detailsElementId}
+						aria-expanded={open}
 					>
 						{open ? 'Hide Description' : 'Show Description'}
 					</span>
 				),
 				<>Published on {publishedAt}</>,
-				maybeLink(getHostnameForUrl(url), linkLikeProps),
+				<span className="location">{getHostnameForUrl(url)}</span>,
 			]}
 			detailsElement={
-				<details open={open}>
+				<details open={open} id={detailsElementId}>
 					<summary>Description</summary>
 					<hr />
 					<p>{description}</p>

--- a/client/components/PubEdge/pubEdge.scss
+++ b/client/components/PubEdge/pubEdge.scss
@@ -105,14 +105,17 @@
 			margin: 4px;
 		}
 
-		.link {
+		.location {
 			white-space: normal;
+		}
+
+		.description-toggle {
+			user-select: none;
 		}
 
 		a {
 			text-decoration: none;
 			&:hover,
-			&:active,
 			&:focus {
 				text-decoration: underline;
 			}

--- a/client/components/PubEdgeListing/PubEdgeListingCard.js
+++ b/client/components/PubEdgeListing/PubEdgeListingCard.js
@@ -134,6 +134,7 @@ const PubEdgeListingCard = (props) => {
 						color={accentColor}
 						iconSize={14}
 						className="drop-return"
+						alt=""
 					/>
 				)}
 				{renderRelation()}


### PR DESCRIPTION
- Screenreader will not read the arrow icon on `PubEdgeListingCard`
- Only one URL tab-target per card
- URL hostname does not have link-like hover effect
- Simplified `PubEdge` markup and handlers

_Test plan:_
Check out the Storybook fixtures and make sure it still looks like it works!