### PR TITLE
fix: Fix the updateCommunityData worker task

### DIFF
--- a/workers/tasks/search.js
+++ b/workers/tasks/search.js
@@ -53,31 +53,18 @@ export const setPubSearchData = (pubId) => {
 };
 
 export const updateCommunityData = (communityId) => {
-	const getObjectIds = (index) => {
-		return new Promise((resolve, reject) => {
-			const browser = index.browseAll('', {
-				filters: `communityId:${communityId}`,
-				attributesToRetrieve: ['objectId'],
-			});
-			let objectIds = [];
-
-			browser.on('result', (content) => {
-				objectIds = objectIds.concat(
-					content.hits.map((hit) => {
-						return hit.objectID;
-					}),
-				);
-			});
-
-			browser.on('end', () => {
-				resolve(objectIds);
-			});
-
-			browser.on('error', (err) => {
-				reject(err);
-			});
+	const getObjectIds = async (index) => {
+		let hits = [];
+		await index.browseObjects({
+			filters: `communityId:${communityId}`,
+			attributesToRetrieve: ['objectId'],
+			batch: (batch) => {
+				hits = hits.concat(batch);
+			},
 		});
+		return hits.map((hit) => hit.objectID);
 	};
+
 	const findCommunityData = Community.findOne({
 		where: {
 			id: communityId,


### PR DESCRIPTION
The `updateCommunityData` worker task references an obsolete Algolia API function — I've updated it to use the new equivalent here.

_Test plan:_
I ran the `updateCommunityData` task locally on a community and verified that it completed without error.