### PR TITLE
feature: editable doi field

### DIFF
--- a/client/components/AssignDoi/AssignDoi.js
+++ b/client/components/AssignDoi/AssignDoi.js
@@ -14,7 +14,7 @@ const propTypes = {
 	communityData: PropTypes.object.isRequired,
 	disabled: PropTypes.bool,
 	pubData: PropTypes.object.isRequired,
-	doi: PropTypes.string,
+	hasExistingDeposit: PropTypes.bool,
 	target: PropTypes.string.isRequired,
 	onDeposit: PropTypes.func,
 	onPreview: PropTypes.func,
@@ -23,7 +23,7 @@ const propTypes = {
 
 const defaultProps = {
 	disabled: false,
-	doi: null,
+	hasExistingDeposit: false,
 	onPreview: noop,
 	onDeposit: noop,
 	onError: noop,
@@ -53,8 +53,8 @@ const buttonTextByState = {
 	[AssignDoiState.Deposited]: 'DOI Deposited',
 };
 
-const getButtonText = (state, doi) => {
-	if (state === AssignDoiState.Initial && doi) {
+const getButtonText = (state, hasExistingDeposit) => {
+	if (state === AssignDoiState.Initial && hasExistingDeposit) {
 		return 'Resubmit DOI deposit';
 	}
 
@@ -121,7 +121,16 @@ const initialState = {
 };
 
 function AssignDoi(props) {
-	const { communityData, disabled, doi, pubData, onPreview, onDeposit, onError, target } = props;
+	const {
+		communityData,
+		disabled,
+		hasExistingDeposit,
+		pubData,
+		onPreview,
+		onDeposit,
+		onError,
+		target,
+	} = props;
 	const [{ state, result }, dispatch] = useReducer(reducer, initialState);
 	const fetchPreview = useCallback(async () => {
 		dispatch({ type: AssignDoiActionType.FetchPreview });
@@ -184,7 +193,7 @@ function AssignDoi(props) {
 		<div className="assign-doi-component">
 			<Button
 				disabled={disabled || !action}
-				text={getButtonText(state, doi)}
+				text={getButtonText(state, hasExistingDeposit)}
 				loading={state === AssignDoiState.Previewing || state === AssignDoiState.Depositing}
 				onClick={action}
 				icon={state === AssignDoiState.Deposited && 'tick'}

--- a/client/components/AssignDoi/assignDoiPreview.scss
+++ b/client/components/AssignDoi/assignDoiPreview.scss
@@ -35,7 +35,8 @@
 
 	pre {
 		font-family: 'Courier', monospace;
-		max-height: 200px;
+		font-size: 12px;
+		max-height: 300px;
 		overflow: auto;
 		font-size: inherit;
 		background-color: #f1f1f1;

--- a/client/containers/DashboardSettings/PubSettings/Doi.js
+++ b/client/containers/DashboardSettings/PubSettings/Doi.js
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FormGroup } from '@blueprintjs/core';
+import { FormGroup, ControlGroup, Button, InputGroup } from '@blueprintjs/core';
 
+import { apiFetch } from 'client/utils/apiFetch';
 import { getSchemaForKind } from 'utils/collections/schemas';
+import { isDoi } from 'utils/crossref/parseDoi';
 
 import { AssignDoi } from 'components';
 
@@ -19,15 +21,54 @@ class Doi extends Component {
 	constructor(props) {
 		super(props);
 		this.state = {
+			doi: props.pubData.doi || '',
+			updating: false,
+			error: false,
+			success: false,
 			justSetDoi: false,
 		};
+
 		this.handleDeposit = this.handleDeposit.bind(this);
+		this.handleDoiUpdate = this.handleDoiUpdate.bind(this);
 	}
 
 	handleDeposit(doi) {
 		const { updatePubData } = this.props;
+
 		this.setState({ justSetDoi: true });
 		updatePubData({ doi: doi });
+	}
+
+	async handleDoiUpdate() {
+		const { doi } = this.state;
+		const { communityData, pubData } = this.props;
+
+		this.setState({
+			error: false,
+			success: false,
+			updating: true,
+		});
+
+		try {
+			await apiFetch('/api/pubs', {
+				method: 'PUT',
+				body: JSON.stringify({
+					doi: doi,
+					pubId: pubData.id,
+					communityId: communityData.id,
+				}),
+			});
+			this.setState({
+				success: true,
+				updating: false,
+			});
+		} catch (err) {
+			this.setState({
+				success: false,
+				updating: false,
+				error: true,
+			});
+		}
 	}
 
 	renderCollectionContextMessage() {
@@ -54,9 +95,7 @@ class Doi extends Component {
 	renderStatusMessage() {
 		const { pubData } = this.props;
 		const { justSetDoi } = this.state;
-		if (!pubData.doi) {
-			return <p>A DOI can be registered for each Pub by admins of this community.</p>;
-		}
+
 		if (justSetDoi) {
 			return (
 				<React.Fragment>
@@ -69,15 +108,68 @@ class Doi extends Component {
 				</React.Fragment>
 			);
 		}
+
+		if (!pubData.doi) {
+			return <p>A DOI can be registered for each Pub by admins of this community.</p>;
+		}
+
 		return <p>DOIs have been registered for this pub.</p>;
 	}
 
-	renderDoi() {
-		const { pubData } = this.props;
-		if (!pubData.doi) {
-			return null;
+	getHelperText(invalidDoi) {
+		const { success, error } = this.state;
+		let helperText = '';
+
+		if (invalidDoi) {
+			helperText = 'Invalid DOI';
+		} else if (error) {
+			helperText = 'There was a problem updating the DOI';
+		} else if (success) {
+			helperText = 'DOI updated successfully!';
 		}
-		return (
+
+		return helperText;
+	}
+
+	getIntent(invalidDoi) {
+		const { success, error } = this.state;
+		let intent = 'none';
+
+		if (invalidDoi || error) {
+			intent = 'danger';
+		} else if (success) {
+			intent = 'success';
+		}
+
+		return intent;
+	}
+
+	renderDoi() {
+		const { canIssueDoi, pubData } = this.props;
+		const { justSetDoi, doi, updating } = this.state;
+		const doiIsEditable = canIssueDoi && !(justSetDoi || pubData.crossrefDepositRecordId);
+		const invalidDoi = doi && !isDoi(doi);
+		const intent = this.getIntent(invalidDoi);
+		const helperText = this.getHelperText(invalidDoi);
+
+		return doiIsEditable ? (
+			<FormGroup helperText={helperText} intent={intent}>
+				<ControlGroup>
+					<InputGroup
+						label="DOI"
+						placeholder="Enter a DOI..."
+						value={doi}
+						onChange={(e) => this.setState({ doi: e.target.value })}
+					/>
+					<Button
+						disabled={!doi || invalidDoi}
+						text="Update DOI"
+						loading={updating}
+						onClick={this.handleDoiUpdate}
+					/>
+				</ControlGroup>
+			</FormGroup>
+		) : (
 			<p>
 				Pub DOI:{' '}
 				<a className="doi-link" href={`https://doi.org/${pubData.doi}`}>
@@ -88,11 +180,9 @@ class Doi extends Component {
 	}
 
 	render() {
-		const {
-			pubData: { doi },
-			canIssueDoi,
-		} = this.props;
+		const { pubData, canIssueDoi } = this.props;
 		const { justSetDoi } = this.state;
+		const hasExistingDeposit = justSetDoi || Boolean(pubData.crossrefDepositRecordId);
 
 		return (
 			<div className="pub-settings-container_doi-component">
@@ -100,9 +190,18 @@ class Doi extends Component {
 				{this.renderCollectionContextMessage()}
 				{this.renderDoi()}
 
+				{!hasExistingDeposit && (
+					<p>
+						You may also use the button below to have PubPub automatically{' '}
+						{!hasExistingDeposit && 'assign a DOI and '} deposit this work to Crossref.
+						Depositing the work will overwrite a manually assigned DOI, and{' '}
+						<strong>the DOI will no longer be editable.</strong>
+					</p>
+				)}
+
 				<FormGroup
 					helperText={
-						doi &&
+						pubData.doi &&
 						!justSetDoi && (
 							<React.Fragment>
 								If you&apos;ve changed aspects of this pub and wish to update its
@@ -117,7 +216,7 @@ class Doi extends Component {
 						disabled={!canIssueDoi}
 						onDeposit={this.handleDeposit}
 						pubData={this.props.pubData}
-						doi={doi}
+						hasExistingDeposit={hasExistingDeposit}
 						target="pub"
 					/>
 				</FormGroup>

--- a/client/containers/DashboardSettings/PubSettings/Doi.js
+++ b/client/containers/DashboardSettings/PubSettings/Doi.js
@@ -152,40 +152,55 @@ class Doi extends Component {
 		const intent = this.getIntent(invalidDoi);
 		const helperText = this.getHelperText(invalidDoi);
 
-		return doiIsEditable ? (
-			<FormGroup helperText={helperText} intent={intent}>
-				<ControlGroup>
-					<InputGroup
-						label="DOI"
-						placeholder="Enter a DOI..."
-						value={doi}
-						onChange={(e) => this.setState({ doi: e.target.value })}
-					/>
-					<Button
-						disabled={!doi || invalidDoi}
-						text="Update DOI"
-						loading={updating}
-						onClick={this.handleDoiUpdate}
-					/>
-				</ControlGroup>
-			</FormGroup>
-		) : (
-			<p>
-				Pub DOI:{' '}
-				<a className="doi-link" href={`https://doi.org/${pubData.doi}`}>
-					{pubData.doi}
-				</a>
-			</p>
+		if (doiIsEditable) {
+			return (
+				<FormGroup helperText={helperText} intent={intent}>
+					<ControlGroup>
+						<InputGroup
+							label="DOI"
+							placeholder="Enter a DOI..."
+							value={doi}
+							onChange={(e) => this.setState({ doi: e.target.value })}
+						/>
+						<Button
+							disabled={!doi || invalidDoi}
+							text="Update"
+							loading={updating}
+							onClick={this.handleDoiUpdate}
+						/>
+					</ControlGroup>
+				</FormGroup>
+			);
+		}
+
+		return (
+			pubData.doi && (
+				<p>
+					Pub DOI:{' '}
+					<a className="doi-link" href={`https://doi.org/${pubData.doi}`}>
+						{pubData.doi}
+					</a>
+				</p>
+			)
 		);
 	}
 
-	render() {
+	renderContent() {
 		const { pubData, canIssueDoi } = this.props;
 		const { justSetDoi } = this.state;
 		const hasExistingDeposit = justSetDoi || Boolean(pubData.crossrefDepositRecordId);
 
+		if (!canIssueDoi) {
+			return (
+				<>
+					{this.renderStatusMessage()}
+					{this.renderDoi()}
+				</>
+			);
+		}
+
 		return (
-			<div className="pub-settings-container_doi-component">
+			<>
 				{this.renderStatusMessage()}
 				{this.renderCollectionContextMessage()}
 				{this.renderDoi()}
@@ -213,15 +228,18 @@ class Doi extends Component {
 				>
 					<AssignDoi
 						communityData={this.props.communityData}
-						disabled={!canIssueDoi}
 						onDeposit={this.handleDeposit}
 						pubData={this.props.pubData}
 						hasExistingDeposit={hasExistingDeposit}
 						target="pub"
 					/>
 				</FormGroup>
-			</div>
+			</>
 		);
+	}
+
+	render() {
+		return <div className="pub-settings-container_doi-component">{this.renderContent()}</div>;
 	}
 }
 

--- a/client/containers/DashboardSettings/PubSettings/PubSettings.js
+++ b/client/containers/DashboardSettings/PubSettings/PubSettings.js
@@ -221,7 +221,7 @@ const PubSettings = (props) => {
 		return (
 			<SettingsSection title="DOI">
 				<Doi
-					pubData={pubData}
+					pubData={persistedPubData}
 					communityData={activeCommunity}
 					updatePubData={updatePersistedPubData}
 					canIssueDoi={canAdminCommunity}

--- a/client/containers/DashboardSettings/PubSettings/doi.scss
+++ b/client/containers/DashboardSettings/PubSettings/doi.scss
@@ -2,4 +2,8 @@
 	a.doi-link {
 		font-family: 'Courier', monospace;
 	}
+
+	.bp3-input-group {
+		flex-basis: 324px;
+	}
 }

--- a/server/pub/permissions.js
+++ b/server/pub/permissions.js
@@ -17,8 +17,8 @@ export const getPermissions = async ({ userId, communityId, pubId, licenseSlug }
 		licenseSlug === 'cc-by' ||
 		licenseSlug === 'cc-0';
 	const canManage = validLicenseSlug && scopeData.activePermissions.canManage;
+	const canAdmin = validLicenseSlug && scopeData.activePermissions.canAdmin;
 	const editProps = [
-		'doi',
 		'slug',
 		'title',
 		'description',
@@ -33,6 +33,11 @@ export const getPermissions = async ({ userId, communityId, pubId, licenseSlug }
 		'citationStyle',
 		'citationInlineStyle',
 	];
+
+	if (canAdmin) {
+		editProps.push('doi');
+	}
+
 	return {
 		create: true,
 		update: canManage ? editProps : false,

--- a/server/pub/permissions.js
+++ b/server/pub/permissions.js
@@ -18,6 +18,7 @@ export const getPermissions = async ({ userId, communityId, pubId, licenseSlug }
 		licenseSlug === 'cc-0';
 	const canManage = validLicenseSlug && scopeData.activePermissions.canManage;
 	const editProps = [
+		'doi',
 		'slug',
 		'title',
 		'description',


### PR DESCRIPTION
This PR adds an editable DOI field to the Pub settings page. The DOI is editable when users have the correct permissions and a Crossref deposit has not been submit. Once a Crossref deposit record is created, the DOI field will become uneditable.

### Test Plan

#### Permissions

* Create a new Pub.
* Log in with a user without manage permissions.
* Go to the settings page.
* The DOI field should not be editable.

#### Update DOI

* Log in with a user with manage permissions.
* Go to the setting spage.
* The DOI field should be editable.
* Enter an invalid DOI, e.g. `10.116299608f92.834c6596`
* An error message should appear in red and the DOI should not be updateable.
* Enter a valid DOI, e.g. `10.1162/99608f92.834c6596`
* Click "Update DOI"
* The error message should disappear and be replaced by the "DOI updated successfully" message in green.

#### Submit Crossref Deposit

* Click the "Assign DOI" button.
* Click the "Submit Deposit" button.
* The DOI field should no longer be editable, and the DOI should be replaced with a PubPub generated DOI, prefixed with `10.21428/`

Partial #910