### PR TITLE
chore: add deposit record backfill tool

### DIFF
--- a/tools/backfillCrossrefDepositRecords.js
+++ b/tools/backfillCrossrefDepositRecords.js
@@ -1,0 +1,60 @@
+import { Op } from 'sequelize';
+
+import { managedDoiPrefixes } from 'utils/crossref/communities';
+import { promptOkay } from './utils/prompt';
+import { Pub, Collection, CrossrefDepositRecord } from 'server/models';
+
+async function runForModel(model) {
+	const tableName = model.getTableName();
+
+	const models = await model.findAll({
+		where: {
+			doi: {
+				[Op.like]: { [Op.any]: managedDoiPrefixes.map((prefix) => `%${prefix}%`) },
+			},
+			crossrefDepositRecordId: null,
+		},
+	});
+
+	const yes = await promptOkay(
+		`Create CrossrefDepositRecords for ${
+			models.length
+		} ${tableName} with the following DOI prefixes: \n${managedDoiPrefixes.join(', ')}?`,
+		{
+			throwIfNo: false,
+			yesIsDefault: false,
+		},
+	);
+
+	if (!yes) {
+		return;
+	}
+
+	const depositRecords = await CrossrefDepositRecord.bulkCreate(models.map(() => ({})));
+
+	const updates = models.map((model, i) => {
+		return {
+			...model.dataValues,
+			crossrefDepositRecordId: depositRecords[i].id,
+		};
+	});
+
+	console.log(`Associating CrossrefDepositRecords with ${models.length} ${tableName}...`);
+
+	// Use bulkCreate to associate existing rows with the newly created
+	// deposit records.
+	await model.bulkCreate(
+		updates,
+		// Only update crossrefDepositRecordId field.
+		{ updateOnDuplicate: ['crossrefDepositRecordId'] },
+	);
+}
+
+async function main() {
+	await runForModel(Pub);
+	await runForModel(Collection);
+
+	console.log('Done!');
+}
+
+main();

--- a/tools/backfillCrossrefDepositRecords.js
+++ b/tools/backfillCrossrefDepositRecords.js
@@ -1,8 +1,9 @@
 import { Op } from 'sequelize';
 
 import { managedDoiPrefixes } from 'utils/crossref/communities';
-import { promptOkay } from './utils/prompt';
 import { Pub, Collection, CrossrefDepositRecord } from 'server/models';
+
+import { promptOkay } from './utils/prompt';
 
 async function runForModel(model) {
 	const tableName = model.getTableName();

--- a/tools/index.js
+++ b/tools/index.js
@@ -15,6 +15,7 @@ require('utils/environment').setEnvironment(process.env.PUBPUB_PRODUCTION, proce
 const command = process.argv[2];
 const commandFiles = {
 	backfillCheckpoints: './backfillCheckpoints.js',
+	backfillCrossrefDepositRecords: './backfillCrossrefDepositRecords.js',
 	branchMaintenance: './branchMaintenance.js',
 	bulkimport: '../workers/tasks/import/bulk/cli.js',
 	checkpointBackfill: './dashboardMigrations/backfillCheckpoints.js',

--- a/utils/crossref/communities.js
+++ b/utils/crossref/communities.js
@@ -7,6 +7,15 @@ const AAS_DOI_PREFIX = '10.3847';
 const MEDIASTUDIES_DOI_PREFIX = '10.32376';
 const RS_DOI_PREFIX = '10.46470';
 
+export const managedDoiPrefixes = [
+	PUBPUB_DOI_PREFIX,
+	MITP_DOI_PREFIX,
+	IASTATE_DOI_PREFIX,
+	AAS_DOI_PREFIX,
+	MEDIASTUDIES_DOI_PREFIX,
+	RS_DOI_PREFIX,
+];
+
 export const communityDoiOverrides = [
 	{
 		communityIds: [


### PR DESCRIPTION
This PR adds a new tool which creates CrossrefDepositRecords for Pubs and Collections that have a "managed DOI prefix" found in `utils/crossref/communities`.

**Test Plan**

* Update a Pub or Collection with a unique DOI prefix, e.g. `10.111111`
* Modify the script so that the `managedDoiPrefixes` variable contains that single prefix, e.g. `['10.111111']`
* Run the script: `npm run tools backfillCrossrefDepositRecords`
* Respond yes to the following prompt:
    ```
    prompt: Create CrossrefDepositRecords for 1 Pubs with the following DOI prefixes: 
    10.111111?:  (no) yes
    ```
* Run the script. Verify that a new `CrossrefDepositRecord` was created and the Pub's `crossrefDepositRecordId` is equal to the new record's `id`
