### PR TITLE
update: parse content of citation and use as customLabel if available

### DIFF
--- a/workers/tasks/import/rules.js
+++ b/workers/tasks/import/rules.js
@@ -5,6 +5,7 @@ import * as katex from 'katex';
 
 import {
 	pandocInlineToHtmlString,
+	pandocInlineToPlain,
 	htmlStringToPandocInline,
 	pandocBlocksToHtmlString,
 	htmlStringToPandocBlocks,
@@ -269,6 +270,7 @@ rules.transform('Cite', 'citation', {
 					structuredValue: structuredValue,
 					unstructuredValue: unstructuredValue,
 					count: 1 + count('Cite'),
+					customLabel: pandocInlineToPlain(node.content) || '',
 				},
 			};
 		});

--- a/workers/tasks/import/util.js
+++ b/workers/tasks/import/util.js
@@ -13,6 +13,9 @@ const { flatten } = transformUtil;
 const getHtmlStringForPandocDoc = (document) =>
 	callPandoc(JSON.stringify(emitPandocJson(document)), 'json', 'html').trim();
 
+const getPlainForPandocDoc = (document) =>
+	callPandoc(JSON.stringify(emitPandocJson(document)), 'json', 'plain').trim();
+
 const getPandocDocForHtmlString = (htmlString) =>
 	parsePandocJson(JSON.parse(callPandoc(htmlString, 'html', 'json')));
 
@@ -26,6 +29,18 @@ export const pandocInlineToHtmlString = (nodes) => {
 		meta: {},
 	};
 	return getHtmlStringForPandocDoc(doc);
+};
+
+export const pandocInlineToPlain = (nodes) => {
+	if (nodes.length === 0) {
+		return '';
+	}
+	const doc = {
+		type: 'Doc',
+		blocks: [{ type: 'Para', content: nodes }],
+		meta: {},
+	};
+	return getPlainForPandocDoc(doc);
 };
 
 export const pandocBlocksToHtmlString = (blocks) => {


### PR DESCRIPTION
Updates the import task to use the `content` of a citation as the `customLabel` if available. This typically applies to JATS, which can have custom citation content. If no citation content is available, it reverts to the default. This saves a ton of time importing files from pre-formatted JATS that have custom citation labels.

_Test plan_
1. Import a JATS file with both citation content (ie `<xref ref-type="bibr"...>content</xref>` and without (ie `<xref ref-type="bibr" />` (attached as text – change extension to xml, for your convenience)
1. Verify that the first citation, `rid="c8"` which has no content, uses the default inline for the Pub
1. Verify that custom citation labels match the text between xrefs (ie `<xrex...>content</xref>`) for other citations in the file
1. Switch citation styles and inline format and verify that custom labels stay the same and that the non-custom citation updates to the new inline format
1. Import a LaTeX file with refs and make sure citations still work even without content

[tmb_tmb0000007.txt](https://github.com/pubpub/pubpub/files/4984551/tmb_tmb0000007.txt)
