### PR TITLE
fix: use date helper to get published date for meta tags

### DIFF
--- a/server/routes/pubDocument.js
+++ b/server/routes/pubDocument.js
@@ -9,6 +9,7 @@ import { handleErrors, NotFoundError, ForbiddenError } from 'server/utils/errors
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
+import { getPubPublishedDate } from 'utils/pub/pubDates';
 import {
 	getPub,
 	getMembers,
@@ -33,7 +34,7 @@ const renderPubDocument = (res, pubData, initialData) => {
 				description: pubData.description,
 				image: pubData.avatar,
 				attributions: pubData.attributions,
-				publishedAt: pubData.originallyPublishedAt || pubData.firstPublishedAt,
+				publishedAt: getPubPublishedDate(pubData),
 				doi: pubData.doi,
 				collection: chooseCollectionForPub(pubData, initialData.locationData),
 				download: getPDFDownload(pubData),

--- a/server/utils/ssr.js
+++ b/server/utils/ssr.js
@@ -197,10 +197,12 @@ export const generateMetaComponents = ({
 	if (publishedAt) {
 		const googleScholarPublishedAt = `${publishedAt.getFullYear()}/${publishedAt.getMonth() +
 			1}/${publishedAt.getDate()}`;
+		const dcPublishedAt = `${publishedAt.getFullYear()}-${publishedAt.getMonth()}-${publishedAt.getDate()}`;
 		outputComponents = [
 			...outputComponents,
 			<meta key="pa1" property="article:published_time" content={publishedAt} />,
-			<meta key="pa2" name="citation_publication_date" content={googleScholarPublishedAt} />,
+			<meta ket="pa2" property="dc.date" content={dcPublishedAt} />,
+			<meta key="pa3" name="citation_publication_date" content={googleScholarPublishedAt} />,
 			<meta key="pub1" name="citation_publisher" content="PubPub" />,
 			<meta key="pub2" property="dc.publisher" content="PubPub" />,
 		];

--- a/server/utils/ssr.js
+++ b/server/utils/ssr.js
@@ -201,7 +201,7 @@ export const generateMetaComponents = ({
 		outputComponents = [
 			...outputComponents,
 			<meta key="pa1" property="article:published_time" content={publishedAt} />,
-			<meta ket="pa2" property="dc.date" content={dcPublishedAt} />,
+			<meta key="pa2" property="dc.date" content={dcPublishedAt} />,
 			<meta key="pa3" name="citation_publication_date" content={googleScholarPublishedAt} />,
 			<meta key="pub1" name="citation_publisher" content="PubPub" />,
 			<meta key="pub2" property="dc.publisher" content="PubPub" />,


### PR DESCRIPTION
Resolves #948 by updating the pub route to use the `getPubPublishedDate` helper instead of relying on now nonexistent `publishedAt` fields in `pubData`.

Also adds dc.date metadata if there is a published on date.

_Test plan_
1. Visit a Pub that is not released (ie http://demo.duqduq.org/pub/b7ag4toy/draft), verify that no `dc.date` nor `citation_publication_date` meta tag is present.
1. Visit a pub that is released (ie http://demo.duqduq.org/pub/xp0zizup/release/1), verify that `dc.date` meta tag is present with a result in the `YYYY-MM-DD` format, and verify that `citation_publication_date` meta tag is present with a result in the `YYYY/MM/DD` format.