### PR TITLE
fix: use the latest formatted PDF or export in metadata

### DIFF
--- a/server/utils/ssr.js
+++ b/server/utils/ssr.js
@@ -111,8 +111,6 @@ export const generateMetaComponents = ({
 		}
 	}
 
-	/* Assumes the first PDF download is the canonical one, which is true right now
-	but in the future we may want to support multiple download URLs for various purposes. */
 	if (download) {
 		outputComponents = [
 			...outputComponents,

--- a/utils/pub/metadata.js
+++ b/utils/pub/metadata.js
@@ -1,7 +1,6 @@
 export const getPDFDownload = (pub) => {
 	const downloads = pub.downloads;
 	const exports = pub.activeBranch.exports;
-	// console.log(exports);
 	if (downloads) {
 		const matchingDownload = downloads
 			.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))

--- a/utils/pub/metadata.js
+++ b/utils/pub/metadata.js
@@ -1,12 +1,17 @@
 export const getPDFDownload = (pub) => {
 	const downloads = pub.downloads;
 	const exports = pub.activeBranch.exports;
+	// console.log(exports);
 	if (downloads) {
-		const matchingDownload = downloads.find((dl) => dl.url.endsWith('.pdf'));
+		const matchingDownload = downloads
+			.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+			.find((dl) => dl.url.endsWith('.pdf'));
 		if (matchingDownload) return matchingDownload;
 	}
 	if (exports) {
-		const matchingExport = exports.find((exportFile) => exportFile.format === 'pdf');
+		const matchingExport = exports
+			.sort((a, b) => (a.historyKey < b.historyKey ? 1 : -1))
+			.find((exportFile) => exportFile.format === 'pdf');
 		if (matchingExport) return matchingExport;
 	}
 	return false;


### PR DESCRIPTION
Sorry, one more! Resolves #923 by ordering downloads by date and exports by historyKey.