### PR TITLE
feature: Editable DOI suffix for communities with custom DOI prefix

### DIFF
--- a/client/components/AssignDoi/AssignDoi.js
+++ b/client/components/AssignDoi/AssignDoi.js
@@ -13,20 +13,20 @@ const noop = () => {};
 const propTypes = {
 	communityData: PropTypes.object.isRequired,
 	disabled: PropTypes.bool,
-	pubData: PropTypes.object.isRequired,
 	hasExistingDeposit: PropTypes.bool,
-	target: PropTypes.string.isRequired,
 	onDeposit: PropTypes.func,
-	onPreview: PropTypes.func,
 	onError: PropTypes.func,
+	onPreview: PropTypes.func,
+	pubData: PropTypes.object.isRequired,
+	target: PropTypes.string.isRequired,
 };
 
 const defaultProps = {
 	disabled: false,
 	hasExistingDeposit: false,
-	onPreview: noop,
 	onDeposit: noop,
 	onError: noop,
+	onPreview: noop,
 };
 
 const AssignDoiState = {
@@ -46,7 +46,7 @@ const AssignDoiActionType = {
 };
 
 const buttonTextByState = {
-	[AssignDoiState.Initial]: 'Assign DOI',
+	[AssignDoiState.Initial]: 'Preview Deposit',
 	[AssignDoiState.Previewing]: 'Getting Preview',
 	[AssignDoiState.Previewed]: 'Submit Deposit',
 	[AssignDoiState.Depositing]: 'Depositing',
@@ -204,7 +204,7 @@ function AssignDoi(props) {
 						Review the information below, then use the button above to submit the
 						deposit to Crossref.
 					</p>
-					<AssignDoiPreview {...result} />
+					<AssignDoiPreview {...result} doi={pubData.doi} />
 				</>
 			)}
 		</div>

--- a/client/components/AssignDoi/AssignDoiPreview.js
+++ b/client/components/AssignDoi/AssignDoiPreview.js
@@ -7,6 +7,7 @@ import { formatDate } from 'utils/dates';
 require('./assignDoiPreview.scss');
 
 const propTypes = {
+	doi: PropTypes.string.isRequired,
 	depositJson: PropTypes.object.isRequired,
 	depositXml: PropTypes.string.isRequired,
 };
@@ -174,9 +175,12 @@ const renderConferencePreview = (doi_batch) => {
 function AssignDoiPreview(props) {
 	const [selectedTab, setSelectedTab] = useState('preview');
 	const {
-		deposit: { doi_batch },
-		dois: { community: communityDoi, pub: pubDoi },
-	} = props.depositJson;
+		doi,
+		depositJson: {
+			deposit: { doi_batch },
+			dois: { community: communityDoi, pub: pubDoi },
+		},
+	} = props;
 
 	const renderPreviewTab = () => {
 		return (
@@ -186,7 +190,7 @@ function AssignDoiPreview(props) {
 					<dt>Community</dt>
 					<dd>{communityDoi}</dd>
 					<dt>Pub</dt>
-					<dd>{pubDoi}</dd>
+					<dd>{doi || pubDoi}</dd>
 				</dl>
 				{isJournal(doi_batch) && renderArticlePreview(doi_batch)}
 				{isBook(doi_batch) && renderBookPreview(doi_batch)}

--- a/client/containers/DashboardSettings/PubSettings/Doi.js
+++ b/client/containers/DashboardSettings/PubSettings/Doi.js
@@ -222,29 +222,32 @@ class Doi extends Component {
 				{this.renderCollectionContextMessage()}
 				{this.renderDoi()}
 
-				{!hasExistingDeposit && (
-					<p>Use the button below to have PubPub deposit this work to Crossref.</p>
-				)}
-
-				{this.isDoiEditable() && (
-					<p>
-						PubPub will automatically assign a DOI if the suffix is left blank. Please
-						note that <strong>once submit, the DOI will no longer be editable.</strong>
-					</p>
-				)}
-
 				<FormGroup
 					helperText={
 						pubData.doi &&
 						!justSetDoi && (
-							<React.Fragment>
+							<>
 								If you&apos;ve changed aspects of this pub and wish to update its
 								DOI deposit, you can do so here. In the future, PubPub will resubmit
-								such changes automatically.
-							</React.Fragment>
+								such changes automatically.{' '}
+								{this.isDoiEditable() && (
+									<>
+										{' '}
+										PubPub will automatically assign a DOI if the suffix is left
+										blank. Please note that{' '}
+										<strong>
+											once submit, the DOI will no longer be editable.
+										</strong>
+									</>
+								)}
+							</>
 						)
 					}
 				>
+					{!hasExistingDeposit && (
+						<p>Use the button below to deposit this work to Crossref.</p>
+					)}
+
 					<AssignDoi
 						communityData={this.props.communityData}
 						onDeposit={this.handleDeposit}
@@ -267,30 +270,32 @@ class Doi extends Component {
 
 		if (this.isDoiEditable()) {
 			return (
-				<FormGroup helperText={helperText} intent={intent}>
-					<ControlGroup>
-						<InputGroup
-							label="DOI Suffix"
-							placeholder="Enter a DOI suffix..."
-							value={doiSuffix}
-							onChange={(e) => this.setState({ doiSuffix: e.target.value })}
-							leftElement={<span className="doi-prefix">{this.getDoiPrefix()}/</span>}
-							style={{ zIndex: 0 }}
-						/>
-						<Button
-							disabled={!doiSuffix || invalidDoi || deleting}
-							text="Update"
-							loading={updating}
-							onClick={this.handleUpdateDoiClick}
-						/>
-						<Button
-							disabled={!pubData.doi || invalidDoi || updating}
-							text="Delete"
-							loading={deleting}
-							onClick={this.handleDeleteDoiClick}
-							intent="danger"
-						/>
-					</ControlGroup>
+				<FormGroup
+					helperText={helperText}
+					intent={intent}
+					className="doi"
+					label="DOI Suffix"
+				>
+					<InputGroup
+						placeholder="Enter a DOI suffix..."
+						value={doiSuffix}
+						onChange={(e) => this.setState({ doiSuffix: e.target.value })}
+						leftElement={<span className="doi-prefix">{this.getDoiPrefix()}/</span>}
+						style={{ zIndex: 0 }}
+					/>
+					<Button
+						disabled={!doiSuffix || invalidDoi || deleting}
+						text="Update"
+						loading={updating}
+						onClick={this.handleUpdateDoiClick}
+					/>
+					<Button
+						disabled={!pubData.doi || invalidDoi || updating}
+						text="Delete"
+						loading={deleting}
+						onClick={this.handleDeleteDoiClick}
+						intent="danger"
+					/>
 				</FormGroup>
 			);
 		}

--- a/client/containers/DashboardSettings/PubSettings/Doi.js
+++ b/client/containers/DashboardSettings/PubSettings/Doi.js
@@ -2,6 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup, ControlGroup, Button, InputGroup } from '@blueprintjs/core';
 
+import {
+	choosePrefixByCommunityId,
+	managedDoiPrefixes,
+	PUBPUB_DOI_PREFIX,
+} from 'utils/crossref/communities';
 import { apiFetch } from 'client/utils/apiFetch';
 import { getSchemaForKind } from 'utils/collections/schemas';
 import { isDoi } from 'utils/crossref/parseDoi';
@@ -17,19 +22,64 @@ const propTypes = {
 	updatePubData: PropTypes.func.isRequired,
 };
 
+const extractDoiSuffix = (doi, community) => {
+	const prefix = choosePrefixByCommunityId(community.id);
+
+	return doi.replace(`${prefix}/`, '');
+};
+
 class Doi extends Component {
 	constructor(props) {
 		super(props);
+
 		this.state = {
-			doi: props.pubData.doi || '',
-			updating: false,
+			doiSuffix: extractDoiSuffix(props.pubData.doi || '', props.communityData),
 			error: false,
-			success: false,
 			justSetDoi: false,
+			deleting: false,
+			success: false,
+			updating: false,
 		};
 
 		this.handleDeposit = this.handleDeposit.bind(this);
-		this.handleDoiUpdate = this.handleDoiUpdate.bind(this);
+		this.handleUpdateDoiClick = this.handleUpdateDoiClick.bind(this);
+		this.handleDeleteDoiClick = this.handleDeleteDoiClick.bind(this);
+	}
+
+	getDoiPrefix() {
+		return choosePrefixByCommunityId(this.props.communityData.id);
+	}
+
+	getFullDoi() {
+		return `${this.getDoiPrefix()}/${this.state.doiSuffix}`;
+	}
+
+	getHelperText(invalidDoi) {
+		const { success, error } = this.state;
+		let helperText = '';
+
+		if (invalidDoi) {
+			helperText = 'Invalid DOI';
+		} else if (error) {
+			helperText = 'There was a problem updating the DOI';
+		} else if (success) {
+			helperText = 'DOI updated succesfully!';
+		}
+
+		return helperText;
+	}
+
+	getIntent(invalidDoi) {
+		const { success, error } = this.state;
+		let intent = 'none';
+
+		if (invalidDoi || error) {
+			intent = 'danger';
+		} else if (success) {
+			intent = 'success';
+		}
+
+		return intent;
 	}
 
 	handleDeposit(doi) {
@@ -39,18 +89,22 @@ class Doi extends Component {
 		updatePubData({ doi: doi });
 	}
 
-	async handleDoiUpdate() {
-		const { doi } = this.state;
-		const { communityData, pubData } = this.props;
+	async updateDoi(doi, pendingStateKey, fallback) {
+		const { updating, deleting } = this.state;
+		const { communityData, pubData, updatePubData } = this.props;
+
+		if (updating || deleting) {
+			return;
+		}
 
 		this.setState({
+			[pendingStateKey]: true,
 			error: false,
 			success: false,
-			updating: true,
 		});
 
 		try {
-			await apiFetch('/api/pubs', {
+			const response = await apiFetch('/api/pubs', {
 				method: 'PUT',
 				body: JSON.stringify({
 					doi: doi,
@@ -59,16 +113,48 @@ class Doi extends Component {
 				}),
 			});
 			this.setState({
+				[pendingStateKey]: false,
+				doiSuffix: extractDoiSuffix(response.doi, communityData),
+				error: false,
 				success: true,
-				updating: false,
 			});
+			updatePubData({ doi: response.doi });
 		} catch (err) {
 			this.setState({
-				success: false,
-				updating: false,
+				[pendingStateKey]: false,
+				doiSuffix: fallback,
 				error: true,
+				success: false,
 			});
 		}
+	}
+
+	async handleDeleteDoiClick() {
+		this.updateDoi('', 'deleting', this.state.doiSuffix);
+	}
+
+	async handleUpdateDoiClick() {
+		const { pubData, communityData } = this.props;
+		const doi = this.getFullDoi();
+		const currentDoiSuffix = extractDoiSuffix(pubData.doi || '', communityData);
+		this.updateDoi(doi, 'updating', currentDoiSuffix);
+	}
+
+	isDoiEditable() {
+		const { canIssueDoi, pubData } = this.props;
+		const { justSetDoi } = this.state;
+		const doiPrefix = this.getDoiPrefix();
+
+		// The DOI is editable if
+		return (
+			// user has the correct permissions
+			canIssueDoi &&
+			// a deposit has not been submitted yet for this work
+			!(justSetDoi || pubData.crossrefDepositRecordId) &&
+			// and the community has a custom, hardcoded DOI prefix
+			managedDoiPrefixes.includes(doiPrefix) &&
+			doiPrefix !== PUBPUB_DOI_PREFIX
+		);
 	}
 
 	renderCollectionContextMessage() {
@@ -116,75 +202,6 @@ class Doi extends Component {
 		return <p>DOIs have been registered for this pub.</p>;
 	}
 
-	getHelperText(invalidDoi) {
-		const { success, error } = this.state;
-		let helperText = '';
-
-		if (invalidDoi) {
-			helperText = 'Invalid DOI';
-		} else if (error) {
-			helperText = 'There was a problem updating the DOI';
-		} else if (success) {
-			helperText = 'DOI updated successfully!';
-		}
-
-		return helperText;
-	}
-
-	getIntent(invalidDoi) {
-		const { success, error } = this.state;
-		let intent = 'none';
-
-		if (invalidDoi || error) {
-			intent = 'danger';
-		} else if (success) {
-			intent = 'success';
-		}
-
-		return intent;
-	}
-
-	renderDoi() {
-		const { canIssueDoi, pubData } = this.props;
-		const { justSetDoi, doi, updating } = this.state;
-		const doiIsEditable = canIssueDoi && !(justSetDoi || pubData.crossrefDepositRecordId);
-		const invalidDoi = doi && !isDoi(doi);
-		const intent = this.getIntent(invalidDoi);
-		const helperText = this.getHelperText(invalidDoi);
-
-		if (doiIsEditable) {
-			return (
-				<FormGroup helperText={helperText} intent={intent}>
-					<ControlGroup>
-						<InputGroup
-							label="DOI"
-							placeholder="Enter a DOI..."
-							value={doi}
-							onChange={(e) => this.setState({ doi: e.target.value })}
-						/>
-						<Button
-							disabled={!doi || invalidDoi}
-							text="Update"
-							loading={updating}
-							onClick={this.handleDoiUpdate}
-						/>
-					</ControlGroup>
-				</FormGroup>
-			);
-		}
-
-		return (
-			pubData.doi && (
-				<p>
-					Pub DOI:{' '}
-					<a className="doi-link" href={`https://doi.org/${pubData.doi}`}>
-						{pubData.doi}
-					</a>
-				</p>
-			)
-		);
-	}
-
 	renderContent() {
 		const { pubData, canIssueDoi } = this.props;
 		const { justSetDoi } = this.state;
@@ -206,11 +223,13 @@ class Doi extends Component {
 				{this.renderDoi()}
 
 				{!hasExistingDeposit && (
+					<p>Use the button below to have PubPub deposit this work to Crossref.</p>
+				)}
+
+				{this.isDoiEditable() && (
 					<p>
-						You may also use the button below to have PubPub automatically{' '}
-						{!hasExistingDeposit && 'assign a DOI and '} deposit this work to Crossref.
-						Depositing the work will overwrite a manually assigned DOI, and{' '}
-						<strong>the DOI will no longer be editable.</strong>
+						PubPub will automatically assign a DOI if the suffix is left blank. Please
+						note that <strong>once submit, the DOI will no longer be editable.</strong>
 					</p>
 				)}
 
@@ -235,6 +254,56 @@ class Doi extends Component {
 					/>
 				</FormGroup>
 			</>
+		);
+	}
+
+	renderDoi() {
+		const { pubData } = this.props;
+		const { doiSuffix, updating, deleting } = this.state;
+		const fullDoi = this.getFullDoi();
+		const invalidDoi = doiSuffix && !isDoi(fullDoi);
+		const intent = this.getIntent(invalidDoi);
+		const helperText = this.getHelperText(invalidDoi);
+
+		if (this.isDoiEditable()) {
+			return (
+				<FormGroup helperText={helperText} intent={intent}>
+					<ControlGroup>
+						<InputGroup
+							label="DOI Suffix"
+							placeholder="Enter a DOI suffix..."
+							value={doiSuffix}
+							onChange={(e) => this.setState({ doiSuffix: e.target.value })}
+							leftElement={<span className="doi-prefix">{this.getDoiPrefix()}/</span>}
+							style={{ zIndex: 0 }}
+						/>
+						<Button
+							disabled={!doiSuffix || invalidDoi || deleting}
+							text="Update"
+							loading={updating}
+							onClick={this.handleUpdateDoiClick}
+						/>
+						<Button
+							disabled={!pubData.doi || invalidDoi || updating}
+							text="Delete"
+							loading={deleting}
+							onClick={this.handleDeleteDoiClick}
+							intent="danger"
+						/>
+					</ControlGroup>
+				</FormGroup>
+			);
+		}
+
+		return (
+			pubData.doi && (
+				<p>
+					Pub DOI:{' '}
+					<a className="doi-link" href={`https://doi.org/${pubData.doi}`}>
+						{pubData.doi}
+					</a>
+				</p>
+			)
 		);
 	}
 

--- a/client/containers/DashboardSettings/PubSettings/doi.scss
+++ b/client/containers/DashboardSettings/PubSettings/doi.scss
@@ -5,23 +5,31 @@
 		font-family: 'Courier', monospace;
 	}
 
-	.bp3-input-group {
-		flex-basis: 324px;
-		font-family: 'Courier', monospace;
-		font-size: 14px;
+	> .doi {
+		max-width: 416px;
 
-		line-height: 30px;
-		height: 30px;
+		.bp3-input-group {
+			font-family: 'Courier', monospace;
+			font-size: 14px;
+			margin-bottom: 12px;
 
-		::placeholder {
-			font-family: $base-font;
+			line-height: 30px;
+			height: 30px;
+
+			::placeholder {
+				font-family: $base-font;
+			}
+
+			.doi-prefix {
+				display: flex;
+				margin-left: 5px;
+				line-height: 31px;
+				height: 30px;
+			}
 		}
 
-		.doi-prefix {
-			display: flex;
-			margin-left: 5px;
-			line-height: 31px;
-			height: 30px;
+		.bp3-button {
+			margin-right: 8px;
 		}
 	}
 }

--- a/client/containers/DashboardSettings/PubSettings/doi.scss
+++ b/client/containers/DashboardSettings/PubSettings/doi.scss
@@ -1,3 +1,5 @@
+@import 'styles/variables.scss';
+
 .pub-settings-container_doi-component {
 	a.doi-link {
 		font-family: 'Courier', monospace;
@@ -5,5 +7,21 @@
 
 	.bp3-input-group {
 		flex-basis: 324px;
+		font-family: 'Courier', monospace;
+		font-size: 14px;
+
+		line-height: 30px;
+		height: 30px;
+
+		::placeholder {
+			font-family: $base-font;
+		}
+
+		.doi-prefix {
+			display: flex;
+			margin-left: 5px;
+			line-height: 31px;
+			height: 30px;
+		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	},
 	"main": "init.js",
 	"scripts": {
-		"api-dev": "NODE_PATH=./client:./ node init.js --watch ./server --watch ./shared --watch ./client",
+		"api-dev": "NODE_PATH=./client:./ node init.js --watch ./server --watch ./utils --watch ./client",
 		"api-prod": "NODE_PATH=./client:./ node init.js",
 		"build-dev": "webpack --config ./client/webpack/webpackConfig.dev.js --watch",
 		"build-dev-once": "rm -rf ./dist && webpack --config ./client/webpack/webpackConfig.dev.js",

--- a/server/crossrefDepositRecord/queries.js
+++ b/server/crossrefDepositRecord/queries.js
@@ -2,7 +2,7 @@ import { CrossrefDepositRecord } from 'server/models';
 
 export const createCrossrefDepositRecord = ({ depositJson }) => {
 	return CrossrefDepositRecord.create({
-		depositJson,
+		depositJson: depositJson,
 	});
 };
 

--- a/server/doi/queries.js
+++ b/server/doi/queries.js
@@ -78,13 +78,13 @@ const persistCrossrefDepositRecord = async (ids, depositJson) => {
 			crossrefDepositRecordId: crossrefDepositRecordId,
 			depositJson: depositJson,
 		});
-	} else {
-		const crossrefDepositRecord = await createCrossrefDepositRecord({ depositJson });
-
-		await targetModel.update({
-			crossrefDepositRecordId: crossrefDepositRecord.id,
-		});
 	}
+
+	const crossrefDepositRecord = await createCrossrefDepositRecord({ depositJson: depositJson });
+
+	await targetModel.update({
+		crossrefDepositRecordId: crossrefDepositRecord.id,
+	});
 
 	return targetModel;
 };

--- a/tools/backfillCrossrefDepositRecords.js
+++ b/tools/backfillCrossrefDepositRecords.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { Op } from 'sequelize';
 
 import { managedDoiPrefixes } from 'utils/crossref/communities';
@@ -33,9 +34,9 @@ async function runForModel(model) {
 
 	const depositRecords = await CrossrefDepositRecord.bulkCreate(models.map(() => ({})));
 
-	const updates = models.map((model, i) => {
+	const updates = models.map(({ dataValues }, i) => {
 		return {
-			...model.dataValues,
+			...dataValues,
 			crossrefDepositRecordId: depositRecords[i].id,
 		};
 	});

--- a/utils/crossref/communities.js
+++ b/utils/crossref/communities.js
@@ -1,6 +1,6 @@
 // Some overrides for specific communities.
 // TODO(ian): Handle this with the database instead.
-const PUBPUB_DOI_PREFIX = '10.21428';
+export const PUBPUB_DOI_PREFIX = '10.21428';
 const MITP_DOI_PREFIX = '10.1162';
 const IASTATE_DOI_PREFIX = '10.31274';
 const AAS_DOI_PREFIX = '10.3847';

--- a/utils/crossref/createDeposit.js
+++ b/utils/crossref/createDeposit.js
@@ -54,7 +54,7 @@ const getDois = (context, doiTarget) => {
 	dois.pub =
 		pub &&
 		(doiTarget === 'pub'
-			? createDoi({ community: community, collection: collection, target: pub })
+			? pub.doi || createDoi({ community: community, collection: collection, target: pub })
 			: pub.doi);
 	dois.collection =
 		collection &&


### PR DESCRIPTION
This PR makes the DOI suffix editable for communities with custom DOI prefixes. The field is no longer editable after the first deposit is made. If no custom DOI prefix is specified, the DOI will be automatically generated in the same manner it usually is.

A delete button was added to remove a DOI from a Pub. This button is also only accessible while the DOI is editable.

<img src="https://user-images.githubusercontent.com/6402908/88825360-77e43c00-d195-11ea-8be6-685bc6106aa4.gif" width="400px" />

**Test Plan**
1. Create a new Pub within a community with a custom DOI prefix.
2. Navigate to the Pub settings page in the dashboard.
2. Assign a custom DOI prefix using the text field and clicking "Update".
3. Open the deposit preview by clicking the "Preview Deposit" button. The custom suffix should be applied to the DOI within the preview.
4. Assign a new custom DOI prefix by repeating step 2.
5. The custom suffix should update within the preview.
6. Click the "Delete" button. The text field should be cleared (except for the DOI prefix) and the DOI within the deposit preview should change the a PubPub-generated DOI.
7. Click the "Submit Deposit" button. The DOI should convert to read-only.
8. Reload the page. The DOI should remain read-only.