### PR TITLE
fix: Fixes for date picking and display for ExternalPublication objects

### DIFF
--- a/client/components/PubEdge/PubEdge.js
+++ b/client/components/PubEdge/PubEdge.js
@@ -9,6 +9,7 @@ import { pubUrl, pubShortUrl } from 'utils/canonicalUrls';
 import { getPubPublishedDate } from 'utils/pub/pubDates';
 
 import { pubEdgeType } from './constants';
+import { getHostnameForUrl } from './util';
 import PubEdgeLayout from './PubEdgeLayout';
 import PubEdgePlaceholderThumbnail from './PubEdgePlaceholderThumbnail';
 
@@ -37,26 +38,18 @@ const getUrlForPub = (pubData, communityData) => {
 	return pubShortUrl(pubData);
 };
 
-const getHostnameForUrl = (url) => {
-	try {
-		const parsedUrl = new URL(url);
-		return parsedUrl.hostname;
-	} catch (_) {
-		return url;
-	}
-};
-
 const getValuesFromPubEdge = (pubEdge, communityData, viewingFromTarget) => {
 	const { externalPublication, targetPub, pub } = pubEdge;
 	const displayedPub = viewingFromTarget ? pub : targetPub;
 	if (displayedPub) {
 		const { title, description, attributions, avatar } = displayedPub;
 		const url = getUrlForPub(displayedPub, communityData);
+		const publishedDate = getPubPublishedDate(displayedPub);
 		return {
 			avatar: avatar,
 			contributors: attributions || [],
 			description: description,
-			publicationDate: getPubPublishedDate(displayedPub),
+			publishedAt: publishedDate && formatDate(publishedDate),
 			title: title,
 			url: url,
 		};
@@ -74,7 +67,7 @@ const getValuesFromPubEdge = (pubEdge, communityData, viewingFromTarget) => {
 			avatar: avatar,
 			contributors: contributors || '',
 			description: description,
-			publicationDate: publicationDate,
+			publishedAt: publicationDate && formatDate(publicationDate, { inUTCTime: true }),
 			title: title,
 			url: url,
 		};
@@ -87,14 +80,13 @@ const PubEdge = (props) => {
 	const [open, setOpen] = useState(false);
 	const { communityData } = usePageContext();
 	const hasExternalPublication = Boolean(pubEdge.externalPublication);
-	const { avatar, contributors, description, publicationDate, title, url } = getValuesFromPubEdge(
+	const { avatar, contributors, description, publishedAt, title, url } = getValuesFromPubEdge(
 		pubEdge,
 		communityData,
 		viewingFromTarget,
 	);
 
 	const detailsElementId = `edge-details-${pubEdge.id}`;
-	const publishedAt = formatDate(publicationDate);
 
 	const handleToggleDescriptionClick = useCallback(
 		(e) => {
@@ -163,7 +155,7 @@ const PubEdge = (props) => {
 						{open ? 'Hide Description' : 'Show Description'}
 					</span>
 				),
-				<>Published on {publishedAt}</>,
+				publishedAt && <>Published on {publishedAt}</>,
 				<span className="location">{getHostnameForUrl(url)}</span>,
 			]}
 			detailsElement={

--- a/client/components/PubEdge/PubEdgeEditor.js
+++ b/client/components/PubEdge/PubEdgeEditor.js
@@ -1,10 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { EditableText, TagInput, InputGroup } from '@blueprintjs/core';
 import { Button as RKButton } from 'reakit/Button';
-import dateFormat from 'dateformat';
 
 import { externalPublicationType } from './constants';
+import { getHostnameForUrl } from './util';
 import PubEdgeLayout from './PubEdgeLayout';
 import PubEdgePlaceholderThumbnail from './PubEdgePlaceholderThumbnail';
 
@@ -21,21 +21,19 @@ const PubEdgeEditor = (props) => {
 		onUpdateExternalPublication,
 	} = props;
 
-	const [publicationDateString, setPublicationDateString] = useState(
-		dateFormat(publicationDate, 'yyyy-mm-dd'),
-	);
+	const dateInputRef = useRef();
 
 	useEffect(() => {
-		if (publicationDate) {
-			setPublicationDateString(dateFormat(publicationDate, 'yyyy-mm-dd'));
+		const { current: dateInput } = dateInputRef;
+		if (publicationDate && dateInput) {
+			dateInput.valueAsDate = new Date(publicationDate);
 		}
 	}, [publicationDate]);
 
 	const handlePublicationDateChange = (evt) => {
-		const nextDateString = evt.target.value;
-		onUpdateExternalPublication({
-			publicationDate: nextDateString ? new Date(nextDateString).toString() : null,
-		});
+		const { valueAsDate } = evt.target;
+		const nextPublicationDate = valueAsDate ? valueAsDate.toUTCString() : null;
+		onUpdateExternalPublication({ publicationDate: nextPublicationDate });
 	};
 
 	const renderPublicationDate = () => {
@@ -47,14 +45,16 @@ const PubEdgeEditor = (props) => {
 						small
 						className="editable-date"
 						type="date"
-						value={publicationDateString}
+						ref={dateInputRef}
 						onChange={handlePublicationDateChange}
 					/>
 				</>
 			);
 		}
+
 		const addPublicationDate = () =>
-			onUpdateExternalPublication({ publicationDate: new Date() });
+			onUpdateExternalPublication({ publicationDate: new Date().toUTCString() });
+
 		return (
 			<RKButton
 				as="a"
@@ -95,7 +95,7 @@ const PubEdgeEditor = (props) => {
 			metadataElements={[
 				renderPublicationDate(),
 				<a href={url} alt={title}>
-					{url}
+					{getHostnameForUrl(url)}
 				</a>,
 			]}
 			detailsElement={

--- a/client/components/PubEdge/PubEdgeEditor.js
+++ b/client/components/PubEdge/PubEdgeEditor.js
@@ -31,9 +31,16 @@ const PubEdgeEditor = (props) => {
 	}, [publicationDate]);
 
 	const handlePublicationDateChange = (evt) => {
-		const { valueAsDate } = evt.target;
-		const nextPublicationDate = valueAsDate ? valueAsDate.toUTCString() : null;
-		onUpdateExternalPublication({ publicationDate: nextPublicationDate });
+		const { valueAsDate, value } = evt.target;
+		if (valueAsDate) {
+			const nextPublicationDate = valueAsDate.toUTCString();
+			onUpdateExternalPublication({ publicationDate: nextPublicationDate });
+		} else {
+			const nextPublicationDate = new Date(value);
+			if (!Number.isNaN(nextPublicationDate.valueOf())) {
+				onUpdateExternalPublication({ publicationDate: nextPublicationDate });
+			}
+		}
 	};
 
 	const renderPublicationDate = () => {
@@ -47,6 +54,7 @@ const PubEdgeEditor = (props) => {
 						type="date"
 						ref={dateInputRef}
 						onChange={handlePublicationDateChange}
+						placeholder="YYYY-MM-DD"
 					/>
 				</>
 			);

--- a/client/components/PubEdge/PubEdgeEditor.js
+++ b/client/components/PubEdge/PubEdgeEditor.js
@@ -52,7 +52,7 @@ const PubEdgeEditor = (props) => {
 						small
 						className="editable-date"
 						type="date"
-						ref={dateInputRef}
+						inputRef={dateInputRef}
 						onChange={handlePublicationDateChange}
 						placeholder="YYYY-MM-DD"
 					/>

--- a/client/components/PubEdge/util.js
+++ b/client/components/PubEdge/util.js
@@ -1,0 +1,8 @@
+export const getHostnameForUrl = (url) => {
+	try {
+		const parsedUrl = new URL(url);
+		return parsedUrl.hostname;
+	} catch (_) {
+		return url;
+	}
+};

--- a/utils/dates.js
+++ b/utils/dates.js
@@ -7,10 +7,12 @@ export const formatDate = (
 		includeDate = true,
 		includePreposition = false,
 		use12HourDate = true,
+		inUTCTime = false,
 	} = {},
 ) => {
+	const formatMask = `${inUTCTime ? 'UTC:' : ''}mmm dd, yyyy`;
 	const formattedDate = includeDate
-		? (includePreposition ? 'on ' : '') + dateFormat(date, 'mmm dd, yyyy')
+		? (includePreposition ? 'on ' : '') + dateFormat(date, formatMask)
 		: '';
 	if (includeTime) {
 		const formattedTime =


### PR DESCRIPTION
Resolves #945 

This is a quick PR to fix my rather goofy attempt at using the native `input type="date"` in the `ExternalPublication` connection creator interface. Things that change:

- We use the `input.valueAsDate` property where available, and fall back to parsing `input.value` in browsers where this isn't supported — as far as I can tell, this is just Safari, which makes you input a date by hand as well.
- We render the stored `publicationDate` in UTC time, so users in western time zones don't see it rendered as the day before.

![image](https://user-images.githubusercontent.com/2208769/88833068-b67ef400-d19f-11ea-941b-be4e89879c67.png)

_Test plan:_
- Make sure you can still create Connections to other Pubs as always
- In (Chrome, Firefox, Edge) make sure that you can select a publication date, and that the date, rather than an adjacent date, is actually chosen and displayed.
- In Safari make sure that you can type in a value in `YYYY-MM-DD` format, and that intermediate, invalid date values don't crash the browser. Trying to create the edge with an unparseable date string should cause a server-side error.
- Make sure that the dates displayed in the created Connections cards are the same as the ones chosen, irrespective of your own time zone.
- Make sure that `ExternalPublication` connections without a date don't show any date at all.