### PR TITLE
fix: Remove the scourge of overflow: scroll

### DIFF
--- a/client/components/FormattingBar/controlComponents/controls.scss
+++ b/client/components/FormattingBar/controlComponents/controls.scss
@@ -85,7 +85,7 @@
         textarea {
             flex-grow: 1;
             resize: none;
-            overflow: scroll;
+            overflow: auto;
         }
     }
 
@@ -155,7 +155,7 @@
             color: white !important;
         }
         .pub-note-content-component {
-            overflow-y: scroll;
+            overflow-y: auto;
             flex-grow: 1;
         }
     }
@@ -219,7 +219,7 @@
     }
 
     .preview {
-        overflow-y: scroll;
+        overflow-y: auto;
         flex-grow: 1;
     }
 }

--- a/client/components/FormattingBar/media/media.scss
+++ b/client/components/FormattingBar/media/media.scss
@@ -48,9 +48,6 @@
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			&.scroll {
-				overflow: auto;
-			}
 		}
 		iframe {
 			width: 90%;

--- a/client/components/FormattingBar/media/media.scss
+++ b/client/components/FormattingBar/media/media.scss
@@ -6,7 +6,7 @@
 	.options {
 		flex: 0 0 auto;
 		border-right: 1px solid #ddd;
-		overflow: scroll;
+		overflow: auto;
 	}
 	.formatting-bar_media-component-content {
 		flex: 1 1 auto;
@@ -49,7 +49,7 @@
 			align-items: center;
 			justify-content: center;
 			&.scroll {
-				overflow: scroll;
+				overflow: auto;
 			}
 		}
 		iframe {

--- a/client/components/FormattingBarLegacy/Controls/controls.scss
+++ b/client/components/FormattingBarLegacy/Controls/controls.scss
@@ -40,7 +40,7 @@
 		width: 100%;
 		// height: 50px;
 		height: 45px;
-		overflow-y: scroll;
+		overflow-y: auto;
 	}
 	textarea {
 		height: 45px;

--- a/client/components/FormattingBarLegacy/Media/media.scss
+++ b/client/components/FormattingBarLegacy/Media/media.scss
@@ -48,9 +48,6 @@
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			&.scroll {
-				overflow: auto;
-			}
 		}
 		iframe {
 			width: 90%;

--- a/client/components/FormattingBarLegacy/Media/media.scss
+++ b/client/components/FormattingBarLegacy/Media/media.scss
@@ -6,7 +6,7 @@
 	.options {
 		flex: 0 0 auto;
 		border-right: 1px solid #ddd;
-		overflow: scroll;
+		overflow: auto;
 	}
 	.formatting-bar_media-component-content {
 		flex: 1 1 auto;
@@ -49,7 +49,7 @@
 			align-items: center;
 			justify-content: center;
 			&.scroll {
-				overflow: scroll;
+				overflow: auto;
 			}
 		}
 		iframe {

--- a/client/components/MinimalEditor/minimalEditor.scss
+++ b/client/components/MinimalEditor/minimalEditor.scss
@@ -13,7 +13,7 @@ $border-style: 1px solid #ddd;
         height: 100%;
         .editor-wrapper {
             height: 100%;
-            overflow-y: scroll;
+            overflow-y: auto;
         }
         &.has-formatting-bar {
             display: flex;

--- a/client/components/PubHistoryViewer/pubHistoryViewer.scss
+++ b/client/components/PubHistoryViewer/pubHistoryViewer.scss
@@ -68,7 +68,7 @@
 
     ul.bp3-menu {
         position: relative;
-        overflow: scroll;
+        overflow: auto;
         border-radius: 4px;
         background: darken(white, 4%);
         border: 4px solid darken(white, 4%);

--- a/client/containers/Pub/PubDocument/PubFileImport/fileImportDialog.scss
+++ b/client/containers/Pub/PubDocument/PubFileImport/fileImportDialog.scss
@@ -47,7 +47,7 @@ $drop-area-bkg: rgba(138, 155, 168, .15);
     .import-message {
         margin-top: 10px;
         pre {
-            overflow-y: scroll;
+            overflow-y: auto;
         }
     }
     .files-listing {

--- a/client/containers/Pub/PubHeader/collections/collectionBrowser.scss
+++ b/client/containers/Pub/PubHeader/collections/collectionBrowser.scss
@@ -3,7 +3,7 @@
 .collection-browser-component_menu {
     border-left: 0;
     border-right: 0;
-    overflow-y: scroll;
+    overflow-y: auto;
     max-height: 50vh;
     min-height: 50px;
     max-width: 80vw;


### PR DESCRIPTION
Recently I dragged myself kicking and screaming back to the macOS setting with real scroll bars, and to my horror there are quite a few places where we are using `overflow: scroll` (which always shows a scrollbar whether one is needed or not) instead of `overflow: auto` (which only shows a scrollbar if there is overflowing content to scroll). Most of these usages can be chalked up to my past misunderstanding of how this property works, so I have gone in and removed `overflow: scroll` wherever I found it.

I'll include screenshots inline to demonstrate the before/after of these usages.