### PR TITLE
feature: add content version field and preprint (posted_content) deposits

### DIFF
--- a/client/components/AssignDoi/AssignDoi.js
+++ b/client/components/AssignDoi/AssignDoi.js
@@ -150,15 +150,16 @@ const initialState = {
 	error: null,
 };
 
+const contentVersionItems = [
+	{ title: '(None)', key: 'none' },
+	{ title: 'Preprint', key: 'preprint' },
+	{ title: 'Version of Record', key: 'vor' },
+	{ title: 'Advance Manuscript', key: 'am' },
+];
+
 function AssignDoi(props) {
 	const { communityData, disabled, pubData, onPreview, onDeposit, onError, target } = props;
 	const [{ state, result, error }, dispatch] = useReducer(reducer, initialState);
-	const contentVersionItems = [
-		{ title: '(None)', key: 'none' },
-		{ title: 'Preprint', key: 'preprint' },
-		{ title: 'Version of Record', key: 'vor' },
-		{ title: 'Advance Manuscript', key: 'am' },
-	];
 
 	// Extract the content version from current result (i.e. preview).
 	let contentVersion = getDepositRecordContentVersion(result);

--- a/client/components/AssignDoi/AssignDoi.js
+++ b/client/components/AssignDoi/AssignDoi.js
@@ -167,10 +167,7 @@ function AssignDoi(props) {
 	let contentVersion = getDepositRecordContentVersion(result);
 
 	// Assume preprint if no content version is present and body consists of posted_content.
-	if (
-		!contentVersion &&
-		(result ? isPreprint(result) : isPreprint(pubData.crossrefDepositRecord))
-	) {
+	if (!contentVersion && isPreprint(result || pubData.crossrefDepositRecord)) {
 		contentVersion = 'preprint';
 	}
 

--- a/client/components/AssignDoi/AssignDoiPreview.js
+++ b/client/components/AssignDoi/AssignDoiPreview.js
@@ -244,6 +244,7 @@ function AssignDoiPreview(props) {
 		},
 		depositXml,
 	} = crossrefDepositRecord;
+	const contentVersion = getDepositRecordContentVersion(crossrefDepositRecord);
 
 	const renderPreviewTab = () => {
 		return (
@@ -254,8 +255,12 @@ function AssignDoiPreview(props) {
 					<dd>{communityDoi}</dd>
 					<dt>Pub</dt>
 					<dd>{doi || pubDoi}</dd>
-					<dt>Content Version</dt>
-					<dd>{getDepositRecordContentVersion(crossrefDepositRecord)}</dd>
+					{contentVersion && contentVersion !== 'none' && (
+						<>
+							<dt>Content Version</dt>
+							<dd>{contentVersion}</dd>
+						</>
+					)}
 				</dl>
 				{isJournal(crossrefDepositRecord) && renderArticlePreview(body)}
 				{isBook(crossrefDepositRecord) && renderBookPreview(body)}

--- a/client/components/AssignDoi/AssignDoiPreview.js
+++ b/client/components/AssignDoi/AssignDoiPreview.js
@@ -3,42 +3,57 @@ import PropTypes from 'prop-types';
 import { Tab, Tabs } from '@blueprintjs/core';
 
 import { formatDate } from 'utils/dates';
+import {
+	getDepositBody,
+	getDepositRecordContentVersion,
+	isPreprint,
+	isBook,
+	isJournal,
+	isConference,
+} from 'utils/crossref/parseDeposit';
 
 require('./assignDoiPreview.scss');
 
 const propTypes = {
-	doi: PropTypes.string.isRequired,
-	depositJson: PropTypes.object.isRequired,
-	depositXml: PropTypes.string.isRequired,
+	crossrefDepositRecord: PropTypes.object.isRequired,
 };
 const defaultProps = {};
 
-const isBook = (doiBatch) => 'book' in doiBatch.body;
-const isJournal = (doiBatch) => 'journal' in doiBatch.body;
-const isConference = (doiBatch) => 'conference' in doiBatch.body;
+const renderRelationships = (program) => {
+	if (!program) {
+		return null;
+	}
 
-const renderRelations = (relatedItems) => {
+	const { 'rel:related_item': relatedItems } = program;
+
+	if (relatedItems.length === 0) {
+		return null;
+	}
+
 	return (
-		<dl>
-			{relatedItems.map(
-				({
-					'rel:inter_work_relation': interWorkRelation,
-					'rel:intra_work_relation': intraWorkRelation,
-				}) => {
-					const { '#text': identifier, '@relationship-type': relationshipType } =
-						interWorkRelation || intraWorkRelation;
+		<>
+			<h6>Relationships</h6>
+			<dl>
+				{relatedItems.map(
+					({
+						'rel:inter_work_relation': interWorkRelation,
+						'rel:intra_work_relation': intraWorkRelation,
+					}) => {
+						const { '#text': identifier, '@relationship-type': relationshipType } =
+							interWorkRelation || intraWorkRelation;
 
-					return (
-						<React.Fragment key={identifier}>
-							<dt>Relationship Type</dt>
-							<dd>{relationshipType}</dd>
-							<dt>Identifier</dt>
-							<dd>{identifier}</dd>
-						</React.Fragment>
-					);
-				},
-			)}
-		</dl>
+						return (
+							<React.Fragment key={identifier}>
+								<dt>Relationship Type</dt>
+								<dd>{relationshipType}</dd>
+								<dt>Identifier</dt>
+								<dd>{identifier}</dd>
+							</React.Fragment>
+						);
+					},
+				)}
+			</dl>
+		</>
 	);
 };
 
@@ -60,12 +75,12 @@ const renderPublisher = (publisher) => {
 	);
 };
 
-const renderPublicationDate = (publication_date) => {
+const renderPublicationDate = (publication_date, title = 'Publication Date') => {
 	const { day, month, year } = publication_date;
 
 	return (
 		<>
-			<dt>Publication Date</dt>
+			<dt>{title}</dt>
 			<dd>{formatDate(new Date([month, day, year]))}</dd>
 		</>
 	);
@@ -87,23 +102,21 @@ const renderContributors = (contributors) => {
 	);
 };
 
-const renderArticlePreview = (doi_batch) => {
+const renderArticlePreview = (body) => {
 	const {
-		body: {
-			journal: {
-				journal_article: {
-					titles,
-					publication_date,
-					contributors,
-					'rel:program': { related_item: relatedItems },
-				},
-				journal_metadata: {
-					full_title: journalFullTitle,
-					doi_data: { doi: journalDoi },
-				},
+		journal: {
+			journal_article: {
+				titles,
+				publication_date,
+				contributors,
+				'rel:program': relationships,
+			},
+			journal_metadata: {
+				full_title: journalFullTitle,
+				doi_data: { doi: journalDoi },
 			},
 		},
-	} = doi_batch;
+	} = body;
 
 	return (
 		<>
@@ -120,31 +133,28 @@ const renderArticlePreview = (doi_batch) => {
 				<dt>DOI</dt>
 				<dd>{journalDoi}</dd>
 			</dl>
-			<h6>Relationships</h6>
-			{relProgram && renderRelations(relatedItems)}
+			{renderRelationships(relationships)}
 		</>
 	);
 };
 
-const renderBookPreview = (doi_batch) => {
+const renderBookPreview = (body) => {
 	const {
-		body: {
-			book: {
-				book_metadata: {
-					titles: bookTitles,
-					edition_number,
-					publisher,
-					publication_date: bookPublicationDate,
-				},
-				content_item: {
-					titles: contentTitles,
-					contributors,
-					publication_date: contentPublicationDate,
-					'rel:program': { related_item: relatedItems },
-				},
+		book: {
+			book_metadata: {
+				titles: bookTitles,
+				edition_number,
+				publisher,
+				publication_date: bookPublicationDate,
+			},
+			content_item: {
+				titles: contentTitles,
+				contributors,
+				publication_date: contentPublicationDate,
+				'rel:program': relationships,
 			},
 		},
-	} = doi_batch;
+	} = body;
 
 	return (
 		<>
@@ -162,35 +172,28 @@ const renderBookPreview = (doi_batch) => {
 				{renderContributors(contributors)}
 				{renderPublicationDate(contentPublicationDate)}
 			</dl>
-			<h6>Relationships</h6>
-			{relProgram && renderRelations(relatedItems)}
+			{renderRelationships(relationships)}
 		</>
 	);
 };
 
-const renderConferencePreview = (doi_batch) => {
+const renderConferencePreview = (body) => {
 	const {
-		body: {
-			conference: {
-				conference_paper: {
-					contributors,
-					titles: paperTitles,
-					'rel:program': { related_item: relatedItems },
-				},
-				event_metadata: {
-					conference_name,
-					conference_date: { '#text': conferenceDate },
-				},
-				proceedings_metadata: { proceedings_title, publication_date, publisher },
+		conference: {
+			conference_paper: { contributors, titles, 'rel:program': relationships },
+			event_metadata: {
+				conference_name,
+				conference_date: { '#text': conferenceDate },
 			},
+			proceedings_metadata: { proceedings_title, publication_date, publisher },
 		},
-	} = doi_batch;
+	} = body;
 
 	return (
 		<>
 			<h6>Conference Paper</h6>
 			<dl>
-				{renderTitles(paperTitles)}
+				{renderTitles(titles)}
 				{renderContributors(contributors)}
 			</dl>
 			<h6>Event Metadata</h6>
@@ -207,21 +210,40 @@ const renderConferencePreview = (doi_batch) => {
 				{renderPublicationDate(publication_date)}
 				{renderPublisher(publisher)}
 			</dl>
-			<h6>Relationships</h6>
-			{relProgram && renderRelations(relatedItems)}
+			{renderRelationships(relationships)}
+		</>
+	);
+};
+
+const renderPreprintPreview = (body) => {
+	const {
+		posted_content: { contributors, titles, 'rel:program': relationships, posted_date },
+	} = body;
+
+	return (
+		<>
+			<h6>Preprint</h6>
+			<dl>
+				{renderTitles(titles)}
+				{renderContributors(contributors)}
+				{renderPublicationDate(posted_date, 'Posted Date')}
+			</dl>
+			{renderRelationships(relationships)}
 		</>
 	);
 };
 
 function AssignDoiPreview(props) {
 	const [selectedTab, setSelectedTab] = useState('preview');
+	const { crossrefDepositRecord } = props;
+	const body = getDepositBody(crossrefDepositRecord);
 	const {
 		doi,
 		depositJson: {
-			deposit: { doi_batch },
 			dois: { community: communityDoi, pub: pubDoi },
 		},
-	} = props;
+		depositXml,
+	} = crossrefDepositRecord;
 
 	const renderPreviewTab = () => {
 		return (
@@ -232,10 +254,13 @@ function AssignDoiPreview(props) {
 					<dd>{communityDoi}</dd>
 					<dt>Pub</dt>
 					<dd>{doi || pubDoi}</dd>
+					<dt>Content Version</dt>
+					<dd>{getDepositRecordContentVersion(crossrefDepositRecord)}</dd>
 				</dl>
-				{isJournal(doi_batch) && renderArticlePreview(doi_batch)}
-				{isBook(doi_batch) && renderBookPreview(doi_batch)}
-				{isConference(doi_batch) && renderConferencePreview(doi_batch)}
+				{isJournal(crossrefDepositRecord) && renderArticlePreview(body)}
+				{isBook(crossrefDepositRecord) && renderBookPreview(body)}
+				{isConference(crossrefDepositRecord) && renderConferencePreview(body)}
+				{isPreprint(crossrefDepositRecord) && renderPreprintPreview(body)}
 			</>
 		);
 	};
@@ -247,7 +272,7 @@ function AssignDoiPreview(props) {
 			className="assign-doi-preview-component"
 		>
 			<Tab id="preview" title="Preview" panel={renderPreviewTab()} />
-			<Tab id="xml" title="XML" panel={<pre>{props.depositXml}</pre>} />
+			<Tab id="xml" title="XML" panel={<pre>{depositXml}</pre>} />
 		</Tabs>
 	);
 }

--- a/client/components/AssignDoi/assignDoi.scss
+++ b/client/components/AssignDoi/assignDoi.scss
@@ -1,5 +1,5 @@
 .assign-doi-component {
 	> p {
-		margin: 12px 0;
+		margin: 0 0 12px 0;
 	}
 }

--- a/client/containers/DashboardSettings/PubSettings/Doi.js
+++ b/client/containers/DashboardSettings/PubSettings/Doi.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { FormGroup, ControlGroup, Button, InputGroup } from '@blueprintjs/core';
+import { FormGroup, Button, InputGroup } from '@blueprintjs/core';
 
 import {
 	choosePrefixByCommunityId,
@@ -252,7 +252,6 @@ class Doi extends Component {
 						communityData={this.props.communityData}
 						onDeposit={this.handleDeposit}
 						pubData={this.props.pubData}
-						hasExistingDeposit={hasExistingDeposit}
 						target="pub"
 					/>
 				</FormGroup>

--- a/server/doi/api.js
+++ b/server/doi/api.js
@@ -5,12 +5,9 @@ import xmlbuilder from 'xmlbuilder';
 import { getDoiData, setDoiData } from './queries';
 import { getPermissions } from './permissions';
 
-const previewOrDepositDoi = async (req, options = { deposit: false }) => {
+const previewOrDepositDoi = async (user, body, options = { deposit: false }) => {
 	const { deposit } = options;
-	const user = req.user || {};
-	const { target, communityId, collectionId, pubId, contentVersion } = deposit
-		? req.body
-		: req.query;
+	const { target, communityId, collectionId, pubId, contentVersion } = body;
 	const requestIds = {
 		userId: user.id,
 		communityId: communityId,
@@ -42,7 +39,7 @@ const previewOrDepositDoi = async (req, options = { deposit: false }) => {
 app.post(
 	'/api/doi',
 	wrap(async (req, res) => {
-		const depositJson = await previewOrDepositDoi(req, { deposit: true });
+		const depositJson = await previewOrDepositDoi(req.user || {}, req.body, { deposit: true });
 
 		return res.status(201).json(depositJson);
 	}),
@@ -51,7 +48,7 @@ app.post(
 app.get(
 	'/api/doiPreview',
 	wrap(async (req, res) => {
-		const depositJson = await previewOrDepositDoi(req);
+		const depositJson = await previewOrDepositDoi(req.user || {}, req.query);
 		const depositXml = xmlbuilder.create(depositJson, { headless: true }).end({ pretty: true });
 
 		return res.status(201).json({

--- a/server/doi/api.js
+++ b/server/doi/api.js
@@ -8,7 +8,9 @@ import { getPermissions } from './permissions';
 const previewOrDepositDoi = async (req, options = { deposit: false }) => {
 	const { deposit } = options;
 	const user = req.user || {};
-	const { target, communityId, collectionId, pubId } = deposit ? req.body : req.query;
+	const { target, communityId, collectionId, pubId, contentVersion } = deposit
+		? req.body
+		: req.query;
 	const requestIds = {
 		userId: user.id,
 		communityId: communityId,
@@ -29,6 +31,7 @@ const previewOrDepositDoi = async (req, options = { deposit: false }) => {
 			communityId: communityId,
 			collectionId: collectionId,
 			pubId: pubId,
+			contentVersion: contentVersion,
 		},
 		target,
 	);

--- a/server/doi/queries.js
+++ b/server/doi/queries.js
@@ -98,7 +98,7 @@ const persistDoiData = (ids, dois) => {
 	return Promise.all(updates);
 };
 
-export const getDoiData = ({ communityId, collectionId, pubId }, doiTarget) =>
+export const getDoiData = ({ communityId, collectionId, pubId, contentVersion }, doiTarget) =>
 	Promise.all([
 		findCommunity(communityId),
 		collectionId && findCollection(collectionId),
@@ -112,14 +112,20 @@ export const getDoiData = ({ communityId, collectionId, pubId }, doiTarget) =>
 				collection: resolvedCollection,
 				community: community,
 				pub: pub,
+				contentVersion: contentVersion,
 			},
 			doiTarget,
 		);
 	});
 
-export const setDoiData = ({ communityId, collectionId, pubId }, doiTarget) =>
+export const setDoiData = ({ communityId, collectionId, pubId, contentVersion }, doiTarget) =>
 	getDoiData(
-		{ communityId: communityId, collectionId: collectionId, pubId: pubId },
+		{
+			communityId: communityId,
+			collectionId: collectionId,
+			pubId: pubId,
+			contentVersion: contentVersion,
+		},
 		doiTarget,
 	).then((depositJson) => {
 		const ids = { collectionId: collectionId, pubId: pubId };

--- a/server/utils/queryHelpers/pubOptions.js
+++ b/server/utils/queryHelpers/pubOptions.js
@@ -4,6 +4,7 @@ import {
 	CollectionAttribution,
 	CollectionPub,
 	Community,
+	CrossrefDepositRecord,
 	Export,
 	Page,
 	PubAttribution,
@@ -198,6 +199,10 @@ export default ({
 				model: ReviewNew,
 				as: 'reviews',
 				include: [...author, ...visibility, ...thread],
+			},
+			{
+				model: CrossrefDepositRecord,
+				as: 'crossrefDepositRecord',
 			},
 			...collectionPubs,
 			...community,

--- a/utils/crossref/createDeposit.js
+++ b/utils/crossref/createDeposit.js
@@ -6,11 +6,16 @@ import doiBatch from './schema/doiBatch';
 import renderBook from './render/book';
 import renderConference from './render/conference';
 import renderJournal from './render/journal';
+import renderPreprint from './render/preprint';
 import createDoi from './createDoi';
 import getCollectionDoi from '../collections/getCollectionDoi';
 
 const renderBody = (context) => {
-	const { collection } = context;
+	const { collection, globals } = context;
+
+	if (globals.contentVersion === 'preprint') {
+		return renderPreprint(context);
+	}
 
 	if (collection) {
 		if (collection.kind === 'book') {
@@ -66,7 +71,7 @@ const getDois = (context, doiTarget) => {
 
 export default (context, doiTarget, dateForTimestamp) => {
 	checkDepositAssertions(context, doiTarget);
-	const { community } = context;
+	const { community, contentVersion } = context;
 	const timestamp = (dateForTimestamp || new Date()).getTime();
 	const doiBatchId = `${timestamp}_${community.id.slice(0, 8)}`;
 	const dois = getDois(context, doiTarget);
@@ -77,6 +82,7 @@ export default (context, doiTarget, dateForTimestamp) => {
 				globals: {
 					dois: dois,
 					timestamp: timestamp,
+					contentVersion: contentVersion,
 				},
 			}),
 			doiBatchId: doiBatchId,

--- a/utils/crossref/parseDeposit.js
+++ b/utils/crossref/parseDeposit.js
@@ -1,0 +1,79 @@
+const doiDataPaths = [
+	['book', 'content_item'],
+	['conference', 'conference_paper'],
+	['journal', 'journal_article'],
+	['posted_content'],
+];
+
+export const getDoiData = ({ doi_batch: { body } }) => {
+	let i = 0;
+
+	while (i < doiDataPaths.length) {
+		const path = doiDataPaths[i];
+		let visiting = body;
+		let j = 0;
+
+		while (j < path.length) {
+			const key = path[j];
+			visiting = visiting[key];
+
+			if (!visiting) {
+				break;
+			}
+
+			if (j === path.length - 1) {
+				return visiting.doi_data;
+			}
+
+			j++;
+		}
+
+		i++;
+	}
+
+	return null;
+};
+
+export const setDepositRecordContentVersion = (depositRecord, contentVersion) => {
+	const {
+		depositJson: { deposit },
+	} = depositRecord;
+	const doiData = getDoiData(deposit);
+
+	if (!contentVersion) {
+		delete doiData.resource['@content_version'];
+	} else {
+		doiData.resource['@content_version'] = contentVersion;
+	}
+
+	return depositRecord;
+};
+
+export const getDepositRecordContentVersion = (depositRecord) => {
+	if (!depositRecord) {
+		return null;
+	}
+
+	const {
+		depositJson: { deposit },
+	} = depositRecord;
+	const doiData = getDoiData(deposit);
+
+	if (!doiData) {
+		return null;
+	}
+
+	return doiData.resource['@content_version'];
+};
+
+export const getDepositBody = (crossrefDepositRecord) =>
+	crossrefDepositRecord.depositJson.deposit.doi_batch.body;
+
+export const isBook = (crossrefDepositRecord) =>
+	crossrefDepositRecord && 'book' in getDepositBody(crossrefDepositRecord);
+export const isJournal = (crossrefDepositRecord) =>
+	crossrefDepositRecord && 'journal' in getDepositBody(crossrefDepositRecord);
+export const isConference = (crossrefDepositRecord) =>
+	crossrefDepositRecord && 'conference' in getDepositBody(crossrefDepositRecord);
+export const isPreprint = (crossrefDepositRecord) =>
+	crossrefDepositRecord && 'posted_content' in getDepositBody(crossrefDepositRecord);

--- a/utils/crossref/parseDeposit.js
+++ b/utils/crossref/parseDeposit.js
@@ -45,8 +45,6 @@ export const setDepositRecordContentVersion = (depositRecord, contentVersion) =>
 	} else {
 		doiData.resource['@content_version'] = contentVersion;
 	}
-
-	return depositRecord;
 };
 
 export const getDepositRecordContentVersion = (depositRecord) => {

--- a/utils/crossref/render/preprint.js
+++ b/utils/crossref/render/preprint.js
@@ -1,6 +1,5 @@
 /**
- * Renders a submission for a journal article within a journal, possibly including journal issue
- * data derived from an optional collection.
+ * Renders a preprint for a journal article.
  */
 import postedContent from '../schema/postedContent';
 

--- a/utils/crossref/render/preprint.js
+++ b/utils/crossref/render/preprint.js
@@ -1,0 +1,18 @@
+/**
+ * Renders a submission for a journal article within a journal, possibly including journal issue
+ * data derived from an optional collection.
+ */
+import postedContent from '../schema/postedContent';
+
+import transformCommunity from '../transform/community';
+import transformPub from '../transform/pub';
+
+export default ({ globals, community, pub }) => {
+	const communityProps = transformCommunity({ globals: globals })(community);
+	const pubProps = pub && transformPub({ globals: globals, community: community })(pub);
+	return postedContent({
+		...communityProps,
+		timestamp: globals.timestamp,
+		...pubProps,
+	});
+};

--- a/utils/crossref/schema/book.js
+++ b/utils/crossref/schema/book.js
@@ -14,6 +14,7 @@ export default ({
 	timestamp,
 	title,
 	url,
+	contentVersion,
 }) => {
 	return {
 		book: {
@@ -28,7 +29,7 @@ export default ({
 				...date('publication_date', publicationDate),
 				...renderIsbn(isbn),
 				...publisher(),
-				...doiData(doi, timestamp, url),
+				...doiData(doi, timestamp, url, contentVersion),
 			},
 			...children,
 		},

--- a/utils/crossref/schema/conference.js
+++ b/utils/crossref/schema/conference.js
@@ -17,6 +17,7 @@ export default ({
 	timestamp,
 	title,
 	url,
+	contentVersion,
 }) => ({
 	conference: {
 		...contributors(attributions),
@@ -34,7 +35,7 @@ export default ({
 			...publisher(),
 			...renderDate('publication_date', date),
 			...isbn(null, 'archive_volume'),
-			...doiData(doi, timestamp, url),
+			...doiData(doi, timestamp, url, contentVersion),
 		},
 		...children,
 	},

--- a/utils/crossref/schema/conferencePaper.js
+++ b/utils/crossref/schema/conferencePaper.js
@@ -2,7 +2,16 @@ import contributors from './contributors';
 import doiData from './doiData';
 import relations from './relations';
 
-export default ({ attributions, doi, language, resourceUrl, timestamp, title, relatedItems }) => {
+export default ({
+	attributions,
+	doi,
+	language,
+	resourceUrl,
+	timestamp,
+	title,
+	relatedItems,
+	contentVersion,
+}) => {
 	return {
 		conference_paper: {
 			'@xmlns:rel': 'http://www.crossref.org/relations.xsd',
@@ -12,7 +21,7 @@ export default ({ attributions, doi, language, resourceUrl, timestamp, title, re
 				title: title,
 			},
 			...(relatedItems.length > 0 && relations(relatedItems)),
-			...doiData(doi, timestamp, resourceUrl),
+			...doiData(doi, timestamp, resourceUrl, contentVersion),
 		},
 	};
 };

--- a/utils/crossref/schema/contentItem.js
+++ b/utils/crossref/schema/contentItem.js
@@ -12,6 +12,7 @@ export default ({
 	timestamp,
 	title,
 	relatedItems,
+	contentVersion,
 }) => {
 	return {
 		content_item: {
@@ -23,7 +24,7 @@ export default ({
 			},
 			...date('publication_date', publicationDate),
 			...(relatedItems.length > 0 && relations(relatedItems)),
-			...doiData(doi, timestamp, resourceUrl),
+			...doiData(doi, timestamp, resourceUrl, contentVersion),
 		},
 	};
 };

--- a/utils/crossref/schema/doiData.js
+++ b/utils/crossref/schema/doiData.js
@@ -1,7 +1,7 @@
 /**
  * Renders a doi_data
  */
-export default (doi, timestamp, resource) => {
+export default (doi, timestamp, resource, contentVersion) => {
 	if (!doi) {
 		return {};
 	}
@@ -9,7 +9,10 @@ export default (doi, timestamp, resource) => {
 		doi_data: {
 			doi: doi,
 			timestamp: timestamp,
-			resource: resource,
+			resource: {
+				'#text': resource,
+				'@content_version': contentVersion,
+			},
 		},
 	};
 };

--- a/utils/crossref/schema/journal.js
+++ b/utils/crossref/schema/journal.js
@@ -1,13 +1,13 @@
 import doiData from './doiData';
 
-export default ({ title, issn, language, children, doi, timestamp, url }) => ({
+export default ({ title, issn, language, children, doi, timestamp, url, contentVersion }) => ({
 	journal: {
 		journal_metadata: {
 			'@language': language,
 			full_title: title,
 			abbrev_title: title,
 			...(issn ? { '@media_type': 'electronic', '#text': issn } : {}),
-			...doiData(doi, timestamp, url),
+			...doiData(doi, timestamp, url, contentVersion),
 		},
 		...children,
 	},

--- a/utils/crossref/schema/journalArticle.js
+++ b/utils/crossref/schema/journalArticle.js
@@ -11,6 +11,7 @@ export default ({
 	timestamp,
 	title,
 	relatedItems,
+	contentVersion,
 }) => {
 	return {
 		journal_article: {
@@ -22,7 +23,7 @@ export default ({
 			...contributors(attributions),
 			...date('publication_date', publicationDate),
 			...(relatedItems.length > 0 && relations(relatedItems)),
-			...doiData(doi, timestamp, resourceUrl),
+			...doiData(doi, timestamp, resourceUrl, contentVersion),
 		},
 	};
 };

--- a/utils/crossref/schema/journalIssue.js
+++ b/utils/crossref/schema/journalIssue.js
@@ -2,7 +2,17 @@ import date from './helpers/date';
 import contributors from './contributors';
 import doiData from './doiData';
 
-export default ({ title, attributions, volume, issue, publicationDate, doi, timestamp, url }) => ({
+export default ({
+	title,
+	attributions,
+	volume,
+	issue,
+	publicationDate,
+	doi,
+	timestamp,
+	url,
+	contentVersion,
+}) => ({
 	journal_issue: {
 		...contributors(attributions),
 		titles: {
@@ -17,6 +27,6 @@ export default ({ title, attributions, volume, issue, publicationDate, doi, time
 			  }
 			: {}),
 		issue: issue,
-		...doiData(doi, timestamp, url),
+		...doiData(doi, timestamp, url, contentVersion),
 	},
 });

--- a/utils/crossref/schema/postedContent.js
+++ b/utils/crossref/schema/postedContent.js
@@ -1,0 +1,28 @@
+import contributors from './contributors';
+import doiData from './doiData';
+import date from './helpers/date';
+import relations from './relations';
+
+export default ({
+	attributions,
+	language,
+	doi,
+	publicationDate,
+	resourceUrl,
+	timestamp,
+	title,
+	relatedItems,
+}) => ({
+	posted_content: {
+		'@xmlns:rel': 'http://www.crossref.org/relations.xsd',
+		'@language': language,
+		'@type': 'preprint',
+		...contributors(attributions),
+		titles: {
+			title: title,
+		},
+		...date('posted_date', publicationDate, 'print'),
+		...(relatedItems.length > 0 && relations(relatedItems)),
+		...doiData(doi, timestamp, resourceUrl),
+	},
+});

--- a/utils/crossref/transform/collection.js
+++ b/utils/crossref/transform/collection.js
@@ -1,5 +1,6 @@
 import { collectionUrl } from 'utils/canonicalUrls';
 import { deserializeMetadata } from 'utils/collections/metadata';
+import { getDepositRecordContentVersion } from 'utils/crossref/parseDeposit';
 
 import transformAttributions from './attributions';
 
@@ -19,13 +20,17 @@ const transformMetadata = (metadata, kind, timestamp) =>
 	});
 
 export default ({ globals, community }) => (collection) => {
-	const { title, metadata, attributions } = collection;
+	const { timestamp, dois, contentVersion } = globals;
+	const { crossrefDepositRecord, title, metadata, attributions } = collection;
 	return {
 		url: collectionUrl(community, collection),
 		...transformMetadata(metadata, collection.kind, globals.timestamp),
 		title: title,
-		timestamp: globals.timestamp,
+		timestamp: timestamp,
 		attributions: transformAttributions(attributions),
-		doi: globals.dois.collection,
+		doi: dois.collection,
+		contentVersion:
+			contentVersion ||
+			(crossrefDepositRecord ? getDepositRecordContentVersion(crossrefDepositRecord) : null),
 	};
 };

--- a/utils/crossref/transform/pub.js
+++ b/utils/crossref/transform/pub.js
@@ -1,6 +1,7 @@
 import { pubUrl } from 'utils/canonicalUrls';
 import { getPubPublishedDate } from 'utils/pub/pubDates';
 import { relationTypeDefinitions } from 'utils/pubEdge/relations';
+import { getDepositRecordContentVersion } from 'utils/crossref/parseDeposit';
 
 import transformAttributions from './attributions';
 
@@ -40,8 +41,8 @@ function getEdgeCrossrefRelationship(pubEdge, isInboundEdge = false) {
 }
 
 export default ({ globals, community }) => (pub) => {
-	const { timestamp, dois } = globals;
-	const { title, inboundEdges, outboundEdges } = pub;
+	const { timestamp, dois, contentVersion } = globals;
+	const { crossrefDepositRecord, title, inboundEdges, outboundEdges } = pub;
 	const publicationDate = getPubPublishedDate(pub);
 	const relatedItems = outboundEdges
 		.map((pubEdge) => {
@@ -61,5 +62,8 @@ export default ({ globals, community }) => (pub) => {
 		resourceUrl: pubUrl(community, pub),
 		doi: dois.pub,
 		relatedItems: relatedItems,
+		contentVersion:
+			contentVersion ||
+			(crossrefDepositRecord ? getDepositRecordContentVersion(crossrefDepositRecord) : null),
 	};
 };


### PR DESCRIPTION
Closes #912

This PR adds a new field to the deposit form that allows a Pub admin to update the resource's `content_version`.

![Screen Shot 2020-07-31 at 4 32 19 PM](https://user-images.githubusercontent.com/6402908/89075092-6c3a7600-d34b-11ea-8647-05ebbf23f2dc.png)

The field's options are detailed below:

* **(None)** un-sets the `<resource>` element's `content_version` attribute of the work
* **Advance Manuscript** sets the `<resource>` element's `content_version` attribute to `"am"`(advance manuscript)
* **Version of Record** sets the `<resource>` element's `content_version` attribute to `"vor"`
* **Preprint** converts the record to a `posted_content` item

Since changing the content version of the work results in changes to the deposit, the entire deposit preview is re-fetched each time the dropdown's selected item changes, as demonstrated below:

<img src="https://user-images.githubusercontent.com/6402908/89075212-ad328a80-d34b-11ea-8a7f-e1c2554b1162.gif" width="550">

(sorry for the blurry gif)

**This PR does not include:**

- Automatically generating more specific deposits for peer reviews and supplementary material.
- Defaulting to preprint content version for Pubs with an `isPreprintOf` edge.

**Test Plan:**

1. Create a new Pub and publish it.
2. Click the "Preview Deposit" button in the Pub settings.
3. Toggle between the various options in the content version dropdown and verify they work as described above.