### PR TITLE
feature: Custom publication date picker for Pubs

### DIFF
--- a/client/components/DatePicker/DatePicker.js
+++ b/client/components/DatePicker/DatePicker.js
@@ -1,3 +1,10 @@
+/**
+ * This component picks dates in UTC time, e.g.: March 10, 2018 is `Fri Mar 10 2018 00:00:00 GMT+0`.
+ * This means that without special handling, the dates it provides may render unexpectedly in
+ * certain timezones, very possibly the one in which you are reading this code! It is the caller's
+ * responsibility to handle these dates correctly, perhaps by using the inUtcTime option of
+ * formatDate(), or the getLocalDateMatchingUtcCalendarDate() utility.
+ */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { InputGroup } from '@blueprintjs/core';

--- a/client/components/DatePicker/DatePicker.js
+++ b/client/components/DatePicker/DatePicker.js
@@ -1,0 +1,95 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import { InputGroup } from '@blueprintjs/core';
+import dateFormat from 'dateformat';
+
+const propTypes = {
+	onSelectDate: PropTypes.func.isRequired,
+	date: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+};
+
+const isValidDate = (date) => !Number.isNaN(date.valueOf());
+
+const getDateFromEvent = (evt) => {
+	const { value } = evt.target;
+	if (value) {
+		const [year, month, day] = value.split('-');
+		if (year && year.length === 4 && !year.startsWith('0') && month && day) {
+			const date = new Date(value);
+			if (isValidDate(date)) {
+				return date;
+			}
+		}
+		throw new Error();
+	}
+	return null;
+};
+
+const getInputValueFromDateProp = (dateProp) => {
+	if (dateProp) {
+		const date = new Date(dateProp);
+		if (isValidDate(date)) {
+			return dateFormat(date, 'UTC:yyyy-mm-dd');
+		}
+		throw new Error();
+	}
+	return dateProp;
+};
+
+const getEarlyRenderableProps = (dateProp, hasMounted) => {
+	if (!hasMounted) {
+		try {
+			const value = getInputValueFromDateProp(dateProp);
+			return { value: value };
+		} catch (_) {
+			return {};
+		}
+	}
+	return {};
+};
+
+const DatePicker = (props) => {
+	const { date: dateProp, onSelectDate, ...restProps } = props;
+	const inputRef = useRef();
+	const [hasMounted, setHasMounted] = useState(false);
+
+	useEffect(() => setHasMounted(true), []);
+
+	useEffect(() => {
+		const { current: input } = inputRef;
+		if (input) {
+			try {
+				const value = getInputValueFromDateProp(dateProp);
+				input.value = value;
+			} catch (_) {
+				// Don't do anything with an invalid date
+			}
+		}
+	}, [dateProp]);
+
+	const handleInput = useCallback(
+		(evt) => {
+			try {
+				const nextDate = getDateFromEvent(evt);
+				onSelectDate(nextDate);
+			} catch (_) {
+				// Don't do anything with an invalid date
+			}
+		},
+		[onSelectDate],
+	);
+
+	return (
+		<InputGroup
+			placeholder="YYYY-MM-DD"
+			{...restProps}
+			{...getEarlyRenderableProps(dateProp, hasMounted)}
+			type="date"
+			inputRef={inputRef}
+			onInput={handleInput}
+		/>
+	);
+};
+
+DatePicker.propTypes = propTypes;
+export default DatePicker;

--- a/client/components/DatePicker/datePickerStories.js
+++ b/client/components/DatePicker/datePickerStories.js
@@ -12,7 +12,7 @@ const StatefulDatePicker = ({ initialDate }) => {
 		<div>
 			<DatePicker date={date} onSelectDate={setDate} />
 			<div>
-				Selected date: {date ? formatDate(new Date(date), { inUTCTime: true }) : 'none'}
+				Selected date: {date ? formatDate(new Date(date), { inUtcTime: true }) : 'none'}
 			</div>
 		</div>
 	);

--- a/client/components/DatePicker/datePickerStories.js
+++ b/client/components/DatePicker/datePickerStories.js
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { formatDate } from 'utils/dates';
+
+import DatePicker from './DatePicker';
+
+// eslint-disable-next-line react/prop-types
+const StatefulDatePicker = ({ initialDate }) => {
+	const [date, setDate] = useState(initialDate);
+	return (
+		<div>
+			<DatePicker date={date} onSelectDate={setDate} />
+			<div>
+				Selected date: {date ? formatDate(new Date(date), { inUTCTime: true }) : 'none'}
+			</div>
+		</div>
+	);
+};
+
+storiesOf('components/DatePicker', module).add('default', () => {
+	return (
+		<div style={{ margin: '1em' }}>
+			<h4>With Date object</h4>
+			<p>
+				<StatefulDatePicker initialDate={new Date('2019-03-05')} />
+			</p>
+			<h4>With date string</h4>
+			<p>
+				<StatefulDatePicker initialDate="2015-11-02" />
+			</p>
+			<h4>Empty</h4>
+			<p>
+				<StatefulDatePicker initialDate={null} />
+			</p>
+		</div>
+	);
+});

--- a/client/components/PubEdge/PubEdge.js
+++ b/client/components/PubEdge/PubEdge.js
@@ -67,7 +67,7 @@ const getValuesFromPubEdge = (pubEdge, communityData, viewingFromTarget) => {
 			avatar: avatar,
 			contributors: contributors || '',
 			description: description,
-			publishedAt: publicationDate && formatDate(publicationDate, { inUTCTime: true }),
+			publishedAt: publicationDate && formatDate(publicationDate, { inUtcTime: true }),
 			title: title,
 			url: url,
 		};

--- a/client/components/PubEdge/PubEdgeEditor.js
+++ b/client/components/PubEdge/PubEdgeEditor.js
@@ -1,7 +1,9 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { EditableText, TagInput, InputGroup } from '@blueprintjs/core';
+import { EditableText, TagInput } from '@blueprintjs/core';
 import { Button as RKButton } from 'reakit/Button';
+
+import { DatePicker } from 'components';
 
 import { externalPublicationType } from './constants';
 import { getHostnameForUrl } from './util';
@@ -21,47 +23,25 @@ const PubEdgeEditor = (props) => {
 		onUpdateExternalPublication,
 	} = props;
 
-	const dateInputRef = useRef();
-
-	useEffect(() => {
-		const { current: dateInput } = dateInputRef;
-		if (publicationDate && dateInput) {
-			dateInput.valueAsDate = new Date(publicationDate);
-		}
-	}, [publicationDate]);
-
-	const handlePublicationDateChange = (evt) => {
-		const { valueAsDate, value } = evt.target;
-		if (valueAsDate) {
-			const nextPublicationDate = valueAsDate.toUTCString();
-			onUpdateExternalPublication({ publicationDate: nextPublicationDate });
-		} else {
-			const nextPublicationDate = new Date(value);
-			if (!Number.isNaN(nextPublicationDate.valueOf())) {
-				onUpdateExternalPublication({ publicationDate: nextPublicationDate });
-			}
-		}
-	};
-
 	const renderPublicationDate = () => {
 		if (publicationDate) {
 			return (
 				<>
 					Published on{' '}
-					<InputGroup
+					<DatePicker
 						small
 						className="editable-date"
-						type="date"
-						inputRef={dateInputRef}
-						onChange={handlePublicationDateChange}
-						placeholder="YYYY-MM-DD"
+						onSelectDate={(date) =>
+							onUpdateExternalPublication({ publicationDate: date })
+						}
+						date={publicationDate}
 					/>
 				</>
 			);
 		}
 
 		const addPublicationDate = () =>
-			onUpdateExternalPublication({ publicationDate: new Date().toUTCString() });
+			onUpdateExternalPublication({ publicationDate: new Date() });
 
 		return (
 			<RKButton

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -10,6 +10,7 @@ export { default as ConfirmDialog } from './ConfirmDialog/ConfirmDialog';
 export { default as DashboardFrame } from './DashboardFrame/DashboardFrame';
 export { default as DashboardRow } from './DashboardRow/DashboardRow';
 export { default as DashboardRowListing } from './DashboardRow/DashboardRowListing';
+export { default as DatePicker } from './DatePicker/DatePicker';
 export { default as DialogLauncher } from './DialogLauncher/DialogLauncher';
 export { default as DragDropListing } from './DragDropListing/DragDropListing';
 export { default as DropdownButton } from './DropdownButton/DropdownButton';

--- a/client/containers/DashboardSettings/PubSettings/PubSettings.js
+++ b/client/containers/DashboardSettings/PubSettings/PubSettings.js
@@ -6,6 +6,7 @@ import { Button, Tooltip } from '@blueprintjs/core';
 import {
 	Icon,
 	DashboardFrame,
+	DatePicker,
 	SettingsSection,
 	ImageUpload,
 	InputField,
@@ -121,6 +122,18 @@ const PubSettings = (props) => {
 						onChange={(evt) => updatePubData({ slug: slugifyString(evt.target.value) })}
 						error={!pubData.slug ? 'Required' : null}
 					/>
+					<InputField
+						label="Custom publication date"
+						helperText="If set, this will be shown instead of the first Release date."
+					>
+						<DatePicker
+							style={{ width: 200 }}
+							date={pubData.customPublishedAt}
+							onSelectDate={(date) =>
+								updatePubData({ customPublishedAt: date && date.toUTCString() })
+							}
+						/>
+					</InputField>
 					<InputField
 						label="Description"
 						placeholder="Enter description"

--- a/server/pub/permissions.js
+++ b/server/pub/permissions.js
@@ -31,6 +31,7 @@ export const getPermissions = async ({ userId, communityId, pubId, licenseSlug }
 		'licenseSlug',
 		'citationStyle',
 		'citationInlineStyle',
+		'customPublishedAt',
 	];
 	return {
 		create: true,

--- a/utils/dates.js
+++ b/utils/dates.js
@@ -7,10 +7,10 @@ export const formatDate = (
 		includeDate = true,
 		includePreposition = false,
 		use12HourDate = true,
-		inUTCTime = false,
+		inUtcTime = false,
 	} = {},
 ) => {
-	const formatMask = `${inUTCTime ? 'UTC:' : ''}mmm dd, yyyy`;
+	const formatMask = `${inUtcTime ? 'UTC:' : ''}mmm dd, yyyy`;
 	const formattedDate = includeDate
 		? (includePreposition ? 'on ' : '') + dateFormat(date, formatMask)
 		: '';

--- a/utils/dates.js
+++ b/utils/dates.js
@@ -39,3 +39,11 @@ export const timeAgoBaseProps = {
 		return `${value} ${newUnit} ${suffix}`;
 	},
 };
+
+export const getLocalDateMatchingUtcCalendarDate = (utcDate) => {
+	const formattedUtcDate = dateFormat(utcDate, 'UTC:yyyy-mm-dd');
+	const localDateOnSameDay = new Date(formattedUtcDate);
+	const returnDate = new Date(utcDate);
+	returnDate.setMinutes(returnDate.getMinutes() + localDateOnSameDay.getTimezoneOffset());
+	return returnDate;
+};

--- a/utils/pub/pubDates.js
+++ b/utils/pub/pubDates.js
@@ -1,3 +1,5 @@
+import { getLocalDateMatchingUtcCalendarDate } from 'utils/dates';
+
 const selectBranch = (pub, branch) => {
 	if (!branch && !pub.branches) {
 		return null;
@@ -22,7 +24,10 @@ export const getPubCreatedDate = (pub) => {
 
 export const getPubPublishedDate = (pub) => {
 	if (pub.customPublishedAt) {
-		return pub.customPublishedAt;
+		// This is a date string representing a time at midnight UTC for a given date.
+		// Unfortunately, that represents a time during the previous day in the Western hemisphere,
+		// which will cause this to improperly render the previous day.
+		return getLocalDateMatchingUtcCalendarDate(pub.customPublishedAt);
 	}
 	const { releases } = pub;
 	if (releases.length > 0) {


### PR DESCRIPTION
This PR allows users to set the `customPublishedAt` field that is displayed in place of the first Release date for a Pub as its publication date, as shown here:

![Screen Recording 2020-07-31 at 4 54 30 PM 2020-07-31 16_56_26](https://user-images.githubusercontent.com/2208769/89076873-1ff13500-d34f-11ea-9b98-2c1b9bddf996.gif)

There is a new `DatePicker` component in this PR that will make this sort of thing easier in the future. It uses the browser's built-in datepicker, which is good and getting better in most browsers, but still requires desktop Safari users to manually type dates in the indicated YYYY-MM-DD format, which is not the worst fate. The innards of this component do not look like idiomatic React, but its interface is much nicer than `<input type="date">` as it will only return a valid `Date` object or `null`.

_Test plan:_
- In the Storybook fixture for `DatePicker`, make sure the component works (including picking, typing, and clearing dates) in Firefox, Chrome, Safari, and Edger.
- Make sure that the `customPublishedAt` field works as expected as shown in the GIF above. Try picking dates from both sides of US daylight savings to make sure offsets are calculated correctly throughout the year when reverse-engineering a local date from a UTC date.

Resolves #903