### PR TITLE
feature: deposit supplements, preprints, and peer reviews

### DIFF
--- a/client/components/AssignDoi/AssignDoi.js
+++ b/client/components/AssignDoi/AssignDoi.js
@@ -1,10 +1,9 @@
 import React, { useReducer, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { Button, Callout, MenuItem } from '@blueprintjs/core';
-import { Select } from '@blueprintjs/select';
+import { Button, Callout } from '@blueprintjs/core';
 import pickBy from 'lodash.pickby';
 
-import { InputField } from 'components';
+import { InputField, Menu, MenuItem, DropdownButton, MenuButton } from 'components';
 import {
 	getDepositRecordContentVersion,
 	setDepositRecordContentVersion,
@@ -371,73 +370,61 @@ function AssignDoi(props) {
 						the information below, then click the "Submit Deposit" button to submit the
 						deposit to Crossref.
 					</Callout>
+
 					{!isStandaloneComponentDeposit(crossrefDepositRecord) && (
 						<InputField label="Content Version">
-							<Select
-								items={contentVersionItems}
-								itemRenderer={(item, { handleClick }) => (
+							<MenuButton
+								buttonContent={activeContentVersionItem.title}
+								buttonProps={{ rightIcon: 'caret-down' }}
+								aria-label="content-version"
+							>
+								{contentVersionItems.map((item) => (
 									<MenuItem
 										key={item.key}
 										active={item === activeContentVersionItem}
-										onClick={handleClick}
-										text={<span>{item.title}</span>}
+										onClick={() => handleContentVersionItemSelect(item)}
+										text={item.title}
 									/>
-								)}
-								onItemSelect={handleContentVersionItemSelect}
-								filterable={false}
-								popoverProps={{ minimal: true }}
-							>
-								<Button
-									text={<span>{activeContentVersionItem.title}</span>}
-									rightIcon="caret-down"
-								/>
-							</Select>
+								))}
+							</MenuButton>
 						</InputField>
 					)}
 
 					{isPeerReviewDeposit(crossrefDepositRecord) && (
 						<div className="dropdowns">
 							<InputField label="Review Type">
-								<Select
-									items={reviewTypeItems}
-									itemRenderer={(item, { handleClick }) => (
+								<MenuButton
+									buttonContent={activeReviewTypeItem.title}
+									buttonProps={{ rightIcon: 'caret-down' }}
+									aria-label="review-type"
+								>
+									{reviewTypeItems.map((item) => (
 										<MenuItem
 											key={item.key}
 											active={item === activeReviewTypeItem}
-											onClick={handleClick}
+											onClick={() => handleReviewTypeItemSelect(item)}
 											text={<span>{item.title}</span>}
 										/>
-									)}
-									onItemSelect={handleReviewTypeItemSelect}
-									filterable={false}
-									popoverProps={{ minimal: true }}
-								>
-									<Button
-										text={<span>{activeReviewTypeItem.title}</span>}
-										rightIcon="caret-down"
-									/>
-								</Select>
+									))}
+								</MenuButton>
 							</InputField>
 							<InputField label="Review Recommendation">
-								<Select
-									items={reviewRecommendationItems}
-									itemRenderer={(item, { handleClick }) => (
+								<MenuButton
+									buttonContent={activeReviewRecommendationItem.title}
+									buttonProps={{ rightIcon: 'caret-down' }}
+									aria-label="review-type"
+								>
+									{reviewRecommendationItems.map((item) => (
 										<MenuItem
 											key={item.key}
 											active={item === activeReviewRecommendationItem}
-											onClick={handleClick}
+											onClick={() =>
+												handleReviewRecommendationItemSelect(item)
+											}
 											text={<span>{item.title}</span>}
 										/>
-									)}
-									onItemSelect={handleReviewRecommendationItemSelect}
-									filterable={false}
-									popoverProps={{ minimal: true }}
-								>
-									<Button
-										text={<span>{activeReviewRecommendationItem.title}</span>}
-										rightIcon="caret-down"
-									/>
-								</Select>
+									))}
+								</MenuButton>
 							</InputField>
 						</div>
 					)}

--- a/client/components/AssignDoi/AssignDoi.js
+++ b/client/components/AssignDoi/AssignDoi.js
@@ -11,8 +11,8 @@ import {
 	setDepositRecordReviewType,
 	getDepositRecordReviewRecommendation,
 	setDepositRecordReviewRecommendation,
-	isPreprint,
-	isReview,
+	isPreprintDeposit,
+	isPeerReviewDeposit,
 	getDepositTypeTitle,
 } from 'utils/crossref/parseDeposit';
 import { apiFetch } from 'client/utils/apiFetch';
@@ -235,7 +235,7 @@ function AssignDoi(props) {
 	let contentVersion = getDepositRecordContentVersion(result);
 
 	// Assume preprint if no content version is present and body consists of posted_content.
-	if (!contentVersion && isPreprint(result || pubData.crossrefDepositRecord)) {
+	if (!contentVersion && isPreprintDeposit(result || pubData.crossrefDepositRecord)) {
 		contentVersion = 'preprint';
 	}
 
@@ -378,7 +378,7 @@ function AssignDoi(props) {
 						</Select>
 					</InputField>
 
-					{isReview(result) && (
+					{isPeerReviewDeposit(result) && (
 						<div className="dropdowns">
 							<InputField label="Review Type">
 								<Select

--- a/client/components/AssignDoi/AssignDoiPreview.js
+++ b/client/components/AssignDoi/AssignDoiPreview.js
@@ -237,7 +237,14 @@ const renderPreprintPreview = (body) => {
 
 const renderPeerReviewPreview = (body) => {
 	const {
-		peer_review: { contributors, titles, 'rel:program': relationships, review_date },
+		peer_review: {
+			'@type': type,
+			'@recommendation': recommendation,
+			contributors,
+			titles,
+			'rel:program': relationships,
+			review_date,
+		},
 	} = body;
 
 	return (
@@ -247,6 +254,18 @@ const renderPeerReviewPreview = (body) => {
 				{renderTitles(titles)}
 				{renderContributors(contributors)}
 				{renderPublicationDate(review_date, 'Review Date')}
+				{type && (
+					<>
+						<dt>Review Type</dt>
+						<dd>{type}</dd>
+					</>
+				)}
+				{recommendation && (
+					<>
+						<dt>Review Recommendation</dt>
+						<dd>{recommendation}</dd>
+					</>
+				)}
 			</dl>
 			{renderRelationships(relationships)}
 		</>

--- a/client/components/AssignDoi/AssignDoiPreview.js
+++ b/client/components/AssignDoi/AssignDoiPreview.js
@@ -6,10 +6,12 @@ import { formatDate } from 'utils/dates';
 import {
 	getDepositBody,
 	getDepositRecordContentVersion,
-	isPreprint,
-	isBook,
-	isJournal,
-	isConference,
+	isPreprintDeposit,
+	isBookDeposit,
+	isJournalDeposit,
+	isConferenceDeposit,
+	isPeerReviewDeposit,
+	isStandaloneComponentDeposit,
 } from 'utils/crossref/parseDeposit';
 
 require('./assignDoiPreview.scss');
@@ -233,6 +235,50 @@ const renderPreprintPreview = (body) => {
 	);
 };
 
+const renderPeerReviewPreview = (body) => {
+	const {
+		peer_review: { contributors, titles, 'rel:program': relationships, review_date },
+	} = body;
+
+	return (
+		<>
+			<h6>Peer Review</h6>
+			<dl>
+				{renderTitles(titles)}
+				{renderContributors(contributors)}
+				{renderPublicationDate(review_date, 'Review Date')}
+			</dl>
+			{renderRelationships(relationships)}
+		</>
+	);
+};
+
+const renderSupplementPreview = (body) => {
+	const {
+		sa_component: {
+			['@parent_doi']: parentDoi,
+			component_list: {
+				component: { contributors, titles, publication_date },
+			},
+		},
+	} = body;
+
+	return (
+		<>
+			<h6>Standalone Component</h6>
+			<dl>
+				<dt>Parent DOI</dt>
+				<dd>{parentDoi}</dd>
+				<dt>Parent Relation</dt>
+				<dd>isPartOf</dd>
+				{renderTitles(titles)}
+				{renderContributors(contributors)}
+				{renderPublicationDate(publication_date)}
+			</dl>
+		</>
+	);
+};
+
 function AssignDoiPreview(props) {
 	const [selectedTab, setSelectedTab] = useState('preview');
 	const { crossrefDepositRecord } = props;
@@ -262,10 +308,13 @@ function AssignDoiPreview(props) {
 						</>
 					)}
 				</dl>
-				{isJournal(crossrefDepositRecord) && renderArticlePreview(body)}
-				{isBook(crossrefDepositRecord) && renderBookPreview(body)}
-				{isConference(crossrefDepositRecord) && renderConferencePreview(body)}
-				{isPreprint(crossrefDepositRecord) && renderPreprintPreview(body)}
+				{isJournalDeposit(crossrefDepositRecord) && renderArticlePreview(body)}
+				{isBookDeposit(crossrefDepositRecord) && renderBookPreview(body)}
+				{isConferenceDeposit(crossrefDepositRecord) && renderConferencePreview(body)}
+				{isPreprintDeposit(crossrefDepositRecord) && renderPreprintPreview(body)}
+				{isPeerReviewDeposit(crossrefDepositRecord) && renderPeerReviewPreview(body)}
+				{isStandaloneComponentDeposit(crossrefDepositRecord) &&
+					renderSupplementPreview(body)}
 			</>
 		);
 	};

--- a/client/components/AssignDoi/assignDoi.scss
+++ b/client/components/AssignDoi/assignDoi.scss
@@ -3,10 +3,6 @@
 		margin: 0 0 12px 0;
 	}
 
-	.bp3-callout {
-		margin: 20px 0;
-	}
-
 	.dropdowns {
 		display: flex;
 

--- a/client/components/AssignDoi/assignDoi.scss
+++ b/client/components/AssignDoi/assignDoi.scss
@@ -2,4 +2,16 @@
 	> p {
 		margin: 0 0 12px 0;
 	}
+
+	.bp3-callout {
+		margin: 20px 0;
+	}
+
+	.dropdowns {
+		display: flex;
+
+		> .bp3-form-group.input-field-component {
+			margin-right: 36px;
+		}
+	}
 }

--- a/client/components/AssignDoi/assignDoi.scss
+++ b/client/components/AssignDoi/assignDoi.scss
@@ -6,6 +6,7 @@
 	.dropdowns {
 		display: flex;
 
+		// Added .bp3-form-group to increase selector specificity.
 		> .bp3-form-group.input-field-component {
 			margin-right: 36px;
 		}

--- a/client/containers/DashboardSettings/PubSettings/Doi.js
+++ b/client/containers/DashboardSettings/PubSettings/Doi.js
@@ -246,16 +246,14 @@ class Doi extends Component {
 
 		return (
 			<>
+				{!pubData.doi && <p>A DOI can be set for each Pub by admins of this community.</p>}
+				{pubData.crossrefDepositRecordId && <p>This Pub has been deposited to Crossref.</p>}
 				{this.findSupplementTo() && (
 					<Callout intent="warning">
 						The DOI for this Pub is not editable because it is a{' '}
 						<strong>Supplement</strong> to another Pub.
 					</Callout>
 				)}
-				{!pubData.doi && this.isDoiEditable() && (
-					<p>A DOI can be set for each Pub by admins of this community.</p>
-				)}
-				{pubData.crossrefDepositRecordId && <p>DOIs have been registered for this pub.</p>}
 			</>
 		);
 	}

--- a/client/containers/DashboardSettings/PubSettings/Doi.js
+++ b/client/containers/DashboardSettings/PubSettings/Doi.js
@@ -198,7 +198,7 @@ class Doi extends Component {
 			canIssueDoi &&
 			// a deposit has not been submitted yet for this work
 			!(justSetDoi || pubData.crossrefDepositRecordId) &&
-			// a deposit record does not exist OR the deposit record does exist and is not a peer review
+			// the Pub is not a supplement to another work
 			!this.findSupplementTo() &&
 			// and the community has a custom, hardcoded DOI prefix
 			managedDoiPrefixes.includes(doiPrefix) &&

--- a/client/containers/DashboardSettings/PubSettings/Doi.js
+++ b/client/containers/DashboardSettings/PubSettings/Doi.js
@@ -10,7 +10,7 @@ import {
 import { apiFetch } from 'client/utils/apiFetch';
 import { getSchemaForKind } from 'utils/collections/schemas';
 import { isDoi } from 'utils/crossref/parseDoi';
-import { RelationType, findParentEdgeByRelationType } from 'utils/pubEdge/relations';
+import { RelationType, findParentEdgeByRelationTypes } from 'utils/pubEdge/relations';
 
 import { AssignDoi } from 'components';
 
@@ -94,7 +94,7 @@ class Doi extends Component {
 
 	findSupplementTo() {
 		const { pubData } = this.props;
-		return findParentEdgeByRelationType(pubData, RelationType.Supplement);
+		return findParentEdgeByRelationTypes(pubData, [RelationType.Supplement]);
 	}
 
 	async updateDoi(doi, pendingStateKey, fallback) {

--- a/client/containers/DashboardSettings/PubSettings/doi.scss
+++ b/client/containers/DashboardSettings/PubSettings/doi.scss
@@ -5,6 +5,14 @@
 		font-family: 'Courier', monospace;
 	}
 
+	.bp3-callout {
+		margin-bottom: 20px;
+
+		&:not(:first-child) {
+			margin-top: 20px;
+		}
+	}
+
 	> .doi {
 		max-width: 416px;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13539,6 +13539,11 @@
 				"lodash.restparam": "^3.0.0"
 			}
 		},
+		"lodash.pickby": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+			"integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
+		},
 		"lodash.restparam": {
 			"version": "3.6.1",
 			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
 		"keen-tracking": "^4.4.0",
 		"keyboardjs": "^2.5.1",
 		"lodash.mergewith": "^4.6.2",
+		"lodash.pickby": "^4.6.0",
 		"lodash.throttle": "^4.1.1",
 		"mailgun.js": "^2.0.1",
 		"mini-css-extract-plugin": "^0.7.0",

--- a/server/doi/api.js
+++ b/server/doi/api.js
@@ -34,7 +34,7 @@ const previewOrDepositDoi = async (user, body, options = { deposit: false }) => 
 		pubId: pubId || null,
 	};
 
-	assertUserAuthenticated(target, requestIds);
+	await assertUserAuthenticated(target, requestIds);
 
 	const depositJson = await (deposit ? setDoiData : getDoiData)(
 		{
@@ -85,7 +85,7 @@ app.get(
 			pubId: pubId || null,
 		};
 
-		assertUserAuthenticated(target, requestIds);
+		await assertUserAuthenticated(target, requestIds);
 
 		return res.status(200).json({
 			dois: await generateDoi({ communityId, collectionId, pubId }, target),

--- a/server/doi/api.js
+++ b/server/doi/api.js
@@ -7,7 +7,15 @@ import { getPermissions } from './permissions';
 
 const previewOrDepositDoi = async (user, body, options = { deposit: false }) => {
 	const { deposit } = options;
-	const { target, communityId, collectionId, pubId, contentVersion } = body;
+	const {
+		target,
+		communityId,
+		collectionId,
+		pubId,
+		contentVersion,
+		reviewType,
+		reviewRecommendation,
+	} = body;
 	const requestIds = {
 		userId: user.id,
 		communityId: communityId,
@@ -29,6 +37,8 @@ const previewOrDepositDoi = async (user, body, options = { deposit: false }) => 
 			collectionId: collectionId,
 			pubId: pubId,
 			contentVersion: contentVersion,
+			reviewType: reviewType,
+			reviewRecommendation: reviewRecommendation,
 		},
 		target,
 	);

--- a/server/doi/queries.js
+++ b/server/doi/queries.js
@@ -98,7 +98,10 @@ const persistDoiData = (ids, dois) => {
 	return Promise.all(updates);
 };
 
-export const getDoiData = ({ communityId, collectionId, pubId, contentVersion }, doiTarget) =>
+export const getDoiData = (
+	{ communityId, collectionId, pubId, contentVersion, reviewType, reviewRecommendation },
+	doiTarget,
+) =>
 	Promise.all([
 		findCommunity(communityId),
 		collectionId && findCollection(collectionId),
@@ -113,6 +116,8 @@ export const getDoiData = ({ communityId, collectionId, pubId, contentVersion },
 				community: community,
 				pub: pub,
 				contentVersion: contentVersion,
+				reviewType: reviewType,
+				reviewRecommendation: reviewRecommendation,
 			},
 			doiTarget,
 		);

--- a/server/doi/queries.js
+++ b/server/doi/queries.js
@@ -1,4 +1,5 @@
-import createDeposit from 'utils/crossref/createDeposit';
+import createDeposit, { getDois } from 'utils/crossref/createDeposit';
+
 import {
 	Collection,
 	CollectionAttribution,
@@ -151,3 +152,20 @@ export const setDoiData = (
 				return { deposit: deposit, dois: dois };
 			});
 	});
+
+export const generateDoi = async ({ communityId, collectionId, pubId }, target) => {
+	const [community, collection, pub] = await Promise.all([
+		findCommunity(communityId),
+		collectionId && findCollection(collectionId),
+		pubId && findPub(pubId),
+	]);
+
+	return getDois(
+		{
+			pub: pub,
+			community: community,
+			collection: collection,
+		},
+		target,
+	);
+};

--- a/server/doi/queries.js
+++ b/server/doi/queries.js
@@ -123,13 +123,18 @@ export const getDoiData = (
 		);
 	});
 
-export const setDoiData = ({ communityId, collectionId, pubId, contentVersion }, doiTarget) =>
+export const setDoiData = (
+	{ communityId, collectionId, pubId, contentVersion, reviewType, reviewRecommendation },
+	doiTarget,
+) =>
 	getDoiData(
 		{
 			communityId: communityId,
 			collectionId: collectionId,
 			pubId: pubId,
 			contentVersion: contentVersion,
+			reviewType: reviewType,
+			reviewRecommendation: reviewRecommendation,
 		},
 		doiTarget,
 	).then((depositJson) => {

--- a/server/pub/model.js
+++ b/server/pub/model.js
@@ -127,7 +127,6 @@ export default (sequelize, dataTypes) => {
 						foreignKey: 'targetPubId',
 					});
 					Pub.belongsTo(CrossrefDepositRecord, {
-						onDelete: 'CASCADE',
 						as: 'crossrefDepositRecord',
 						foreignKey: 'crossrefDepositRecordId',
 					});

--- a/server/routes/dashboardSettings.js
+++ b/server/routes/dashboardSettings.js
@@ -10,7 +10,7 @@ import { getPub, sanitizePub } from 'server/utils/queryHelpers';
 
 const getSettingsData = async (pubSlug, initialData) => {
 	if (pubSlug) {
-		const pubData = await getPub(pubSlug, initialData.communityData.id);
+		const pubData = await getPub(pubSlug, initialData.communityData.id, { getEdges: 'all' });
 		return { pubData: sanitizePub(pubData, initialData) };
 	}
 	return {};

--- a/tools/migrations/2020_07_22_addCrossrefDepositRecord.js
+++ b/tools/migrations/2020_07_22_addCrossrefDepositRecord.js
@@ -6,7 +6,6 @@ module.exports = async ({ Sequelize, sequelize }) => {
 			model: 'CrossrefDepositRecords',
 			key: 'id',
 		},
-		onDelete: 'CASCADE',
 	});
 	await sequelize.queryInterface.addColumn('Collections', 'crossrefDepositRecordId', {
 		type: Sequelize.UUID,
@@ -15,6 +14,5 @@ module.exports = async ({ Sequelize, sequelize }) => {
 			model: 'CrossrefDepositRecords',
 			key: 'id',
 		},
-		onDelete: 'CASCADE',
 	});
 };

--- a/utils/crossref/createDeposit.js
+++ b/utils/crossref/createDeposit.js
@@ -89,7 +89,7 @@ const assertParentPubHasDoi = (parentPub) => {
 	return true;
 };
 
-const getDois = (context, doiTarget) => {
+export const getDois = (context, doiTarget) => {
 	const { pub, collection, community, pubEdge } = context;
 	const dois = {};
 

--- a/utils/crossref/createDeposit.js
+++ b/utils/crossref/createDeposit.js
@@ -103,7 +103,7 @@ export const getDois = (context, doiTarget) => {
 			if (pubEdge && pubEdge.relationType === RelationType.Supplement) {
 				const parentPub = pubEdge.pubIsParent ? pubEdge.pub : pubEdge.targetPub;
 				assertParentPubHasDoi(parentPub);
-				doi.pub = createComponentDoi(parentPub, pubEdge);
+				dois.pub = createComponentDoi(parentPub, pubEdge);
 			} else {
 				dois.pub =
 					pub.doi ||

--- a/utils/crossref/createDoi.js
+++ b/utils/crossref/createDoi.js
@@ -2,17 +2,14 @@ import { choosePrefixByCommunityId } from './communities';
 
 const splitId = (item) => item.id.split('-')[0];
 
-export const makeComponentId = (community, collection, pub) =>
-	[community && splitId(community), collection && splitId(collection), pub && splitId(pub)]
-		.map((result) => result || 'none')
-		.join('-');
+export const createComponentDoi = (parentPub, pubEdge) => {
+	return `${parentPub.doi}/${splitId(pubEdge)}`;
+};
 
-export default ({ community, target, pubEdge }) => {
+export default ({ community, target }) => {
 	const communityPart = splitId(community);
 	const targetPart = target ? `.${splitId(target)}` : '';
 	const component = communityPart + targetPart;
 
-	return `${choosePrefixByCommunityId(community.id)}/${component}${
-		pubEdge ? `/${splitId(pubEdge)}` : ''
-	}`;
+	return `${choosePrefixByCommunityId(community.id)}/${component}`;
 };

--- a/utils/crossref/createDoi.js
+++ b/utils/crossref/createDoi.js
@@ -7,9 +7,12 @@ export const makeComponentId = (community, collection, pub) =>
 		.map((result) => result || 'none')
 		.join('-');
 
-export default ({ community, target }) => {
+export default ({ community, target, pubEdge }) => {
 	const communityPart = splitId(community);
 	const targetPart = target ? `.${splitId(target)}` : '';
 	const component = communityPart + targetPart;
-	return `${choosePrefixByCommunityId(community.id)}/${component}`;
+
+	return `${choosePrefixByCommunityId(community.id)}/${component}${
+		pubEdge ? `/${splitId(pubEdge)}` : ''
+	}`;
 };

--- a/utils/crossref/parseDeposit.js
+++ b/utils/crossref/parseDeposit.js
@@ -49,10 +49,17 @@ export const getDepositRecordContentVersion = (depositRecord) => {
 		return null;
 	}
 
+	if (doiData.resource['@content_version'] === 'none') {
+		throw new Error('What th efuck');
+	}
+
 	return doiData.resource['@content_version'];
 };
 
 export const setDepositRecordContentVersion = (depositRecord, contentVersion) => {
+	if (contentVersion === 'none') {
+		throw new Error('What th efuck');
+	}
 	const {
 		depositJson: { deposit },
 	} = depositRecord;

--- a/utils/crossref/parseDeposit.js
+++ b/utils/crossref/parseDeposit.js
@@ -138,11 +138,19 @@ export const isPeerReviewDeposit = createIsDeposit('peer_review');
 export const isStandaloneComponentDeposit = createIsDeposit('sa_component');
 
 export const getDepositTypeTitle = (crossrefDepositRecord) => {
-	if (isBookDeposit(crossrefDepositRecord)) return 'Book Chapter';
-	if (isJournalDeposit(crossrefDepositRecord)) return 'Journal Article';
-	if (isConferenceDeposit(crossrefDepositRecord)) return 'Conference Proceeding';
-	if (isPreprintDeposit(crossrefDepositRecord)) return 'Preprint';
-	if (isPeerReviewDeposit(crossrefDepositRecord)) return 'Peer Review';
-	if (isStandaloneComponentDeposit(crossrefDepositRecord)) return 'Supplement';
+	switch (true) {
+		case isBookDeposit(crossrefDepositRecord):
+			return 'Book Chapter';
+		case isJournalDeposit(crossrefDepositRecord):
+			return 'Journal Article';
+		case isConferenceDeposit(crossrefDepositRecord):
+			return 'Conference Proceeding';
+		case isPreprintDeposit(crossrefDepositRecord):
+			return 'Preprint';
+		case isPeerReviewDeposit(crossrefDepositRecord):
+			return 'Peer Review';
+		case isStandaloneComponentDeposit(crossrefDepositRecord):
+			return 'Supplement';
+	}
 	return '';
 };

--- a/utils/crossref/parseDeposit.js
+++ b/utils/crossref/parseDeposit.js
@@ -3,6 +3,7 @@ const doiDataPaths = [
 	['conference', 'conference_paper'],
 	['journal', 'journal_article'],
 	['posted_content'],
+	['peer_review'],
 ];
 
 export const getDoiData = ({ doi_batch: { body } }) => {
@@ -34,19 +35,6 @@ export const getDoiData = ({ doi_batch: { body } }) => {
 	return null;
 };
 
-export const setDepositRecordContentVersion = (depositRecord, contentVersion) => {
-	const {
-		depositJson: { deposit },
-	} = depositRecord;
-	const doiData = getDoiData(deposit);
-
-	if (!contentVersion) {
-		delete doiData.resource['@content_version'];
-	} else {
-		doiData.resource['@content_version'] = contentVersion;
-	}
-};
-
 export const getDepositRecordContentVersion = (depositRecord) => {
 	if (!depositRecord) {
 		return null;
@@ -64,6 +52,77 @@ export const getDepositRecordContentVersion = (depositRecord) => {
 	return doiData.resource['@content_version'];
 };
 
+export const setDepositRecordContentVersion = (depositRecord, contentVersion) => {
+	const {
+		depositJson: { deposit },
+	} = depositRecord;
+	const doiData = getDoiData(deposit);
+
+	if (!contentVersion) {
+		delete doiData.resource['@content_version'];
+	} else {
+		doiData.resource['@content_version'] = contentVersion;
+	}
+};
+
+export const getDepositRecordReviewType = (depositRecord) => {
+	if (!depositRecord) {
+		return null;
+	}
+
+	const {
+		depositJson: {
+			deposit: {
+				doi_batch: { body },
+			},
+		},
+	} = depositRecord;
+
+	if (!('peer_review' in body)) {
+		return null;
+	}
+
+	return body.peer_review['@type'];
+};
+
+export const setDepositRecordReviewType = (depositRecord, reviewType) => {
+	if (!depositRecord) {
+		return null;
+	}
+
+	depositRecord.depositJson.deposit.doi_batch.body.peer_review['@type'] = reviewType;
+};
+
+export const getDepositRecordReviewRecommendation = (depositRecord) => {
+	if (!depositRecord) {
+		return null;
+	}
+
+	const {
+		depositJson: {
+			deposit: {
+				doi_batch: { body },
+			},
+		},
+	} = depositRecord;
+
+	if (!('peer_review' in body)) {
+		return null;
+	}
+
+	return body.peer_review['@recommendation'];
+};
+
+export const setDepositRecordReviewRecommendation = (depositRecord, recommendation) => {
+	if (!depositRecord) {
+		return null;
+	}
+
+	depositRecord.depositJson.deposit.doi_batch.body.peer_review[
+		'@recommendation'
+	] = recommendation;
+};
+
 export const getDepositBody = (crossrefDepositRecord) =>
 	crossrefDepositRecord.depositJson.deposit.doi_batch.body;
 
@@ -75,3 +134,17 @@ export const isConference = (crossrefDepositRecord) =>
 	crossrefDepositRecord && 'conference' in getDepositBody(crossrefDepositRecord);
 export const isPreprint = (crossrefDepositRecord) =>
 	crossrefDepositRecord && 'posted_content' in getDepositBody(crossrefDepositRecord);
+export const isReview = (crossrefDepositRecord) =>
+	crossrefDepositRecord && 'peer_review' in getDepositBody(crossrefDepositRecord);
+export const isSupplementaryMaterial = (crossrefDepositRecord) =>
+	crossrefDepositRecord && 'component_list' in getDepositBody(crossrefDepositRecord);
+
+export const getDepositTypeTitle = (crossrefDepositRecord) => {
+	if (isBook(crossrefDepositRecord)) return 'Book';
+	if (isJournal(crossrefDepositRecord)) return 'Journal';
+	if (isConference(crossrefDepositRecord)) return 'Conference';
+	if (isPreprint(crossrefDepositRecord)) return 'Preprint';
+	if (isReview(crossrefDepositRecord)) return 'Peer Review';
+	if (isSupplementaryMaterial(crossrefDepositRecord)) return 'Supplementary Material';
+	return '';
+};

--- a/utils/crossref/parseDeposit.js
+++ b/utils/crossref/parseDeposit.js
@@ -4,6 +4,7 @@ const doiDataPaths = [
 	['journal', 'journal_article'],
 	['posted_content'],
 	['peer_review'],
+	['sa_component', 'component_list', 'component'],
 ];
 
 export const getDoiData = ({ doi_batch: { body } }) => {
@@ -49,17 +50,10 @@ export const getDepositRecordContentVersion = (depositRecord) => {
 		return null;
 	}
 
-	if (doiData.resource['@content_version'] === 'none') {
-		throw new Error('What th efuck');
-	}
-
 	return doiData.resource['@content_version'];
 };
 
 export const setDepositRecordContentVersion = (depositRecord, contentVersion) => {
-	if (contentVersion === 'none') {
-		throw new Error('What th efuck');
-	}
 	const {
 		depositJson: { deposit },
 	} = depositRecord;
@@ -144,9 +138,9 @@ export const isPeerReviewDeposit = createIsDeposit('peer_review');
 export const isStandaloneComponentDeposit = createIsDeposit('sa_component');
 
 export const getDepositTypeTitle = (crossrefDepositRecord) => {
-	if (isBookDeposit(crossrefDepositRecord)) return 'Book';
-	if (isJournalDeposit(crossrefDepositRecord)) return 'Journal';
-	if (isConferenceDeposit(crossrefDepositRecord)) return 'Conference';
+	if (isBookDeposit(crossrefDepositRecord)) return 'Book Chapter';
+	if (isJournalDeposit(crossrefDepositRecord)) return 'Journal Article';
+	if (isConferenceDeposit(crossrefDepositRecord)) return 'Conference Proceeding';
 	if (isPreprintDeposit(crossrefDepositRecord)) return 'Preprint';
 	if (isPeerReviewDeposit(crossrefDepositRecord)) return 'Peer Review';
 	if (isStandaloneComponentDeposit(crossrefDepositRecord)) return 'Supplement';

--- a/utils/crossref/parseDeposit.js
+++ b/utils/crossref/parseDeposit.js
@@ -126,25 +126,22 @@ export const setDepositRecordReviewRecommendation = (depositRecord, recommendati
 export const getDepositBody = (crossrefDepositRecord) =>
 	crossrefDepositRecord.depositJson.deposit.doi_batch.body;
 
-export const isBook = (crossrefDepositRecord) =>
-	crossrefDepositRecord && 'book' in getDepositBody(crossrefDepositRecord);
-export const isJournal = (crossrefDepositRecord) =>
-	crossrefDepositRecord && 'journal' in getDepositBody(crossrefDepositRecord);
-export const isConference = (crossrefDepositRecord) =>
-	crossrefDepositRecord && 'conference' in getDepositBody(crossrefDepositRecord);
-export const isPreprint = (crossrefDepositRecord) =>
-	crossrefDepositRecord && 'posted_content' in getDepositBody(crossrefDepositRecord);
-export const isReview = (crossrefDepositRecord) =>
-	crossrefDepositRecord && 'peer_review' in getDepositBody(crossrefDepositRecord);
-export const isSupplementaryMaterial = (crossrefDepositRecord) =>
-	crossrefDepositRecord && 'component_list' in getDepositBody(crossrefDepositRecord);
+const createIsDeposit = (key) => (crossrefDepositRecord) =>
+	crossrefDepositRecord && key in getDepositBody(crossrefDepositRecord);
+
+export const isBookDeposit = createIsDeposit('book');
+export const isJournalDeposit = createIsDeposit('journal');
+export const isConferenceDeposit = createIsDeposit('conference');
+export const isPreprintDeposit = createIsDeposit('posted_content');
+export const isPeerReviewDeposit = createIsDeposit('peer_review');
+export const isStandaloneComponentDeposit = createIsDeposit('sa_component');
 
 export const getDepositTypeTitle = (crossrefDepositRecord) => {
-	if (isBook(crossrefDepositRecord)) return 'Book';
-	if (isJournal(crossrefDepositRecord)) return 'Journal';
-	if (isConference(crossrefDepositRecord)) return 'Conference';
-	if (isPreprint(crossrefDepositRecord)) return 'Preprint';
-	if (isReview(crossrefDepositRecord)) return 'Peer Review';
-	if (isSupplementaryMaterial(crossrefDepositRecord)) return 'Supplementary Material';
+	if (isBookDeposit(crossrefDepositRecord)) return 'Book';
+	if (isJournalDeposit(crossrefDepositRecord)) return 'Journal';
+	if (isConferenceDeposit(crossrefDepositRecord)) return 'Conference';
+	if (isPreprintDeposit(crossrefDepositRecord)) return 'Preprint';
+	if (isPeerReviewDeposit(crossrefDepositRecord)) return 'Peer Review';
+	if (isStandaloneComponentDeposit(crossrefDepositRecord)) return 'Supplement';
 	return '';
 };

--- a/utils/crossref/render/review.js
+++ b/utils/crossref/render/review.js
@@ -1,0 +1,17 @@
+/**
+ * Renders a peer review of another work.
+ */
+import peerReview from '../schema/peerReview';
+
+import transformCommunity from '../transform/community';
+import transformPub from '../transform/pub';
+
+export default ({ globals, community, pub }) => {
+	const communityProps = transformCommunity({ globals: globals })(community);
+	const pubProps = pub && transformPub({ globals: globals, community: community })(pub);
+	return peerReview({
+		...communityProps,
+		timestamp: globals.timestamp,
+		...pubProps,
+	});
+};

--- a/utils/crossref/render/supplement.js
+++ b/utils/crossref/render/supplement.js
@@ -6,12 +6,17 @@ import componentList from '../schema/componentList';
 import transformCommunity from '../transform/community';
 import transformPub from '../transform/pub';
 
-export default ({ globals, community, pub }) => {
+export default ({ globals, community, pub, parentDoi }) => {
 	const communityProps = transformCommunity({ globals: globals })(community);
 	const pubProps = pub && transformPub({ globals: globals, community: community })(pub);
-	return componentList({
-		...communityProps,
-		timestamp: globals.timestamp,
-		...pubProps,
-	});
+	return {
+		sa_component: {
+			'@parent_doi': parentDoi,
+			...componentList({
+				...communityProps,
+				timestamp: globals.timestamp,
+				...pubProps,
+			}),
+		},
+	};
 };

--- a/utils/crossref/render/supplement.js
+++ b/utils/crossref/render/supplement.js
@@ -1,0 +1,17 @@
+/**
+ * Renders a preprint for a journal article.
+ */
+import componentList from '../schema/componentList';
+
+import transformCommunity from '../transform/community';
+import transformPub from '../transform/pub';
+
+export default ({ globals, community, pub }) => {
+	const communityProps = transformCommunity({ globals: globals })(community);
+	const pubProps = pub && transformPub({ globals: globals, community: community })(pub);
+	return componentList({
+		...communityProps,
+		timestamp: globals.timestamp,
+		...pubProps,
+	});
+};

--- a/utils/crossref/schema/componentList.js
+++ b/utils/crossref/schema/componentList.js
@@ -1,0 +1,28 @@
+import contributors from './contributors';
+import doiData from './doiData';
+import date from './helpers/date';
+import relations from './relations';
+
+export default ({
+	// attributions,
+	// language,
+	doi,
+	// publicationDate,
+	resourceUrl,
+	timestamp,
+	title,
+	relatedItems,
+}) => ({
+	component_list: {
+		'@xmlns:rel': 'http://www.crossref.org/relations.xsd',
+		sa_component: {
+			'@parent_doi': '',
+		},
+		titles: {
+			title: title,
+		},
+		// ...date('posted_date', publicationDate, 'print'),
+		...(relatedItems.length > 0 && relations(relatedItems)),
+		...doiData(doi, timestamp, resourceUrl),
+	},
+});

--- a/utils/crossref/schema/componentList.js
+++ b/utils/crossref/schema/componentList.js
@@ -1,28 +1,26 @@
 import contributors from './contributors';
 import doiData from './doiData';
 import date from './helpers/date';
-import relations from './relations';
 
 export default ({
-	// attributions,
-	// language,
+	attributions,
+	language,
 	doi,
-	// publicationDate,
+	publicationDate,
 	resourceUrl,
 	timestamp,
 	title,
-	relatedItems,
 }) => ({
 	component_list: {
-		'@xmlns:rel': 'http://www.crossref.org/relations.xsd',
-		sa_component: {
-			'@parent_doi': '',
+		component: {
+			'@language': language,
+			'@parent_relation': 'isPartOf',
+			titles: {
+				title: title,
+			},
+			...contributors(attributions),
+			...date('publication_date', publicationDate, 'print'),
+			...doiData(doi, timestamp, resourceUrl),
 		},
-		titles: {
-			title: title,
-		},
-		// ...date('posted_date', publicationDate, 'print'),
-		...(relatedItems.length > 0 && relations(relatedItems)),
-		...doiData(doi, timestamp, resourceUrl),
 	},
 });

--- a/utils/crossref/schema/doiBatch.js
+++ b/utils/crossref/schema/doiBatch.js
@@ -9,7 +9,7 @@ const SCHEMA_METADATA = {
 const HEAD_METADATA = {
 	depositor: {
 		depositor_name: 'PubPub',
-		email_address: 'pubpub@media.mit.edu',
+		email_address: 'crossref@pubpub.org',
 	},
 	registrant: 'PubPub',
 };

--- a/utils/crossref/schema/doiData.js
+++ b/utils/crossref/schema/doiData.js
@@ -11,7 +11,7 @@ export default (doi, timestamp, resource, contentVersion) => {
 			timestamp: timestamp,
 			resource: {
 				'#text': resource,
-				'@content_version': contentVersion,
+				...(contentVersion && { '@content_version': contentVersion }),
 			},
 		},
 	};

--- a/utils/crossref/schema/helpers/date.js
+++ b/utils/crossref/schema/helpers/date.js
@@ -7,7 +7,7 @@ export default (kind, date, mediaType = 'online') => {
 	}
 	return {
 		[kind]: {
-			'@media_type': mediaType,
+			...(mediaType && { '@media_type': mediaType }),
 			month: `0${date.getMonth() + 1}`.slice(-2),
 			day: `0${date.getDate()}`.toString().slice(-2),
 			year: date.getFullYear().toString(),

--- a/utils/crossref/schema/peerReview.js
+++ b/utils/crossref/schema/peerReview.js
@@ -25,7 +25,7 @@ export default ({
 		titles: {
 			title: title,
 		},
-		...date('review_date', publicationDate),
+		...date('review_date', publicationDate, null),
 		...(relatedItems.length > 0 && relations(relatedItems)),
 		...doiData(doi, timestamp, resourceUrl, contentVersion),
 	},

--- a/utils/crossref/schema/peerReview.js
+++ b/utils/crossref/schema/peerReview.js
@@ -1,0 +1,32 @@
+import contributors from './contributors';
+import doiData from './doiData';
+import date from './helpers/date';
+import relations from './relations';
+
+export default ({
+	attributions,
+	language,
+	doi,
+	publicationDate,
+	resourceUrl,
+	timestamp,
+	title,
+	relatedItems,
+	contentVersion,
+	reviewType,
+	reviewRecommendation,
+}) => ({
+	peer_review: {
+		'@xmlns:rel': 'http://www.crossref.org/relations.xsd',
+		'@language': language,
+		'@type': reviewType,
+		'@recommendation': reviewRecommendation,
+		...contributors(attributions),
+		titles: {
+			title: title,
+		},
+		...date('review_date', publicationDate),
+		...(relatedItems.length > 0 && relations(relatedItems)),
+		...doiData(doi, timestamp, resourceUrl, contentVersion),
+	},
+});

--- a/utils/crossref/transform/collection.js
+++ b/utils/crossref/transform/collection.js
@@ -1,6 +1,5 @@
 import { collectionUrl } from 'utils/canonicalUrls';
 import { deserializeMetadata } from 'utils/collections/metadata';
-import { getDepositRecordContentVersion } from 'utils/crossref/parseDeposit';
 
 import transformAttributions from './attributions';
 
@@ -21,7 +20,8 @@ const transformMetadata = (metadata, kind, timestamp) =>
 
 export default ({ globals, community }) => (collection) => {
 	const { timestamp, dois, contentVersion } = globals;
-	const { crossrefDepositRecord, title, metadata, attributions } = collection;
+	const { title, metadata, attributions } = collection;
+
 	return {
 		url: collectionUrl(community, collection),
 		...transformMetadata(metadata, collection.kind, globals.timestamp),
@@ -29,8 +29,6 @@ export default ({ globals, community }) => (collection) => {
 		timestamp: timestamp,
 		attributions: transformAttributions(attributions),
 		doi: dois.collection,
-		contentVersion:
-			contentVersion ||
-			(crossrefDepositRecord ? getDepositRecordContentVersion(crossrefDepositRecord) : null),
+		contentVersion: contentVersion,
 	};
 };

--- a/utils/crossref/transform/pub.js
+++ b/utils/crossref/transform/pub.js
@@ -45,14 +45,8 @@ export default ({ globals, community }) => (pub) => {
 	const { crossrefDepositRecord, title, inboundEdges, outboundEdges } = pub;
 	const publicationDate = getPubPublishedDate(pub);
 	const relatedItems = outboundEdges
-		.map((pubEdge) => {
-			return getEdgeCrossrefRelationship(pubEdge);
-		})
-		.concat(
-			inboundEdges.map((pubEdge) => {
-				return getEdgeCrossrefRelationship(pubEdge, true);
-			}),
-		);
+		.map(getEdgeCrossrefRelationship)
+		.concat(inboundEdges.map((pubEdge) => getEdgeCrossrefRelationship(pubEdge, true)));
 
 	return {
 		title: title,

--- a/utils/crossref/transform/pub.js
+++ b/utils/crossref/transform/pub.js
@@ -1,7 +1,6 @@
 import { pubUrl } from 'utils/canonicalUrls';
 import { getPubPublishedDate } from 'utils/pub/pubDates';
 import { relationTypeDefinitions } from 'utils/pubEdge/relations';
-import { getDepositRecordContentVersion } from 'utils/crossref/parseDeposit';
 
 import transformAttributions from './attributions';
 
@@ -42,7 +41,7 @@ function getEdgeCrossrefRelationship(pubEdge, isInboundEdge = false) {
 
 export default ({ globals, community }) => (pub) => {
 	const { timestamp, dois, contentVersion, reviewType, reviewRecommendation } = globals;
-	const { crossrefDepositRecord, title, inboundEdges, outboundEdges } = pub;
+	const { title, inboundEdges, outboundEdges } = pub;
 	const publicationDate = getPubPublishedDate(pub);
 	const relatedItems = outboundEdges
 		.map(getEdgeCrossrefRelationship)
@@ -56,9 +55,7 @@ export default ({ globals, community }) => (pub) => {
 		resourceUrl: pubUrl(community, pub),
 		doi: dois.pub,
 		relatedItems: relatedItems,
-		contentVersion:
-			contentVersion ||
-			(crossrefDepositRecord ? getDepositRecordContentVersion(crossrefDepositRecord) : null),
+		contentVersion: contentVersion,
 		reviewType: reviewType,
 		reviewRecommendation: reviewRecommendation,
 	};

--- a/utils/crossref/transform/pub.js
+++ b/utils/crossref/transform/pub.js
@@ -41,7 +41,7 @@ function getEdgeCrossrefRelationship(pubEdge, isInboundEdge = false) {
 }
 
 export default ({ globals, community }) => (pub) => {
-	const { timestamp, dois, contentVersion } = globals;
+	const { timestamp, dois, contentVersion, reviewType, reviewRecommendation } = globals;
 	const { crossrefDepositRecord, title, inboundEdges, outboundEdges } = pub;
 	const publicationDate = getPubPublishedDate(pub);
 	const relatedItems = outboundEdges
@@ -65,5 +65,7 @@ export default ({ globals, community }) => (pub) => {
 		contentVersion:
 			contentVersion ||
 			(crossrefDepositRecord ? getDepositRecordContentVersion(crossrefDepositRecord) : null),
+		reviewType: reviewType,
+		reviewRecommendation: reviewRecommendation,
 	};
 };

--- a/utils/pubEdge/relations.js
+++ b/utils/pubEdge/relations.js
@@ -77,14 +77,15 @@ const createRelationTypeEnum = () => {
 export const relationTypes = Object.keys(relationTypeDefinitions);
 export const RelationType = createRelationTypeEnum();
 
-export const findParentPubFromEdges = (edges, relationTypes, inbound) => {
-	for (let i = 0; i < edges.length; i++) {
-		const { pubIsParent, pub, targetPub, relationType } = edges[i];
+const findParentEdge = (pubEdges, relationTypes, inbound) => {
+	for (let i = 0; i < pubEdges.length; i++) {
+		const pubEdge = pubEdges[i];
+		const { pubIsParent, relationType } = pubEdge;
 
 		if (inbound ? pubIsParent : !pubIsParent) {
 			for (let j = 0; j < relationTypes.length; j++) {
 				if (relationType === relationTypes[j]) {
-					return inbound ? pub : targetPub;
+					return pubEdge;
 				}
 			}
 		}
@@ -93,11 +94,12 @@ export const findParentPubFromEdges = (edges, relationTypes, inbound) => {
 	return null;
 };
 
-export const findParentPubByRelationTypes = (pub, ...relationTypes) => {
+export const findParentEdgeByRelationType = (pub, ...relationTypes) => {
 	const { inboundEdges, outboundEdges } = pub;
 
 	return (
-		findParentPubFromEdges(inboundEdges, relationTypes, true) ||
-		findParentPubFromEdges(outboundEdges, relationTypes)
+		findParentEdge(inboundEdges, relationTypes, true) ||
+		findParentEdge(outboundEdges, relationTypes) ||
+		null
 	);
 };

--- a/utils/pubEdge/relations.js
+++ b/utils/pubEdge/relations.js
@@ -94,7 +94,7 @@ const findParentEdge = (pubEdges, relationTypes, inbound) => {
 	return null;
 };
 
-export const findParentEdgeByRelationType = (pub, ...relationTypes) => {
+export const findParentEdgeByRelationTypes = (pub, relationTypes) => {
 	const { inboundEdges, outboundEdges } = pub;
 
 	return (

--- a/utils/pubEdge/relations.js
+++ b/utils/pubEdge/relations.js
@@ -76,3 +76,28 @@ const createRelationTypeEnum = () => {
 
 export const relationTypes = Object.keys(relationTypeDefinitions);
 export const RelationType = createRelationTypeEnum();
+
+export const findParentPubFromEdges = (edges, relationTypes, inbound) => {
+	for (let i = 0; i < edges.length; i++) {
+		const { pubIsParent, pub, targetPub, relationType } = edges[i];
+
+		if (inbound ? pubIsParent : !pubIsParent) {
+			for (let j = 0; j < relationTypes.length; j++) {
+				if (relationType === relationTypes[j]) {
+					return inbound ? pub : targetPub;
+				}
+			}
+		}
+	}
+
+	return null;
+};
+
+export const findParentPubByRelationTypes = (pub, ...relationTypes) => {
+	const { inboundEdges, outboundEdges } = pub;
+
+	return (
+		findParentPubFromEdges(inboundEdges, relationTypes, true) ||
+		findParentPubFromEdges(outboundEdges, relationTypes)
+	);
+};


### PR DESCRIPTION
Closes #911

Supplements, Preprints, Reviews (oh my). This PR does a lot of things:

> Note: Looks like GitHub is auto-collapsing the first file (AssignDoi.js), so make sure to expand it when reviewing.

#### Pub Connections
- Derives `sa_component` deposit type for deposited Pub when it `isSupplementTo` another Pub.
- Derives `peer_review` deposit type for deposited Pub when it `isReviewOf` another Pub.
- Derives `posted_content` deposit type for deposited Pub when it `isPreprintOf` another Pub.

#### Deposit Workflow
- Allows user to set the Content Version of a work deposited to Crossref with a dropdown (unavailable to preprints).
- Allows user to set the Review Type and Review Recommendation of a peer review.
- Automatic re-loading of the deposit preview when any of the above information changes.
- Automatic generation of DOIs for supplements using a suffix (concatenated PubEdge id) appended to the DOI of the "parent" Pub (i.e. Pub which is `isSupplementedBy` the Pub being deposited.)

#### UX Enhancements
- Shows a warning callout indicating that a Pub cannot be deposited when Pub does not have at least one release.
- Shows a warning callout when DOI is not editable for supplements (and prevents DOIs of supplements from being edited).
- Shows a warning callout when `sa_component` (supplement) deposit is not submittable due to parent pub not having a DOI.
- Shows a neutral callout containing _what_ the Pub is being deposited as, with a human-readable title (e.g. `sa_component` becomes "Supplementary Material").

#### General Changes
- Allows users to automatically generate DOIs for Pubs using a new "Generate" button and `/api/generateDoi` endpoint.
- Removes cascading delete behavior from `CrossrefDepositRecords` table.

### Screen captures
WIP

### Test Plan

* **Disclaimer**: I haven't tested these changes in Crossref since the test queue has been backed up the last couple of days. Looks like things are moving today so I'll fix any issues with the XML in a subsequent PR.

WIP