### PR TITLE
feature: Pub Connection DOI deposits cleanup

### DIFF
--- a/client/components/AssignDoi/AssignDoiPreview.js
+++ b/client/components/AssignDoi/AssignDoiPreview.js
@@ -275,7 +275,7 @@ const renderPeerReviewPreview = (body) => {
 const renderSupplementPreview = (body) => {
 	const {
 		sa_component: {
-			['@parent_doi']: parentDoi,
+			'@parent_doi': parentDoi,
 			component_list: {
 				component: { contributors, titles, publication_date },
 			},

--- a/client/containers/DashboardSettings/PubSettings/Doi.js
+++ b/client/containers/DashboardSettings/PubSettings/Doi.js
@@ -85,16 +85,29 @@ class Doi extends Component {
 		return intent;
 	}
 
+	findSupplementTo() {
+		const { pubData } = this.props;
+		return findParentEdgeByRelationTypes(pubData, [RelationType.Supplement]);
+	}
+
+	disabledDueToParentWithoutDoi() {
+		const supplementTo = this.findSupplementTo();
+		return (
+			supplementTo &&
+			!(supplementTo.pubIsParent ? supplementTo.pub : supplementTo.targetPub).doi
+		);
+	}
+
+	disabledDueToNoReleases() {
+		const { pubData } = this.props;
+		return pubData.releases.length === 0;
+	}
+
 	handleDeposit(doi) {
 		const { updatePubData } = this.props;
 
 		this.setState({ justSetDoi: true });
 		updatePubData({ doi: doi });
-	}
-
-	findSupplementTo() {
-		const { pubData } = this.props;
-		return findParentEdgeByRelationTypes(pubData, [RelationType.Supplement]);
 	}
 
 	async updateDoi(doi, pendingStateKey, fallback) {
@@ -263,19 +276,6 @@ class Doi extends Component {
 				)}
 			</>
 		);
-	}
-
-	disabledDueToParentWithoutDoi() {
-		const supplementTo = this.findSupplementTo();
-		return (
-			supplementTo &&
-			!(supplementTo.pubIsParent ? supplementTo.pub : supplementTo.targetPub).doi
-		);
-	}
-
-	disabledDueToNoReleases() {
-		const { pubData } = this.props;
-		return pubData.releases.length === 0;
 	}
 
 	renderContent() {

--- a/client/containers/DashboardSettings/PubSettings/Doi.js
+++ b/client/containers/DashboardSettings/PubSettings/Doi.js
@@ -187,7 +187,7 @@ class Doi extends Component {
 		this.updateDoi(doi, 'updating', currentDoiSuffix);
 	}
 
-	isDoiEditable() {
+	isDoiEditableWithoutRelations() {
 		const { canIssueDoi, pubData } = this.props;
 		const { justSetDoi } = this.state;
 		const doiPrefix = this.getDoiPrefix();
@@ -199,10 +199,17 @@ class Doi extends Component {
 			// a deposit has not been submitted yet for this work
 			!(justSetDoi || pubData.crossrefDepositRecordId) &&
 			// the Pub is not a supplement to another work
-			!this.findSupplementTo() &&
 			// and the community has a custom, hardcoded DOI prefix
 			managedDoiPrefixes.includes(doiPrefix) &&
 			doiPrefix !== PUBPUB_DOI_PREFIX
+		);
+	}
+
+	isDoiEditable() {
+		return (
+			this.isDoiEditableWithoutRelations() &&
+			// the Pub is not a supplement to another work
+			!this.findSupplementTo()
 		);
 	}
 
@@ -248,7 +255,7 @@ class Doi extends Component {
 			<>
 				{!pubData.doi && <p>A DOI can be set for each Pub by admins of this community.</p>}
 				{pubData.crossrefDepositRecordId && <p>This Pub has been deposited to Crossref.</p>}
-				{this.findSupplementTo() && (
+				{this.isDoiEditableWithoutRelations() && this.findSupplementTo() && (
 					<Callout intent="warning">
 						The DOI for this Pub is not editable because it is a{' '}
 						<strong>Supplement</strong> to another Pub.
@@ -274,7 +281,6 @@ class Doi extends Component {
 	renderContent() {
 		const { pubData, canIssueDoi } = this.props;
 		const { justSetDoi } = this.state;
-		const supplementTo = this.findSupplementTo();
 
 		if (!canIssueDoi) {
 			return (

--- a/server/doi/api.js
+++ b/server/doi/api.js
@@ -88,7 +88,10 @@ app.get(
 		await assertUserAuthenticated(target, requestIds);
 
 		return res.status(200).json({
-			dois: await generateDoi({ communityId, collectionId, pubId }, target),
+			dois: await generateDoi(
+				{ communityId: communityId, collectionId: collectionId, pubId: pubId },
+				target,
+			),
 		});
 	}),
 );

--- a/server/doi/queries.js
+++ b/server/doi/queries.js
@@ -44,6 +44,9 @@ const findPub = (pubId) =>
 		where: { id: pubId },
 		...buildPubOptions({
 			getEdgesOptions: {
+				// Include Pub for both inbound and outbound pub connections
+				// since we do a lot of downstream processing with pubEdges.
+				includePub: true,
 				includeCommunityForPubs: true,
 			},
 		}),

--- a/utils/crossref/__tests__/__snapshots__/createDeposit.test.js.snap
+++ b/utils/crossref/__tests__/__snapshots__/createDeposit.test.js.snap
@@ -44,7 +44,9 @@ Object {
             },
             "doi_data": Object {
               "doi": "an_utterly_fake_doi",
-              "resource": "https://test.com",
+              "resource": Object {
+                "#text": "https://test.com",
+              },
               "timestamp": 1555009335577,
             },
             "edition_number": "3",
@@ -67,7 +69,7 @@ Object {
       "head": Object {
         "depositor": Object {
           "depositor_name": "PubPub",
-          "email_address": "pubpub@media.mit.edu",
+          "email_address": "crossref@pubpub.org",
         },
         "doi_batch_id": "1555009335577_eea8ec7d",
         "registrant": "PubPub",
@@ -78,7 +80,6 @@ Object {
   "dois": Object {
     "collection": "an_utterly_fake_doi",
     "community": "10.21428/eea8ec7d",
-    "pub": undefined,
   },
   "timestamp": 1555009335577,
 }
@@ -128,7 +129,9 @@ Object {
             },
             "doi_data": Object {
               "doi": "an_utterly_fake_doi",
-              "resource": "https://test.com",
+              "resource": Object {
+                "#text": "https://test.com",
+              },
               "timestamp": 1555009335577,
             },
             "edition_number": "3",
@@ -151,7 +154,7 @@ Object {
       "head": Object {
         "depositor": Object {
           "depositor_name": "PubPub",
-          "email_address": "pubpub@media.mit.edu",
+          "email_address": "crossref@pubpub.org",
         },
         "doi_batch_id": "1555009335577_eea8ec7d",
         "registrant": "PubPub",
@@ -162,7 +165,6 @@ Object {
   "dois": Object {
     "collection": "an_utterly_fake_doi",
     "community": "10.21428/eea8ec7d",
-    "pub": undefined,
   },
   "timestamp": 1555009335577,
 }
@@ -220,7 +222,9 @@ Object {
           "proceedings_metadata": Object {
             "doi_data": Object {
               "doi": "yes_it_is_a_conference_doi",
-              "resource": "https://dev.pubpub.org/collection/4c3a0515",
+              "resource": Object {
+                "#text": "https://dev.pubpub.org/collection/4c3a0515",
+              },
               "timestamp": 1555009335577,
             },
             "noisbn": Object {
@@ -242,7 +246,7 @@ Object {
       "head": Object {
         "depositor": Object {
           "depositor_name": "PubPub",
-          "email_address": "pubpub@media.mit.edu",
+          "email_address": "crossref@pubpub.org",
         },
         "doi_batch_id": "1555009335577_eea8ec7d",
         "registrant": "PubPub",
@@ -253,7 +257,6 @@ Object {
   "dois": Object {
     "collection": "yes_it_is_a_conference_doi",
     "community": "10.21428/eea8ec7d",
-    "pub": undefined,
   },
   "timestamp": 1555009335577,
 }
@@ -311,7 +314,9 @@ Object {
           "proceedings_metadata": Object {
             "doi_data": Object {
               "doi": "yes_it_is_a_conference_doi",
-              "resource": "https://dev.pubpub.org/collection/4c3a0515",
+              "resource": Object {
+                "#text": "https://dev.pubpub.org/collection/4c3a0515",
+              },
               "timestamp": 1555009335577,
             },
             "noisbn": Object {
@@ -333,7 +338,7 @@ Object {
       "head": Object {
         "depositor": Object {
           "depositor_name": "PubPub",
-          "email_address": "pubpub@media.mit.edu",
+          "email_address": "crossref@pubpub.org",
         },
         "doi_batch_id": "1555009335577_eea8ec7d",
         "registrant": "PubPub",
@@ -344,7 +349,6 @@ Object {
   "dois": Object {
     "collection": "yes_it_is_a_conference_doi",
     "community": "10.21428/eea8ec7d",
-    "pub": undefined,
   },
   "timestamp": 1555009335577,
 }
@@ -362,6 +366,7 @@ Object {
         "journal": Object {
           "journal_article": Object {
             "@publication_type": "full_text",
+            "@xmlns:rel": "http://www.crossref.org/relations.xsd",
             "contributors": Object {
               "person_name": Array [
                 Object {
@@ -381,7 +386,9 @@ Object {
             },
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d.1519656b",
-              "resource": "https://frankdev.pubpub.org/pub/h2muzdpv",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+              },
               "timestamp": 1555009335577,
             },
             "publication_date": Object {
@@ -399,7 +406,9 @@ Object {
             "abbrev_title": "PubPub Dev",
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d",
-              "resource": "https://frankdev.pubpub.org",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org",
+              },
               "timestamp": 1555009335577,
             },
             "full_title": "PubPub Dev",
@@ -409,7 +418,7 @@ Object {
       "head": Object {
         "depositor": Object {
           "depositor_name": "PubPub",
-          "email_address": "pubpub@media.mit.edu",
+          "email_address": "crossref@pubpub.org",
         },
         "doi_batch_id": "1555009335577_eea8ec7d",
         "registrant": "PubPub",
@@ -470,7 +479,9 @@ Object {
             },
             "doi_data": Object {
               "doi": "an_utterly_fake_doi",
-              "resource": "https://test.com",
+              "resource": Object {
+                "#text": "https://test.com",
+              },
               "timestamp": 1555009335577,
             },
             "edition_number": "3",
@@ -490,6 +501,7 @@ Object {
           },
           "content_item": Object {
             "@component_type": "chapter",
+            "@xmlns:rel": "http://www.crossref.org/relations.xsd",
             "contributors": Object {
               "person_name": Array [
                 Object {
@@ -509,7 +521,9 @@ Object {
             },
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d.1519656b",
-              "resource": "https://frankdev.pubpub.org/pub/h2muzdpv",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+              },
               "timestamp": 1555009335577,
             },
             "publication_date": Object {
@@ -527,7 +541,7 @@ Object {
       "head": Object {
         "depositor": Object {
           "depositor_name": "PubPub",
-          "email_address": "pubpub@media.mit.edu",
+          "email_address": "crossref@pubpub.org",
         },
         "doi_batch_id": "1555009335577_eea8ec7d",
         "registrant": "PubPub",
@@ -555,6 +569,7 @@ Object {
       "body": Object {
         "conference": Object {
           "conference_paper": Object {
+            "@xmlns:rel": "http://www.crossref.org/relations.xsd",
             "contributors": Object {
               "person_name": Array [
                 Object {
@@ -574,7 +589,9 @@ Object {
             },
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d.1519656b",
-              "resource": "https://frankdev.pubpub.org/pub/h2muzdpv",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+              },
               "timestamp": 1555009335577,
             },
             "titles": Object {
@@ -623,7 +640,9 @@ Object {
           "proceedings_metadata": Object {
             "doi_data": Object {
               "doi": "yes_it_is_a_conference_doi",
-              "resource": "https://dev.pubpub.org/collection/4c3a0515",
+              "resource": Object {
+                "#text": "https://dev.pubpub.org/collection/4c3a0515",
+              },
               "timestamp": 1555009335577,
             },
             "noisbn": Object {
@@ -645,7 +664,7 @@ Object {
       "head": Object {
         "depositor": Object {
           "depositor_name": "PubPub",
-          "email_address": "pubpub@media.mit.edu",
+          "email_address": "crossref@pubpub.org",
         },
         "doi_batch_id": "1555009335577_eea8ec7d",
         "registrant": "PubPub",
@@ -674,6 +693,7 @@ Object {
         "journal": Object {
           "journal_article": Object {
             "@publication_type": "full_text",
+            "@xmlns:rel": "http://www.crossref.org/relations.xsd",
             "contributors": Object {
               "person_name": Array [
                 Object {
@@ -693,7 +713,9 @@ Object {
             },
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d.1519656b",
-              "resource": "https://frankdev.pubpub.org/pub/h2muzdpv",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+              },
               "timestamp": 1555009335577,
             },
             "publication_date": Object {
@@ -739,7 +761,9 @@ Object {
             },
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d.e281f63f",
-              "resource": "https://dev.pubpub.org/collection/e281f63f",
+              "resource": Object {
+                "#text": "https://dev.pubpub.org/collection/e281f63f",
+              },
               "timestamp": 1555009335577,
             },
             "issue": "5",
@@ -761,7 +785,9 @@ Object {
             "abbrev_title": "PubPub Dev",
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d",
-              "resource": "https://frankdev.pubpub.org",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org",
+              },
               "timestamp": 1555009335577,
             },
             "full_title": "PubPub Dev",
@@ -771,7 +797,7 @@ Object {
       "head": Object {
         "depositor": Object {
           "depositor_name": "PubPub",
-          "email_address": "pubpub@media.mit.edu",
+          "email_address": "crossref@pubpub.org",
         },
         "doi_batch_id": "1555009335577_eea8ec7d",
         "registrant": "PubPub",
@@ -831,7 +857,9 @@ Object {
             },
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d.e281f63f",
-              "resource": "https://dev.pubpub.org/collection/e281f63f",
+              "resource": Object {
+                "#text": "https://dev.pubpub.org/collection/e281f63f",
+              },
               "timestamp": 1555009335577,
             },
             "issue": "5",
@@ -853,7 +881,9 @@ Object {
             "abbrev_title": "PubPub Dev",
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d",
-              "resource": "https://frankdev.pubpub.org",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org",
+              },
               "timestamp": 1555009335577,
             },
             "full_title": "PubPub Dev",
@@ -863,7 +893,7 @@ Object {
       "head": Object {
         "depositor": Object {
           "depositor_name": "PubPub",
-          "email_address": "pubpub@media.mit.edu",
+          "email_address": "crossref@pubpub.org",
         },
         "doi_batch_id": "1555009335577_eea8ec7d",
         "registrant": "PubPub",
@@ -874,7 +904,6 @@ Object {
   "dois": Object {
     "collection": "10.21428/eea8ec7d.e281f63f",
     "community": "10.21428/eea8ec7d",
-    "pub": undefined,
   },
   "timestamp": 1555009335577,
 }
@@ -923,7 +952,9 @@ Object {
             },
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d.e281f63f",
-              "resource": "https://dev.pubpub.org/collection/e281f63f",
+              "resource": Object {
+                "#text": "https://dev.pubpub.org/collection/e281f63f",
+              },
               "timestamp": 1555009335577,
             },
             "issue": "5",
@@ -945,7 +976,9 @@ Object {
             "abbrev_title": "PubPub Dev",
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d",
-              "resource": "https://frankdev.pubpub.org",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org",
+              },
               "timestamp": 1555009335577,
             },
             "full_title": "PubPub Dev",
@@ -955,7 +988,7 @@ Object {
       "head": Object {
         "depositor": Object {
           "depositor_name": "PubPub",
-          "email_address": "pubpub@media.mit.edu",
+          "email_address": "crossref@pubpub.org",
         },
         "doi_batch_id": "1555009335577_eea8ec7d",
         "registrant": "PubPub",
@@ -966,7 +999,6 @@ Object {
   "dois": Object {
     "collection": "10.21428/eea8ec7d.e281f63f",
     "community": "10.21428/eea8ec7d",
-    "pub": undefined,
   },
   "timestamp": 1555009335577,
 }

--- a/utils/crossref/__tests__/__snapshots__/createDeposit.test.js.snap
+++ b/utils/crossref/__tests__/__snapshots__/createDeposit.test.js.snap
@@ -1,5 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`createDeposit applies content version to the content version attribute of the resource element 1`] = `
+Object {
+  "deposit": Object {
+    "doi_batch": Object {
+      "@version": "4.4.1",
+      "@xmlns": "http://www.crossref.org/schema/4.4.1",
+      "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+      "@xsi:schemaLocation": "http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schema/deposit/crossref4.4.1.xsd",
+      "body": Object {
+        "journal": Object {
+          "journal_article": Object {
+            "@publication_type": "full_text",
+            "@xmlns:rel": "http://www.crossref.org/relations.xsd",
+            "contributors": Object {
+              "person_name": Array [
+                Object {
+                  "@contributor_role": "author",
+                  "@sequence": "first",
+                  "affiliation": "Springfield A&M",
+                  "given_name": "Ian",
+                  "surname": "Reynolds",
+                },
+                Object {
+                  "@contributor_role": "reader",
+                  "@sequence": "additional",
+                  "given_name": "Kevin",
+                  "surname": "Bentham",
+                },
+              ],
+            },
+            "doi_data": Object {
+              "doi": "10.21428/eea8ec7d.1519656b",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+                "@content_version": "am",
+              },
+              "timestamp": 1555009335577,
+            },
+            "publication_date": Object {
+              "@media_type": "online",
+              "day": "01",
+              "month": "03",
+              "year": "2019",
+            },
+            "titles": Object {
+              "title": "In Which Ian Makes A Pub",
+            },
+          },
+          "journal_metadata": Object {
+            "@language": "en",
+            "abbrev_title": "PubPub Dev",
+            "doi_data": Object {
+              "doi": "10.21428/eea8ec7d",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org",
+              },
+              "timestamp": 1555009335577,
+            },
+            "full_title": "PubPub Dev",
+          },
+        },
+      },
+      "head": Object {
+        "depositor": Object {
+          "depositor_name": "PubPub",
+          "email_address": "crossref@pubpub.org",
+        },
+        "doi_batch_id": "1555009335577_eea8ec7d",
+        "registrant": "PubPub",
+        "timestamp": 1555009335577,
+      },
+    },
+  },
+  "dois": Object {
+    "collection": undefined,
+    "community": "10.21428/eea8ec7d",
+    "pub": "10.21428/eea8ec7d.1519656b",
+  },
+  "timestamp": 1555009335577,
+}
+`;
+
 exports[`createDeposit creates a deposit for a book 1`] = `
 Object {
   "deposit": Object {
@@ -999,6 +1081,741 @@ Object {
   "dois": Object {
     "collection": "10.21428/eea8ec7d.e281f63f",
     "community": "10.21428/eea8ec7d",
+  },
+  "timestamp": 1555009335577,
+}
+`;
+
+exports[`createDeposit creates a journal_article deposit for a pub with a hasReview connection 1`] = `
+Object {
+  "deposit": Object {
+    "doi_batch": Object {
+      "@version": "4.4.1",
+      "@xmlns": "http://www.crossref.org/schema/4.4.1",
+      "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+      "@xsi:schemaLocation": "http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schema/deposit/crossref4.4.1.xsd",
+      "body": Object {
+        "journal": Object {
+          "journal_article": Object {
+            "@publication_type": "full_text",
+            "@xmlns:rel": "http://www.crossref.org/relations.xsd",
+            "contributors": Object {
+              "person_name": Array [
+                Object {
+                  "@contributor_role": "author",
+                  "@sequence": "first",
+                  "affiliation": "Springfield A&M",
+                  "given_name": "Ian",
+                  "surname": "Reynolds",
+                },
+                Object {
+                  "@contributor_role": "reader",
+                  "@sequence": "additional",
+                  "given_name": "Kevin",
+                  "surname": "Bentham",
+                },
+              ],
+            },
+            "doi_data": Object {
+              "doi": "10.21428/eea8ec7d.1519656b",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+              },
+              "timestamp": 1555009335577,
+            },
+            "publication_date": Object {
+              "@media_type": "online",
+              "day": "01",
+              "month": "03",
+              "year": "2019",
+            },
+            "rel:program": Object {
+              "@name": "relations",
+              "rel:related_item": Array [
+                Object {
+                  "rel:inter_work_relation": Object {
+                    "#text": "some-doi",
+                    "@identifier-type": "doi",
+                    "@relationship-type": "hasReview",
+                  },
+                },
+              ],
+            },
+            "titles": Object {
+              "title": "In Which Ian Makes A Pub",
+            },
+          },
+          "journal_metadata": Object {
+            "@language": "en",
+            "abbrev_title": "PubPub Dev",
+            "doi_data": Object {
+              "doi": "10.21428/eea8ec7d",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org",
+              },
+              "timestamp": 1555009335577,
+            },
+            "full_title": "PubPub Dev",
+          },
+        },
+      },
+      "head": Object {
+        "depositor": Object {
+          "depositor_name": "PubPub",
+          "email_address": "crossref@pubpub.org",
+        },
+        "doi_batch_id": "1555009335577_eea8ec7d",
+        "registrant": "PubPub",
+        "timestamp": 1555009335577,
+      },
+    },
+  },
+  "dois": Object {
+    "collection": undefined,
+    "community": "10.21428/eea8ec7d",
+    "pub": "10.21428/eea8ec7d.1519656b",
+  },
+  "timestamp": 1555009335577,
+}
+`;
+
+exports[`createDeposit creates a journal_article deposit for a pub with a hasSupplement connection 1`] = `
+Object {
+  "deposit": Object {
+    "doi_batch": Object {
+      "@version": "4.4.1",
+      "@xmlns": "http://www.crossref.org/schema/4.4.1",
+      "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+      "@xsi:schemaLocation": "http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schema/deposit/crossref4.4.1.xsd",
+      "body": Object {
+        "journal": Object {
+          "journal_article": Object {
+            "@publication_type": "full_text",
+            "@xmlns:rel": "http://www.crossref.org/relations.xsd",
+            "contributors": Object {
+              "person_name": Array [
+                Object {
+                  "@contributor_role": "author",
+                  "@sequence": "first",
+                  "affiliation": "Springfield A&M",
+                  "given_name": "Ian",
+                  "surname": "Reynolds",
+                },
+                Object {
+                  "@contributor_role": "reader",
+                  "@sequence": "additional",
+                  "given_name": "Kevin",
+                  "surname": "Bentham",
+                },
+              ],
+            },
+            "doi_data": Object {
+              "doi": "10.21428/eea8ec7d.1519656b",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+              },
+              "timestamp": 1555009335577,
+            },
+            "publication_date": Object {
+              "@media_type": "online",
+              "day": "01",
+              "month": "03",
+              "year": "2019",
+            },
+            "rel:program": Object {
+              "@name": "relations",
+              "rel:related_item": Array [
+                Object {
+                  "rel:inter_work_relation": Object {
+                    "#text": "some-doi",
+                    "@identifier-type": "doi",
+                    "@relationship-type": "isSupplementedBy",
+                  },
+                },
+              ],
+            },
+            "titles": Object {
+              "title": "In Which Ian Makes A Pub",
+            },
+          },
+          "journal_metadata": Object {
+            "@language": "en",
+            "abbrev_title": "PubPub Dev",
+            "doi_data": Object {
+              "doi": "10.21428/eea8ec7d",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org",
+              },
+              "timestamp": 1555009335577,
+            },
+            "full_title": "PubPub Dev",
+          },
+        },
+      },
+      "head": Object {
+        "depositor": Object {
+          "depositor_name": "PubPub",
+          "email_address": "crossref@pubpub.org",
+        },
+        "doi_batch_id": "1555009335577_eea8ec7d",
+        "registrant": "PubPub",
+        "timestamp": 1555009335577,
+      },
+    },
+  },
+  "dois": Object {
+    "collection": undefined,
+    "community": "10.21428/eea8ec7d",
+    "pub": "10.21428/eea8ec7d.1519656b",
+  },
+  "timestamp": 1555009335577,
+}
+`;
+
+exports[`createDeposit creates a peer_review deposit for a pub with an isReviewOf connection 1`] = `
+Object {
+  "deposit": Object {
+    "doi_batch": Object {
+      "@version": "4.4.1",
+      "@xmlns": "http://www.crossref.org/schema/4.4.1",
+      "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+      "@xsi:schemaLocation": "http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schema/deposit/crossref4.4.1.xsd",
+      "body": Object {
+        "peer_review": Object {
+          "@language": "en",
+          "@recommendation": "bar",
+          "@type": "foo",
+          "@xmlns:rel": "http://www.crossref.org/relations.xsd",
+          "contributors": Object {
+            "person_name": Array [
+              Object {
+                "@contributor_role": "author",
+                "@sequence": "first",
+                "affiliation": "Springfield A&M",
+                "given_name": "Ian",
+                "surname": "Reynolds",
+              },
+              Object {
+                "@contributor_role": "reader",
+                "@sequence": "additional",
+                "given_name": "Kevin",
+                "surname": "Bentham",
+              },
+            ],
+          },
+          "doi_data": Object {
+            "doi": "10.21428/eea8ec7d.1519656b",
+            "resource": Object {
+              "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+            },
+            "timestamp": 1555009335577,
+          },
+          "rel:program": Object {
+            "@name": "relations",
+            "rel:related_item": Array [
+              Object {
+                "rel:inter_work_relation": Object {
+                  "#text": "some-doi",
+                  "@identifier-type": "doi",
+                  "@relationship-type": "isReviewOf",
+                },
+              },
+            ],
+          },
+          "review_date": Object {
+            "day": "01",
+            "month": "03",
+            "year": "2019",
+          },
+          "titles": Object {
+            "title": "In Which Ian Makes A Pub",
+          },
+        },
+      },
+      "head": Object {
+        "depositor": Object {
+          "depositor_name": "PubPub",
+          "email_address": "crossref@pubpub.org",
+        },
+        "doi_batch_id": "1555009335577_eea8ec7d",
+        "registrant": "PubPub",
+        "timestamp": 1555009335577,
+      },
+    },
+  },
+  "dois": Object {
+    "collection": undefined,
+    "community": "10.21428/eea8ec7d",
+    "pub": "10.21428/eea8ec7d.1519656b",
+  },
+  "timestamp": 1555009335577,
+}
+`;
+
+exports[`createDeposit creates a posted_content deposit for a pub when contentVersion is "preprint" 1`] = `
+Object {
+  "deposit": Object {
+    "doi_batch": Object {
+      "@version": "4.4.1",
+      "@xmlns": "http://www.crossref.org/schema/4.4.1",
+      "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+      "@xsi:schemaLocation": "http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schema/deposit/crossref4.4.1.xsd",
+      "body": Object {
+        "posted_content": Object {
+          "@language": "en",
+          "@type": "preprint",
+          "@xmlns:rel": "http://www.crossref.org/relations.xsd",
+          "contributors": Object {
+            "person_name": Array [
+              Object {
+                "@contributor_role": "author",
+                "@sequence": "first",
+                "affiliation": "Springfield A&M",
+                "given_name": "Ian",
+                "surname": "Reynolds",
+              },
+              Object {
+                "@contributor_role": "reader",
+                "@sequence": "additional",
+                "given_name": "Kevin",
+                "surname": "Bentham",
+              },
+            ],
+          },
+          "doi_data": Object {
+            "doi": "10.21428/eea8ec7d.1519656b",
+            "resource": Object {
+              "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+            },
+            "timestamp": 1555009335577,
+          },
+          "posted_date": Object {
+            "@media_type": "print",
+            "day": "01",
+            "month": "03",
+            "year": "2019",
+          },
+          "titles": Object {
+            "title": "In Which Ian Makes A Pub",
+          },
+        },
+      },
+      "head": Object {
+        "depositor": Object {
+          "depositor_name": "PubPub",
+          "email_address": "crossref@pubpub.org",
+        },
+        "doi_batch_id": "1555009335577_eea8ec7d",
+        "registrant": "PubPub",
+        "timestamp": 1555009335577,
+      },
+    },
+  },
+  "dois": Object {
+    "collection": undefined,
+    "community": "10.21428/eea8ec7d",
+    "pub": "10.21428/eea8ec7d.1519656b",
+  },
+  "timestamp": 1555009335577,
+}
+`;
+
+exports[`createDeposit creates a posted_content deposit for a pub with a hasPreprint connection 1`] = `
+Object {
+  "deposit": Object {
+    "doi_batch": Object {
+      "@version": "4.4.1",
+      "@xmlns": "http://www.crossref.org/schema/4.4.1",
+      "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+      "@xsi:schemaLocation": "http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schema/deposit/crossref4.4.1.xsd",
+      "body": Object {
+        "journal": Object {
+          "journal_article": Object {
+            "@publication_type": "full_text",
+            "@xmlns:rel": "http://www.crossref.org/relations.xsd",
+            "contributors": Object {
+              "person_name": Array [
+                Object {
+                  "@contributor_role": "author",
+                  "@sequence": "first",
+                  "affiliation": "Springfield A&M",
+                  "given_name": "Ian",
+                  "surname": "Reynolds",
+                },
+                Object {
+                  "@contributor_role": "reader",
+                  "@sequence": "additional",
+                  "given_name": "Kevin",
+                  "surname": "Bentham",
+                },
+              ],
+            },
+            "doi_data": Object {
+              "doi": "10.21428/eea8ec7d.1519656b",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+              },
+              "timestamp": 1555009335577,
+            },
+            "publication_date": Object {
+              "@media_type": "online",
+              "day": "01",
+              "month": "03",
+              "year": "2019",
+            },
+            "rel:program": Object {
+              "@name": "relations",
+              "rel:related_item": Array [
+                Object {
+                  "rel:intra_work_relation": Object {
+                    "#text": "some-doi",
+                    "@identifier-type": "doi",
+                    "@relationship-type": "hasPreprint",
+                  },
+                },
+              ],
+            },
+            "titles": Object {
+              "title": "In Which Ian Makes A Pub",
+            },
+          },
+          "journal_metadata": Object {
+            "@language": "en",
+            "abbrev_title": "PubPub Dev",
+            "doi_data": Object {
+              "doi": "10.21428/eea8ec7d",
+              "resource": Object {
+                "#text": "https://frankdev.pubpub.org",
+              },
+              "timestamp": 1555009335577,
+            },
+            "full_title": "PubPub Dev",
+          },
+        },
+      },
+      "head": Object {
+        "depositor": Object {
+          "depositor_name": "PubPub",
+          "email_address": "crossref@pubpub.org",
+        },
+        "doi_batch_id": "1555009335577_eea8ec7d",
+        "registrant": "PubPub",
+        "timestamp": 1555009335577,
+      },
+    },
+  },
+  "dois": Object {
+    "collection": undefined,
+    "community": "10.21428/eea8ec7d",
+    "pub": "10.21428/eea8ec7d.1519656b",
+  },
+  "timestamp": 1555009335577,
+}
+`;
+
+exports[`createDeposit creates a posted_content deposit for a pub with an isPreprintOf connection 1`] = `
+Object {
+  "deposit": Object {
+    "doi_batch": Object {
+      "@version": "4.4.1",
+      "@xmlns": "http://www.crossref.org/schema/4.4.1",
+      "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+      "@xsi:schemaLocation": "http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schema/deposit/crossref4.4.1.xsd",
+      "body": Object {
+        "posted_content": Object {
+          "@language": "en",
+          "@type": "preprint",
+          "@xmlns:rel": "http://www.crossref.org/relations.xsd",
+          "contributors": Object {
+            "person_name": Array [
+              Object {
+                "@contributor_role": "author",
+                "@sequence": "first",
+                "affiliation": "Springfield A&M",
+                "given_name": "Ian",
+                "surname": "Reynolds",
+              },
+              Object {
+                "@contributor_role": "reader",
+                "@sequence": "additional",
+                "given_name": "Kevin",
+                "surname": "Bentham",
+              },
+            ],
+          },
+          "doi_data": Object {
+            "doi": "10.21428/eea8ec7d.1519656b",
+            "resource": Object {
+              "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+            },
+            "timestamp": 1555009335577,
+          },
+          "posted_date": Object {
+            "@media_type": "print",
+            "day": "01",
+            "month": "03",
+            "year": "2019",
+          },
+          "rel:program": Object {
+            "@name": "relations",
+            "rel:related_item": Array [
+              Object {
+                "rel:intra_work_relation": Object {
+                  "#text": "some-doi",
+                  "@identifier-type": "doi",
+                  "@relationship-type": "isPreprintOf",
+                },
+              },
+            ],
+          },
+          "titles": Object {
+            "title": "In Which Ian Makes A Pub",
+          },
+        },
+      },
+      "head": Object {
+        "depositor": Object {
+          "depositor_name": "PubPub",
+          "email_address": "crossref@pubpub.org",
+        },
+        "doi_batch_id": "1555009335577_eea8ec7d",
+        "registrant": "PubPub",
+        "timestamp": 1555009335577,
+      },
+    },
+  },
+  "dois": Object {
+    "collection": undefined,
+    "community": "10.21428/eea8ec7d",
+    "pub": "10.21428/eea8ec7d.1519656b",
+  },
+  "timestamp": 1555009335577,
+}
+`;
+
+exports[`createDeposit creates a sa_component deposit for a pub with a isSupplementTo connection 1`] = `
+Object {
+  "deposit": Object {
+    "doi_batch": Object {
+      "@version": "4.4.1",
+      "@xmlns": "http://www.crossref.org/schema/4.4.1",
+      "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+      "@xsi:schemaLocation": "http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schema/deposit/crossref4.4.1.xsd",
+      "body": Object {
+        "sa_component": Object {
+          "@parent_doi": "some-doi",
+          "component_list": Object {
+            "component": Object {
+              "@language": "en",
+              "@parent_relation": "isPartOf",
+              "contributors": Object {
+                "person_name": Array [
+                  Object {
+                    "@contributor_role": "author",
+                    "@sequence": "first",
+                    "affiliation": "Springfield A&M",
+                    "given_name": "Ian",
+                    "surname": "Reynolds",
+                  },
+                  Object {
+                    "@contributor_role": "reader",
+                    "@sequence": "additional",
+                    "given_name": "Kevin",
+                    "surname": "Bentham",
+                  },
+                ],
+              },
+              "doi_data": Object {
+                "doi": "some-doi/1519656b",
+                "resource": Object {
+                  "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+                },
+                "timestamp": 1555009335577,
+              },
+              "publication_date": Object {
+                "@media_type": "print",
+                "day": "01",
+                "month": "03",
+                "year": "2019",
+              },
+              "titles": Object {
+                "title": "In Which Ian Makes A Pub",
+              },
+            },
+          },
+        },
+      },
+      "head": Object {
+        "depositor": Object {
+          "depositor_name": "PubPub",
+          "email_address": "crossref@pubpub.org",
+        },
+        "doi_batch_id": "1555009335577_eea8ec7d",
+        "registrant": "PubPub",
+        "timestamp": 1555009335577,
+      },
+    },
+  },
+  "dois": Object {
+    "collection": undefined,
+    "community": "10.21428/eea8ec7d",
+    "pub": "some-doi/1519656b",
+  },
+  "timestamp": 1555009335577,
+}
+`;
+
+exports[`createDeposit creates relationships where the resource is a DOI 1`] = `
+Object {
+  "deposit": Object {
+    "doi_batch": Object {
+      "@version": "4.4.1",
+      "@xmlns": "http://www.crossref.org/schema/4.4.1",
+      "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+      "@xsi:schemaLocation": "http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schema/deposit/crossref4.4.1.xsd",
+      "body": Object {
+        "peer_review": Object {
+          "@language": "en",
+          "@xmlns:rel": "http://www.crossref.org/relations.xsd",
+          "contributors": Object {
+            "person_name": Array [
+              Object {
+                "@contributor_role": "author",
+                "@sequence": "first",
+                "affiliation": "Springfield A&M",
+                "given_name": "Ian",
+                "surname": "Reynolds",
+              },
+              Object {
+                "@contributor_role": "reader",
+                "@sequence": "additional",
+                "given_name": "Kevin",
+                "surname": "Bentham",
+              },
+            ],
+          },
+          "doi_data": Object {
+            "doi": "10.21428/eea8ec7d.1519656b",
+            "resource": Object {
+              "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+            },
+            "timestamp": 1555009335577,
+          },
+          "rel:program": Object {
+            "@name": "relations",
+            "rel:related_item": Array [
+              Object {
+                "rel:inter_work_relation": Object {
+                  "#text": "some-doi",
+                  "@identifier-type": "doi",
+                  "@relationship-type": "isReviewOf",
+                },
+              },
+            ],
+          },
+          "review_date": Object {
+            "day": "01",
+            "month": "03",
+            "year": "2019",
+          },
+          "titles": Object {
+            "title": "In Which Ian Makes A Pub",
+          },
+        },
+      },
+      "head": Object {
+        "depositor": Object {
+          "depositor_name": "PubPub",
+          "email_address": "crossref@pubpub.org",
+        },
+        "doi_batch_id": "1555009335577_eea8ec7d",
+        "registrant": "PubPub",
+        "timestamp": 1555009335577,
+      },
+    },
+  },
+  "dois": Object {
+    "collection": undefined,
+    "community": "10.21428/eea8ec7d",
+    "pub": "10.21428/eea8ec7d.1519656b",
+  },
+  "timestamp": 1555009335577,
+}
+`;
+
+exports[`createDeposit creates relationships where the resource is a URL 1`] = `
+Object {
+  "deposit": Object {
+    "doi_batch": Object {
+      "@version": "4.4.1",
+      "@xmlns": "http://www.crossref.org/schema/4.4.1",
+      "@xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+      "@xsi:schemaLocation": "http://www.crossref.org/schema/4.4.1 http://www.crossref.org/schema/deposit/crossref4.4.1.xsd",
+      "body": Object {
+        "peer_review": Object {
+          "@language": "en",
+          "@xmlns:rel": "http://www.crossref.org/relations.xsd",
+          "contributors": Object {
+            "person_name": Array [
+              Object {
+                "@contributor_role": "author",
+                "@sequence": "first",
+                "affiliation": "Springfield A&M",
+                "given_name": "Ian",
+                "surname": "Reynolds",
+              },
+              Object {
+                "@contributor_role": "reader",
+                "@sequence": "additional",
+                "given_name": "Kevin",
+                "surname": "Bentham",
+              },
+            ],
+          },
+          "doi_data": Object {
+            "doi": "10.21428/eea8ec7d.1519656b",
+            "resource": Object {
+              "#text": "https://frankdev.pubpub.org/pub/h2muzdpv",
+            },
+            "timestamp": 1555009335577,
+          },
+          "rel:program": Object {
+            "@name": "relations",
+            "rel:related_item": Array [
+              Object {
+                "rel:inter_work_relation": Object {
+                  "#text": "https://foo.pubpub.org/pub/has-review",
+                  "@identifier-type": "uri",
+                  "@relationship-type": "isReviewOf",
+                },
+              },
+            ],
+          },
+          "review_date": Object {
+            "day": "01",
+            "month": "03",
+            "year": "2019",
+          },
+          "titles": Object {
+            "title": "In Which Ian Makes A Pub",
+          },
+        },
+      },
+      "head": Object {
+        "depositor": Object {
+          "depositor_name": "PubPub",
+          "email_address": "crossref@pubpub.org",
+        },
+        "doi_batch_id": "1555009335577_eea8ec7d",
+        "registrant": "PubPub",
+        "timestamp": 1555009335577,
+      },
+    },
+  },
+  "dois": Object {
+    "collection": undefined,
+    "community": "10.21428/eea8ec7d",
+    "pub": "10.21428/eea8ec7d.1519656b",
   },
   "timestamp": 1555009335577,
 }

--- a/utils/crossref/__tests__/createDeposit.test.js
+++ b/utils/crossref/__tests__/createDeposit.test.js
@@ -6,6 +6,12 @@ import createDepositPartial from '../createDeposit';
 
 import community from './data/community';
 import pub from './data/pub';
+import pubIsReviewOf from './data/pubIsReviewOf';
+import pubHasReview from './data/pubHasReview';
+import pubIsSupplementTo from './data/pubIsSupplementTo';
+import pubHasSupplement from './data/pubHasSupplement';
+import pubIsPreprintOf from './data/pubIsPreprintOf';
+import pubHasPreprint from './data/pubHasPreprint';
 import makeCollectionPub from './data/makeCollectionPub';
 import { book, issue, conference } from './data/collections';
 
@@ -145,6 +151,133 @@ describe('createDeposit', () => {
 					collection: stripDatesFromCollectionMetadata(conference),
 				},
 				'collection',
+			),
+		).toMatchSnapshot();
+	});
+
+	it('creates relationships where the resource is a URL', () => {
+		const [edge] = pubIsReviewOf.outboundEdges;
+		const { doi, ...targetPubProps } = edge.targetPub;
+
+		expect(
+			createDeposit(
+				{
+					pub: {
+						...pubIsReviewOf,
+						outboundEdges: [
+							{
+								...edge,
+								targetPub: targetPubProps,
+							},
+						],
+					},
+				},
+				'pub',
+			),
+		).toMatchSnapshot();
+	});
+
+	it('creates relationships where the resource is a DOI', () => {
+		expect(
+			createDeposit(
+				{
+					pub: pubIsReviewOf,
+				},
+				'pub',
+			),
+		).toMatchSnapshot();
+	});
+
+	it('applies content version to the content version attribute of the resource element', () => {
+		expect(
+			createDeposit(
+				{
+					pub: pub,
+					contentVersion: 'am',
+				},
+				'pub',
+			),
+		).toMatchSnapshot();
+	});
+
+	it('creates a peer_review deposit for a pub with an isReviewOf connection', () => {
+		expect(
+			createDeposit(
+				{
+					pub: pubIsReviewOf,
+					reviewType: 'foo',
+					reviewRecommendation: 'bar',
+				},
+				'pub',
+			),
+		).toMatchSnapshot();
+	});
+
+	it('creates a journal_article deposit for a pub with a hasReview connection', () => {
+		expect(
+			createDeposit(
+				{
+					pub: pubHasReview,
+					reviewType: 'foo',
+					reviewRecommendation: 'bar',
+				},
+				'pub',
+			),
+		).toMatchSnapshot();
+	});
+
+	it('creates a sa_component deposit for a pub with a isSupplementTo connection', () => {
+		expect(
+			createDeposit(
+				{
+					pub: pubIsSupplementTo,
+				},
+				'pub',
+			),
+		).toMatchSnapshot();
+	});
+
+	it('creates a journal_article deposit for a pub with a hasSupplement connection', () => {
+		expect(
+			createDeposit(
+				{
+					pub: pubHasSupplement,
+				},
+				'pub',
+			),
+		).toMatchSnapshot();
+	});
+
+	it('creates a posted_content deposit for a pub with an isPreprintOf connection', () => {
+		expect(
+			createDeposit(
+				{
+					pub: pubIsPreprintOf,
+				},
+				'pub',
+			),
+		).toMatchSnapshot();
+	});
+
+	it('creates a posted_content deposit for a pub with a hasPreprint connection', () => {
+		expect(
+			createDeposit(
+				{
+					pub: pubHasPreprint,
+				},
+				'pub',
+			),
+		).toMatchSnapshot();
+	});
+
+	it('creates a posted_content deposit for a pub when contentVersion is "preprint"', () => {
+		expect(
+			createDeposit(
+				{
+					pub: pub,
+					contentVersion: 'preprint',
+				},
+				'pub',
 			),
 		).toMatchSnapshot();
 	});

--- a/utils/crossref/__tests__/createDeposit.test.js
+++ b/utils/crossref/__tests__/createDeposit.test.js
@@ -162,7 +162,7 @@ describe('createDeposit', () => {
 			doi_data: { doi, resource },
 		} = deposit.doi_batch.body.book.book_metadata;
 		expect(doi).toEqual('an_utterly_fake_doi');
-		expect(resource).toEqual('https://test.com');
+		expect(resource['#text']).toEqual('https://test.com');
 	});
 
 	it('correctly handles date metadata provided by a collection', () => {

--- a/utils/crossref/__tests__/data/pubHasPreprint.js
+++ b/utils/crossref/__tests__/data/pubHasPreprint.js
@@ -1,0 +1,32 @@
+import pub from './pub';
+
+export default {
+	...pub,
+	outboundEdges: [
+		{
+			id: 'd6671d94-3527-4f73-9955-55acfe362442',
+			pubId: '1519656b-cc26-43ad-83f2-dbf5b828a8c7',
+			targetExternalPublication: null,
+			targetPubId: '303f1efa-3c7b-41e3-bc53-877815b35099',
+			relationType: 'preprint',
+			rank: '8',
+			pubIsParent: true,
+			approvedByTarget: true,
+			createdAt: new Date('2020-08-07T16:35:00.224Z'),
+			updatedAt: new Date('2020-08-07T16:35:00.224Z'),
+			externalPublicationId: null,
+			targetPub: {
+				id: '303f1efa-3c7b-41e3-bc53-877815b35099',
+				doi: 'some-doi',
+				slug: 'has-preprint',
+				community: {
+					subdomain: 'foo',
+				},
+				collectionPubs: [],
+				releases: [],
+				attributions: [],
+			},
+			externalPublication: null,
+		},
+	],
+};

--- a/utils/crossref/__tests__/data/pubHasReview.js
+++ b/utils/crossref/__tests__/data/pubHasReview.js
@@ -1,0 +1,32 @@
+import pub from './pub';
+
+export default {
+	...pub,
+	outboundEdges: [
+		{
+			id: 'd6671d94-3527-4f73-9955-55acfe362442',
+			pubId: '1519656b-cc26-43ad-83f2-dbf5b828a8c7',
+			targetExternalPublication: null,
+			targetPubId: '303f1efa-3c7b-41e3-bc53-877815b35099',
+			relationType: 'review',
+			rank: '8',
+			pubIsParent: true,
+			approvedByTarget: true,
+			createdAt: new Date('2020-08-07T16:35:00.224Z'),
+			updatedAt: new Date('2020-08-07T16:35:00.224Z'),
+			externalPublicationId: null,
+			targetPub: {
+				id: '303f1efa-3c7b-41e3-bc53-877815b35099',
+				doi: 'some-doi',
+				slug: 'is-review',
+				community: {
+					subdomain: 'foo',
+				},
+				collectionPubs: [],
+				releases: [],
+				attributions: [],
+			},
+			externalPublication: null,
+		},
+	],
+};

--- a/utils/crossref/__tests__/data/pubHasSupplement.js
+++ b/utils/crossref/__tests__/data/pubHasSupplement.js
@@ -1,0 +1,32 @@
+import pub from './pub';
+
+export default {
+	...pub,
+	outboundEdges: [
+		{
+			id: 'd6671d94-3527-4f73-9955-55acfe362442',
+			pubId: '1519656b-cc26-43ad-83f2-dbf5b828a8c7',
+			targetExternalPublication: null,
+			targetPubId: '303f1efa-3c7b-41e3-bc53-877815b35099',
+			relationType: 'supplement',
+			rank: '8',
+			pubIsParent: true,
+			approvedByTarget: true,
+			createdAt: new Date('2020-08-07T16:35:00.224Z'),
+			updatedAt: new Date('2020-08-07T16:35:00.224Z'),
+			externalPublicationId: null,
+			targetPub: {
+				id: '303f1efa-3c7b-41e3-bc53-877815b35099',
+				doi: 'some-doi',
+				slug: 'has-supplement',
+				community: {
+					subdomain: 'foo',
+				},
+				collectionPubs: [],
+				releases: [],
+				attributions: [],
+			},
+			externalPublication: null,
+		},
+	],
+};

--- a/utils/crossref/__tests__/data/pubIsPreprintOf.js
+++ b/utils/crossref/__tests__/data/pubIsPreprintOf.js
@@ -1,0 +1,32 @@
+import pub from './pub';
+
+export default {
+	...pub,
+	outboundEdges: [
+		{
+			id: 'd6671d94-3527-4f73-9955-55acfe362442',
+			pubId: '1519656b-cc26-43ad-83f2-dbf5b828a8c7',
+			targetExternalPublication: null,
+			targetPubId: '303f1efa-3c7b-41e3-bc53-877815b35099',
+			relationType: 'preprint',
+			rank: '8',
+			pubIsParent: false,
+			approvedByTarget: true,
+			createdAt: new Date('2020-08-07T16:35:00.224Z'),
+			updatedAt: new Date('2020-08-07T16:35:00.224Z'),
+			externalPublicationId: null,
+			targetPub: {
+				id: '303f1efa-3c7b-41e3-bc53-877815b35099',
+				doi: 'some-doi',
+				slug: 'is-preprint',
+				community: {
+					subdomain: 'foo',
+				},
+				collectionPubs: [],
+				releases: [],
+				attributions: [],
+			},
+			externalPublication: null,
+		},
+	],
+};

--- a/utils/crossref/__tests__/data/pubIsReviewOf.js
+++ b/utils/crossref/__tests__/data/pubIsReviewOf.js
@@ -1,0 +1,32 @@
+import pub from './pub';
+
+export default {
+	...pub,
+	outboundEdges: [
+		{
+			id: 'd6671d94-3527-4f73-9955-55acfe362442',
+			pubId: '1519656b-cc26-43ad-83f2-dbf5b828a8c7',
+			targetExternalPublication: null,
+			targetPubId: '303f1efa-3c7b-41e3-bc53-877815b35099',
+			relationType: 'review',
+			rank: '8',
+			pubIsParent: false,
+			approvedByTarget: true,
+			createdAt: new Date('2020-08-07T16:35:00.224Z'),
+			updatedAt: new Date('2020-08-07T16:35:00.224Z'),
+			externalPublicationId: null,
+			targetPub: {
+				id: '303f1efa-3c7b-41e3-bc53-877815b35099',
+				doi: 'some-doi',
+				slug: 'has-review',
+				community: {
+					subdomain: 'foo',
+				},
+				collectionPubs: [],
+				releases: [],
+				attributions: [],
+			},
+			externalPublication: null,
+		},
+	],
+};

--- a/utils/crossref/__tests__/data/pubIsSupplementTo.js
+++ b/utils/crossref/__tests__/data/pubIsSupplementTo.js
@@ -1,0 +1,32 @@
+import pub from './pub';
+
+export default {
+	...pub,
+	outboundEdges: [
+		{
+			id: 'd6671d94-3527-4f73-9955-55acfe362442',
+			pubId: '1519656b-cc26-43ad-83f2-dbf5b828a8c7',
+			targetExternalPublication: null,
+			targetPubId: '303f1efa-3c7b-41e3-bc53-877815b35099',
+			relationType: 'supplement',
+			rank: '8',
+			pubIsParent: false,
+			approvedByTarget: true,
+			createdAt: new Date('2020-08-07T16:35:00.224Z'),
+			updatedAt: new Date('2020-08-07T16:35:00.224Z'),
+			externalPublicationId: null,
+			targetPub: {
+				id: '303f1efa-3c7b-41e3-bc53-877815b35099',
+				doi: 'some-doi',
+				slug: 'is-supplement',
+				community: {
+					subdomain: 'foo',
+				},
+				collectionPubs: [],
+				releases: [],
+				attributions: [],
+			},
+			externalPublication: null,
+		},
+	],
+};

--- a/utils/crossref/createDeposit.js
+++ b/utils/crossref/createDeposit.js
@@ -103,14 +103,24 @@ const getPubDoiPart = (context, doiTarget) => {
 			assertParentPubHasDoi(parentPub);
 			doi = createComponentDoi(parentPub, pubEdge);
 		} else {
-			doi =
-				pub.doi ||
-				createDoi({
-					community: community,
-					collection: collection,
-					target: pub,
-					pubEdge: pubEdge,
-				});
+			// Create component DOIs for supplementary material.
+			if (pubEdge && pubEdge.relationType === RelationType.Supplement) {
+				const parentPub = pubEdge.pubIsParent ? pubEdge.pub : pubEdge.targetPub;
+				const childPub = pubEdge.pubIsParent ? pubEdge.targetPub : pubEdge.pub;
+
+				assertParentPubHasDoi(parentPub);
+
+				doi = createComponentDoi(parentPub, childPub);
+			} else {
+				doi =
+					pub.doi ||
+					createDoi({
+						community: community,
+						collection: collection,
+						target: pub,
+						pubEdge: pubEdge,
+					});
+			}
 		}
 	}
 

--- a/utils/crossref/createDeposit.js
+++ b/utils/crossref/createDeposit.js
@@ -92,6 +92,10 @@ const assertParentPubHasDoi = (parentPub) => {
 const getPubDoiPart = (context, doiTarget) => {
 	const { pub, collection, community, pubEdge } = context;
 
+	if (!pub) {
+		return {};
+	}
+
 	let doi;
 
 	if (doiTarget !== 'pub') {

--- a/utils/crossref/createDeposit.js
+++ b/utils/crossref/createDeposit.js
@@ -96,32 +96,22 @@ const getPubDoiPart = (context, doiTarget) => {
 
 	if (doiTarget !== 'pub') {
 		doi = pub.doi;
-	} else {
+	} else if (pubEdge && pubEdge.relationType === RelationType.Supplement) {
 		// Create component DOIs for supplementary material.
-		if (pubEdge && pubEdge.relationType === RelationType.Supplement) {
-			const parentPub = pubEdge.pubIsParent ? pubEdge.pub : pubEdge.targetPub;
-			assertParentPubHasDoi(parentPub);
-			doi = createComponentDoi(parentPub, pubEdge);
-		} else {
-			// Create component DOIs for supplementary material.
-			if (pubEdge && pubEdge.relationType === RelationType.Supplement) {
-				const parentPub = pubEdge.pubIsParent ? pubEdge.pub : pubEdge.targetPub;
-				const childPub = pubEdge.pubIsParent ? pubEdge.targetPub : pubEdge.pub;
+		const parentPub = pubEdge.pubIsParent ? pubEdge.pub : pubEdge.targetPub;
 
-				assertParentPubHasDoi(parentPub);
+		assertParentPubHasDoi(parentPub);
 
-				doi = createComponentDoi(parentPub, childPub);
-			} else {
-				doi =
-					pub.doi ||
-					createDoi({
-						community: community,
-						collection: collection,
-						target: pub,
-						pubEdge: pubEdge,
-					});
-			}
-		}
+		doi = createComponentDoi(parentPub, pub);
+	} else {
+		doi =
+			pub.doi ||
+			createDoi({
+				community: community,
+				collection: collection,
+				target: pub,
+				pubEdge: pubEdge,
+			});
 	}
 
 	return { pub: doi };

--- a/utils/crossref/createDoi.js
+++ b/utils/crossref/createDoi.js
@@ -2,8 +2,8 @@ import { choosePrefixByCommunityId } from './communities';
 
 const splitId = (item) => item.id.split('-')[0];
 
-export const createComponentDoi = (parentPub, pubEdge) => {
-	return `${parentPub.doi}/${splitId(pubEdge)}`;
+export const createComponentDoi = (parentPub, childPub) => {
+	return `${parentPub.doi}/${splitId(childPub)}`;
 };
 
 export default ({ community, target }) => {

--- a/utils/crossref/parseDeposit.js
+++ b/utils/crossref/parseDeposit.js
@@ -86,13 +86,15 @@ export const getDepositRecordReviewType = (depositRecord) => {
 	return body.peer_review['@type'];
 };
 
-export const setDepositRecordReviewType = (depositRecord, reviewType) => {
+// eslint-disable-next-line consistent-return
+export function setDepositRecordReviewType(depositRecord, reviewType) {
 	if (!depositRecord) {
 		return null;
 	}
 
+	// eslint-disable-next-line no-param-reassign
 	depositRecord.depositJson.deposit.doi_batch.body.peer_review['@type'] = reviewType;
-};
+}
 
 export const getDepositRecordReviewRecommendation = (depositRecord) => {
 	if (!depositRecord) {
@@ -114,15 +116,17 @@ export const getDepositRecordReviewRecommendation = (depositRecord) => {
 	return body.peer_review['@recommendation'];
 };
 
-export const setDepositRecordReviewRecommendation = (depositRecord, recommendation) => {
+// eslint-disable-next-line consistent-return
+export function setDepositRecordReviewRecommendation(depositRecord, recommendation) {
 	if (!depositRecord) {
 		return null;
 	}
 
+	// eslint-disable-next-line no-param-reassign
 	depositRecord.depositJson.deposit.doi_batch.body.peer_review[
 		'@recommendation'
 	] = recommendation;
-};
+}
 
 export const getDepositBody = (crossrefDepositRecord) =>
 	crossrefDepositRecord.depositJson.deposit.doi_batch.body;
@@ -151,6 +155,7 @@ export const getDepositTypeTitle = (crossrefDepositRecord) => {
 			return 'Peer Review';
 		case isStandaloneComponentDeposit(crossrefDepositRecord):
 			return 'Supplement';
+		default:
+			return '';
 	}
-	return '';
 };

--- a/utils/crossref/transform/pub.js
+++ b/utils/crossref/transform/pub.js
@@ -44,7 +44,7 @@ export default ({ globals, community }) => (pub) => {
 	const { title, inboundEdges, outboundEdges } = pub;
 	const publicationDate = getPubPublishedDate(pub);
 	const relatedItems = outboundEdges
-		.map(getEdgeCrossrefRelationship)
+		.map((pubEdge) => getEdgeCrossrefRelationship(pubEdge))
 		.concat(inboundEdges.map((pubEdge) => getEdgeCrossrefRelationship(pubEdge, true)));
 
 	return {

--- a/utils/pubEdge/relations.js
+++ b/utils/pubEdge/relations.js
@@ -77,14 +77,14 @@ const createRelationTypeEnum = () => {
 export const relationTypes = Object.keys(relationTypeDefinitions);
 export const RelationType = createRelationTypeEnum();
 
-const findParentEdge = (pubEdges, relationTypes, inbound) => {
+const findParentEdge = (pubEdges, validRelationTypes, inbound) => {
 	for (let i = 0; i < pubEdges.length; i++) {
 		const pubEdge = pubEdges[i];
 		const { pubIsParent, relationType } = pubEdge;
 
 		if (inbound ? pubIsParent : !pubIsParent) {
-			for (let j = 0; j < relationTypes.length; j++) {
-				if (relationType === relationTypes[j]) {
+			for (let j = 0; j < validRelationTypes.length; j++) {
+				if (relationType === validRelationTypes[j]) {
 					return pubEdge;
 				}
 			}
@@ -94,12 +94,12 @@ const findParentEdge = (pubEdges, relationTypes, inbound) => {
 	return null;
 };
 
-export const findParentEdgeByRelationTypes = (pub, relationTypes) => {
+export const findParentEdgeByRelationTypes = (pub, validRelationTypes) => {
 	const { inboundEdges, outboundEdges } = pub;
 
 	return (
-		findParentEdge(inboundEdges, relationTypes, true) ||
-		findParentEdge(outboundEdges, relationTypes) ||
+		findParentEdge(inboundEdges, validRelationTypes, true) ||
+		findParentEdge(outboundEdges, validRelationTypes) ||
 		null
 	);
 };


### PR DESCRIPTION
This PR:
- Fixes linting errors and tests.
- Adds new snapshot tests for the more complex relationship types: preprints, peer reviews, and supplements.
- Updates the component IDs to use truncated pub ids as the component suffix,e.g. `{community}/{parent.collection.id}.{parent.id}/{supplement.id}`
- Filters out PubEdges for preprints and supplements when the relationship approved by the target for both inbound AND outbound connections (was previously just for outbound).