### PR TITLE
fix: Forbid null CollectionPub ranks

### DIFF
--- a/server/collectionPub/model.js
+++ b/server/collectionPub/model.js
@@ -6,7 +6,7 @@ export default (sequelize, dataTypes) => {
 			pubId: { type: dataTypes.UUID, allowNull: false },
 			collectionId: { type: dataTypes.UUID, allowNull: false },
 			contextHint: { type: dataTypes.TEXT },
-			rank: { type: dataTypes.TEXT },
+			rank: { type: dataTypes.TEXT, allowNull: false },
 			isPrimary: { type: dataTypes.BOOLEAN, defaultValue: false, allowNull: false },
 		},
 		{

--- a/server/member/__tests__/api.test.js
+++ b/server/member/__tests__/api.test.js
@@ -43,6 +43,7 @@ const models = modelize`
                 User iCannotCreateAPubViewer {}
             }
             CollectionPub {
+				rank: "h"
                 Pub pub {
                     Member pubAdminMember {
                         permissions: "admin"

--- a/server/pubHistory/__tests__/api.test.js
+++ b/server/pubHistory/__tests__/api.test.js
@@ -14,6 +14,7 @@ const models = modelize`
                 User collectionMember {}
             }
             CollectionPub {
+				rank: "h"
                 Pub pub {
 					viewHash: "blah-blah-blah"
                     Release {}

--- a/server/utils/collectionQueries.js
+++ b/server/utils/collectionQueries.js
@@ -19,7 +19,7 @@ export const getCollectionAttributions = (collectionId) =>
 export const getCollectionPubsInCollection = (collectionId) =>
 	CollectionPub.findAll({
 		where: { collectionId: collectionId },
-		order: [['createdAt', 'ASC']],
+		order: [['rank', 'ASC']],
 	});
 
 export const rerankCollection = async (collectionId) => {

--- a/server/utils/collectionQueries.js
+++ b/server/utils/collectionQueries.js
@@ -1,4 +1,5 @@
 import ensureUserForAttribution from 'utils/ensureUserForAttribution';
+import { generateRanks } from 'utils/rank';
 import { CollectionAttribution, CollectionPub, includeUserModel } from 'server/models';
 
 export const getCollectionAttributions = (collectionId) =>
@@ -18,5 +19,15 @@ export const getCollectionAttributions = (collectionId) =>
 export const getCollectionPubsInCollection = (collectionId) =>
 	CollectionPub.findAll({
 		where: { collectionId: collectionId },
-		order: [['rank', 'ASC']],
+		order: [['createdAt', 'ASC']],
 	});
+
+export const rerankCollection = async (collectionId) => {
+	const collectionPubs = await getCollectionPubsInCollection(collectionId);
+	const ranks = generateRanks(collectionPubs.length);
+	await Promise.all(
+		collectionPubs.map((collectionPub, index) =>
+			CollectionPub.update({ rank: ranks[index] }, { where: { id: collectionPub.id } }),
+		),
+	);
+};

--- a/tools/index.js
+++ b/tools/index.js
@@ -27,6 +27,7 @@ const commandFiles = {
 	migration2020_06_24: './migration2020_06_24.js',
 	migrationsDeprecated: './migrationsDeprecated.js',
 	rerunExport: './rerunExport.js',
+	rerankCollections: './rerankCollections.js',
 	searchSync: './searchSync.js',
 	switchBranchOrders: './switchBranchOrders.js',
 	syncDbSchema: './syncDbSchema.js',

--- a/tools/migrations/2020_08_12_noNullCollectionPubRanks.js
+++ b/tools/migrations/2020_08_12_noNullCollectionPubRanks.js
@@ -1,0 +1,6 @@
+module.exports = async ({ Sequelize, sequelize }) => {
+	await sequelize.queryInterface.changeColumn('CollectionPubs', 'rank', {
+		type: Sequelize.TEXT,
+		allowNull: false,
+	});
+};

--- a/tools/rerankCollections.js
+++ b/tools/rerankCollections.js
@@ -1,0 +1,13 @@
+import Bluebird from 'bluebird';
+import { rerankCollection } from 'server/utils/collectionQueries';
+import { CollectionPub } from 'server/models';
+
+const main = async () => {
+	const collectionIdsMis = await CollectionPub.findAll({ where: { rank: null } });
+	const collectionIdsMissingRanks = [
+		...new Set(collectionIdsMis.map((collectionPub) => collectionPub.collectionId)),
+	];
+	await Bluebird.map(collectionIdsMissingRanks, rerankCollection, { concurrency: 5 });
+};
+
+main().finally(() => process.exit(0));

--- a/utils/rank.js
+++ b/utils/rank.js
@@ -42,6 +42,10 @@ export const findRank = (ranks, index, count = 1) => {
 	return result;
 };
 
+export const generateRanks = (count) => {
+	return mudder.base36.mudder(BOTTOM, TOP, count);
+};
+
 export const findRankInRankedList = (rankedList, index) =>
 	findRank(
 		sortByRank(rankedList).map((s) => s.rank),


### PR DESCRIPTION
A ticket came across Freshdesk today where a user was prevented from reordering a Collection in the Collection Dashboard. An intermediate cause of this was that some of the `CollectionPubs` in the Collection had `rank = NULL`, which makes it impossible to find a rank between it and another Pub.

While we originally allowed null ranks in Collections (either I was lazy or the old Collections editor might have handled this gracefully?) we do now need to enforce that `CollectionPubs` have a string rank. So this PR contains:

- A change to the Sequelize model definition
- A migration to make this change to the live database schema
- A small script to identify Collections with null ranks lurking in them and re-rank them. It's important that this script preserves ordering in these Collections as much as possible!

I should note that, from reading the code, I am still unable to determine where the null ranks are originally coming from. Some of them predate the 2019 Collections refactor, and those will generate more null ranks within a Collection, but there are some freshly-created Collections that are also seeing this problem. So I expect to eventually encounter a new class of error caused by violating the new non-null condition when creating a `CollectionPub`, but at least then we'll be able to debug it.

_Test plan:_
- I added logging statements to the new `rerankCollection` function and observed that the `getCollectionPubsInCollection` correctly returns CollectionPubs in rank order, meaning `rerankCollection` should apply new ranks that preserve ordering.
- I ran the `rerankCollections` tool on the dev database and observed that there were no more null ranks in the `CollectionPubs` table.
- I ran the migration and observed that it correctly marked the `rank` field in the database as non-nullable.