### PR TITLE
dev: Add snapshot testing for searchUtils functions

### DIFF
--- a/stubstub/determinize.js
+++ b/stubstub/determinize.js
@@ -1,0 +1,9 @@
+export const determinize = (deterministicKeys) => (object) => {
+	const res = {};
+	Object.keys(object).forEach((key) => {
+		if (deterministicKeys.includes(key)) {
+			res[key] = object[key];
+		}
+	});
+	return res;
+};

--- a/stubstub/index.js
+++ b/stubstub/index.js
@@ -2,3 +2,4 @@ export { setup, teardown } from './prepare';
 export { login } from './userToAgentMap';
 export { stubModule as stub, stubOut, stubFirebaseAdmin } from './stub';
 export { modelize } from './modelize/modelize';
+export { determinize } from './determinize';

--- a/stubstub/stub.js
+++ b/stubstub/stub.js
@@ -26,6 +26,11 @@ const getStubEntries = (functions) => {
 };
 
 export const stubModule = (module, functions) => {
+	if (typeof module === 'string') {
+		// lol,
+		// eslint-disable-next-line
+		module = require(module);
+	}
 	const stubEntries = getStubEntries(functions);
 	const stubs = stubManyFunctions(module, stubEntries);
 	return {
@@ -35,11 +40,6 @@ export const stubModule = (module, functions) => {
 };
 
 export const stubOut = (module, functions, before = beforeAll, after = afterAll) => {
-	if (typeof module === 'string') {
-		// lol,
-		// eslint-disable-next-line
-		module = require(module);
-	}
 	let restore;
 	before(() => {
 		restore = stubModule(module, functions).restore;

--- a/workers/utils/__tests__/__snapshots__/searchUtils.test.js.snap
+++ b/workers/utils/__tests__/__snapshots__/searchUtils.test.js.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getPageSearchData produces the expected data for a Page 1`] = `
+Array [
+  Object {
+    "avatar": "page.png",
+    "communityDomain": "tc1.pubpub.org",
+    "communityTitle": "Test Community",
+    "description": "You can put text or Pubs on me",
+    "slug": "test-page",
+    "title": "I am a test page",
+  },
+]
+`;
+
+exports[`getPubSearchData produces the expected data for a long Pub 1`] = `
+Array [
+  Object {
+    "avatar": "long.png",
+    "branchIsPublic": true,
+    "branchShortId": 1,
+    "byline": "by First Author, Second Author, and Test Testington",
+    "communityDomain": "tc1.pubpub.org",
+    "communityTitle": "Test Community",
+    "description": "I am very lengthy",
+    "slug": "a-long-pub",
+    "title": "A Long Pub",
+  },
+  Object {
+    "avatar": "long.png",
+    "branchIsPublic": false,
+    "branchShortId": 2,
+    "byline": "by First Author, Second Author, and Test Testington",
+    "communityDomain": "tc1.pubpub.org",
+    "communityTitle": "Test Community",
+    "description": "I am very lengthy",
+    "slug": "a-long-pub",
+    "title": "A Long Pub",
+  },
+]
+`;
+
+exports[`getPubSearchData produces the expected data for a short Pub 1`] = `
+Array [
+  Object {
+    "avatar": "short.png",
+    "branchIsPublic": true,
+    "branchShortId": 1,
+    "byline": "by Test Testington",
+    "communityDomain": "tc1.pubpub.org",
+    "communityTitle": "Test Community",
+    "description": "I am very brief",
+    "slug": "a-short-pub",
+    "title": "A Short Pub",
+  },
+  Object {
+    "avatar": "short.png",
+    "branchIsPublic": false,
+    "branchShortId": 2,
+    "byline": "by Test Testington",
+    "communityDomain": "tc1.pubpub.org",
+    "communityTitle": "Test Community",
+    "description": "I am very brief",
+    "slug": "a-short-pub",
+    "title": "A Short Pub",
+  },
+]
+`;

--- a/workers/utils/__tests__/searchUtils.test.js
+++ b/workers/utils/__tests__/searchUtils.test.js
@@ -1,0 +1,114 @@
+/* global describe, it, expect, beforeAll, afterAll */
+import { stub, modelize, setup, teardown, determinize } from 'stubstub';
+import { plainDoc, fullDoc } from 'utils/storybook/data';
+
+import { getPageSearchData, getPubSearchData } from '../searchUtils';
+
+const models = modelize`
+    Community {
+        title: "Test Community"
+        subdomain: "tc1"
+        Pub shortPub {
+            title: "A Short Pub"
+            slug: "a-short-pub"
+            description: "I am very brief"
+            avatar: "short.png"
+            PubAttribution {
+                User {
+                    slug: "test1"
+                }
+            }
+        }
+        Pub longPub {
+            title: "A Long Pub"
+            slug: "a-long-pub"
+            description: "I am very lengthy"
+            avatar: "long.png"
+            PubAttribution {
+                isAuthor: false
+                User {
+                    slug: "test3"
+                }
+            }
+            PubAttribution {
+                isAuthor: true
+                User {
+                    firstName: "First"
+                    lastName: "Author"
+                    fullName: "Second Author"
+                    slug: "test4"
+                }
+            }
+            PubAttribution {
+                isAuthor: true
+                User {
+                    firstName: "First"
+                    lastName: "Author"
+                    fullName: "First Author"
+                    slug: "test2"
+                }
+            }
+        }
+        Page testPage {
+            title: "I am a test page"
+            slug: "test-page"
+            description: "You can put text or Pubs on me"
+            avatar: "page.png"
+        }
+    }
+`;
+
+let firebaseStub;
+
+setup(beforeAll, async () => {
+	await models.resolve();
+	firebaseStub = stub('server/utils/firebaseAdmin', {
+		getBranchDoc: (pubId) => {
+			return Promise.resolve({ doc: pubId === models.longPub.id ? fullDoc : plainDoc });
+		},
+	});
+});
+
+teardown(afterAll, () => {
+	firebaseStub.restore();
+});
+
+const determinizePubData = determinize([
+	'avatar',
+	'branchIsPublic',
+	'branchShortId',
+	'byline',
+	'communityDomain',
+	'communityTitle',
+	'description',
+	'slug',
+	'title',
+]);
+
+const determinizePageData = determinize([
+	'avatar',
+	'communityDomain',
+	'communityTitle',
+	'description',
+	'slug',
+	'title',
+]);
+
+describe('getPubSearchData', () => {
+	it('produces the expected data for a long Pub', async () => {
+		const data = await getPubSearchData(models.longPub.id);
+		expect(data.map(determinizePubData)).toMatchSnapshot();
+	});
+
+	it('produces the expected data for a short Pub', async () => {
+		const data = await getPubSearchData(models.shortPub.id);
+		expect(data.map(determinizePubData)).toMatchSnapshot();
+	});
+});
+
+describe('getPageSearchData', () => {
+	it('produces the expected data for a Page', async () => {
+		const data = await getPageSearchData(models.testPage.id);
+		expect(data.map(determinizePageData)).toMatchSnapshot();
+	});
+});

--- a/workers/utils/searchUtils.js
+++ b/workers/utils/searchUtils.js
@@ -73,6 +73,8 @@ export const getPubSearchData = async (pubIds) => {
 				model: Branch,
 				as: 'branches',
 				required: true,
+				separate: true,
+				order: [['shortId', 'ASC']],
 			},
 		],
 	});


### PR DESCRIPTION
Unexpected changes to the behavior of the functions in `searchUtils.js` force us to retroactively update the Algolia index, which is time consuming and expensive, so I've added a bit of snapshot testing for them here.

_Test plan:_

Run `npm run test workers/utils`
