### PR TITLE
feature: remove abbrev_title from journal deposits

### DIFF
--- a/utils/crossref/__tests__/__snapshots__/createDeposit.test.js.snap
+++ b/utils/crossref/__tests__/__snapshots__/createDeposit.test.js.snap
@@ -50,7 +50,6 @@ Object {
           },
           "journal_metadata": Object {
             "@language": "en",
-            "abbrev_title": "PubPub Dev",
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d",
               "resource": Object {
@@ -485,7 +484,6 @@ Object {
           },
           "journal_metadata": Object {
             "@language": "en",
-            "abbrev_title": "PubPub Dev",
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d",
               "resource": Object {
@@ -864,7 +862,6 @@ Object {
           },
           "journal_metadata": Object {
             "@language": "en",
-            "abbrev_title": "PubPub Dev",
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d",
               "resource": Object {
@@ -960,7 +957,6 @@ Object {
           },
           "journal_metadata": Object {
             "@language": "en",
-            "abbrev_title": "PubPub Dev",
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d",
               "resource": Object {
@@ -1055,7 +1051,6 @@ Object {
           },
           "journal_metadata": Object {
             "@language": "en",
-            "abbrev_title": "PubPub Dev",
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d",
               "resource": Object {
@@ -1147,7 +1142,6 @@ Object {
           },
           "journal_metadata": Object {
             "@language": "en",
-            "abbrev_title": "PubPub Dev",
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d",
               "resource": Object {
@@ -1240,7 +1234,6 @@ Object {
           },
           "journal_metadata": Object {
             "@language": "en",
-            "abbrev_title": "PubPub Dev",
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d",
               "resource": Object {
@@ -1481,7 +1474,6 @@ Object {
           },
           "journal_metadata": Object {
             "@language": "en",
-            "abbrev_title": "PubPub Dev",
             "doi_data": Object {
               "doi": "10.21428/eea8ec7d",
               "resource": Object {

--- a/utils/crossref/schema/journal.js
+++ b/utils/crossref/schema/journal.js
@@ -5,7 +5,6 @@ export default ({ title, issn, language, children, doi, timestamp, url, contentV
 		journal_metadata: {
 			'@language': language,
 			full_title: title,
-			abbrev_title: title,
 			...(issn ? { '@media_type': 'electronic', '#text': issn } : {}),
 			...doiData(doi, timestamp, url, contentVersion),
 		},


### PR DESCRIPTION
Closes #985

Fixes an issue where deposits for communities with long titles would fail due to a 150 character restriction on the `abbrev_title` field. This PR simply removes the optional `abbrev_title` element from `journal_metadata` deposits.