### PR TITLE
fix: don't crash when depositing pub with zero contributors

### DIFF
--- a/client/components/AssignDoi/AssignDoiPreview.js
+++ b/client/components/AssignDoi/AssignDoiPreview.js
@@ -89,6 +89,10 @@ const renderPublicationDate = (publication_date, title = 'Publication Date') => 
 };
 
 const renderContributors = (contributors) => {
+	if (!contributors) {
+		return null;
+	}
+
 	const contributorNames = contributors.person_name.map(
 		(contributor) =>
 			`${contributor.given_name} ${contributor.surname} (${contributor['@contributor_role']})`,


### PR DESCRIPTION
A small falsy check to prevent fatal error when deposit doesn't contain a contributors property in the case of no Pub attributions.

Fixes #992