### PR TITLE
feature: sitemap index and dynamic robots.txt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4004,6 +4004,14 @@
 				"@types/react": "*"
 			}
 		},
+		"@types/sax": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.1.tgz",
+			"integrity": "sha512-dqYdvN7Sbw8QT/0Ci5rhjE4/iCMJEM0Y9rHpCu+gGXD9Lwbz28t6HI2yegsB6BoV1sShRMU6lAmAcgRjmFy7LA==",
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/source-list-map": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -4660,6 +4668,11 @@
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
 			}
+		},
+		"arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -19384,6 +19397,24 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+		},
+		"sitemap": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/sitemap/-/sitemap-6.2.0.tgz",
+			"integrity": "sha512-ta9BLo/ZLUNgfGVhknA2IHWuIXfcFPxMvMCY3Xhf141rEZoW8G5nIVCDR0/zeXJCAvWk+UzqxyLBtRBH1OOq6w==",
+			"requires": {
+				"@types/node": "^14.0.18",
+				"@types/sax": "^1.2.1",
+				"arg": "^4.1.3",
+				"sax": "^1.2.4"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "14.0.27",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+					"integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
+				}
+			}
 		},
 		"slash": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
 		"sass-loader": "^7.1.0",
 		"sequelize": "^5.12.2",
 		"sinon": "^7.3.2",
+		"sitemap": "^6.2.0",
 		"slowdance": "0.0.2",
 		"stickybits": "^3.6.5",
 		"stopword": "^0.2.1",

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -36,4 +36,6 @@ require('./passwordReset'); // Route: ['/password-reset', '/password-reset/:rese
 require('./userCreate'); // Route: '/user/create/:hash'
 require('./user'); // Route: ['/user/:slug', '/user/:slug/:mode']
 require('./page'); // Route: ['/', '/:slug']
+require('./sitemap'); // Route: /sitemap-*.xml
+require('./robots'); // Route: /robots.txt
 require('./noMatch'); // Route: '/*'

--- a/server/routes/robots.js
+++ b/server/routes/robots.js
@@ -4,21 +4,27 @@ import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { communityUrl } from 'utils/canonicalUrls';
 
-const getCommunityRobots = (community) => `User-agent: *
-Disallow:
-Sitemap: ${communityUrl(community)}/sitemap-index.xml
-`;
+const BASE_ROBOTS = `User-agent: *
+Disallow:`;
+
+const buildRobotsFile = (community) => {
+	if (community) {
+		return `${BASE_ROBOTS}
+Sitemap: ${communityUrl(community)}/sitemap-index.xml`;
+	}
+	return BASE_ROBOTS;
+};
 
 app.get('/robots.txt', async (req, res, next) => {
 	if (!hostIsValid(req, 'community')) {
-		return next();
+		return buildRobotsFile();
 	}
 
 	try {
 		const { communityData } = await getInitialData(req, true);
 
 		res.header('Content-Type', 'text/plain');
-		return res.send(getCommunityRobots(communityData));
+		return res.send(buildRobotsFile(communityData));
 	} catch (err) {
 		return handleErrors(req, res, next)(err);
 	}

--- a/server/routes/robots.js
+++ b/server/routes/robots.js
@@ -1,5 +1,4 @@
-import app from 'server/server';
-import { handleErrors } from 'server/utils/errors';
+import app, { wrap } from 'server/server';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { communityUrl } from 'utils/canonicalUrls';
@@ -15,17 +14,17 @@ Sitemap: ${communityUrl(community)}/sitemap-index.xml`;
 	return BASE_ROBOTS;
 };
 
-app.get('/robots.txt', async (req, res, next) => {
-	if (!hostIsValid(req, 'community')) {
-		return buildRobotsFile();
-	}
+app.get(
+	'/robots.txt',
+	wrap(async (req, res, next) => {
+		if (!hostIsValid(req, 'community')) {
+			return buildRobotsFile();
+		}
 
-	try {
 		const { communityData } = await getInitialData(req, true);
 
 		res.header('Content-Type', 'text/plain');
+
 		return res.send(buildRobotsFile(communityData));
-	} catch (err) {
-		return handleErrors(req, res, next)(err);
-	}
-});
+	}),
+);

--- a/server/routes/robots.js
+++ b/server/routes/robots.js
@@ -1,0 +1,25 @@
+import app from 'server/server';
+import { handleErrors } from 'server/utils/errors';
+import { getInitialData } from 'server/utils/initData';
+import { hostIsValid } from 'server/utils/routes';
+import { communityUrl } from 'utils/canonicalUrls';
+
+const getCommunityRobots = (community) => `User-agent: *
+Disallow:
+Sitemap: ${communityUrl(community)}/sitemap-index.xml
+`;
+
+app.get('/robots.txt', async (req, res, next) => {
+	if (!hostIsValid(req, 'community')) {
+		return next();
+	}
+
+	try {
+		const { communityData } = await getInitialData(req, true);
+
+		res.header('Content-Type', 'text/plain');
+		return res.send(getCommunityRobots(communityData));
+	} catch (err) {
+		return handleErrors(req, res, next)(err);
+	}
+});

--- a/server/routes/robots.js
+++ b/server/routes/robots.js
@@ -16,7 +16,7 @@ Sitemap: ${communityUrl(community)}/sitemap-index.xml`;
 
 app.get(
 	'/robots.txt',
-	wrap(async (req, res, next) => {
+	wrap(async (req, res) => {
 		if (!hostIsValid(req, 'community')) {
 			return buildRobotsFile();
 		}

--- a/server/routes/sitemap.js
+++ b/server/routes/sitemap.js
@@ -48,11 +48,7 @@ const maybeGenerateSitemapIndex = async (community) => {
 		return false;
 	}
 
-	const hostname = communityUrl({
-		where: {
-			communityId: community.id,
-		},
-	});
+	const hostname = communityUrl(community);
 	const pubs = await Pub.findAll({
 		where: {
 			communityId: community.id,
@@ -70,6 +66,7 @@ const maybeGenerateSitemapIndex = async (community) => {
 	const pages = await Page.findAll({
 		where: {
 			communityId: community.id,
+			isPublic: true,
 		},
 	});
 	// By default, SitemapAndIndexStream will partition sitemaps every 45,000 entries.

--- a/server/routes/sitemap.js
+++ b/server/routes/sitemap.js
@@ -1,0 +1,141 @@
+import AWS from 'aws-sdk';
+import { SitemapAndIndexStream, SitemapStream } from 'sitemap';
+import * as stream from 'stream';
+import { promisify } from 'util';
+import { createGzip } from 'zlib';
+
+import { isProd } from 'utils/environment';
+import { Page, Pub } from 'server/models';
+import app from 'server/server';
+import { handleErrors } from 'server/utils/errors';
+import { getInitialData } from 'server/utils/initData';
+import { hostIsValid } from 'server/utils/routes';
+import { communityUrl, pubUrl, pageUrl } from 'utils/canonicalUrls';
+
+const s3 = new AWS.S3({ params: { Bucket: 'sitemaps.pubpub.org' } });
+const pipeline = promisify(stream.pipeline);
+const keyPrefix = isProd() ? 'prod' : 'dev';
+
+const uploadFromStream = (key) => {
+	const pass = new stream.PassThrough();
+	const params = { Key: key, Body: pass, ACL: 'public-read' };
+
+	s3.upload(params, (err) => {
+		if (err) {
+			console.error(err);
+		}
+		pass.end();
+	});
+
+	return pass;
+};
+
+const getSitemapKey = (community, { filename, index = 'index' } = {}) =>
+	`${keyPrefix}/${community.id}/${filename || `sitemap-${index}.xml`}.gz`;
+
+const shouldGenerateSitemapIndex = async (community) => {
+	try {
+		const metadata = await s3.headObject({ Key: getSitemapKey(community) }).promise();
+		// Re-generate the sitemap index if sitemap has not been updated within
+		// the last 24 hours.
+		return Date.now() - metadata.LastModified >= 8.64e7;
+	} catch (err) {
+		return true;
+	}
+};
+
+const maybeGenerateSitemapIndex = async (community) => {
+	if (!(await shouldGenerateSitemapIndex(community))) {
+		return false;
+	}
+
+	const communityQuery = {
+		where: {
+			communityId: community.id,
+		},
+	};
+	const hostname = communityUrl(community);
+	const pubs = await Pub.findAll(communityQuery);
+	const pages = await Page.findAll(communityQuery);
+	// By default, SitemapAndIndexStream will partition sitemaps every 45,000 entries.
+	const sitemapAndIndexStream = new SitemapAndIndexStream({
+		getSitemapStream: (i) => {
+			const sitemapPath = `./sitemap-${i}.xml`;
+			const sitemapStream = new SitemapStream({
+				hostname: hostname,
+			});
+
+			sitemapStream
+				.pipe(createGzip())
+				.pipe(uploadFromStream(getSitemapKey(community, { index: i })));
+
+			return [new URL(sitemapPath, hostname).toString(), sitemapStream];
+		},
+	});
+	const urls = pubs
+		.map((pub) => ({
+			url: pubUrl(community, pub),
+			changefreq: 'weekly',
+			priority: 1,
+		}))
+		.concat(
+			pages.map((page) => ({
+				url: pageUrl(community, page),
+				changefreq: 'monthly',
+				priority: 0.8,
+			})),
+		);
+
+	await pipeline(
+		stream.Readable.from(urls),
+		sitemapAndIndexStream,
+		createGzip(),
+		uploadFromStream(getSitemapKey(community)),
+	);
+
+	return true;
+};
+
+const getSitemapIndex = async (community, targetFilename) => {
+	await maybeGenerateSitemapIndex(community);
+
+	const indexParams = {
+		Key: getSitemapKey(community, { filename: targetFilename }),
+	};
+
+	await s3.waitFor('objectExists', indexParams).promise();
+
+	return s3.getObject(indexParams).createReadStream();
+};
+
+app.get('/sitemap*', async (req, res, next) => {
+	if (!hostIsValid(req, 'community')) {
+		return next();
+	}
+
+	const { path } = req;
+	const sitemapIndexOrSitemapFilename = path.replace(/^\//, '');
+
+	if (!/^sitemap-([0-9]+|index)\.xml$/.test(sitemapIndexOrSitemapFilename)) {
+		return res.sendStatus(404);
+	}
+
+	try {
+		const { communityData } = await getInitialData(req, true);
+		const sitemapFileStream = await getSitemapIndex(
+			communityData,
+			sitemapIndexOrSitemapFilename,
+		);
+
+		if (sitemapFileStream) {
+			res.header('Content-Encoding', 'gzip');
+			res.header('Content-Type', 'application/xml');
+
+			return sitemapFileStream.pipe(res);
+		}
+
+		return res.sendStatus(404);
+	} catch (err) {
+		return handleErrors(req, res, next)(err);
+	}
+});

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow:

--- a/utils/canonicalUrls.js
+++ b/utils/canonicalUrls.js
@@ -50,3 +50,5 @@ export const bestPubUrl = ({ pubData, communityData }, options = {}) => {
 };
 
 export const doiUrl = (doi) => `https://doi.org/${doi}`;
+
+export const pageUrl = (community, page) => `${communityUrl(community)}/${page.slug}`;


### PR DESCRIPTION
Closes #976

This PR adds sitemaps to communities.

The static robots.txt file is replaced with a dynamic file which builds the robots file on a per-community basis. The robots.txt file for communities will now point to the sitemap via the `Sitemap` rule, e.g. `Sitemap: http://community.pubpub.org/sitemap-index.xml`.

If a sitemap has not been generated for a community, or the sitemap was updated over 24 hours ago, a sitemap index and child sitemaps (e.g. sitemap-0.xml, sitemap-1.xml, ...) will be generated and uploaded to a new S3 bucket, `sitemaps.pubpub.org`. The new bucket structure looks like:

```
sitemaps.pubpub.org
  dev/
    1acefbd-99ecba-301dbe-ffc9ae/
      sitemap-index.xml
      sitemap-0.xml
      ...
  prod/
    ...
```

Where dev and prod directories correspond to the application environment, and the hash corresponds to a community ID.

If a sitemap artifact is requested and the sitemap index for that community has been updated within the last 24 hours, the file will be streamed directly from S3.

The sitemap XML artifacts are generated using the `sitemap` npm library. `sitemap` will automatically chunk sitemaps for every 45,000 entries. To my knowledge, no PubPub communities have >=45,000 combined Pubs and Pages, but this should put us in a good position to scale sitemaps for communities of that size in the future.

Records for Pages are weighted slightly below Pubs. This means (hypothetically) that search engines will crawl Pubs more frequently than pages. Pubs are also labeled as being updated more frequently ("weekly" as opposed to pages' "monthly"), which also signals to search engines that Pubs have a higher rate of change than Pages.

This feature uses Node streams in a few spots, which admittedly aren't my forte. So if you have any feedback or tips, I'm all ears.

**Test Plan:**
- Visit any community's robots.txt file and ensure the `Sitemap: ` rule is present and looks like `http://{community}.pubpub.org/sitemap-index.xml`.
- Explore the sitemaps.pubpub.org S3 bucket.
- Visit any community's sitemap-index.xml file and verify that the sitemap index loads.
- Visit the sitemap-0.xml file and verify that all pages and Pubs of that community have a <url> record.
- Verify the structure of the S3 bucket matches the example above.
