### PR TITLE
feature: resize to 1920px width for breakout images

### DIFF
--- a/client/components/Editor/schemas/image.js
+++ b/client/components/Editor/schemas/image.js
@@ -38,7 +38,7 @@ export default {
 				[
 					'img',
 					{
-						src: resizeFunc(node.attrs.url),
+						src: resizeFunc(node.attrs.url, node.attrs.align),
 						alt: node.attrs.caption,
 					},
 				],

--- a/client/containers/Pub/PubDocument/PubBody.js
+++ b/client/containers/Pub/PubDocument/PubBody.js
@@ -176,8 +176,9 @@ const PubBody = (props) => {
 				}}
 				nodeOptions={{
 					image: {
-						onResizeUrl: (url) => {
-							return getResizedUrl(url, 'fit-in', '800x0');
+						onResizeUrl: (url, align) => {
+							const width = align === 'breakout' ? 1920 : 800;
+							return getResizedUrl(url, 'fit-in', `${width}x0`);
 						},
 					},
 					discussion: {


### PR DESCRIPTION
Closes #964

This PR updates the image resizing code within the Pub body to resize to 1920px for full bleed (or "breakout") images.

**Test Plan**
1. Insert a high resolution image.
2. Toggle the image to full width (but not breakout).
3. Inspect the image URL - it should be resized to a maximum width of 800px.
4. Toggle the image to breakout.
5. The image should be upgraded to a max width of 1920px.