### PR TITLE
fix: Update Pub API and add tests

### DIFF
--- a/client/components/Header/Header.js
+++ b/client/components/Header/Header.js
@@ -30,13 +30,8 @@ const Header = (props) => {
 	};
 	const handleCreatePub = () => {
 		setIsLoading(true);
-		return apiFetch('/api/pubs', {
-			method: 'POST',
-			body: JSON.stringify({
-				communityId: communityData.id,
-				defaultCollectionIds: communityData.defaultPubCollections || [],
-			}),
-		})
+		return apiFetch
+			.post('/api/pubs', { communityId: communityData.id })
 			.then((newPub) => {
 				window.location.href = `/pub/${newPub.slug}`;
 			})

--- a/client/containers/App/Breadcrumbs/Breadcrumbs.js
+++ b/client/containers/App/Breadcrumbs/Breadcrumbs.js
@@ -37,13 +37,11 @@ const Breadcrumbs = () => {
 
 	const handleCreatePub = () => {
 		setNewPubIsLoading(true);
-		return apiFetch('/api/pubs', {
-			method: 'POST',
-			body: JSON.stringify({
+		return apiFetch
+			.post('/api/pubs', {
 				communityId: communityData.id,
-				defaultCollectionIds: activeCollection ? [activeCollection.id] : [],
-			}),
-		})
+				collectionId: activeCollection && activeCollection.id,
+			})
 			.then((newPub) => {
 				window.location.href = `/pub/${newPub.slug}`;
 			})

--- a/server/collection/queries.js
+++ b/server/collection/queries.js
@@ -10,6 +10,7 @@ export const createCollection = ({
 	pageId = null,
 	doi = null,
 	isPublic = false,
+	id = null,
 }) => {
 	return Community.findOne({ where: { id: communityId } }).then((community) => {
 		const collection = {
@@ -23,6 +24,7 @@ export const createCollection = ({
 			pageId: pageId,
 			doi: doi,
 			kind: kind,
+			...(id && { id: id }),
 		};
 		const metadata = normalizeMetadataToKind({}, kind, {
 			community: community,

--- a/server/pub/__tests__/api.test.js
+++ b/server/pub/__tests__/api.test.js
@@ -1,0 +1,198 @@
+/* eslint-disable no-restricted-syntax, no-await-in-loop */
+/* global it, expect, beforeAll, afterAll */
+import uuid from 'uuid/v4';
+
+import { setup, teardown, login, modelize } from 'stubstub';
+import { CollectionPub, Pub } from 'server/models';
+
+const defaultCollectionId = uuid();
+
+const models = modelize`
+	Community community {
+        defaultPubCollections: ${[defaultCollectionId]}
+        Member {
+            permissions: "manage"
+            User communityManager {}
+        }
+        Member {
+            permissions: "edit"
+            User communityMember {}
+        }
+		Collection collection {
+            Member {
+                permissions: "manage"
+                User collectionManager {}
+            }
+            CollectionPub {
+                rank: "h"
+                Pub pub {
+                    Member {
+                        permissions: "admin"
+                        User pubAdmin {}
+                    }
+                    Member {
+                        permissions: "manage"
+                        User pubManager {}
+                    }
+                }
+            }
+        }
+        Collection defaultCollection {
+            id: ${defaultCollectionId}
+        }
+        Pub destroyThisPub {
+            Member {
+                permissions: "manage"
+                User destructivePubManager {}
+            }
+            Member {
+                permissions: "edit"
+                User angryPubEditor {}
+            }
+        }
+        Pub alsoDestroyThisPub {}
+    }
+    Community {
+        Collection nefariousCollection {
+            Member {
+                permissions: "manage"
+                User nefariousUser {}
+            }
+        }
+    }
+`;
+
+setup(beforeAll, async () => {
+	await models.resolve();
+});
+
+it('does not allow random visitors to create a Pub', async () => {
+	const { community } = models;
+	const agent = await login();
+	await agent
+		.post('/api/pubs')
+		.send({ communityId: community.id })
+		.expect(403);
+});
+
+it('does not allow Members with insufficient permissions to create a Pub', async () => {
+	const { community, communityMember } = models;
+	const agent = await login(communityMember);
+	await agent
+		.post('/api/pubs')
+		.send({ communityId: community.id })
+		.expect(403);
+});
+
+it('does not allow Members from other Communities to create a Pub', async () => {
+	const { community, nefariousCollection, nefariousUser } = models;
+	const agent = await login(nefariousUser);
+	await agent
+		.post('/api/pubs')
+		.send({ communityId: community.id, collectionId: nefariousCollection.id })
+		.expect(403);
+});
+
+it('allows a Community manager to create a Pub (and adds it to Community default Collection)', async () => {
+	const { community, communityManager } = models;
+	const agent = await login(communityManager);
+	const { body: pub } = await agent
+		.post('/api/pubs')
+		.send({ communityId: community.id })
+		.expect(201);
+	const collectionPub = await CollectionPub.findOne({
+		where: {
+			pubId: pub.id,
+			collectionId: defaultCollectionId,
+		},
+	});
+	expect(collectionPub).toBeTruthy();
+});
+
+it('allows a Collection manager to create a Pub (and adds it to the Collection)', async () => {
+	const { community, collection, collectionManager } = models;
+	const agent = await login(collectionManager);
+	const { body: pub } = await agent
+		.post('/api/pubs')
+		.send({ communityId: community.id, collectionId: collection.id })
+		.expect(201);
+	const collectionPub = await CollectionPub.findOne({
+		where: {
+			pubId: pub.id,
+			collectionId: collection.id,
+		},
+	});
+	expect(collectionPub).toBeTruthy();
+});
+
+it('forbids a user without permissions from updating a Pub', async () => {
+	const { pub, nefariousUser } = models;
+	const agent = await login(nefariousUser);
+	await agent
+		.put('/api/pubs')
+		.send({ pubId: pub.id, title: 'Bwa ha ha' })
+		.expect(403);
+});
+
+it('allows a Community, Collection, Pub manager to update some fields on a Pub (but not others)', async () => {
+	const { pub, pubManager, collectionManager, communityManager } = models;
+	for (const user of [pubManager, collectionManager, communityManager]) {
+		const agent = await login(user);
+		const title = `${user.id} was here!`;
+		await agent
+			.put('/api/pubs')
+			.send({ pubId: pub.id, title: title, doi: 'some_doi' })
+			.expect(200);
+		const pubNow = await Pub.findOne({ where: { id: pub.id } });
+		expect(pubNow).toMatchObject({ title: title, doi: null });
+	}
+});
+
+it('allows a Pub admin to set a DOI on a Pub', async () => {
+	const { pub, pubAdmin } = models;
+	const agent = await login(pubAdmin);
+	await agent
+		.put('/api/pubs')
+		.send({ pubId: pub.id, doi: 'some_doi' })
+		.expect(200);
+	const pubNow = await Pub.findOne({ where: { id: pub.id } });
+	expect(pubNow).toMatchObject({ doi: 'some_doi' });
+});
+
+it('forbids a user without permissions from deleting a Pub', async () => {
+	const { pub, nefariousUser } = models;
+	const agent = await login(nefariousUser);
+	await agent
+		.delete('/api/pubs')
+		.send({ pubId: pub.id })
+		.expect(403);
+});
+
+it('forbids a Member without sufficient permissions from deleting a Pub', async () => {
+	const { destroyThisPub, angryPubEditor } = models;
+	const agent = await login(angryPubEditor);
+	await agent
+		.delete('/api/pubs')
+		.send({ pubId: destroyThisPub.id })
+		.expect(403);
+});
+
+it('allows a Pub manager to delete a Pub', async () => {
+	const { destroyThisPub, destructivePubManager } = models;
+	const agent = await login(destructivePubManager);
+	await agent
+		.delete('/api/pubs')
+		.send({ pubId: destroyThisPub.id })
+		.expect(200);
+});
+
+it('allows a Community manager to delete a Pub', async () => {
+	const { alsoDestroyThisPub, communityManager } = models;
+	const agent = await login(communityManager);
+	await agent
+		.delete('/api/pubs')
+		.send({ pubId: alsoDestroyThisPub.id })
+		.expect(200);
+});
+
+teardown(afterAll);

--- a/server/pub/api.js
+++ b/server/pub/api.js
@@ -59,7 +59,7 @@ app.delete(
 		const canDestroy = await canDestroyPub({ userId: userId, pubId: pubId });
 		if (canDestroy) {
 			await destroyPub(pubId);
-			return res.status(200).end();
+			return res.status(200).json({});
 		}
 		throw new ForbiddenError();
 	}),

--- a/server/pub/queries.js
+++ b/server/pub/queries.js
@@ -10,7 +10,7 @@ export const createPub = async ({ communityId, collectionId, ...restArgs }, user
 	const newPubSlug = generateHash(8);
 	const date = new Date();
 	const dateString = `${months[date.getMonth()]} ${date.getDate()}`;
-	const { defaultPubCollections = [] } = await Community.findOne({ where: { id: communityId } });
+	const { defaultPubCollections } = await Community.findOne({ where: { id: communityId } });
 
 	const newPub = await Pub.create({
 		title: `Untitled Pub on ${dateString}`,
@@ -54,7 +54,7 @@ export const createPub = async ({ communityId, collectionId, ...restArgs }, user
 	});
 
 	const createCollectionPubs = Promise.all(
-		[...defaultPubCollections, collectionId]
+		[...(defaultPubCollections || []), collectionId]
 			.filter((x) => x)
 			.map(async (collectionIdToAdd) => {
 				// defaultPubCollections isn't constrained by the database in any way and might contain IDs

--- a/server/pubEdge/api.js
+++ b/server/pubEdge/api.js
@@ -81,7 +81,7 @@ app.delete(
 		});
 		if (canDestroyEdge) {
 			await destroyPubEdge(pubEdgeId);
-			return res.status(200).end();
+			return res.status(200).json({});
 		}
 		throw new ForbiddenError();
 	}),


### PR DESCRIPTION
Here we fix some permissions problems with the Pub API, and add some tests to assess this issue.

_Test plan:_
- Ensure you can create a Pub from the global header
- Ensure you can create a Pub from both the Community and Collection dashboards, and that the Pub is inserted into the appropriate scope.
- `npm run test server/pub/`
