### PR TITLE
fix: add max length to pub description to prevent truncation

### DIFF
--- a/client/components/LengthIndicator/LengthIndicator.js
+++ b/client/components/LengthIndicator/LengthIndicator.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
+import classNames from 'classnames';
+import { Classes } from '@blueprintjs/core';
 
 require('./lengthIndicator.scss');
 
@@ -25,9 +26,9 @@ function LengthIndicator(props) {
 
 	return (
 		<span
-			className={classnames(
+			className={classNames(
 				'length-indicator-component',
-				lengthRatio === 1 && 'at-max-length',
+				lengthRatio === 1 && Classes.INTENT_DANGER,
 			)}
 		>
 			{length} / {maxLength}

--- a/client/components/LengthIndicator/LengthIndicator.js
+++ b/client/components/LengthIndicator/LengthIndicator.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Classes } from '@blueprintjs/core';
+import { Text } from '@blueprintjs/core';
 
 require('./lengthIndicator.scss');
 
@@ -25,14 +25,14 @@ function LengthIndicator(props) {
 	}
 
 	return (
-		<span
+		<Text
 			className={classNames(
 				'length-indicator-component',
-				lengthRatio === 1 && Classes.INTENT_DANGER,
+				lengthRatio === 1 && 'at-max-length',
 			)}
 		>
 			{length} / {maxLength}
-		</span>
+		</Text>
 	);
 }
 

--- a/client/components/LengthIndicator/LengthIndicator.js
+++ b/client/components/LengthIndicator/LengthIndicator.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+require('./lengthIndicator.scss');
+
+const propTypes = {
+	length: PropTypes.number.isRequired,
+	maxLength: PropTypes.number.isRequired,
+	visibilityThreshold: PropTypes.number,
+};
+
+const defaultProps = {
+	visibilityThreshold: 0.9,
+};
+
+function LengthIndicator(props) {
+	const { length, maxLength, visibilityThreshold } = props;
+	const lengthRatio = length / maxLength;
+	const showLengthIndicator = lengthRatio > visibilityThreshold;
+
+	if (!showLengthIndicator) {
+		return null;
+	}
+
+	return (
+		<span
+			className={classnames(
+				'length-indicator-component',
+				lengthRatio === 1 && 'at-max-length',
+			)}
+		>
+			{length} / {maxLength}
+		</span>
+	);
+}
+
+LengthIndicator.propTypes = propTypes;
+LengthIndicator.defaultProps = defaultProps;
+export default LengthIndicator;

--- a/client/components/LengthIndicator/lengthIndicator.scss
+++ b/client/components/LengthIndicator/lengthIndicator.scss
@@ -1,5 +1,11 @@
+@import '~@blueprintjs/core/src/common/_variables.scss';
+
 .length-indicator-component {
 	font-size: 16px;
 	color: #666;
 	display: block;
+
+	&.at-max-length {
+		color: $red3;
+	}
 }

--- a/client/components/LengthIndicator/lengthIndicator.scss
+++ b/client/components/LengthIndicator/lengthIndicator.scss
@@ -1,11 +1,5 @@
-@import '~@blueprintjs/core/src/common/_variables.scss';
-
 .length-indicator-component {
 	font-size: 16px;
 	color: #666;
 	display: block;
-
-	&.at-max-length {
-		color: $red3;
-	}
 }

--- a/client/components/LengthIndicator/lengthIndicator.scss
+++ b/client/components/LengthIndicator/lengthIndicator.scss
@@ -1,0 +1,11 @@
+@import '~@blueprintjs/core/src/common/_variables.scss';
+
+.length-indicator-component {
+	font-size: 16px;
+	color: #666;
+	display: block;
+
+	&.at-max-length {
+		color: $red3;
+	}
+}

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -25,6 +25,7 @@ export { default as ImageCropper } from './ImageCropper/ImageCropper';
 export { default as ImageUpload } from './ImageUpload/ImageUpload';
 export { default as InputField } from './InputField/InputField';
 export { default as LegalBanner } from './LegalBanner/LegalBanner';
+export { default as LengthIndicator } from './LengthIndicator/LengthIndicator';
 export { default as LicenseSelect } from './LicenseSelect/LicenseSelect';
 export { default as LinkedPageSelect } from './LinkedPageSelect/LinkedPageSelect';
 export { default as InheritedMembersBlock } from './Members/InheritedMembersBlock';

--- a/client/containers/Pub/PubHeader/EditableHeaderText.js
+++ b/client/containers/Pub/PubHeader/EditableHeaderText.js
@@ -24,7 +24,7 @@ const defaultProps = {
 const EditableHeaderText = (props) => {
 	const { canEdit, className, placeholder, tagName, text, updateText, maxLength } = props;
 	const [hasMounted, setHasMounted] = useState(false);
-	const [intermediateValue, setIntermediateValue] = useState(text);
+	const [intermediateValue, setIntermediateValue] = useState(text || '');
 	const useEditableTitle = hasMounted && canEdit;
 
 	useEffect(() => setHasMounted(true), []);

--- a/client/containers/Pub/PubHeader/EditableHeaderText.js
+++ b/client/containers/Pub/PubHeader/EditableHeaderText.js
@@ -24,7 +24,7 @@ const defaultProps = {
 const EditableHeaderText = (props) => {
 	const { canEdit, className, placeholder, tagName, text, updateText, maxLength } = props;
 	const [hasMounted, setHasMounted] = useState(false);
-	const [intermediateValue, setIntermediateValue] = useState(text || '');
+	const [intermediateValue, setIntermediateValue] = useState(text);
 	const useEditableTitle = hasMounted && canEdit;
 
 	useEffect(() => setHasMounted(true), []);
@@ -44,7 +44,7 @@ const EditableHeaderText = (props) => {
 					confirmOnEnterKey={true}
 					maxLength={maxLength}
 				/>
-				<LengthIndicator maxLength={maxLength} length={intermediateValue.length} />
+				<LengthIndicator maxLength={maxLength} length={(intermediateValue || '').length} />
 			</>
 		) : (
 			<span className="text-wrapper">{text}</span>

--- a/client/containers/Pub/PubHeader/EditableHeaderText.js
+++ b/client/containers/Pub/PubHeader/EditableHeaderText.js
@@ -1,11 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { EditableText } from '@blueprintjs/core';
-import classnames from 'classnames';
 
 import { LengthIndicator } from 'components';
-
-require('./editableHeaderText.scss');
 
 const propTypes = {
 	canEdit: PropTypes.bool.isRequired,
@@ -35,7 +32,7 @@ const EditableHeaderText = (props) => {
 
 	return React.createElement(
 		tagName,
-		{ className: classnames(className, 'editable-header-text-component') },
+		{ className: className },
 		useEditableTitle ? (
 			<>
 				<EditableText

--- a/client/containers/Pub/PubHeader/EditableHeaderText.js
+++ b/client/containers/Pub/PubHeader/EditableHeaderText.js
@@ -1,6 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { EditableText } from '@blueprintjs/core';
+import classnames from 'classnames';
+
+import { LengthIndicator } from 'components';
+
+require('./editableHeaderText.scss');
 
 const propTypes = {
 	canEdit: PropTypes.bool.isRequired,
@@ -9,16 +14,18 @@ const propTypes = {
 	tagName: PropTypes.string,
 	text: PropTypes.string,
 	updateText: PropTypes.func.isRequired,
+	maxLength: PropTypes.number,
 };
 
 const defaultProps = {
 	className: '',
 	tagName: 'h1',
 	text: null,
+	maxLength: Infinity,
 };
 
 const EditableHeaderText = (props) => {
-	const { canEdit, className, placeholder, tagName, text, updateText } = props;
+	const { canEdit, className, placeholder, tagName, text, updateText, maxLength } = props;
 	const [hasMounted, setHasMounted] = useState(false);
 	const [intermediateValue, setIntermediateValue] = useState(text);
 	const useEditableTitle = hasMounted && canEdit;
@@ -28,16 +35,20 @@ const EditableHeaderText = (props) => {
 
 	return React.createElement(
 		tagName,
-		{ className: className },
+		{ className: classnames(className, 'editable-header-text-component') },
 		useEditableTitle ? (
-			<EditableText
-				placeholder={placeholder}
-				onConfirm={(newText) => updateText(newText.replace(/\n/g, ''))}
-				onChange={setIntermediateValue}
-				value={intermediateValue}
-				multiline={true}
-				confirmOnEnterKey={true}
-			/>
+			<>
+				<EditableText
+					placeholder={placeholder}
+					onConfirm={(newText) => updateText(newText.replace(/\n/g, ''))}
+					onChange={setIntermediateValue}
+					value={intermediateValue}
+					multiline={true}
+					confirmOnEnterKey={true}
+					maxLength={maxLength}
+				/>
+				<LengthIndicator maxLength={maxLength} length={intermediateValue.length} />
+			</>
 		) : (
 			<span className="text-wrapper">{text}</span>
 		),

--- a/client/containers/Pub/PubHeader/TitleGroup.js
+++ b/client/containers/Pub/PubHeader/TitleGroup.js
@@ -77,6 +77,7 @@ const TitleGroup = (props) => {
 					tagName="h3"
 					className="description pub-header-themed-secondary"
 					placeholder="Add a description for this Pub"
+					maxLength={280}
 				/>
 			)}
 			<PubByline

--- a/client/containers/Pub/PubHeader/editableHeaderText.scss
+++ b/client/containers/Pub/PubHeader/editableHeaderText.scss
@@ -1,3 +1,0 @@
-.editable-header-text-component {
-	position: relative;
-}

--- a/client/containers/Pub/PubHeader/editableHeaderText.scss
+++ b/client/containers/Pub/PubHeader/editableHeaderText.scss
@@ -1,0 +1,3 @@
+.editable-header-text-component {
+	position: relative;
+}


### PR DESCRIPTION
This PR adds a new component LengthIndicator which shows a simple counter where the numerator is the current length of a text input and the denominator is the maximum acceptable length. By default the component will show after the current length is greater than or equal to 90% of the maximum length.

In addition, this PR adds a maximum length of 280 to the Pub description field (in TitleGroup.js) to prevent unwanted truncation of long descriptions.

Closes #920 

**Test Plan**
1. Create a new Pub
2. Enter some text that approaches 200 or more letters. Eventually you should see the length indicator pop up (at 90% of the maximum 280 length).
3. When you reach 280 characters, the text should turn red.
4. You should be unable to enter more than 280 characters in the Pub description field.