### PR TITLE
fix: exclude collection scope from impact tab

### DIFF
--- a/client/containers/App/SideMenu/SideMenu.tsx
+++ b/client/containers/App/SideMenu/SideMenu.tsx
@@ -25,7 +25,6 @@ const SideMenu = () => {
 		{
 			title: 'Overview',
 			icon: 'home2',
-			// @ts-expect-error ts-migrate(2345) FIXME: Type '{ collectionSlug: any; pubSlug: any; }' is m... Remove this comment to see the full error message
 			href: getDashUrl({ collectionSlug: collectionSlug, pubSlug: pubSlug }),
 		},
 		// {
@@ -40,7 +39,6 @@ const SideMenu = () => {
 		{
 			title: 'Pages',
 			icon: 'page-layout',
-			// @ts-expect-error ts-migrate(2345) FIXME: Property 'subMode' is missing in type '{ collectio... Remove this comment to see the full error message
 			href: getDashUrl({
 				collectionSlug: collectionSlug,
 				pubSlug: pubSlug,
@@ -94,7 +92,6 @@ const SideMenu = () => {
 			title: 'Reviews',
 			icon: 'social-media',
 			count: activeCounts.reviewCount,
-			// @ts-expect-error ts-migrate(2345) FIXME: Property 'subMode' is missing in type '{ collectio... Remove this comment to see the full error message
 			href: getDashUrl({
 				collectionSlug: collectionSlug,
 				pubSlug: pubSlug,
@@ -125,7 +122,6 @@ const SideMenu = () => {
 		{
 			title: 'Connections',
 			icon: 'layout-auto',
-			// @ts-expect-error ts-migrate(2345) FIXME: Property 'subMode' is missing in type '{ collectio... Remove this comment to see the full error message
 			href: getDashUrl({
 				collectionSlug: collectionSlug,
 				pubSlug: pubSlug,
@@ -136,17 +132,16 @@ const SideMenu = () => {
 		{
 			title: 'Impact',
 			icon: 'dashboard',
-			// @ts-expect-error ts-migrate(2345) FIXME: Property 'subMode' is missing in type '{ collectio... Remove this comment to see the full error message
 			href: getDashUrl({
 				collectionSlug: collectionSlug,
 				pubSlug: pubSlug,
 				mode: 'impact',
 			}),
+			validScopes: ['pub', 'community'],
 		},
 		{
 			title: 'Members',
 			icon: 'people',
-			// @ts-expect-error ts-migrate(2345) FIXME: Property 'subMode' is missing in type '{ collectio... Remove this comment to see the full error message
 			href: getDashUrl({
 				collectionSlug: collectionSlug,
 				pubSlug: pubSlug,
@@ -157,7 +152,6 @@ const SideMenu = () => {
 		{
 			title: 'Settings',
 			icon: 'cog',
-			// @ts-expect-error ts-migrate(2345) FIXME: Property 'subMode' is missing in type '{ collectio... Remove this comment to see the full error message
 			href: getDashUrl({
 				collectionSlug: collectionSlug,
 				pubSlug: pubSlug,

--- a/utils/dashboard.ts
+++ b/utils/dashboard.ts
@@ -1,4 +1,11 @@
-export const getDashUrl = ({ collectionSlug, pubSlug, mode, subMode }) => {
+type GetDashUrlOptions = {
+	pubSlug?: string;
+	collectionSlug?: string;
+	mode?: string;
+	subMode?: string;
+};
+
+export const getDashUrl = ({ collectionSlug, pubSlug, mode, subMode }: GetDashUrlOptions) => {
 	let baseHref = '/dash';
 	if (collectionSlug) {
 		baseHref = `/dash/collection/${collectionSlug}`;
@@ -24,7 +31,7 @@ export const getDashUrl = ({ collectionSlug, pubSlug, mode, subMode }) => {
 
 export const groupPubs = ({ pubs, collections }) => {
 	const groupedCollections = {};
-	const basePubs = [];
+	const basePubs: unknown[] = [];
 	pubs.forEach((pub) => {
 		if (!pub.collectionPubs.length) {
 			basePubs.push(pub);


### PR DESCRIPTION
Fixes #1008 

**Test Plan**
- Open the dashboard of a Collection.
- The Impact tab should not be visible.
- Ensure the Impact tab is still visible for Pubs and Communities.