### PR TITLE
update: Download, deposit, and review string changes

### DIFF
--- a/client/components/AssignDoi/AssignDoi.tsx
+++ b/client/components/AssignDoi/AssignDoi.tsx
@@ -60,8 +60,8 @@ const AssignDoiActionType = {
 };
 
 const buttonTextByStatus = {
-	[AssignDoiStatus.Initial]: 'Deposit to Crossref',
-	[AssignDoiStatus.Previewing]: 'Getting Preview',
+	[AssignDoiStatus.Initial]: 'Preview Deposit',
+	[AssignDoiStatus.Previewing]: 'Generating Preview',
 	[AssignDoiStatus.Previewed]: 'Submit Deposit',
 	[AssignDoiStatus.Depositing]: 'Depositing',
 	[AssignDoiStatus.Deposited]: 'DOI Deposited',
@@ -69,7 +69,7 @@ const buttonTextByStatus = {
 
 const getButtonText = (status, deposit) => {
 	if (status === AssignDoiStatus.Initial && deposit) {
-		return 'Resubmit DOI deposit';
+		return 'Update & Preview Deposit';
 	}
 
 	return buttonTextByStatus[status];

--- a/client/components/AssignDoi/AssignDoi.tsx
+++ b/client/components/AssignDoi/AssignDoi.tsx
@@ -71,6 +71,9 @@ const getButtonText = (status, deposit) => {
 	if (status === AssignDoiStatus.Initial && deposit) {
 		return 'Update & Preview Deposit';
 	}
+	if (status === AssignDoiStatus.Previewed && deposit) {
+		return 'Re-Submit Deposit';
+	}
 
 	return buttonTextByStatus[status];
 };

--- a/client/containers/App/SideMenu/SideMenu.tsx
+++ b/client/containers/App/SideMenu/SideMenu.tsx
@@ -91,7 +91,7 @@ const SideMenu = () => {
 		{
 			title: 'Reviews',
 			icon: 'social-media',
-			count: activeCounts.reviewCount,
+			count: activeCounts.reviewCount > 0 ? activeCounts.reviewCount : undefined,
 			href: getDashUrl({
 				collectionSlug: collectionSlug,
 				pubSlug: pubSlug,

--- a/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
+++ b/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
@@ -75,7 +75,7 @@ const PubOverview = (props: Props) => {
 				<div className="section-header">Reviews</div>
 				<Menu className="list-content">
 					{!pubData.reviews.length && (
-						<NonIdealState title="No Reviews Yet" icon="social-media" />
+						<NonIdealState title="No Reviews Yet" description={<>This Pub has not been reviewed using PubPub.</>} icon="social-media" />
 					)}
 					{pubData.reviews
 						.sort((a, b) => a.createdAt - b.createdAt)

--- a/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
+++ b/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
@@ -74,9 +74,6 @@ const PubOverview = (props: Props) => {
 			<div className="section list">
 				<div className="section-header">Reviews</div>
 				<Menu className="list-content">
-					{!pubData.reviews.length && (
-						<NonIdealState title="No Reviews Yet" description={<>This Pub has not been reviewed using PubPub.</>} icon="social-media" />
-					)}
 					{pubData.reviews
 						.sort((a, b) => a.createdAt - b.createdAt)
 						.map((review) => {
@@ -114,9 +111,6 @@ const PubOverview = (props: Props) => {
 		return (
 			<div className="section">
 				<div className="section-header">Attribution</div>
-				{!pubData.attributions.length && (
-					<NonIdealState title="No attributions on this pub" icon="person" />
-				)}
 				{pubData.attributions
 					.sort((a, b) => a.order - b.order)
 					.map((attribution) => {
@@ -177,7 +171,7 @@ const PubOverview = (props: Props) => {
 					{pubData.doi && renderSection('DOI', pubData.doi)}
 					{renderAttribution()}
 					{renderCollections()}
-					{renderReviews()}
+					{!!pubData.reviews.length && renderReviews()}
 				</div>
 				<div className="column">
 					<PubTimeline pubData={pubData} />

--- a/client/containers/DashboardReviews/DashboardReviews.tsx
+++ b/client/containers/DashboardReviews/DashboardReviews.tsx
@@ -38,7 +38,7 @@ const DashboardReviews = (props: Props) => {
 		>
 			{!pubsWithReviews.length && (
 				<Menu className="list-content">
-					<NonIdealState title="No Reviews Yet" icon="social-media" />
+					<NonIdealState title="This Pub has not been reviewed using PubPub" icon="social-media" />
 				</Menu>
 			)}
 			{pubsWithReviews.map((pub) => {

--- a/client/containers/Pub/PubHeader/Download.tsx
+++ b/client/containers/Pub/PubHeader/Download.tsx
@@ -145,7 +145,7 @@ const Download = (props: Props) => {
 			)}
 			<li className="bp3-menu-header">
 				<h6 className="bp3-heading">
-					{formattedDownload ? 'Auto Generated Download' : 'Download'}
+					Auto Generated Download
 				</h6>
 			</li>
 			{formatTypes.map((type, i) => {

--- a/workers/tasks/export/html.js
+++ b/workers/tasks/export/html.js
@@ -295,6 +295,14 @@ export const renderStaticHtml = async ({
 				)}
 			</head>
 			<body>
+				{targetPandoc && (
+					<p>
+						<strong>Notice:</strong> This file is an auto-generated download and, as
+						such, might include minor display or rendering errors. For the version of
+						record, please visit the HTML version or download the PDF.
+						<hr />
+					</p>
+				)}
 				{targetPandoc
 					? renderFrontMatterForPandoc(pubMetadata, targetPandoc)
 					: renderFrontMatterForHtml(pubMetadata)}


### PR DESCRIPTION
This implements a series of small string changes that have been requested by our users over the last few weeks.

### Always Auto Generated
Previously, the downloads dropdown would say "Downloads" if no Formatted download was present, but "Auto Generated Downloads" if a Formatted download was present. This caused some confusion about what was and was not auto-generated.

_Test plan_
- Visit a pub with no formatted download, verify that the dropdown says "auto generated download"
- Visit a pub with a formatted download, verify that the dropdown says "auto generated download"

### Non-PDF and HTML Export Auto-Generation Disclaimer
With guidance from MITP, we've added a disclaimer to the non-PDF and HTML export types to clarify that the export is auto-generated and may contain slight errors. We feel confident enough about PDF and HTML export proofing that we haven't added the disclaimer for that.

_Test plan_
- With your dev queue running, visit any pub and download all non-PDF/HTML formats. Verify that the disclaimer appears.
- With your dev queue running, visit any pub and download the PDF and HTML formats. Verify that the disclaimer **does not** appear.

### Deposit button language
Following @jeffpooley's suggestions, this changes deposit button language to make it clearer which actions are previews and which are permanent submissions, and which actions are initial vs. re-submission.

_Test plan_
- Visit a released pub with no submission. View settings and verify that initial deposit button says "Preview Deposit."
- Click initial deposit button to generate preview. Verify that inactive loading button says "Generating Preview"
- Submit deposit
- Refresh page
- Verify that deposit button says "Update & Preview Deposit"
- Click button
- Verify that button says "Re-Submit Deposit"

### Review clarification
Following suggestions from Author Gate, @djagdish, and @idreyn, this changes the language to clarify that reviews only refer to reviews on PubPub, and removes some overly suggestive null states when no reviews exist.

_Test plan_
- Visit a Pub with no reviews.
- In the Pub Overview, verify that the reviews panel is no longer extant.
- In the dashboard, verify that the review side nav does not display a badge with "0" in it
- Click on the review tab, verify that the null state element says "This Pub has not been reviewed using PubPub"
- Visit a Pub with 1 or more reviews.
- In the Pub Overview, verify that the reviews panel shows reviews as expected.
- In the dashboard, verify that the review side nav displays a badge with the number of reviews in it
- Click on the review tab, verify that the reviews page displays as expected