### PR TITLE
update: include pages where user is collection manager

### DIFF
--- a/server/utils/queryHelpers/communitySanitize.js
+++ b/server/utils/queryHelpers/communitySanitize.js
@@ -29,14 +29,13 @@ export default (communityData, locationData, loginData, scopeData) => {
 			({ pageId }) => typeof pageId === 'string' && pageId === item.id,
 		);
 
-		// If the page has a collection, check if the user has manage permission
+		// If the page has a collection, check if the user has >= manage permission
 		// to that collection. If so, include the page.
 		const hasPageCollectionManageAccess = pageCollection
-			? Boolean(
-					pageCollection.members.find(
-						(member) =>
-							member.userId === loginData.id && member.permissions === 'manage',
-					),
+			? pageCollection.members.some(
+					(member) =>
+						member.userId === loginData.id &&
+						(member.permissions === 'manage' || member.permissions === 'admin'),
 			  )
 			: false;
 

--- a/server/utils/queryHelpers/communitySanitize.js
+++ b/server/utils/queryHelpers/communitySanitize.js
@@ -2,18 +2,6 @@ export default (communityData, locationData, loginData, scopeData) => {
 	const cleanedData = { ...communityData };
 	const { canManageCommunity } = scopeData.activePermissions;
 	const availablePages = {};
-	cleanedData.pages = cleanedData.pages.filter((item) => {
-		if (!canManageCommunity && !item.isPublic && locationData.query.access !== item.viewHash) {
-			return false;
-		}
-
-		availablePages[item.id] = {
-			id: item.id,
-			title: item.title,
-			slug: item.slug,
-		};
-		return true;
-	});
 
 	cleanedData.collections = cleanedData.collections
 		.filter((item) => {
@@ -35,5 +23,39 @@ export default (communityData, locationData, loginData, scopeData) => {
 				page: availablePages[collection.pageId],
 			};
 		});
+
+	cleanedData.pages = cleanedData.pages.filter((item) => {
+		const pageCollection = cleanedData.collections.find(
+			({ pageId }) => typeof pageId === 'string' && pageId === item.id,
+		);
+
+		// If the page has a collection, check if the user has manage permission
+		// to that collection. If so, include the page.
+		const hasPageCollectionManageAccess = pageCollection
+			? Boolean(
+					pageCollection.members.find(
+						(member) =>
+							member.userId === loginData.id && member.permissions === 'manage',
+					),
+			  )
+			: false;
+
+		if (
+			!canManageCommunity &&
+			!hasPageCollectionManageAccess &&
+			!item.isPublic &&
+			locationData.query.access !== item.viewHash
+		) {
+			return false;
+		}
+
+		availablePages[item.id] = {
+			id: item.id,
+			title: item.title,
+			slug: item.slug,
+		};
+		return true;
+	});
+
 	return cleanedData;
 };


### PR DESCRIPTION
This PR updates page sanitation logic to also include collection pages (even when they are private) in page results when the requesting user has collection-level manage permission.

_Test Plan_
* Link a private page to a collection.
* Log in to a user with community-level view or edit permissions (without any collection permissions).
* The page should not be visible in the nav bar.
* Assign the user collection-level view or edit permissions.
* The page should still not be visible in the nav bar.
* Assign the user manage permissions.
* The page should now be visible in the nav bar, and clicking on the link should take you to the private page.