### PR TITLE
fix: Shore up guest Pub creation mechanisms

### DIFF
--- a/.jest/setup-env.js
+++ b/.jest/setup-env.js
@@ -19,6 +19,7 @@ process.env.CLOUDAMQP_URL = '';
 process.env.ALGOLIA_ID = 'ooo';
 process.env.ALGOLIA_KEY = 'ooo';
 process.env.ALGOLIA_SEARCH_KEY = 'ooo';
+process.env.JWT_SIGNING_SECRET = 'shhhhhh';
 
 if (typeof document !== 'undefined') {
     require("mutationobserver-shim");

--- a/client/containers/Page/LayoutBanner.tsx
+++ b/client/containers/Page/LayoutBanner.tsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import Color from 'color';
-import { AnchorButton } from '@blueprintjs/core';
+import { AnchorButton, Tooltip } from '@blueprintjs/core';
 
 import { getResizedUrl } from 'utils/images';
 import { apiFetch } from 'client/utils/apiFetch';
@@ -16,18 +16,21 @@ type Props = {
 
 type State = any;
 
+const createPubFailureText = "Error creating a new Pub. You may want to refresh the page and try again.";
+
 class LayoutBanner extends Component<Props, State> {
 	constructor(props: Props) {
 		super(props);
 		this.state = {
 			isLoading: false,
+			buttonError: null,
 		};
 		this.createPub = this.createPub.bind(this);
 	}
 
 	createPub() {
 		const { communityData, content } = this.props;
-		this.setState({ isLoading: true });
+		this.setState({ isLoading: true, buttonError: null });
 		return apiFetch('/api/pubs', {
 			method: 'POST',
 			body: JSON.stringify({
@@ -41,36 +44,16 @@ class LayoutBanner extends Component<Props, State> {
 			})
 			.catch((err) => {
 				console.error(err);
-				this.setState({ isLoading: false });
+				this.setState({ isLoading: false, buttonError: createPubFailureText });
 			});
 	}
 
-	render() {
-		const backgroundImageCss = this.props.content.backgroundImage
-			? `url("${getResizedUrl(this.props.content.backgroundImage, 'fit-in', '1500x600')}")`
-			: undefined;
+	renderButton() {
+		const { buttonError } = this.state;
 
-		const wrapperStyle = {
-			textAlign: this.props.content.align || 'left',
-		};
-		const textStyle = {
-			color:
-				this.props.content.backgroundImage ||
-				!Color(this.props.content.backgroundColor).isLight()
-					? '#FFFFFF'
-					: '#000000',
-			lineHeight: '1em',
-			fontSize: this.props.content.backgroundHeight === 'narrow' ? '18px' : '28px',
-		};
-
-		const backgroundStyle = {
-			backgroundColor: this.props.content.backgroundColor,
-			backgroundImage: backgroundImageCss,
-			minHeight: this.props.content.backgroundHeight === 'narrow' ? '60px' : '200px',
-			display: 'flex',
-			alignItems: 'center',
-			maxWidth: 'none',
-		};
+		if (!this.props.content.showButton) {
+			return null;
+		}
 
 		const buttonType =
 			this.props.content.buttonType || (this.props.content.showButton && 'create-pub');
@@ -86,6 +69,50 @@ class LayoutBanner extends Component<Props, State> {
 				!this.props.loginData.id &&
 				`/login?redirect=${this.props.locationData.path}`) ||
 			(buttonType === 'signup' && '/signup');
+
+		const button = (
+			<AnchorButton
+				className="bp3-large"
+				onClick={
+					buttonType === 'create-pub' &&
+					this.props.loginData.id &&
+					this.createPub
+				}
+				loading={this.state.isLoading}
+				text={buttonText}
+				href={buttonUrl}
+			/>
+		);
+
+		return buttonError ? <Tooltip content={buttonError} defaultIsOpen={true}>{button}</Tooltip> : button;
+	}
+
+	render() {
+		const backgroundImageCss = this.props.content.backgroundImage
+			? `url("${getResizedUrl(this.props.content.backgroundImage, 'fit-in', '1500x600')}")`
+			: undefined;
+
+		const wrapperStyle = {
+			textAlign: this.props.content.align || 'left',
+		};
+		const textStyle = {
+			color:
+				this.props.content.backgroundImage ||
+					!Color(this.props.content.backgroundColor).isLight()
+					? '#FFFFFF'
+					: '#000000',
+			lineHeight: '1em',
+			fontSize: this.props.content.backgroundHeight === 'narrow' ? '18px' : '28px',
+		};
+
+		const backgroundStyle = {
+			backgroundColor: this.props.content.backgroundColor,
+			backgroundImage: backgroundImageCss,
+			minHeight: this.props.content.backgroundHeight === 'narrow' ? '60px' : '200px',
+			display: 'flex',
+			alignItems: 'center',
+			maxWidth: 'none',
+		};
 
 		return (
 			<div className="layout-banner-component">
@@ -114,19 +141,7 @@ class LayoutBanner extends Component<Props, State> {
 								{this.props.content.text && (
 									<h2 style={textStyle}>{this.props.content.text}</h2>
 								)}
-								{this.props.content.showButton && (
-									<AnchorButton
-										className="bp3-large"
-										onClick={
-											buttonType === 'create-pub' &&
-											this.props.loginData.id &&
-											this.createPub
-										}
-										loading={this.state.isLoading}
-										text={buttonText}
-										href={buttonUrl}
-									/>
-								)}
+								{this.renderButton()}
 							</div>
 						</div>
 					</div>

--- a/client/containers/Page/LayoutBanner.tsx
+++ b/client/containers/Page/LayoutBanner.tsx
@@ -26,16 +26,18 @@ class LayoutBanner extends Component<Props, State> {
 	}
 
 	createPub() {
+		const { communityData, content } = this.props;
 		this.setState({ isLoading: true });
 		return apiFetch('/api/pubs', {
 			method: 'POST',
 			body: JSON.stringify({
-				communityId: this.props.communityData.id,
-				defaultCollectionIds: this.props.content.defaultCollectionIds,
+				communityId: communityData.id,
+				createPubToken: content.createPubToken,
 			}),
 		})
 			.then((newPub) => {
 				window.location.href = `/pub/${newPub.slug}`;
+				this.setState({ isLoading: false });
 			})
 			.catch((err) => {
 				console.error(err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19878,6 +19878,11 @@
 				"minimist": "^1.2.5"
 			}
 		},
+		"mockdate": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.2.tgz",
+			"integrity": "sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA=="
+		},
 		"moment": {
 			"version": "2.24.0",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
 		"lodash.throttle": "^4.1.1",
 		"mailgun.js": "^2.0.1",
 		"mini-css-extract-plugin": "^0.7.0",
+		"mockdate": "^3.0.2",
 		"mudder": "^1.0.4",
 		"mutationobserver-shim": "^0.3.3",
 		"newrelic": "^5.7.0",

--- a/server/pub/api.js
+++ b/server/pub/api.js
@@ -6,11 +6,12 @@ import { createPub, updatePub, destroyPub } from './queries';
 
 const getRequestIds = (req) => {
 	const user = req.user || {};
-	const { communityId, collectionId, pubId, licenseSlug } = req.body;
+	const { communityId, collectionId, pubId, licenseSlug, createPubToken } = req.body;
 	return {
 		userId: user.id,
 		communityId: communityId,
 		collectionId: collectionId,
+		createPubToken: createPubToken,
 		pubId: pubId,
 		licenseSlug: licenseSlug,
 	};
@@ -19,15 +20,16 @@ const getRequestIds = (req) => {
 app.post(
 	'/api/pubs',
 	wrap(async (req, res) => {
-		const { userId, collectionId, communityId } = getRequestIds(req);
-		const canCreate = await canCreatePub({
+		const { userId, collectionId, communityId, createPubToken } = getRequestIds(req);
+		const { create, collectionIds } = await canCreatePub({
 			userId: userId,
 			collectionId: collectionId,
 			communityId: communityId,
+			createPubToken: createPubToken,
 		});
-		if (canCreate) {
+		if (create) {
 			const newPub = await createPub(
-				{ communityId: communityId, collectionId: collectionId },
+				{ communityId: communityId, collectionIds: collectionIds },
 				userId,
 			);
 			return res.status(201).json(newPub);

--- a/server/pub/tokens.js
+++ b/server/pub/tokens.js
@@ -1,0 +1,19 @@
+import { issueToken, verifyAndDecodeToken } from 'server/utils/tokens';
+
+export const issueCreatePubToken = ({ userId, communityId, createInCollectionIds }) =>
+	issueToken({
+		userId: userId,
+		communityId: communityId,
+		type: 'createPub',
+		payload: { collectionIds: createInCollectionIds },
+		expiresIn: 60 * 60, // seconds
+	});
+
+export const getValidCollectionIdsFromCreatePubToken = (token, { userId, communityId }) => {
+	const result = verifyAndDecodeToken(token, {
+		userId: userId,
+		communityId: communityId,
+		type: 'createPub',
+	});
+	return result && result.payload.collectionIds;
+};

--- a/server/utils/__tests__/tokens.test.js
+++ b/server/utils/__tests__/tokens.test.js
@@ -1,0 +1,125 @@
+/* global it, expect, beforeAll, afterAll */
+import MockDate from 'mockdate';
+
+import { issueToken, verifyAndDecodeToken } from '../tokens';
+
+let time = Date.now();
+
+const advanceTime = (dt) => {
+	time += dt;
+	MockDate.set(time);
+};
+
+beforeAll(() => {
+	MockDate.set(time);
+});
+
+afterAll(() => {
+	MockDate.reset();
+});
+
+it('creates a valid JWT that can be decoded later', () => {
+	const token = issueToken({
+		userId: 'me',
+		communityId: 'us',
+		type: 'test_token',
+		expiresIn: '1hr',
+		payload: { number: 35 },
+	});
+	const decoded = verifyAndDecodeToken(token, {
+		userId: 'me',
+		communityId: 'us',
+		type: 'test_token',
+	});
+	expect(decoded.payload.number).toEqual(35);
+});
+
+it('refuses to create a JWT without required values', () => {
+	expect(() =>
+		issueToken({
+			communityId: 'us',
+			type: 'test_token',
+			expiresIn: '1hr',
+			payload: { number: 35 },
+		}),
+	).toThrow();
+	expect(() =>
+		issueToken({
+			userId: 'me',
+			type: 'test_token',
+			expiresIn: '1hr',
+			payload: { number: 35 },
+		}),
+	).toThrow();
+	expect(() =>
+		issueToken({
+			userId: 'me',
+			communityId: 'us',
+			expiresIn: '1hr',
+			payload: { number: 35 },
+		}),
+	).toThrow();
+	expect(() =>
+		issueToken({
+			userId: 'me',
+			communityId: 'us',
+			type: 'test_token',
+			payload: { number: 35 },
+		}),
+	).toThrow();
+});
+
+it('guards decoded values with an assertion of matching type, communityId, and userId', () => {
+	const token = issueToken({
+		userId: 'me',
+		communityId: 'us',
+		type: 'test_token',
+		expiresIn: '1hr',
+		payload: { number: 35 },
+	});
+	expect(
+		verifyAndDecodeToken(token, {
+			userId: 'someone_else',
+			communityId: 'us',
+			type: 'test_token',
+		}),
+	).toEqual(null);
+	expect(
+		verifyAndDecodeToken(token, {
+			userId: 'me',
+			communityId: 'them',
+			type: 'test_token',
+		}),
+	).toEqual(null);
+	expect(
+		verifyAndDecodeToken(token, {
+			userId: 'me',
+			communityId: 'us',
+			type: 'another_token',
+		}),
+	).toEqual(null);
+});
+
+it('correctly expires tokens', () => {
+	const expiresInSeconds = 60 * 30;
+	const token = issueToken({
+		userId: 'me',
+		communityId: 'us',
+		type: 'test_token',
+		expiresIn: expiresInSeconds,
+		payload: { number: 35 },
+	});
+	const decodedNow = verifyAndDecodeToken(token, {
+		userId: 'me',
+		communityId: 'us',
+		type: 'test_token',
+	});
+	expect(decodedNow.payload.number).toEqual(35);
+	advanceTime(1000 * expiresInSeconds + 1);
+	const decodedLater = verifyAndDecodeToken(token, {
+		userId: 'me',
+		communityId: 'us',
+		type: 'test_token',
+	});
+	expect(decodedLater).toEqual(null);
+});

--- a/server/utils/tokens.js
+++ b/server/utils/tokens.js
@@ -1,0 +1,30 @@
+import jwt from 'jsonwebtoken';
+
+export const issueToken = ({ userId, communityId, type, payload, expiresIn }) => {
+	if (userId && communityId && type && expiresIn) {
+		return jwt.sign(
+			{ userId: userId, communityId: communityId, type: type, payload: payload },
+			process.env.JWT_SIGNING_SECRET,
+			{ expiresIn: expiresIn },
+		);
+	}
+	throw new Error('Refusing to create JWT without userId, communityId, type, and expiresIn');
+};
+
+export const verifyAndDecodeToken = (token, { userId, communityId, type }) => {
+	try {
+		jwt.verify(token, process.env.JWT_SIGNING_SECRET);
+	} catch (_) {
+		return null;
+	}
+	const decodedValue = jwt.decode(token);
+	const {
+		userId: claimedUserId,
+		communityId: claimedCommunityId,
+		type: claimedType,
+	} = decodedValue;
+	if (claimedUserId === userId && claimedCommunityId === communityId && claimedType === type) {
+		return decodedValue;
+	}
+	return null;
+};


### PR DESCRIPTION
This PR re-enables a couple of ways that non-Members can create Pubs that I inadvertently disabled in #1001  

- The global header's Create Pub button when shown to non-Members
- A Page banner block with a Pub creation button enabled (which I only learned about this week!)

Previously these were permitted because there was no permission gating on Pub creation. Re-enabling the global header button is as easy as checking `hideCreatePubButton` on a Community (though this field should be renamed). Enabling this for Page banner blocks proved a little trickier since the permission exists by virtue of the visitor being able to see the Page — ultimately, I went with an approach where we issue expiring JSON web tokens to users visiting Pages with these banner blocks, allowing them to create Pubs.

_Test plan:_
I checked all the ways I know how to create Pubs, including:
- The global nav, as an admin
- The Community Overview dashboard tab
- A Collection's Overview dashboard tab (the button should add the new Pub to the Collection)
- The global nav, as a non-Member with `hideCreatePubButton = false`
- A Page banner block with a `create-pub` button

Note that you will need a truthy `process.env.JWT_SIGNING_SECRET` for this to work for you. It doesn't matter at all what it is, but you'll find one if you go grab the latest config.js