### PR TITLE
feature: Enable removal of formatted download

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -70,6 +70,7 @@
 		"react/jsx-tag-spacing": 0,
 		"react/jsx-wrap-multilines": 0,
 		"react/no-children-prop": 0,
+		"react/static-property-placement": 0,
 		"react/no-unescaped-entities": ["error", { "forbid": [">", "}"] }],
 		"react/require-default-props": 0,
 		"space-before-function-paren": 0

--- a/client/components/FileUploadButton/FileUploadButton.tsx
+++ b/client/components/FileUploadButton/FileUploadButton.tsx
@@ -7,7 +7,7 @@ require('./fileUploadButton.scss');
 
 type OwnProps = {
 	onUploadFinish: (...args: any[]) => any;
-	text?: string;
+	text: string;
 	icon?: string;
 	isLarge?: boolean;
 	isSmall?: boolean;
@@ -17,8 +17,6 @@ type OwnProps = {
 };
 
 const defaultProps = {
-	text: undefined,
-	icon: undefined,
 	isLarge: false,
 	isSmall: false,
 	isMinimal: false,
@@ -33,13 +31,14 @@ type Props = OwnProps & typeof defaultProps;
 class FileUploadButton extends Component<Props, State> {
 	static defaultProps = defaultProps;
 
+	randKey: string;
+
 	constructor(props: Props) {
 		super(props);
 		this.state = {
 			isUploading: false,
 		};
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'randKey' does not exist on type 'FileUpl... Remove this comment to see the full error message
-		this.randKey = Math.round(Math.random() * 99999);
+		this.randKey = Math.round(Math.random() * 99999).toString();
 		this.handleUploadFinish = this.handleUploadFinish.bind(this);
 		this.handleFileSelect = this.handleFileSelect.bind(this);
 	}
@@ -69,10 +68,8 @@ class FileUploadButton extends Component<Props, State> {
 					text={
 						<React.Fragment>
 							{text}
-							{/* @ts-expect-error ts-migrate(2339) FIXME: Property 'randKey' does not exist on type 'FileUpl... Remove this comment to see the full error message */}
 							<label htmlFor={this.randKey} className="file-select">
 								<input
-									// @ts-expect-error ts-migrate(2339) FIXME: Property 'randKey' does not exist on type 'FileUpl... Remove this comment to see the full error message
 									id={this.randKey}
 									name="file-input"
 									type="file"
@@ -83,7 +80,6 @@ class FileUploadButton extends Component<Props, State> {
 							</label>
 						</React.Fragment>
 					}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type 'undefined' is not assignable to type 'string... Remove this comment to see the full error message
 					icon={icon ? <Icon icon={icon} /> : null}
 					large={isLarge}
 					small={isSmall}

--- a/client/containers/DashboardSettings/PubSettings/downloadChooser.scss
+++ b/client/containers/DashboardSettings/PubSettings/downloadChooser.scss
@@ -1,0 +1,11 @@
+.download-chooser-component {
+    .buttons {
+        display: flex;
+        > :not(:last-child) {
+            margin-right: 8px;
+        }
+    }
+    .subtext {
+        margin-top: 0.5em;
+    }
+}


### PR DESCRIPTION
Resolves #797 

The "formatted download" is the (typically PDF) file that we allow users to associate with their Pubs to be downloaded for offline reading. Currently there is a way to add a file to act as this download, but no way to remove it. Until now:

<img width="1178" alt="image" src="https://user-images.githubusercontent.com/2208769/93001713-230b4380-f4ff-11ea-88c3-61a510503809.png">

Of note in this change is that `Pub.downloads` is actually an array of files, and this change causes _all_ the contents to be overwritten when the download is removed. I think this is a vestige of a more feature-rich use of `downloads,` and can be safely ignored, since only one download is currently made available to users at this time anyway. But @isTravis please validate or correct this assumption!

 _Test plan:_
Visit the Settings for a Pub and verify that you can add, remove, and download files as formatted downloads.