### PR TITLE
feature: Only show author contributors in PubEdge

### DIFF
--- a/client/components/Byline/Byline.tsx
+++ b/client/components/Byline/Byline.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ensureUserForAttribution from 'utils/ensureUserForAttribution';
 import { joinOxford, naivePluralize } from 'utils/strings';
 
-export type Props = {
+export type BylineProps = {
 	ampersand?: boolean;
 	bylinePrefix?: null | string;
 	contributors: (string | {})[] | string;
@@ -30,7 +30,7 @@ const joinAndFlattenArrays = (...arrays) =>
 		return [...acc, next];
 	}, []);
 
-const Byline = (props: Props) => {
+const Byline = (props: BylineProps) => {
 	const {
 		ampersand = false,
 		bylinePrefix = 'by',

--- a/client/components/Byline/Byline.tsx
+++ b/client/components/Byline/Byline.tsx
@@ -5,7 +5,7 @@ import { joinOxford, naivePluralize } from 'utils/strings';
 
 export type Props = {
 	ampersand?: boolean;
-	bylinePrefix?: string;
+	bylinePrefix?: null | string;
 	contributors: (string | {})[] | string;
 	linkToUsers?: boolean;
 	renderEmptyState?: () => React.ReactNode;

--- a/client/components/Byline/Byline.tsx
+++ b/client/components/Byline/Byline.tsx
@@ -3,27 +3,23 @@ import React from 'react';
 import ensureUserForAttribution from 'utils/ensureUserForAttribution';
 import { joinOxford, naivePluralize } from 'utils/strings';
 
-type OwnProps = {
+export type Props = {
 	ampersand?: boolean;
 	bylinePrefix?: string;
 	contributors: (string | {})[] | string;
 	linkToUsers?: boolean;
-	renderEmptyState?: (...args: any[]) => any;
-	renderSuffix?: (...args: any[]) => any;
-	renderTruncation?: (...args: any[]) => any;
-	renderUserLabel?: (...args: any[]) => any;
+	renderEmptyState?: () => React.ReactNode;
+	renderSuffix?: () => React.ReactNode;
+	renderTruncation?: (count: number) => React.ReactNode;
+	renderUserLabel?: (user: any, index?: number) => React.ReactNode;
 	truncateAt?: number;
 };
 
-export const defaultProps = {
-	ampersand: false,
-	bylinePrefix: 'by',
-	linkToUsers: true,
+const defaultProps = {
 	renderEmptyState: () => null,
 	renderSuffix: () => null,
 	renderTruncation: (n) => `${n} ${naivePluralize('other', n)}`,
 	renderUserLabel: (user) => user.fullName,
-	truncateAt: null,
 };
 
 const joinAndFlattenArrays = (...arrays) =>
@@ -34,19 +30,17 @@ const joinAndFlattenArrays = (...arrays) =>
 		return [...acc, next];
 	}, []);
 
-type Props = OwnProps & typeof defaultProps;
-
 const Byline = (props: Props) => {
 	const {
-		ampersand,
-		bylinePrefix,
+		ampersand = false,
+		bylinePrefix = 'by',
 		contributors,
-		linkToUsers,
-		renderEmptyState,
-		renderSuffix,
-		renderTruncation,
-		renderUserLabel,
-		truncateAt,
+		linkToUsers = true,
+		renderEmptyState = defaultProps.renderEmptyState,
+		renderSuffix = defaultProps.renderSuffix,
+		renderTruncation = defaultProps.renderTruncation,
+		renderUserLabel = defaultProps.renderUserLabel,
+		truncateAt = null,
 	} = props;
 
 	const renderContributor = (contributor, index) => {
@@ -54,7 +48,6 @@ const Byline = (props: Props) => {
 			return <span key={`author-${contributor}`}>{contributor}</span>;
 		}
 		const { user } = ensureUserForAttribution(contributor);
-		// @ts-expect-error ts-migrate(2349) FIXME: Type 'never' has no call signatures.
 		const label = renderUserLabel(user, index);
 		if (user.slug && linkToUsers) {
 			return (
@@ -72,20 +65,15 @@ const Byline = (props: Props) => {
 		if (typeof contributors === 'string') {
 			return contributors;
 		}
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'length' does not exist on type 'never'.
 		if (truncateAt !== null && contributors.length > truncateAt) {
-			// @ts-expect-error ts-migrate(2339) FIXME: Property 'slice' does not exist on type 'never'.
 			const namedContributors = contributors.slice(0, truncateAt);
-			// @ts-expect-error ts-migrate(2339) FIXME: Property 'length' does not exist on type 'never'.
 			const remainingCount = contributors.length - namedContributors.length;
 			return joinOxford(
-				// @ts-expect-error ts-migrate(2349) FIXME: Type 'never' has no call signatures.
 				[...namedContributors.map(renderContributor), renderTruncation(remainingCount)],
 				// @ts-expect-error ts-migrate(2322) FIXME: Type 'never[]' is not assignable to type 'string'.
 				{ joiner: joinAndFlattenArrays, ampersand: ampersand, empty: [] },
 			);
 		}
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'map' does not exist on type 'never'.
 		return joinOxford(contributors.map(renderContributor), {
 			joiner: joinAndFlattenArrays,
 			ampersand: ampersand,
@@ -97,16 +85,13 @@ const Byline = (props: Props) => {
 	return (
 		<div className="byline-component byline">
 			<span className="text-wrapper">
-				{/* @ts-expect-error ts-migrate(2339) FIXME: Property 'length' does not exist on type 'never'. */}
 				{contributors.length > 0 && (
 					<>
 						{bylinePrefix && <span>{bylinePrefix} </span>}
 						{renderContributors()}
 					</>
 				)}
-				{/* @ts-expect-error ts-migrate(2339) FIXME: Property 'length' does not exist on type 'never'. */}
 				{contributors.length === 0 && renderEmptyState()}
-				{/* @ts-expect-error ts-migrate(2349) FIXME: Type 'never' has no call signatures. */}
 				{renderSuffix && renderSuffix()}
 			</span>
 		</div>

--- a/client/components/Byline/Byline.tsx
+++ b/client/components/Byline/Byline.tsx
@@ -11,7 +11,7 @@ export type Props = {
 	renderEmptyState?: () => React.ReactNode;
 	renderSuffix?: () => React.ReactNode;
 	renderTruncation?: (count: number) => React.ReactNode;
-	renderUserLabel?: (user: any, index?: number) => React.ReactNode;
+	renderUserLabel?: (user: any, index: number) => React.ReactNode;
 	truncateAt?: number;
 };
 

--- a/client/components/Byline/bylineStories.tsx
+++ b/client/components/Byline/bylineStories.tsx
@@ -32,58 +32,44 @@ storiesOf('components/Byline', module).add(
 		<div style={{ margin: '1em' }}>
 			<h4>Basic</h4>
 			<p>
-				{/* @ts-expect-error ts-migrate(2322) FIXME: Type '{ id: string; user: { id: string; fullName: ... Remove this comment to see the full error message */}
 				<Byline contributors={[A, B, C, D]} />
 			</p>
 			<h4>Truncated at number of users</h4>
 			<p>
 				<Byline
-					// @ts-expect-error ts-migrate(2322) FIXME: Type '{ id: string; user: { id: string; fullName: ... Remove this comment to see the full error message
 					contributors={[A, B, C, D, E, F, G]}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type 'number' is not assignable to type 'never'.
 					truncateAt={number('truncateAt', 4, { max: 7, min: 0, range: true })}
 				/>
 			</p>
 			<h4>No linking to users</h4>
 			<p>
-				{/* @ts-expect-error ts-migrate(2322) FIXME: Type '{ id: string; user: { id: string; fullName: ... Remove this comment to see the full error message */}
 				<Byline contributors={[C, F, E, A]} linkToUsers={false} />
 			</p>
 			<h4>No prefix</h4>
 			<p>
-				{/* @ts-expect-error ts-migrate(2322) FIXME: Type '{ id: string; user: { id: string; fullName: ... Remove this comment to see the full error message */}
-				<Byline contributors={[G, A, B, C]} linkToUsers={false} bylinePrefix={null} />
+				<Byline contributors={[G, A, B, C]} linkToUsers={false}/>
 			</p>
 			<h4>Custom empty state</h4>
 			<p>
-				{/* @ts-expect-error ts-migrate(2322) FIXME: Type 'never[]' is not assignable to type 'never'. */}
 				<Byline contributors={[]} renderEmptyState={() => 'No contributors 😥'} />
 			</p>
 			<h4>Custom suffix</h4>
 			<p>
 				<Byline
-					// @ts-expect-error ts-migrate(2322) FIXME: Type '{ id: string; user: { id: string; fullName: ... Remove this comment to see the full error message
 					contributors={[B, F, G, E]}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type '() => JSX.Element' is not assignable to type... Remove this comment to see the full error message
 					renderSuffix={() => <button type="button">Add more</button>}
 				/>
 			</p>
 			<h4>Custom user labels</h4>
 			<p>
 				<Byline
-					// @ts-expect-error ts-migrate(2322) FIXME: Type '{ id: string; user: { id: string; fullName: ... Remove this comment to see the full error message
 					contributors={[C, A, B, D]}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type 'null' is not assignable to type 'never'.
-					bylinePrefix={null}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type 'false' is not assignable to type 'never'.
 					linkToUsers={false}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type '(user: any, index: any) => string' is not as... Remove this comment to see the full error message
 					renderUserLabel={(user, index) => `(${index + 1}) ${user.fullName}`}
 				/>
 			</p>
 			<h4>Use ampersand</h4>
 			<p>
-				{/* @ts-expect-error ts-migrate(2322) FIXME: Type '{ id: string; user: { id: string; fullName: ... Remove this comment to see the full error message */}
 				<Byline contributors={[B, F, G, E]} ampersand />
 			</p>
 		</div>

--- a/client/components/PreviewImage/PreviewImage.tsx
+++ b/client/components/PreviewImage/PreviewImage.tsx
@@ -4,28 +4,20 @@ import classNames from 'classnames';
 import { getResizedUrl } from 'utils/images';
 import { generatePubBackground } from 'utils/pubs';
 
-type OwnProps = {
+type Props = {
 	className?: string;
 	fitIn?: number;
 	src?: string;
 	title: string;
 };
 
-const defaultProps = {
-	className: '',
-	fitIn: 800,
-	src: null,
-};
-
-type Props = OwnProps & typeof defaultProps;
-
 const PreviewImage = (props: Props) => {
-	const { className, fitIn, src, title } = props;
+	const { className = '', fitIn = 800, src = null, title } = props;
 	const resizedImage = getResizedUrl(src, 'fit-in', `${fitIn}x0`);
 	const style = src
 		? { backgroundImage: `url("${resizedImage}")` }
 		: { background: generatePubBackground(title) };
 	return <div className={classNames('preview-image-component', className)} style={style} />;
 };
-PreviewImage.defaultProps = defaultProps;
+
 export default PreviewImage;

--- a/client/components/PubByline/PubByline.tsx
+++ b/client/components/PubByline/PubByline.tsx
@@ -1,30 +1,22 @@
 import React from 'react';
 
-import { Byline } from 'components';
+import Byline, { Props as BylineProps } from 'components/Byline/Byline';
 import { getAllPubContributors } from 'utils/pub/contributors';
 
-/*
-(ts-migrate) TODO: Migrate the remaining prop types
-...bylinePropTypesWithoutContributors
-*/
-type OwnProps = {
+type Props = {
 	pubData: {};
 	hideAuthors?: boolean;
 	hideContributors?: boolean;
-};
+} & Omit<BylineProps, 'contributors'>;
+
 const defaultProps = {
 	hideAuthors: false,
 	hideContributors: true,
-	...Byline.defaultProps,
 };
 
-type Props = OwnProps & typeof defaultProps;
-
 const PubByline = (props: Props) => {
-	const { pubData, hideAuthors, hideContributors } = props;
+	const { pubData, hideAuthors = false, hideContributors = false } = props;
 	const authors = getAllPubContributors(pubData, hideAuthors, hideContributors);
-
-	// @ts-expect-error ts-migrate(2322) FIXME: Type 'any[]' is not assignable to type 'never'.
 	return <Byline {...props} contributors={authors} />;
 };
 PubByline.defaultProps = defaultProps;

--- a/client/components/PubByline/PubByline.tsx
+++ b/client/components/PubByline/PubByline.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Byline, { Props as BylineProps } from 'components/Byline/Byline';
+import Byline, { BylineProps } from 'components/Byline/Byline';
 import { getAllPubContributors } from 'utils/pub/contributors';
 
 type Props = {

--- a/client/components/PubEdge/PubEdge.tsx
+++ b/client/components/PubEdge/PubEdge.tsx
@@ -6,6 +6,7 @@ import { usePageContext } from 'utils/hooks';
 import { formatDate } from 'utils/dates';
 import { pubUrl, pubShortUrl } from 'utils/canonicalUrls';
 import { getPubPublishedDate } from 'utils/pub/pubDates';
+import { getAllPubContributors } from 'utils/pub/contributors';
 
 import { pubEdgeType } from './constants';
 import { getHostnameForUrl } from './util';
@@ -41,12 +42,12 @@ const getValuesFromPubEdge = (pubEdge, communityData, viewingFromTarget) => {
 	const { externalPublication, targetPub, pub } = pubEdge;
 	const displayedPub = viewingFromTarget ? pub : targetPub;
 	if (displayedPub) {
-		const { title, description, attributions, avatar } = displayedPub;
+		const { title, description, avatar } = displayedPub;
 		const url = getUrlForPub(displayedPub, communityData);
 		const publishedDate = getPubPublishedDate(displayedPub);
 		return {
 			avatar: avatar,
-			contributors: attributions || [],
+			contributors: getAllPubContributors(displayedPub, false, true),
 			description: description,
 			publishedAt: publishedDate && formatDate(publishedDate),
 			title: title,

--- a/client/components/PubEdge/PubEdgePlaceholderThumbnail.tsx
+++ b/client/components/PubEdge/PubEdgePlaceholderThumbnail.tsx
@@ -17,7 +17,6 @@ type Props = OwnProps & typeof defaultProps;
 
 function PubEdgePlaceholderThumbnail(props: Props) {
 	const style = useMemo(() => ({ backgroundColor: props.color }), [props.color]);
-
 	return (
 		<div className="pub-edge-placeholder-thumbnail-component" style={style}>
 			<Icon icon={props.external ? 'link' : 'pubDoc'} color="#ffffff" />

--- a/client/components/PubEdgeListing/PubEdgeListingCard.tsx
+++ b/client/components/PubEdgeListing/PubEdgeListingCard.tsx
@@ -54,7 +54,7 @@ type Props = OwnProps & typeof defaultProps;
 const PubEdgeListingCard = (props: Props) => {
 	const { communityData } = usePageContext();
 	const {
-		accentColor = communityData.accentColorDark,
+		accentColor,
 		children,
 		inPubBody,
 		isInboundEdge,
@@ -68,7 +68,7 @@ const PubEdgeListingCard = (props: Props) => {
 	const [hover, setHover] = useState(false);
 	const handleMouseEnter = useCallback(() => setHover(true), []);
 	const handleMouseLeave = useCallback(() => setHover(false), []);
-	const hoverAccentColor = hover ? accentColor : '#ddd';
+	const hoverAccentColor = hover ? accentColor || communityData.accentColorDark : '#ddd';
 	const style = { borderColor: hoverAccentColor };
 
 	const renderRelation = () => {

--- a/client/components/PubMenuItem/PubMenuItem.tsx
+++ b/client/components/PubMenuItem/PubMenuItem.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Button } from 'reakit/Button';
 
@@ -7,33 +6,32 @@ import { Byline, PreviewImage } from 'components';
 
 require('./pubMenuItem.scss');
 
-const propTypes = {
-	active: PropTypes.bool,
-	disabled: PropTypes.bool,
-	contributors: PropTypes.array.isRequired,
-	image: PropTypes.string,
-	isSkeleton: PropTypes.bool,
-	onClick: PropTypes.func.isRequired,
-	showImage: PropTypes.bool,
-	title: PropTypes.string.isRequired,
-};
+interface Props {
+	active?: boolean;
+	disabled?: boolean;
+	contributors: any[];
+	image?: string;
+	isSkeleton?: boolean;
+	onClick: () => any;
+	showImage?: boolean;
+	title: string;
+}
 
-const defaultProps = {
-	active: false,
-	disabled: false,
-	image: null,
-	isSkeleton: false,
-	showImage: false,
-};
-
-const PubMenuItem = React.forwardRef((props, ref) => {
-	// @ts-expect-error ts-migrate(2339) FIXME: Property 'active' does not exist on type '{ childr... Remove this comment to see the full error message
-	const { active, contributors, disabled, image, isSkeleton, onClick, showImage, title } = props;
+const PubMenuItem = React.forwardRef((props: Props, ref: React.Ref<HTMLAnchorElement>) => {
+	const {
+		active = false,
+		contributors,
+		disabled = false,
+		image = '',
+		isSkeleton = false,
+		onClick,
+		showImage = false,
+		title,
+	} = props;
 	const skeletonClass = classNames(isSkeleton && 'bp3-skeleton');
 	return (
 		<Button
 			as="a"
-			// @ts-expect-error ts-migrate(2769) FIXME: Type 'unknown' is not assignable to type 'HTMLAnch... Remove this comment to see the full error message
 			ref={ref}
 			className={classNames(
 				'bp3-menu-item',
@@ -44,12 +42,10 @@ const PubMenuItem = React.forwardRef((props, ref) => {
 			)}
 			onClick={onClick}
 		>
-			{/* @ts-expect-error ts-migrate(2322) FIXME: Type 'any' is not assignable to type 'never'. */}
 			{showImage && <PreviewImage src={image} title={title} className={skeletonClass} />}
 			<div className="inner">
 				<div className={classNames('title', skeletonClass)}>{title}</div>
 				<div className={classNames('subtitle', skeletonClass)}>
-					{/* @ts-expect-error ts-migrate(2322) FIXME: Type 'any' is not assignable to type 'never'. */}
 					<Byline contributors={contributors} linkToUsers={false} />
 				</div>
 			</div>
@@ -57,8 +53,4 @@ const PubMenuItem = React.forwardRef((props, ref) => {
 	);
 });
 
-// @ts-expect-error ts-migrate(2559) FIXME: Type '{ active: Requireable<boolean>; disabled: Re... Remove this comment to see the full error message
-PubMenuItem.propTypes = propTypes;
-// @ts-expect-error ts-migrate(2559) FIXME: Type '{ active: boolean; disabled: boolean; image:... Remove this comment to see the full error message
-PubMenuItem.defaultProps = defaultProps;
 export default PubMenuItem;

--- a/client/components/PubPreview/ManyAuthorsByline.tsx
+++ b/client/components/PubPreview/ManyAuthorsByline.tsx
@@ -27,16 +27,12 @@ const ManyAuthorsByline = (props: Props) => {
 		return (
 			<>
 				<Byline
-					// @ts-expect-error ts-migrate(2322) FIXME: Type 'any[]' is not assignable to type 'never'.
 					contributors={authors}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 					bylinePrefix={`by ${authors.length} ${naivePluralize(
 						'author',
 						authors.length,
 					)}: `}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type '(user: any, index: any) => string' is not as... Remove this comment to see the full error message
 					renderUserLabel={(user, index) => `(${index + 1}) ${user.fullName}`}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type 'false' is not assignable to type 'never'.
 					linkToUsers={false}
 				/>
 			</>
@@ -44,11 +40,8 @@ const ManyAuthorsByline = (props: Props) => {
 	}
 	return (
 		<Byline
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'any[]' is not assignable to type 'never'.
 			contributors={authors}
-			// @ts-expect-error ts-migrate(2322) FIXME: Type '(n: any) => string' is not assignable to typ... Remove this comment to see the full error message
 			renderTruncation={(n) => `${n} more`}
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'number' is not assignable to type 'never'.
 			truncateAt={truncateAt}
 			{...restProps}
 		/>

--- a/client/components/PubPreview/PubPreviewEdges.tsx
+++ b/client/components/PubPreview/PubPreviewEdges.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import { Icon, Byline, PubByline } from 'components';
 import { pubShortUrl } from 'utils/canonicalUrls';
@@ -8,39 +7,24 @@ import { getRelationTypeName } from 'utils/pubEdge/relations';
 
 require('./pubPreviewEdges.scss');
 
-type referencedPubShape = {
-	attributions?: any[];
+type ReferencedPub = {
+	attributions: any[];
 };
 
-// @ts-expect-error ts-migrate(2322) FIXME: Type 'null' is not assignable to type 'any[] | und... Remove this comment to see the full error message
-const referencedPubShape: PropTypes.Requireable<referencedPubShape> = PropTypes.shape({
-	attributions: PropTypes.array,
-});
-
-type pubEdgeShape = {
-	externalPublication?: any;
-	pub?: referencedPubShape;
-	pubId?: string;
-	relationType?: string;
-	targetPub?: referencedPubShape;
+type PubEdge = {
+	externalPublication?: {};
+	pub?: ReferencedPub;
+	pubId: string;
+	relationType: string;
+	targetPub?: ReferencedPub;
 	targetPubId?: string;
 };
-
-// @ts-expect-error ts-migrate(2322) FIXME: Type 'null' is not assignable to type 'referencedP... Remove this comment to see the full error message
-const pubEdgeShape: PropTypes.Requireable<pubEdgeShape> = PropTypes.shape({
-	externalPublication: PropTypes.object,
-	pub: referencedPubShape,
-	pubId: PropTypes.string,
-	relationType: PropTypes.string,
-	targetPub: referencedPubShape,
-	targetPubId: PropTypes.string,
-});
 
 type Props = {
 	accentColor: string;
 	pubData: {
-		inboundEdges?: pubEdgeShape[];
-		outboundEdges?: pubEdgeShape[];
+		inboundEdges?: PubEdge[];
+		outboundEdges?: PubEdge[];
 	};
 };
 
@@ -80,9 +64,7 @@ const renderEdgeLink = (edge) => {
 			<a href={url} key={edge.id} className="edge-link">
 				<Byline
 					{...sharedBylineProps}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type 'any' is not assignable to type 'never'.
 					contributors={contributors}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type '() => any' is not assignable to type 'never'... Remove this comment to see the full error message
 					renderEmptyState={() => title}
 				/>
 			</a>
@@ -91,7 +73,6 @@ const renderEdgeLink = (edge) => {
 	const childPub = pubIsParent ? targetPub : pub;
 	return (
 		<a href={pubShortUrl(childPub)} key={edge.id} className="edge-link">
-			{/* @ts-expect-error ts-migrate(2322) FIXME: Type 'null' is not assignable to type 'string | un... Remove this comment to see the full error message */}
 			<PubByline
 				{...sharedBylineProps}
 				pubData={childPub}

--- a/client/containers/DashboardEdges/DashboardEdges.tsx
+++ b/client/containers/DashboardEdges/DashboardEdges.tsx
@@ -12,7 +12,11 @@ require('./dashboardEdges.scss');
 
 type Props = {
 	overviewData: {
-		pubs: {}[];
+		pubs: {
+			id: string;
+			title: string;
+			avatar?: string;
+		}[];
 	};
 	pubData: {
 		id?: string;

--- a/client/containers/DashboardEdges/NewEdgeEditor.tsx
+++ b/client/containers/DashboardEdges/NewEdgeEditor.tsx
@@ -14,7 +14,8 @@ require('./newEdgeEditor.scss');
 
 type Props = {
 	availablePubs: {
-		title?: string;
+		id: string;
+		title: string;
 		avatar?: string;
 	}[];
 	onCreateNewEdge: (...args: any[]) => any;

--- a/client/containers/DashboardEdges/NewEdgeEditor.tsx
+++ b/client/containers/DashboardEdges/NewEdgeEditor.tsx
@@ -45,16 +45,14 @@ const stripMarkupFromString = (string) => {
 
 const NewEdgeEditor = (props: Props) => {
 	const { availablePubs, onChangeCreatingState, onCreateNewEdge, pubData, usedPubIds } = props;
-	const [newEdge, setNewEdge] = useState(null);
+	const [newEdge, setNewEdge] = useState<any>(null);
 	const [isCreatingEdge, setIsCreatingEdge] = useState(false);
 	const [errorCreatingEdge, setErrorCreatingEdge] = useState(null);
 	const { pendingPromise } = usePendingChanges();
 
 	const currentRelationName =
 		newEdge &&
-		// @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
 		relationTypeDefinitions[newEdge.relationType] &&
-		// @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
 		relationTypeDefinitions[newEdge.relationType].name;
 
 	useEffect(() => onChangeCreatingState(!!newEdge), [newEdge, onChangeCreatingState]);
@@ -86,7 +84,6 @@ const NewEdgeEditor = (props: Props) => {
 
 	const handleEdgeDirectionSwitch = () => {
 		setNewEdge({
-			// @ts-expect-error ts-migrate(2698) FIXME: Spread types may only be created from object types... Remove this comment to see the full error message
 			...newEdge,
 			pubIsParent: !newEdge.pubIsParent,
 		});
@@ -94,7 +91,6 @@ const NewEdgeEditor = (props: Props) => {
 
 	const handleEdgeRelationTypeChange = (relationType) => {
 		setNewEdge({
-			// @ts-expect-error ts-migrate(2698) FIXME: Spread types may only be created from object types... Remove this comment to see the full error message
 			...newEdge,
 			relationType: relationType,
 		});
@@ -106,7 +102,6 @@ const NewEdgeEditor = (props: Props) => {
 		pendingPromise(
 			// @ts-expect-error ts-migrate(2339) FIXME: Property 'post' does not exist on type '(path: any... Remove this comment to see the full error message
 			apiFetch.post('/api/pubEdges', {
-				// @ts-expect-error ts-migrate(2698) FIXME: Spread types may only be created from object types... Remove this comment to see the full error message
 				...newEdge,
 				pubId: pubData.id,
 				// Don't send the whole Pub, just the ID
@@ -125,7 +120,6 @@ const NewEdgeEditor = (props: Props) => {
 	};
 
 	const renderNewEdgeControls = () => {
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'externalPublication' does not exist on t... Remove this comment to see the full error message
 		const { externalPublication, targetPub } = newEdge;
 		const canCreateEdge = targetPub || (externalPublication && externalPublication.title);
 		return (
@@ -136,13 +130,12 @@ const NewEdgeEditor = (props: Props) => {
 					// @ts-expect-error ts-migrate(2322) FIXME: Type 'null' is not assignable to type 'never'.
 					pubEdge={newEdge}
 					// @ts-expect-error ts-migrate(2322) FIXME: Type 'Element' is not assignable to type 'never'.
-					pubEdgeElement={
+					pubEdgeElemSeent={
 						externalPublication && (
 							<PubEdgeEditor
 								externalPublication={externalPublication}
 								onUpdateExternalPublication={(update) =>
 									setNewEdge({
-										// @ts-expect-error ts-migrate(2698) FIXME: Spread types may only be created from object types... Remove this comment to see the full error message
 										...newEdge,
 										externalPublication: { ...externalPublication, ...update },
 									})
@@ -171,7 +164,6 @@ const NewEdgeEditor = (props: Props) => {
 						{Object.entries(relationTypeDefinitions).map(
 							([relationType, definition]) => {
 								const { name } = definition;
-								// @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
 								const selected = newEdge.relationType === relationType;
 								return (
 									<MenuItem

--- a/client/containers/DashboardEdges/NewEdgeEditor.tsx
+++ b/client/containers/DashboardEdges/NewEdgeEditor.tsx
@@ -131,7 +131,7 @@ const NewEdgeEditor = (props: Props) => {
 					// @ts-expect-error ts-migrate(2322) FIXME: Type 'null' is not assignable to type 'never'.
 					pubEdge={newEdge}
 					// @ts-expect-error ts-migrate(2322) FIXME: Type 'Element' is not assignable to type 'never'.
-					pubEdgeElemSeent={
+					pubEdgeElement={
 						externalPublication && (
 							<PubEdgeEditor
 								externalPublication={externalPublication}

--- a/client/containers/DashboardEdges/NewEdgeInput.tsx
+++ b/client/containers/DashboardEdges/NewEdgeInput.tsx
@@ -13,8 +13,9 @@ require('./newEdgeInput.scss');
 
 type Props = {
 	availablePubs: {
-		title?: string;
+		title: string;
 		avatar?: string;
+		id: string;
 	}[];
 	onSelectItem: (...args: any[]) => any;
 	usedPubIds: string[];
@@ -34,7 +35,6 @@ const suggestPopoverProps = {
 const indeterminateMenuItem = (
 	<PubMenuItem
 		key="indeterminate"
-		// @ts-expect-error ts-migrate(2322) FIXME: Property 'title' does not exist on type 'Intrinsic... Remove this comment to see the full error message
 		title={'X'.repeat(50)}
 		contributors={['ABC', 'XYZ']}
 		isSkeleton={true}
@@ -49,32 +49,27 @@ const renderInputValue = () => '';
 const NewEdgeInput = (props: Props) => {
 	const { availablePubs, usedPubIds, onSelectItem } = props;
 	const [queryValue, setQueryValue] = useState('');
-	const [suggestedItems, setSuggestedItems] = useState([]);
+	const [suggestedItems, setSuggestedItems] = useState<any[]>([]);
 	const throttledQueryValue = useThrottled(queryValue, 250, true, true);
 
 	useEffect(() => {
 		if (isUrl(throttledQueryValue) || isDoi(throttledQueryValue)) {
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'true' is not assignable to type 'never'.
 			setSuggestedItems([{ indeterminate: true }]);
 			apiFetch
 				// @ts-expect-error ts-migrate(2339) FIXME: Property 'get' does not exist on type '(path: any,... Remove this comment to see the full error message
 				.get(`/api/pubEdgeProposal?object=${encodeURIComponent(throttledQueryValue)}`)
 				.then((res) => {
 					if (res) {
-						// @ts-expect-error ts-migrate(2322) FIXME: Type 'any' is not assignable to type 'never'.
 						setSuggestedItems([res]);
 					} else {
-						// @ts-expect-error ts-migrate(2322) FIXME: Type 'any' is not assignable to type 'never'.
 						setSuggestedItems([{ createNewFromUrl: throttledQueryValue }]);
 					}
 				});
 		} else if (throttledQueryValue) {
 			setSuggestedItems(
-				// @ts-expect-error ts-migrate(2345) FIXME: Type '{ targetPub: { title?: string | undefined; a... Remove this comment to see the full error message
 				availablePubs
 					.filter(
 						(pub) =>
-							// @ts-expect-error ts-migrate(2339) FIXME: Property 'id' does not exist on type '{ title?: st... Remove this comment to see the full error message
 							fuzzyMatchPub(pub, throttledQueryValue) && !usedPubIds.includes(pub.id),
 					)
 					.slice(0, 5)
@@ -94,9 +89,8 @@ const NewEdgeInput = (props: Props) => {
 			return (
 				<PubMenuItem
 					key={targetPub.title}
-					// @ts-expect-error ts-migrate(2322) FIXME: Property 'title' does not exist on type 'Intrinsic... Remove this comment to see the full error message
 					title={targetPub.title}
-					contributors={targetPub.attributions}
+					contributors={targetPub.attributions.filter((attr) => attr.isAuthor)}
 					image={targetPub.avatar}
 					active={modifiers.active}
 					onClick={handleClick}
@@ -109,7 +103,6 @@ const NewEdgeInput = (props: Props) => {
 			return (
 				<PubMenuItem
 					key={title}
-					// @ts-expect-error ts-migrate(2322) FIXME: Property 'title' does not exist on type 'Intrinsic... Remove this comment to see the full error message
 					title={title}
 					contributors={contributors}
 					image={avatar}

--- a/client/containers/DashboardOverview/CollectionOverview/PubSelect.tsx
+++ b/client/containers/DashboardOverview/CollectionOverview/PubSelect.tsx
@@ -28,7 +28,6 @@ const PubSelect = (props: Props) => {
 		return (
 			<PubMenuItem
 				key={pub.id}
-				// @ts-expect-error ts-migrate(2322) FIXME: Property 'onClick' does not exist on type 'Intrins... Remove this comment to see the full error message
 				onClick={handleClick}
 				title={pub.title}
 				contributors={pub.attributions}

--- a/client/containers/Pub/PubHeader/TitleGroup.tsx
+++ b/client/containers/Pub/PubHeader/TitleGroup.tsx
@@ -82,9 +82,7 @@ const TitleGroup = (props: Props) => {
 			)}
 			<PubByline
 				pubData={pubData}
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'false' is not assignable to type 'null'.
 				renderSuffix={() => !isRelease && renderBylineEditor()}
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'Element' is not assignable to type 'null'.
 				renderEmptyState={renderBylineEmptyState}
 			/>
 			{publishedDate && (


### PR DESCRIPTION
Resolves #1005

This PR updates Pub Connections cards to only show authors of a Pub, rather than all of its contributors. I also fixed a related problem where non-author contributors would be shown in the dropdown used to select connected Pubs.

_Test plan:_
Create a Pub with author and non-author contributors and verify that only the authors are shown in a PubEdge card pointing towards that Pub. 