### PR TITLE
feature: show private collection pages to users with explicit collection-level permission

### DIFF
--- a/server/utils/queryHelpers/communitySanitize.js
+++ b/server/utils/queryHelpers/communitySanitize.js
@@ -29,14 +29,10 @@ export default (communityData, locationData, loginData, scopeData) => {
 			({ pageId }) => typeof pageId === 'string' && pageId === item.id,
 		);
 
-		// If the page has a collection, check if the user has >= manage permission
+		// If the page has a collection, check if the user has explicit permission
 		// to that collection. If so, include the page.
 		const hasPageCollectionManageAccess = pageCollection
-			? pageCollection.members.some(
-					(member) =>
-						member.userId === loginData.id &&
-						(member.permissions === 'manage' || member.permissions === 'admin'),
-			  )
+			? pageCollection.members.some((member) => member.userId === loginData.id)
 			: false;
 
 		if (


### PR DESCRIPTION
This PR removes the predicate that you must be a manager or admin of a collection to see its private pages. This means that anyone with explicit collection-level permissions can see a private page linked to that collection, regardless of their access level (i.e. view and above).