### PR TITLE
feature: add automatic labeling of media, equations, and tables

### DIFF
--- a/client/components/Editor/Editor.tsx
+++ b/client/components/Editor/Editor.tsx
@@ -13,8 +13,8 @@ import nodeViews from './views';
 
 require('./styles/base.scss');
 
-type OwnProps = {
-	blockNames: { [key: string]: string };
+export type EditorProps = {
+	blockNames?: { [key: string]: string };
 	citationManager?: any;
 	customNodes?: any;
 	customMarks?: any;
@@ -33,6 +33,7 @@ type OwnProps = {
 };
 
 const defaultProps = {
+	blockNames: {},
 	citationManager: null,
 	collaborativeOptions: {},
 	customMarks: {}, // defaults: 'em', 'strong', 'link', 'sub', 'sup', 'strike', 'code'
@@ -89,7 +90,7 @@ const getInitialArguments = (props) => {
 	return { schema: schema, initialDoc: initialDoc, staticContent: staticContent };
 };
 
-type Props = OwnProps & typeof defaultProps;
+type Props = EditorProps & typeof defaultProps;
 
 const Editor = (props: Props) => {
 	const editorRef = useRef<HTMLElement>();

--- a/client/components/Editor/Editor.tsx
+++ b/client/components/Editor/Editor.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useRef, useMemo } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
 import { keydownHandler } from 'prosemirror-keymap';
-import { DOMSerializer } from 'prosemirror-model';
 import { addTemporaryIdsToDoc } from '@pubpub/prosemirror-reactive';
 
 import { getPlugins } from './plugins';
@@ -50,22 +49,6 @@ const defaultProps = {
 	onScrollToSelection: undefined,
 	placeholder: '',
 };
-
-function wrapDomSerializer(domSerializer: DOMSerializer) {
-	return Object.assign(Object.create(domSerializer), {
-		// Strip table captions when copying/pasting table elements.
-		serializeFragment(fragment, options) {
-			const result = domSerializer.serializeFragment(fragment, options);
-			const tableCaptions = result.querySelectorAll('table > caption');
-
-			tableCaptions.forEach((tableCaption) =>
-				tableCaption.parentElement.removeChild(tableCaption),
-			);
-
-			return result;
-		},
-	});
-}
 
 const getInitialArguments = (props) => {
 	const {
@@ -144,7 +127,6 @@ const Editor = (props: Props) => {
 				handleClickOn: props.handleSingleClick,
 				handleDoubleClickOn: props.handleDoubleClick,
 				handleScrollToSelection: props.onScrollToSelection,
-				clipboardSerializer: wrapDomSerializer(DOMSerializer.fromSchema(schema)),
 			},
 		);
 		// Sometimes the view will call its dispatchTransaction from the constructor, but the

--- a/client/components/Editor/plugins/reactive.ts
+++ b/client/components/Editor/plugins/reactive.ts
@@ -4,11 +4,9 @@ export default (schema, props) => {
 	return createReactivePlugin({
 		schema: schema,
 		documentState: {
+			blockNames: props.blockNames,
 			citationManager: props.citationManager,
-			blockNames: {
-				image: 'Figure',
-				video: 'Video',
-			},
+			isReadOnly: props.isReadOnly,
 		},
 	});
 };

--- a/client/components/Editor/plugins/reactive.ts
+++ b/client/components/Editor/plugins/reactive.ts
@@ -6,7 +6,6 @@ export default (schema, props) => {
 		documentState: {
 			blockNames: props.blockNames,
 			citationManager: props.citationManager,
-			isReadOnly: props.isReadOnly,
 		},
 	});
 };

--- a/client/components/Editor/plugins/table.ts
+++ b/client/components/Editor/plugins/table.ts
@@ -1,15 +1,19 @@
 import { keymap } from 'prosemirror-keymap';
 // @ts-ignore
 import { columnResizing, tableEditing, goToNextCell, TableView } from 'prosemirror-tables';
+import { counter } from '../schemas/reactive/counter';
 
+/**
+ * Synchronize the reactive id attribute of default prosemirror-tables NodeView.
+ */
 class PubTableView extends TableView {
 	constructor(node, whatever) {
 		super(node, whatever);
 		this.syncId(node);
 	}
 
-	update(node) {
-		const shouldUpdate = super.update(node);
+	update(node, decorations) {
+		const shouldUpdate = super.update(node, decorations);
 		this.syncId(node);
 		return shouldUpdate;
 	}

--- a/client/components/Editor/plugins/table.ts
+++ b/client/components/Editor/plugins/table.ts
@@ -3,7 +3,6 @@ import { DOMSerializer } from 'prosemirror-model';
 import { Plugin } from 'prosemirror-state';
 // @ts-ignore
 import { columnResizing, tableEditing, goToNextCell, TableView } from 'prosemirror-tables';
-import { counter } from '../schemas/reactive/counter';
 
 function wrapDomSerializer(domSerializer: DOMSerializer) {
 	return Object.assign(Object.create(domSerializer), {
@@ -55,6 +54,8 @@ export default (schema, props) => {
 			handleWidth does appear in the documentation, but is initialized in the code:
 			https://github.com/ProseMirror/prosemirror-tables/blob/master/src/columnresizing.js#L10
 		*/
+		// @ts-expect-error The type definitions are incorrect for the View option,
+		// according to the docs, View accepts a NodeView constructor, not an instance.
 		return [columnResizing({ handleWidth: -1, View: PubTableView })];
 	}
 
@@ -65,6 +66,7 @@ export default (schema, props) => {
 
 	return [
 		columnResizing({
+			// @ts-expect-error See @ts-expect-error comment above.
 			View: PubTableView,
 		}),
 		tableEditing(),

--- a/client/components/Editor/schemas/audio.ts
+++ b/client/components/Editor/schemas/audio.ts
@@ -1,14 +1,22 @@
 import { renderHtmlChildren } from '../utils/renderHtml';
+import { label } from './reactive/label';
+import { buildLabel } from '../utils/references';
+import { counter } from './reactive/counter';
 
 export default {
 	audio: {
 		atom: true,
+		reactive: true,
 		attrs: {
 			id: { default: null },
 			url: { default: null },
 			size: { default: 50 }, // number as percentage
 			align: { default: 'center' },
 			caption: { default: '' },
+		},
+		reactiveAttrs: {
+			count: counter('audio'),
+			label: label(),
 		},
 		parseDOM: [
 			{
@@ -46,7 +54,15 @@ export default {
 						alt: node.attrs.caption,
 					},
 				],
-				['figcaption', {}, renderHtmlChildren(isReact, node.attrs.caption, 'div')],
+				[
+					'figcaption',
+					{},
+					[
+						'div',
+						['strong', buildLabel(node)],
+						renderHtmlChildren(isReact, node.attrs.caption, 'div'),
+					],
+				],
 			];
 		},
 		inline: false,

--- a/client/components/Editor/schemas/equation.tsx
+++ b/client/components/Editor/schemas/equation.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import { renderHtmlChildren } from '../utils/renderHtml';
+import { counter } from './reactive/counter';
 
 export default {
 	equation: {
 		atom: true,
 		attrs: {
-			id: { default: null },
 			value: { default: '' },
 			html: { default: '' },
 			renderForPandoc: { default: false },
@@ -20,7 +20,6 @@ export default {
 					}
 
 					return {
-						id: node.getAttribute('id') || null,
 						value: node.getAttribute('data-value') || '',
 						html: node.firstChild.innerHTML || '',
 					};
@@ -41,7 +40,6 @@ export default {
 			return [
 				'span',
 				{
-					...(node.attrs.id && { id: node.attrs.id }),
 					'data-node-type': 'math-inline',
 					'data-value': node.attrs.value,
 				},
@@ -66,10 +64,15 @@ export default {
 	},
 	block_equation: {
 		atom: true,
+		reactive: true,
 		attrs: {
+			id: { default: null },
 			value: { default: '' },
 			html: { default: '' },
 			renderForPandoc: { default: false },
+		},
+		reactiveAttrs: {
+			count: counter('equation'),
 		},
 		parseDOM: [
 			{
@@ -80,6 +83,7 @@ export default {
 					}
 
 					return {
+						id: node.getAttribute('id') || null,
 						value: node.getAttribute('data-value') || '',
 						html: node.firstChild.innerHTML || '',
 					};
@@ -100,10 +104,13 @@ export default {
 			return [
 				'div',
 				{
+					...(node.attrs.id && { id: node.attrs.id }),
 					'data-node-type': 'math-block',
 					'data-value': node.attrs.value,
 				},
+				['span'],
 				renderHtmlChildren(isReact, node.attrs.html),
+				['span', { class: 'equation-label' }, `(${node.attrs.count})`],
 			];
 		},
 

--- a/client/components/Editor/schemas/image.ts
+++ b/client/components/Editor/schemas/image.ts
@@ -1,5 +1,7 @@
 import { renderHtmlChildren } from '../utils/renderHtml';
 import { counter } from './reactive/counter';
+import { buildLabel } from '../utils/references';
+import { label } from './reactive/label';
 
 export default {
 	image: {
@@ -13,7 +15,8 @@ export default {
 			caption: { default: '' },
 		},
 		reactiveAttrs: {
-			count: counter('figure'),
+			count: counter('image'),
+			label: label(),
 		},
 		parseDOM: [
 			{
@@ -35,6 +38,7 @@ export default {
 		// @ts-expect-error ts-migrate(2525) FIXME: Initializer provides no value for this binding ele... Remove this comment to see the full error message
 		toDOM: (node, { isReact } = {}) => {
 			const resizeFunc = node.type.spec.defaultOptions.onResizeUrl;
+
 			return [
 				'figure',
 				{
@@ -51,7 +55,15 @@ export default {
 						alt: node.attrs.caption,
 					},
 				],
-				['figcaption', {}, renderHtmlChildren(isReact, node.attrs.caption, 'div')],
+				[
+					'figcaption',
+					{},
+					[
+						'div',
+						['strong', buildLabel(node)],
+						renderHtmlChildren(isReact, node.attrs.caption, 'div'),
+					],
+				],
 			];
 		},
 		inline: false,

--- a/client/components/Editor/schemas/reactive/label.ts
+++ b/client/components/Editor/schemas/reactive/label.ts
@@ -1,0 +1,6 @@
+export const label = () =>
+	function(node) {
+		// @ts-expect-error
+		const { blockNames } = this.useDocumentState();
+		return blockNames[node.type.name];
+	};

--- a/client/components/Editor/schemas/reference.ts
+++ b/client/components/Editor/schemas/reference.ts
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import { Hooks } from '@pubpub/prosemirror-reactive/src/store/types';
 
+import { buildLabel } from '../utils/references';
+
 export default {
 	reference: {
 		isLeaf: true,
@@ -19,13 +21,16 @@ export default {
 
 				if (targetId) {
 					return this.useDeferredNode(targetId, (target) => {
-						return target
-							? `${blockNames[target.type.name]} ${target.attrs.count}`
-							: null;
+						return target ? buildLabel(target, blockNames[target.type.name]) : null;
 					});
 				}
 
 				return null;
+			},
+			isReadOnly: function(this: Hooks, node) {
+				const { isReadOnly } = this.useDocumentState();
+
+				return isReadOnly;
 			},
 		},
 		parseDOM: [
@@ -42,13 +47,14 @@ export default {
 				},
 			},
 		],
-		toDOM: (node) => {
-			const { id, targetId, label } = node.attrs;
+		toDOM(node) {
+			const { id, targetId, label, isReadOnly } = node.attrs;
+
 			return [
 				'a',
 				{
 					...(id && { id: id }),
-					// href: `#${targetId}`,
+					...(isReadOnly && { href: `#${targetId}` }),
 					class: classNames('reference', !label && 'missing'),
 					'data-node-type': 'reference',
 					'data-target-id': targetId,

--- a/client/components/Editor/schemas/reference.ts
+++ b/client/components/Editor/schemas/reference.ts
@@ -27,11 +27,6 @@ export default {
 
 				return null;
 			},
-			isReadOnly: function(this: Hooks, node) {
-				const { isReadOnly } = this.useDocumentState();
-
-				return isReadOnly;
-			},
 		},
 		parseDOM: [
 			{
@@ -40,21 +35,25 @@ export default {
 					if (node.getAttribute('data-node-type') !== 'reference') {
 						return false;
 					}
+
+					const targetId = node.getAttribute('data-target-id');
+
 					return {
 						id: node.getAttribute('id'),
-						targetId: node.getAttribute('data-target-id'),
+						targetId: targetId,
+						href: `#${targetId}`,
 					};
 				},
 			},
 		],
 		toDOM(node) {
-			const { id, targetId, label, isReadOnly } = node.attrs;
+			const { id, targetId, label } = node.attrs;
 
 			return [
 				'a',
 				{
 					...(id && { id: id }),
-					...(isReadOnly && { href: `#${targetId}` }),
+					href: `#${targetId}`,
 					class: classNames('reference', !label && 'missing'),
 					'data-node-type': 'reference',
 					'data-target-id': targetId,

--- a/client/components/Editor/schemas/table.ts
+++ b/client/components/Editor/schemas/table.ts
@@ -1,5 +1,8 @@
 import { tableNodes } from 'prosemirror-tables';
 import { Fragment } from 'prosemirror-model';
+import { counter } from './reactive/counter';
+import { label } from './reactive/label';
+import { buildLabel } from '../utils/references';
 
 const pmTableNodes = tableNodes({
 	tableGroup: 'block',
@@ -22,7 +25,9 @@ const pmTableNodes = tableNodes({
 	},
 });
 
-pmTableNodes.table.onInsert = (view) => {
+const { table, table_cell } = pmTableNodes;
+
+table.onInsert = (view) => {
 	const numRows = 3;
 	const numCols = 3;
 	const { tr, schema } = view.state;
@@ -39,6 +44,28 @@ pmTableNodes.table.onInsert = (view) => {
 	for (let i = 0; i < numRows; i += 1) rows.push(rowNode);
 	const tableNode = tableType.create(null, Fragment.from(rows));
 	view.dispatch(tr.replaceSelectionWith(tableNode).scrollIntoView());
+};
+
+// Enhance table node with reactive id attribute.
+const { toDOM: tableToDOM } = table;
+
+table.attrs = { ...table.attrs, id: { default: null } };
+table.reactive = true;
+table.reactiveAttrs = {
+	count: counter('table'),
+	label: label(),
+};
+
+table.parseDOM[0].getAttrs = (node) => {
+	return {
+		id: node.getAttribute('id') || null,
+	};
+};
+
+table.toDOM = (node, decorations) => {
+	const spec = tableToDOM(node, decorations);
+
+	return [spec[0], { id: node.attrs.id }, ['caption', buildLabel(node)], spec[1]];
 };
 
 export default pmTableNodes;

--- a/client/components/Editor/schemas/table.ts
+++ b/client/components/Editor/schemas/table.ts
@@ -1,5 +1,5 @@
 import { tableNodes } from 'prosemirror-tables';
-import { Fragment } from 'prosemirror-model';
+import { DOMOutputSpec, Fragment, Node as ProsemirrorNode } from 'prosemirror-model';
 import { counter } from './reactive/counter';
 import { label } from './reactive/label';
 import { buildLabel } from '../utils/references';
@@ -25,7 +25,7 @@ const pmTableNodes = tableNodes({
 	},
 });
 
-const { table, table_cell } = pmTableNodes;
+const { table } = pmTableNodes;
 
 table.onInsert = (view) => {
 	const numRows = 3;
@@ -46,7 +46,7 @@ table.onInsert = (view) => {
 	view.dispatch(tr.replaceSelectionWith(tableNode).scrollIntoView());
 };
 
-// Enhance table node with reactive id attribute.
+// Enhance table node with reactive attributes.
 const { toDOM: tableToDOM } = table;
 
 table.attrs = { ...table.attrs, id: { default: null } };
@@ -56,16 +56,21 @@ table.reactiveAttrs = {
 	label: label(),
 };
 
-table.parseDOM[0].getAttrs = (node) => {
+table.parseDOM![0].getAttrs = (node) => {
 	return {
-		id: node.getAttribute('id') || null,
+		id: (node as Element).getAttribute('id') || null,
 	};
 };
 
-table.toDOM = (node, decorations) => {
-	const spec = tableToDOM(node, decorations);
+table.toDOM = (node: ProsemirrorNode) => {
+	const spec = tableToDOM!(node);
 
-	return [spec[0], { id: node.attrs.id }, ['caption', buildLabel(node)], spec[1]];
+	return [
+		spec[0],
+		{ id: node.attrs.id },
+		['caption', buildLabel(node)],
+		spec[1],
+	] as DOMOutputSpec;
 };
 
 export default pmTableNodes;

--- a/client/components/Editor/schemas/video.ts
+++ b/client/components/Editor/schemas/video.ts
@@ -1,5 +1,7 @@
 import { renderHtmlChildren } from '../utils/renderHtml';
 import { counter } from './reactive/counter';
+import { label } from './reactive/label';
+import { buildLabel } from '../utils/references';
 
 export default {
 	video: {
@@ -13,7 +15,8 @@ export default {
 			caption: { default: '' },
 		},
 		reactiveAttrs: {
-			count: counter('figure'),
+			count: counter('video'),
+			label: label(),
 		},
 		parseDOM: [
 			{
@@ -51,7 +54,15 @@ export default {
 						alt: node.attrs.caption,
 					},
 				],
-				['figcaption', {}, renderHtmlChildren(isReact, node.attrs.caption, 'div')],
+				[
+					'figcaption',
+					{},
+					[
+						'div',
+						['strong', buildLabel(node)],
+						renderHtmlChildren(isReact, node.attrs.caption, 'div'),
+					],
+				],
 			];
 		},
 		inline: false,

--- a/client/components/Editor/styles/latex.scss
+++ b/client/components/Editor/styles/latex.scss
@@ -1,15 +1,39 @@
 @import '~katex/dist/katex';
+@import '../../../styles/variables.scss';
 
 [data-node-type='math-inline'] {
-    font-size: 0.9em;
-    display: inline-block;
-    vertical-align: middle;
-    max-width: 100%;
+	font-size: 0.9em;
+	display: inline-block;
+	vertical-align: middle;
+	max-width: 100%;
 }
 
 [data-node-type='math-block'] {
-    font-size: 20px;
-    display: block;
-    text-align: center;
-    max-width: 100%;
+	font-size: 20px;
+	text-align: center;
+	max-width: 100%;
+	position: relative;
+	display: flex;
+
+	> span {
+		flex-grow: 1;
+	}
+
+	> span:first-child {
+		flex-shrink: 2;
+	}
+
+	> span:nth-child(2) {
+		flex-shrink: 0;
+	}
+
+	> span:last-child {
+		flex-shrink: 1;
+		text-align: right;
+	}
+}
+
+.equation-label {
+	text-align: center;
+	font-family: $body-font;
 }

--- a/client/components/Editor/styles/table.scss
+++ b/client/components/Editor/styles/table.scss
@@ -1,3 +1,6 @@
+/* This clunky table, tableWrapper thing is because */
+/* isReadOnly removes the wrapping div, so margins don't */
+/* collapse as expected in all situations. */
 .tableWrapper {
 	margin: 1em 0;
 	table {
@@ -25,9 +28,6 @@ table caption {
 	}
 }
 
-/* This clunky table, tableWrapper thing is because */
-/* isReadOnly removes the wrapping div, so margins don't */
-/* collapse as expected in all situations. */
 table {
 	margin: 1em 0;
 	max-width: 100%;

--- a/client/components/Editor/styles/table.scss
+++ b/client/components/Editor/styles/table.scss
@@ -1,9 +1,19 @@
-table {
-	margin: 0;
-	max-width: 100%;
+.tableWrapper {
+	margin: 1em 0;
+	table {
+		margin: 0em;
+	}
 }
+
+th {
+	font-weight: bold;
+	text-align: left;
+	background-color: #f0f0f4;
+}
+
 th,
-td {
+td,
+table caption {
 	min-width: 1em;
 	border: 1px solid #ddd;
 	padding: 3px 5px;
@@ -14,20 +24,17 @@ td {
 		margin-bottom: 0;
 	}
 }
+
 /* This clunky table, tableWrapper thing is because */
 /* isReadOnly removes the wrapping div, so margins don't */
 /* collapse as expected in all situations. */
 table {
 	margin: 1em 0;
-}
-.tableWrapper {
-	margin: 1em 0;
-	table {
-		margin: 0em;
+	max-width: 100%;
+
+	caption {
+		text-align: left;
+		border-bottom: none;
+		padding: 3px 5px;
 	}
-}
-th {
-	font-weight: bold;
-	text-align: left;
-	background-color: #f0f0f4;
 }

--- a/client/components/Editor/utils/renderStatic.ts
+++ b/client/components/Editor/utils/renderStatic.ts
@@ -140,22 +140,26 @@ const createOutputSpecFromNode = (node, schema, context) => {
 	return marks ? wrapOutputSpecInMarks(outputSpec, marks, schema) : outputSpec;
 };
 
-export const getReactedDocFromJson = (doc, schema, citationManager) => {
+export const getReactedDocFromJson = (doc, schema, citationManager, blockNames) => {
 	const hydratedDoc = Node.fromJSON(schema, doc);
 	const reactedDoc = getReactedDoc(hydratedDoc, {
 		documentState: {
 			citationManager: citationManager,
-			blockNames: {
-				image: 'Figure',
-				video: 'Video',
-			},
+			blockNames: blockNames,
 		},
 	});
 	return reactedDoc.toJSON();
 };
 
-export const renderStatic = ({ schema, doc, reactedDoc, citationManager, context = {} }) => {
-	const finalDoc = reactedDoc || getReactedDocFromJson(doc, schema, citationManager);
+export const renderStatic = ({
+	schema,
+	doc,
+	reactedDoc,
+	citationManager,
+	blockNames,
+	context = {},
+}) => {
+	const finalDoc = reactedDoc || getReactedDocFromJson(doc, schema, citationManager, blockNames);
 	return finalDoc.content.map((node, index) => {
 		const outputSpec = createOutputSpecFromNode(node, schema, context);
 		return createReactFromOutputSpec(outputSpec, index);

--- a/client/components/Editor/utils/renderStatic.ts
+++ b/client/components/Editor/utils/renderStatic.ts
@@ -156,7 +156,7 @@ export const renderStatic = ({
 	doc,
 	reactedDoc,
 	citationManager,
-	blockNames,
+	blockNames = {},
 	context = {},
 }) => {
 	const finalDoc = reactedDoc || getReactedDocFromJson(doc, schema, citationManager, blockNames);

--- a/client/components/Editor/views/ReferenceView.ts
+++ b/client/components/Editor/views/ReferenceView.ts
@@ -1,0 +1,39 @@
+import { Node } from 'prosemirror-model';
+import { EditorView } from 'prosemirror-view';
+
+export default class ReferenceView {
+	view: EditorView;
+	dom: HTMLAnchorElement;
+	contentDOM: HTMLAnchorElement;
+
+	constructor(node: Node, view: EditorView) {
+		const { targetId, label } = node.attrs;
+
+		this.view = view;
+		this.dom = this.contentDOM = document.createElement('a');
+
+		this.dom.textContent = label || `(ref?)`;
+		this.dom.classList.add('reference');
+		this.dom.setAttribute('data-node-type', 'reference');
+		this.dom.setAttribute('data-target-id', targetId);
+		this.dom.setAttribute('href', `#${targetId}`);
+
+		this.onClick = this.onClick.bind(this);
+
+		this.dom.addEventListener('click', this.onClick);
+	}
+
+	onClick(e: MouseEvent) {
+		if (this.view.editable) {
+			e.preventDefault();
+		}
+	}
+
+	stopEvent() {
+		return this.view.editable;
+	}
+
+	destroy() {
+		this.dom.removeEventListener('click', this.onClick);
+	}
+}

--- a/client/components/Editor/views/index.ts
+++ b/client/components/Editor/views/index.ts
@@ -1,44 +1,5 @@
-import { Node } from 'prosemirror-model';
-import { EditorView } from 'prosemirror-view';
 import NotePopover from './NotePopover';
-
-class ReferenceView {
-	view: EditorView;
-	dom: HTMLAnchorElement;
-	contentDOM: HTMLAnchorElement;
-
-	constructor(node: Node, view: EditorView) {
-		const { targetId, label } = node.attrs;
-
-		this.view = view;
-		this.dom = this.contentDOM = document.createElement('a');
-
-		this.dom.textContent = label || `(ref?)`;
-		this.dom.classList.add('reference');
-		this.dom.classList.add('testy');
-		this.dom.setAttribute('data-node-type', 'reference');
-		this.dom.setAttribute('data-target-id', targetId);
-		this.dom.setAttribute('href', `#${targetId}`);
-
-		this.onClick = this.onClick.bind(this);
-
-		this.dom.addEventListener('click', this.onClick);
-	}
-
-	onClick(e: MouseEvent) {
-		if (this.view.editable) {
-			e.preventDefault();
-		}
-	}
-
-	stopEvent() {
-		return this.view.editable;
-	}
-
-	destroy() {
-		this.dom.removeEventListener('click', this.onClick);
-	}
-}
+import ReferenceView from './ReferenceView';
 
 export default {
 	citation: (node, view) => new NotePopover(node, view, 'unstructuredValue'),

--- a/client/components/Editor/views/index.ts
+++ b/client/components/Editor/views/index.ts
@@ -1,6 +1,47 @@
+import { Node } from 'prosemirror-model';
+import { EditorView } from 'prosemirror-view';
 import NotePopover from './NotePopover';
+
+class ReferenceView {
+	view: EditorView;
+	dom: HTMLAnchorElement;
+	contentDOM: HTMLAnchorElement;
+
+	constructor(node: Node, view: EditorView) {
+		const { targetId, label } = node.attrs;
+
+		this.view = view;
+		this.dom = this.contentDOM = document.createElement('a');
+
+		this.dom.textContent = label || `(ref?)`;
+		this.dom.classList.add('reference');
+		this.dom.classList.add('testy');
+		this.dom.setAttribute('data-node-type', 'reference');
+		this.dom.setAttribute('data-target-id', targetId);
+		this.dom.setAttribute('href', `#${targetId}`);
+
+		this.onClick = this.onClick.bind(this);
+
+		this.dom.addEventListener('click', this.onClick);
+	}
+
+	onClick(e: MouseEvent) {
+		if (this.view.editable) {
+			e.preventDefault();
+		}
+	}
+
+	stopEvent() {
+		return this.view.editable;
+	}
+
+	destroy() {
+		this.dom.removeEventListener('click', this.onClick);
+	}
+}
 
 export default {
 	citation: (node, view) => new NotePopover(node, view, 'unstructuredValue'),
 	footnote: (node, view) => new NotePopover(node, view, 'value'),
+	reference: (node, view) => new ReferenceView(node, view),
 };

--- a/client/containers/DashboardOverview/CollectionOverview/CollectionControls.tsx
+++ b/client/containers/DashboardOverview/CollectionOverview/CollectionControls.tsx
@@ -32,6 +32,7 @@ const CollectionControls = (props: Props) => {
 					aria-label="Set collection public or private"
 					buttonContent={isPublic ? 'Public' : 'Private'}
 					buttonProps={{
+						// @ts-expect-error: "lock2" not valid in TS definitions
 						icon: isPublic ? 'globe' : 'lock2',
 						rightIcon: 'caret-down',
 					}}

--- a/client/containers/Pub/PubDocument/PubBody.tsx
+++ b/client/containers/Pub/PubDocument/PubBody.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useContext, useState } from 'react';
+import React, { useRef, useContext, useState, useMemo } from 'react';
 import ReactDOM from 'react-dom';
 import { useBeforeUnload } from 'react-use';
 import * as Sentry from '@sentry/browser';
@@ -52,7 +52,7 @@ const PubBody = (props: Props) => {
 		editorWrapperRef,
 	} = props;
 	const { communityData } = usePageContext();
-	const { citationManager } = usePubContext();
+	const { blockNames, citationManager } = usePubContext();
 	const { isViewingHistory } = historyData;
 	const prevStatusRef = useRef(null);
 	const embedDiscussions = useRef({});
@@ -145,6 +145,7 @@ const PubBody = (props: Props) => {
 						},
 					},
 				}}
+				blockNames={blockNames}
 				citationManager={citationManager}
 				placeholder={pubData.isReadOnly ? undefined : 'Begin writing here...'}
 				initialContent={initialContent}

--- a/client/containers/Pub/PubSyncManager.tsx
+++ b/client/containers/Pub/PubSyncManager.tsx
@@ -134,7 +134,7 @@ class PubSyncManager extends React.Component<Props, State> {
 				historyDocKey: `history-${historyData.currentKey}`,
 			},
 			blockNames: {
-				image: 'Image',
+				image: 'Figure',
 				video: 'Video',
 				table: 'Table',
 			},

--- a/client/containers/Pub/PubSyncManager.tsx
+++ b/client/containers/Pub/PubSyncManager.tsx
@@ -15,6 +15,7 @@ export const PubContext = React.createContext({
 	historyData: {},
 	firebaseBranchRef: null,
 	updateLocalData: null,
+	blockNames: {} as { [key: string]: string },
 	// @ts-expect-error ts-migrate(2554) FIXME: Expected 2-3 arguments, but got 0.
 	citationManager: new CitationManager(),
 });
@@ -131,6 +132,11 @@ class PubSyncManager extends React.Component<Props, State> {
 				isViewingHistory: isViewingHistory,
 				loadedIntoHistory: isViewingHistory,
 				historyDocKey: `history-${historyData.currentKey}`,
+			},
+			blockNames: {
+				image: 'Image',
+				video: 'Video',
+				table: 'Table',
 			},
 			citationManager: new CitationManager(
 				pubData.citationStyle,
@@ -415,6 +421,7 @@ class PubSyncManager extends React.Component<Props, State> {
 			pubData: this.state.pubData,
 			collabData: this.state.collabData,
 			historyData: this.state.historyData,
+			blockNames: this.state.blockNames,
 			citationManager: this.state.citationManager,
 			firebaseBranchRef: this.state.firebaseBranchRef,
 			updateLocalData: this.updateLocalData,


### PR DESCRIPTION
This PR adds automatic labeling of audio, video, images, equations, and tables. The labels aren't customizable yet, but this code adds a hook into the labeling logic via the `blockNames` object injected via document state.