### PR TITLE
feature: Add route to directly access 'best' Pub download

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,6 +3,7 @@ require('./pubRedirects');
 
 /* Routes for Communities */
 require('./pubDocument');
+require('./pubDownloads');
 require('./collection'); // Route: /collection/:id
 require('./dashboardActivity');
 require('./dashboardDiscussions');

--- a/server/routes/pubDownloads.js
+++ b/server/routes/pubDownloads.js
@@ -1,0 +1,43 @@
+import fetch from 'node-fetch';
+import { pipeline } from 'stream';
+import { promisify } from 'util';
+
+import app, { wrap } from 'server/server';
+import { ForbiddenError, NotFoundError } from 'server/utils/errors';
+import { getInitialData } from 'server/utils/initData';
+import { getPub } from 'server/utils/queryHelpers';
+
+import { getFormattedDownloadUrl, getPublicExportUrl } from 'utils/pub/downloads';
+
+const getBestDownloadUrl = (pubData) => {
+	const formattedDownloadUrl = getFormattedDownloadUrl(pubData);
+	if (formattedDownloadUrl) {
+		return formattedDownloadUrl;
+	}
+	return getPublicExportUrl(pubData, 'pdf');
+};
+
+app.get(
+	'/pub/:pubSlug/download',
+	wrap(async (req, res) => {
+		const { communityData } = await getInitialData(req);
+		const { pubSlug } = req.params;
+
+		const pubData = await getPub(pubSlug, communityData.id);
+		const bestPubDownloadUrl = getBestDownloadUrl(pubData);
+
+		if (pubData.releases.length === 0) {
+			throw new ForbiddenError();
+		}
+
+		if (bestPubDownloadUrl) {
+			res.attachment(bestPubDownloadUrl);
+			const downloadResponse = await fetch(bestPubDownloadUrl);
+			if (downloadResponse.ok) {
+				return promisify(pipeline)(downloadResponse.body, res);
+			}
+		}
+
+		throw new NotFoundError();
+	}),
+);


### PR DESCRIPTION
Resolves #1027 

This PR adds a new `/pub/:slug/download` route that directly downloads (using `Content-Disposition: attachment`):

- The formatted download for a Pub, if it exists
- The latest automatically generated PDF export for the Pub's latest release, otherwise

throwing a 404 if neither is available.

_Test plan:_
Verify that `/download` downloads the formatted download for a Pub if it exists, or the latest public PDF export if it exists, and otherwise produces a 404. Pubs with no Releases should likewise produce a 404.