### PR TITLE
update: support position: absolute within HTML page blocks

### DIFF
--- a/client/containers/Page/page.scss
+++ b/client/containers/Page/page.scss
@@ -48,6 +48,10 @@
 		}
 	}
 
+	.layout-html-component {
+		position: relative;
+	}
+
 	.layout-text-component,
 	.layout-html-component {
 		p,


### PR DESCRIPTION
This small change makes the wrapper for HTML blocks `position: relative` so that we can position elements absolutely within them.