### PR TITLE
update: Use the PubPub-internal download URL in the citation_pdf_url meta tag

### DIFF
--- a/server/routes/pubDocument.js
+++ b/server/routes/pubDocument.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { getPubPageContextTitle } from 'utils/pubPageTitle';
-import { getPDFDownload, getTextAbstract, getGoogleScholarNotes } from 'utils/pub/metadata';
+import { getPdfDownloadUrl, getTextAbstract, getGoogleScholarNotes } from 'utils/pub/metadata';
 import { chooseCollectionForPub } from 'client/utils/collections';
 import Html from 'server/Html';
 import app from 'server/server';
@@ -33,7 +33,7 @@ const renderPubDocument = (res, pubData, initialData) => {
 				contextTitle: getPubPageContextTitle(pubData, initialData.communityData),
 				description: pubData.description,
 				doi: pubData.doi,
-				download: getPDFDownload(pubData),
+				pdfDownloadUrl: getPdfDownloadUrl(initialData.communityData, pubData),
 				image: pubData.avatar,
 				initialData: initialData,
 				notes: getGoogleScholarNotes(Object.values(pubData.initialStructuredCitations)),

--- a/server/routes/pubDownloads.js
+++ b/server/routes/pubDownloads.js
@@ -7,24 +7,16 @@ import { ForbiddenError, NotFoundError } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { getPub } from 'server/utils/queryHelpers';
 
-import { getFormattedDownloadUrl, getPublicExportUrl } from 'utils/pub/downloads';
-
-const getBestDownloadUrl = (pubData) => {
-	const formattedDownloadUrl = getFormattedDownloadUrl(pubData);
-	if (formattedDownloadUrl) {
-		return formattedDownloadUrl;
-	}
-	return getPublicExportUrl(pubData, 'pdf');
-};
+import { getBestDownloadUrl } from 'utils/pub/downloads';
 
 app.get(
-	'/pub/:pubSlug/download',
+	['/pub/:pubSlug/download', '/pub/:pubSlug/download/:format'],
 	wrap(async (req, res) => {
 		const { communityData } = await getInitialData(req);
-		const { pubSlug } = req.params;
+		const { pubSlug, format = null } = req.params;
 
 		const pubData = await getPub(pubSlug, communityData.id);
-		const bestPubDownloadUrl = getBestDownloadUrl(pubData);
+		const bestPubDownloadUrl = getBestDownloadUrl(pubData, format);
 
 		if (pubData.releases.length === 0) {
 			throw new ForbiddenError();

--- a/server/utils/ssr.js
+++ b/server/utils/ssr.js
@@ -19,7 +19,7 @@ export const generateMetaComponents = ({
 	publishedAt,
 	unlisted,
 	collection,
-	download,
+	pdfDownloadUrl,
 	textAbstract,
 	notes,
 	canonicalUrl,
@@ -111,10 +111,10 @@ export const generateMetaComponents = ({
 		}
 	}
 
-	if (download) {
+	if (pdfDownloadUrl) {
 		outputComponents = [
 			...outputComponents,
-			<meta key="dl1" name="citation_pdf_url" content={download.url} />,
+			<meta key="dl1" name="citation_pdf_url" content={pdfDownloadUrl} />,
 		];
 	}
 

--- a/utils/canonicalUrls.js
+++ b/utils/canonicalUrls.js
@@ -29,8 +29,11 @@ export const pubShortUrl = (pub) => {
 
 export const pubUrl = (community, pub, options = {}) => {
 	let baseUrl = `${communityUrl(community)}/pub/${pub.slug}`;
-	const { isDraft, historyKey, releaseNumber, accessHash, query } = options;
-	if (isDraft) {
+	const { isDraft, historyKey, releaseNumber, accessHash, query, download } = options;
+	if (download) {
+		const downloadType = typeof download === 'string' ? `/${download}` : '';
+		baseUrl = `${baseUrl}/download${downloadType}`;
+	} else if (isDraft) {
 		const appendedHistoryKey = historyKey !== undefined ? `/${historyKey}` : '';
 		baseUrl = `${baseUrl}/draft${appendedHistoryKey}`;
 	} else if (releaseNumber !== undefined) {

--- a/utils/pub/downloads.js
+++ b/utils/pub/downloads.js
@@ -1,11 +1,12 @@
-export const getFormattedDownloadUrl = (pubData) => {
+export const getFormattedDownloadUrl = (pubData, requiredFormat) => {
 	const { downloads } = pubData;
 	if (!downloads) {
 		return null;
 	}
 	const download = downloads.reduce((best, next) => {
 		const isNewer = !best || !best.createdAt || next.createdAt > best.createdAt;
-		if (next.type === 'formatted' && isNewer) {
+		const isCorrectFormat = !requiredFormat || next.url.endsWith(requiredFormat);
+		if (next.type === 'formatted' && isNewer && isCorrectFormat) {
 			return next;
 		}
 		return best;
@@ -31,4 +32,12 @@ export const getPublicExportUrl = (pubData, format) => {
 		}
 	}
 	return null;
+};
+
+export const getBestDownloadUrl = (pubData, requiredFormat) => {
+	const formattedDownloadUrl = getFormattedDownloadUrl(pubData, requiredFormat);
+	if (formattedDownloadUrl) {
+		return formattedDownloadUrl;
+	}
+	return getPublicExportUrl(pubData, requiredFormat || 'pdf');
 };

--- a/utils/pub/downloads.js
+++ b/utils/pub/downloads.js
@@ -20,7 +20,7 @@ export const getFormattedDownloadUrl = (pubData, requiredFormat) => {
 export const getPublicExportUrl = (pubData, format) => {
 	const { branches, releases } = pubData;
 	const publicBranch = branches.find((b) => b.title === 'public');
-	if (publicBranch && publicBranch.exports && releases) {
+	if (publicBranch && publicBranch.exports && releases && releases.length) {
 		const latestHistoryKey = releases.map((r) => r.branchKey).reduce((a, b) => Math.max(a, b));
 		if (typeof latestHistoryKey === 'number') {
 			const validExport = publicBranch.exports.find(

--- a/utils/pub/metadata.js
+++ b/utils/pub/metadata.js
@@ -1,19 +1,12 @@
-export const getPDFDownload = (pub) => {
-	const downloads = pub.downloads;
-	const exports = pub.activeBranch.exports;
-	if (downloads) {
-		const matchingDownload = downloads
-			.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
-			.find((dl) => dl.url.endsWith('.pdf'));
-		if (matchingDownload) return matchingDownload;
+import { getBestDownloadUrl } from 'utils/pub/downloads';
+import { pubUrl } from 'utils/canonicalUrls';
+
+export const getPdfDownloadUrl = (communityData, pubData) => {
+	const hasPdfDownload = !!getBestDownloadUrl(pubData, 'pdf');
+	if (hasPdfDownload) {
+		return pubUrl(communityData, pubData, { download: 'pdf' });
 	}
-	if (exports) {
-		const matchingExport = exports
-			.sort((a, b) => (a.historyKey < b.historyKey ? 1 : -1))
-			.find((exportFile) => exportFile.format === 'pdf');
-		if (matchingExport) return matchingExport;
-	}
-	return false;
+	return null;
 };
 
 export const getTextAbstract = (docJson) => {


### PR DESCRIPTION
Actually resolves #1027 

...so that archival services and indexes can link to PubPub or third-party domain URLs rather than `assets.pubpub` ones.

This PR adds the `/pub/:slug/download/:format` route to complement `/pub/:slug/download`. The former will only resolve files of the type `format`. The latter will resolve any formatted download, defaulting to PDF when selecting among the auto-generated exports. Then, `https://<domain>/pub/:slug/download/pdf` is set as the `citation_pdf_url` meta tag value.

_Test plan:_
- `/pub/:slug/download` still works as before, resolving _any_ formatted download or a PDF export
- `/pub/:slug/download/:format` will return a file of type `format`, preferrably a formatted download, but otherwise an export.
- Pubs have a `citation_pdf_url` meta tag linking to the appropriate download URL iff they have a PDF download to offer