### PR TITLE
fix PubHistoricalNotice

### DIFF
--- a/client/containers/Pub/PubDocument/pubHistoricalNotice.scss
+++ b/client/containers/Pub/PubDocument/pubHistoricalNotice.scss
@@ -107,7 +107,7 @@
 					font-size: 10px;
 					text-transform: uppercase;
 					padding: 2px 5px;
-					border-radius: 6px;
+					border-radius: 2px;
 					text-align: center;
 					max-width: 85px;
 				}


### PR DESCRIPTION
It had a null property access on `release.noteText`, but I streamlined/deduped a few calculations. The diff is kind of ugly, sorry. I also changed the border-radius on the little VIEWING/LATEST things 'cause I couldn't resist :^)

_Test plan:_
I ran `PUBPUB_PRODUCTION=true PUBPUB_LOCAL_COMMUNITY=kfg-notes npm start` and then navigated to [an older release of a Pub we spotted issues with in prod](http://localhost:9876/pub/pubpub-roadmap/release/17). I verified that all of the release numbers, dates, and links in the notice and the changelog appear correct.