### PR TITLE
update: More performant Page layout loading

### DIFF
--- a/server/routes/dashboardPage.js
+++ b/server/routes/dashboardPage.js
@@ -15,7 +15,11 @@ app.get(['/dash/pages/:subMode'], async (req, res, next) => {
 		}
 		const initialData = await getInitialData(req, true);
 		const pageSlug = req.params.subMode === 'home' ? '' : req.params.subMode;
-		const pageData = await getPage({ slug: pageSlug }, initialData);
+		const pageData = await getPage({
+			query: { slug: pageSlug },
+			forLayoutEditor: true,
+			initialData: initialData,
+		});
 		return renderToNodeStream(
 			res,
 			<Html

--- a/server/routes/page.js
+++ b/server/routes/page.js
@@ -28,7 +28,7 @@ app.get(['/', '/:slug'], async (req, res, next) => {
 		if (!pageId) {
 			throw new Error('Page Not Found');
 		}
-		const pageData = await getPage({ id: pageId }, initialData);
+		const pageData = await getPage({ query: { id: pageId }, initialData: initialData });
 		const pageTitle = !pageData.slug
 			? initialData.communityData.title
 			: `${pageData.title} · ${initialData.communityData.title}`;

--- a/server/utils/queryHelpers/layout.js
+++ b/server/utils/queryHelpers/layout.js
@@ -1,0 +1,118 @@
+import { Op } from 'sequelize';
+
+import { CollectionPub, Pub } from 'server/models';
+import { issueCreatePubToken } from 'server/pub/tokens';
+
+import buildPubOptions from './pubOptions';
+import sanitizePub from './pubSanitize';
+
+const getPubIdWhereQueryForCollectionIds = async (collectionIds) => {
+	if (collectionIds && collectionIds.length > 0) {
+		const collectionPubs = await CollectionPub.findAll({
+			where: {
+				collectionId: {
+					[Op.in]: collectionIds,
+				},
+			},
+		});
+		return {
+			[Op.in]: collectionPubs.map((collectionPub) => collectionPub.pubId),
+		};
+	}
+	return null;
+};
+
+const getPubsForLayoutBlock = async (blockContent, initialData) => {
+	const {
+		communityData: { id: communityId },
+	} = initialData;
+	const { limit, collectionIds, pubIds } = blockContent;
+
+	const sharedOptions = {
+		...buildPubOptions({
+			isPreview: true,
+			getMembers: true,
+			getCollections: true,
+		}),
+		...(limit && { limit: limit }),
+	};
+
+	const [pubsInPubIds, otherPubs] = await Promise.all([
+		Pub.findAll({
+			where: { communityId: communityId, id: { [Op.in]: pubIds } },
+			...(limit && { limit: limit }),
+			...sharedOptions,
+		}),
+		Pub.findAll({
+			where: {
+				communityId: communityId,
+				id: {
+					[Op.notIn]: pubIds,
+					...(await getPubIdWhereQueryForCollectionIds(collectionIds)),
+				},
+			},
+			order: [['createdAt', 'DESC']],
+			...sharedOptions,
+		}),
+	]);
+
+	const sanitizedPubs = [...pubsInPubIds, ...otherPubs]
+		.map((pub) => sanitizePub(pub.toJSON(), initialData))
+		.filter((pub) => !!pub);
+
+	if (limit) {
+		return sanitizedPubs.slice(0, limit);
+	}
+	return sanitizedPubs;
+};
+
+export const getPubsForLayout = async (layoutBlocks, forLayoutEditor, initialData) => {
+	if (forLayoutEditor) {
+		const pubs = await Pub.findAll({
+			where: { communityId: initialData.communityData.id },
+			...buildPubOptions({ isPreview: true, getMembers: true, getCollections: true }),
+		});
+		return pubs.map((pub) => sanitizePub(pub.toJSON(), initialData)).filter((pub) => !!pub);
+	}
+
+	const pubsPerBlock = await Promise.all(
+		(layoutBlocks || [])
+			.filter((block) => block.type === 'pubs')
+			.map((block) => getPubsForLayoutBlock(block.content, initialData)),
+	);
+	return pubsPerBlock.reduce(
+		(acc, next) => [
+			...acc,
+			...next.filter((nextPub) => !acc.some((accPub) => accPub.id === nextPub.id)),
+		],
+		[],
+	);
+};
+
+export const enrichLayoutWithPubTokens = (layoutBlocks, initialData) => {
+	const { loginData, communityData } = initialData;
+	const userId = loginData && loginData.id;
+	if (layoutBlocks && userId) {
+		return layoutBlocks.map((block) => {
+			const { type, content } = block;
+			if (type === 'banner') {
+				const { buttonType, defaultCollectionIds } = content;
+				if (buttonType === 'create-pub') {
+					return {
+						...block,
+						content: {
+							...content,
+							createPubToken: issueCreatePubToken({
+								userId: userId,
+								communityId: communityData.id,
+								createInCollectionIds: defaultCollectionIds,
+							}),
+						},
+					};
+				}
+			}
+			return block;
+		});
+	}
+	return layoutBlocks;
+};

--- a/server/utils/queryHelpers/pageGet.js
+++ b/server/utils/queryHelpers/pageGet.js
@@ -1,130 +1,16 @@
-import { Op } from 'sequelize';
+import { Page } from 'server/models';
 
-import { CollectionPub, Pub, Page } from 'server/models';
-import { issueCreatePubToken } from 'server/pub/tokens';
+import { enrichLayoutWithPubTokens, getPubsForLayout } from './layout';
 
-import buildPubOptions from './pubOptions';
-import sanitizePub from './pubSanitize';
-
-const getPubIdWhereQueryForCollectionIds = async (collectionIds) => {
-	if (collectionIds && collectionIds.length > 0) {
-		const collectionPubs = await CollectionPub.findAll({
-			where: {
-				collectionId: {
-					[Op.in]: collectionIds,
-				},
-			},
-		});
-		return {
-			[Op.in]: collectionPubs.map((collectionPub) => collectionPub.pubId),
-		};
-	}
-	return null;
-};
-
-const getPubsForPageBlock = async (blockContent, initialData) => {
-	const {
-		communityData: { id: communityId },
-	} = initialData;
-	const { limit, collectionIds, pubIds } = blockContent;
-
-	const sharedOptions = {
-		...buildPubOptions({
-			isPreview: true,
-			getMembers: true,
-			getCollections: true,
-		}),
-		...(limit && { limit: limit }),
-	};
-
-	const [pubsInPubIds, otherPubs] = await Promise.all([
-		Pub.findAll({
-			where: { communityId: communityId, id: { [Op.in]: pubIds } },
-			...(limit && { limit: limit }),
-			...sharedOptions,
-		}),
-		Pub.findAll({
-			where: {
-				communityId: communityId,
-				id: {
-					[Op.notIn]: pubIds,
-					...(await getPubIdWhereQueryForCollectionIds(collectionIds)),
-				},
-			},
-			order: [['createdAt', 'DESC']],
-			...sharedOptions,
-		}),
-	]);
-
-	const sanitizedPubs = [...pubsInPubIds, ...otherPubs]
-		.map((pub) => sanitizePub(pub.toJSON(), initialData))
-		.filter((pub) => !!pub);
-
-	if (limit) {
-		return sanitizedPubs.slice(0, limit);
-	}
-	return sanitizedPubs;
-};
-
-const getPubsForPageLayout = async (layout, initialData) => {
-	const {
-		communityData: { subdomain: communitySubdomain },
-	} = initialData;
-
-	// TODO(ian): Remove this once we're sure that the less aggressive query works everywhere.
-	if (communitySubdomain !== 'baas') {
-		const pubs = await Pub.findAll({
-			where: { communityId: initialData.communityData.id },
-			...buildPubOptions({ isPreview: true, getMembers: true, getCollections: true }),
-		});
-		return pubs.map((pub) => sanitizePub(pub.toJSON(), initialData)).filter((pub) => !!pub);
-	}
-
-	const pubsPerBlock = await Promise.all(
-		(layout || [])
-			.filter((block) => block.type === 'pubs')
-			.map((block) => getPubsForPageBlock(block.content, initialData)),
-	);
-	return pubsPerBlock.reduce((acc, next) => [...acc, ...next], []);
-};
-
-const enrichLayoutWithPubTokens = (layout, initialData) => {
-	const { loginData, communityData } = initialData;
-	const userId = loginData && loginData.id;
-	if (layout && userId) {
-		return layout.map((block) => {
-			const { type, content } = block;
-			if (type === 'banner') {
-				const { buttonType, defaultCollectionIds } = content;
-				if (buttonType === 'create-pub') {
-					return {
-						...block,
-						content: {
-							...content,
-							createPubToken: issueCreatePubToken({
-								userId: userId,
-								communityId: communityData.id,
-								createInCollectionIds: defaultCollectionIds,
-							}),
-						},
-					};
-				}
-			}
-			return block;
-		});
-	}
-	return layout;
-};
-
-export default async (idOrSlugObject, initialData) => {
+export default async ({ query, forLayoutEditor, initialData }) => {
 	const pageData = await Page.findOne({
 		where: {
-			...idOrSlugObject,
+			...query,
 			communityId: initialData.communityData.id,
 		},
 	});
 
-	const pubsData = await getPubsForPageLayout(pageData.layout, initialData);
+	const pubsData = await getPubsForLayout(pageData.layout, forLayoutEditor, initialData);
 
 	return {
 		...pageData.toJSON(),


### PR DESCRIPTION
A few weeks(?) back I wrote a bit of code to do more performant Page loading by only fetching the Pubs that are actually needed to render the Page. Because it was late and I wasn't sure whether the code really worked, I scoped it to a specific community that was suffering from degraded homepage performance due to a large number of Pubs.

This PR enables that code for all communities. It has a few differences:
- Variable names changed to reference "layouts" as a nod to our upcoming Collections work, and Collection-Page layout functionality broken into a new `layout.js` in `queryHelpers`
- A few bugs are fixed: the Page editor will still load all Pubs in a community (as it must) and we will never send more than one copy of a Pub down to the client.

_Test plan:_
Create [a Page](https://demo.duqduq.org/blox) with two different Page blocks each referencing a different Collection. The Collections should share at least one Pub. Verify that:
- All required Pubs load
- No Pub is ever shown twice
- Unreleased Pubs are not visible when logged out

Then, visit the Dashboard layout editor for the Page and verify that _all_ Pubs in the Community are still visible there.
