### PR TITLE
feature: Allow adding Collections to Community nav

### DIFF
--- a/client/components/NavBar/NavBar.tsx
+++ b/client/components/NavBar/NavBar.tsx
@@ -22,7 +22,7 @@ const defaultProps = {
 	previewContext: undefined,
 };
 
-const NavBar = function (props) {
+const NavBar = function(props) {
 	const { communityData } = usePageContext(props.previewContext);
 	const { pages = [], collections = [], navigation = [] } = communityData;
 	const navItems = getNavItemsForCommunityNavigation({

--- a/client/containers/DashboardSettings/CommunitySettings.tsx
+++ b/client/containers/DashboardSettings/CommunitySettings.tsx
@@ -171,7 +171,7 @@ const CommunitySettings = () => {
 			});
 	};
 
-	const pages = activeCommunity.pages || [];
+	const { pages = [], collections = [] } = activeCommunity;
 	const activeHeroTextColor = heroTextColor || '#FFFFFF';
 
 	return (
@@ -430,9 +430,9 @@ const CommunitySettings = () => {
 					<InputField label="Navigation">
 						<NavBuilder
 							initialNav={activeCommunity.navigation}
-							// @ts-expect-error ts-migrate(2322) FIXME: Type 'any' is not assignable to type 'never'.
 							prefix={[activeCommunity.navigation[0]]}
 							pages={pages}
+							collections={collections}
 							onChange={(val) => {
 								setNavigation(val);
 							}}
@@ -800,9 +800,9 @@ const CommunitySettings = () => {
 				<InputField label="Footer Links">
 					<NavBuilder
 						initialNav={activeCommunity.footerLinks || defaultFooterLinks}
-						// @ts-expect-error ts-migrate(2322) FIXME: Type '{ id: string; title: string; href: string; }... Remove this comment to see the full error message
 						suffix={defaultFooterLinks}
 						pages={pages}
+						collections={collections}
 						onChange={(val) => {
 							setFooterLinks(val);
 						}}

--- a/client/containers/DashboardSettings/NavBuilder.tsx
+++ b/client/containers/DashboardSettings/NavBuilder.tsx
@@ -3,7 +3,7 @@ import { DragDropContext } from 'react-beautiful-dnd';
 import { Button } from '@blueprintjs/core';
 
 import { generateHash } from 'utils/hashes';
-import { CommunityNavigationEntry } from 'client/utils/navigation';
+import { CommunityNavigationEntry, isCommunityNavigationMenu } from 'client/utils/navigation';
 
 import PageCollectionAutocomplete from './PageCollectionAutocomplete';
 import NavBuilderList from './NavBuilderList';
@@ -49,8 +49,7 @@ const NavBuilder = (props: Props) => {
 					? reorder(userSetElements, result.source.index, result.destination.index)
 					: userSetElements.map((item) => {
 							if (
-								typeof item === 'object' &&
-								'children' in item &&
+								isCommunityNavigationMenu(item) &&
 								item.id === result.destination.droppableId
 							) {
 								return {

--- a/client/containers/DashboardSettings/NavBuilder.tsx
+++ b/client/containers/DashboardSettings/NavBuilder.tsx
@@ -3,49 +3,56 @@ import { DragDropContext } from 'react-beautiful-dnd';
 import { Button } from '@blueprintjs/core';
 
 import { generateHash } from 'utils/hashes';
+import { CommunityNavigationEntry } from 'client/utils/navigation';
 
-import PageAutocomplete from './PageAutocomplete';
+import PageCollectionAutocomplete from './PageCollectionAutocomplete';
 import NavBuilderList from './NavBuilderList';
 import NavBuilderRow from './NavBuilderRow';
+import { NavBuilderContext } from './navBuilderContext';
 
 require('./navBuilder.scss');
 
-type OwnProps = {
-	initialNav: any[];
-	prefix?: any[];
-	suffix?: any[];
+type Props = {
+	initialNav: CommunityNavgiationEntry[];
+	prefix?: CommunityNavigationEntry[];
+	suffix?: CommunityNavigationEntry[];
 	pages: any[];
+	collections: any[];
 	onChange: (...args: any[]) => any;
 	disableDropdown?: boolean;
 };
 
-const defaultProps = {
-	prefix: [],
-	suffix: [],
-	disableDropdown: false,
-};
-
-type Props = OwnProps & typeof defaultProps;
-
 const NavBuilder = (props: Props) => {
-	const { initialNav, pages, onChange, prefix, suffix, disableDropdown } = props;
-	const [currentNav, setCurrentNav] = useState(initialNav);
+	const {
+		initialNav,
+		pages,
+		collections,
+		onChange,
+		prefix = [],
+		suffix = [],
+		disableDropdown = false,
+	} = props;
+	const [currentNav, setCurrentNav] = useState<CommunityNavigationEntry[]>(initialNav);
 	const userSetElements = currentNav.slice(prefix.length, currentNav.length - suffix.length);
 
-	const reorder = (list, startIndex, endIndex) => {
+	const reorder = (list: CommunityNavigationEntry[], startIndex: number, endIndex: number) => {
 		const result = Array.from(list);
 		const [removed] = result.splice(startIndex, 1);
 		result.splice(endIndex, 0, removed);
-
 		return result;
 	};
+
 	const onDragEnd = (result) => {
 		if (result.destination) {
 			const nextUserElements =
 				result.destination.droppableId === 'main-list'
 					? reorder(userSetElements, result.source.index, result.destination.index)
 					: userSetElements.map((item) => {
-							if (item.id === result.destination.droppableId) {
+							if (
+								typeof item === 'object' &&
+								'children' in item &&
+								item.id === result.destination.droppableId
+							) {
 								return {
 									...item,
 									children: reorder(
@@ -53,7 +60,7 @@ const NavBuilder = (props: Props) => {
 										result.source.index,
 										result.destination.index,
 									),
-								};
+								} as CommunityNavigationEntry;
 							}
 							return item;
 					  });
@@ -62,24 +69,29 @@ const NavBuilder = (props: Props) => {
 			onChange(newNav);
 		}
 	};
-	const addItem = (newItem) => {
+
+	const addItem = (newItem: CommunityNavigationEntry) => {
 		const newNav = [...prefix, newItem, ...userSetElements, ...suffix];
 		setCurrentNav(newNav);
 		onChange(newNav);
 	};
-	const updateItem = (dropdownId, index, newItemValues) => {
+
+	const updateItem = (dropdownId, index, newItemValues: Partial<CommunityNavigationEntry>) => {
+		// TODO(ian): Remove this cast after completing migration
+		const newItemValuesObject = newItemValues as {};
 		const nextUserElements =
+			// TODO(ian): Remove these any casts after completing migration
 			dropdownId === 'main-list'
-				? userSetElements.map((item, currIndex) => {
-						return currIndex === index ? { ...item, ...newItemValues } : item;
+				? userSetElements.map((item: any, currIndex) => {
+						return currIndex === index ? { ...item, ...newItemValuesObject } : item;
 				  })
-				: userSetElements.map((item) => {
+				: userSetElements.map((item: any) => {
 						if (item.id === dropdownId) {
 							return {
 								...item,
 								children: item.children.map((subItem, subCurrIndex) => {
 									return subCurrIndex === index
-										? { ...subItem, ...newItemValues }
+										? { ...subItem, ...newItemValuesObject }
 										: subItem;
 								}),
 							};
@@ -90,13 +102,13 @@ const NavBuilder = (props: Props) => {
 		setCurrentNav(newNav);
 		onChange(newNav);
 	};
+
 	const removeItem = (itemId, dropdownId) => {
 		const nextUserElements =
+			// TODO(ian): Remove these any casts after completing migration
 			dropdownId === 'main-list'
-				? userSetElements.filter((item) => {
-						return item.id !== itemId && item !== itemId;
-				  })
-				: userSetElements.map((item) => {
+				? userSetElements.filter((item: any) => item.id !== itemId && item !== itemId)
+				: userSetElements.map((item: any) => {
 						if (item.id === dropdownId) {
 							return {
 								...item,
@@ -114,20 +126,33 @@ const NavBuilder = (props: Props) => {
 
 	const newLink = { id: generateHash(8), title: 'Link Title', href: '' };
 	const newDropdown = { id: generateHash(8), title: 'Menu Title', children: [] };
+
 	return (
 		<div className="nav-builder-component">
 			<style>{`body { height: 100vh; overflow: scroll }`}</style>
 			<div className="new-items">
-				<PageAutocomplete
-					pages={pages}
+				<PageCollectionAutocomplete
+					items={pages}
 					placeholder="Add Page"
-					// @ts-expect-error ts-migrate(2322) FIXME: Type 'any' is not assignable to type 'never'.
-					usedItems={pages.filter((item) => {
-						return currentNav.includes(item.id);
-					})}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type '(newItem: any) => void' is not assignable to... Remove this comment to see the full error message
-					onSelect={(newItem) => {
-						addItem(newItem.id);
+					usedItems={pages.filter((page) =>
+						// TODO(ian): Remove these any casts after completing migration
+						currentNav.some(
+							(current: any) => current === page.id || current.id === page.id,
+						),
+					)}
+					onSelect={(page) => {
+						addItem({ type: 'page', id: page.id });
+					}}
+				/>
+				<PageCollectionAutocomplete
+					items={collections}
+					placeholder="Add Collection"
+					usedItems={collections.filter((collection) =>
+						// TODO(ian): Remove these any casts after completing migration
+						currentNav.some((current: any) => current.id === collection.id),
+					)}
+					onSelect={(collection) => {
+						addItem({ type: 'collection', id: collection.id });
 					}}
 				/>
 				<Button
@@ -148,39 +173,49 @@ const NavBuilder = (props: Props) => {
 				)}
 			</div>
 			<DragDropContext onDragEnd={onDragEnd}>
-				<div className="items">
-					{prefix.map((item, index) => {
-						const key = `prefix-${index}`;
-						/* Use wrapper div to get margin-collapse styling right */
-						return (
-							<div key={key} className="nav-builder-row">
-								<NavBuilderRow item={item} pages={pages} isStatic={true} />
-							</div>
-						);
-					})}
-					<NavBuilderList
-						id="main-list"
-						// @ts-expect-error ts-migrate(2322) FIXME: Type 'any[]' is not assignable to type 'never[]'.
-						items={userSetElements}
-						removeItem={removeItem}
-						updateItem={updateItem}
-						pages={pages}
-						newLink={newLink}
-						disableDropdown={disableDropdown}
-					/>
-					{suffix.map((item, index) => {
-						const key = `suffix-${index}`;
-						/* Use wrapper div to get margin-collapse styling right */
-						return (
-							<div key={key} className="nav-builder-row">
-								<NavBuilderRow item={item} pages={pages} isStatic={true} />
-							</div>
-						);
-					})}
-				</div>
+				<NavBuilderContext.Provider
+					value={{
+						removeItem: removeItem,
+						updateItem: updateItem,
+						pages: pages,
+						collections: collections,
+					}}
+				>
+					<div className="items">
+						{prefix.map((item, index) => {
+							const key = `prefix-${index}`;
+							/* Use wrapper div to get margin-collapse styling right */
+							return (
+								<div key={key} className="nav-builder-row">
+									<NavBuilderRow
+										item={item}
+										isStatic={true}
+										dropdownId="main-list"
+										index={-1}
+									/>
+								</div>
+							);
+						})}
+						<NavBuilderList id="main-list" items={userSetElements} newLink={newLink} />
+						{suffix.map((item, index) => {
+							const key = `suffix-${index}`;
+							/* Use wrapper div to get margin-collapse styling right */
+							return (
+								<div key={key} className="nav-builder-row">
+									<NavBuilderRow
+										item={item}
+										isStatic={true}
+										dropdownId="main-list"
+										index={-1}
+									/>
+								</div>
+							);
+						})}
+					</div>
+				</NavBuilderContext.Provider>
 			</DragDropContext>
 		</div>
 	);
 };
-NavBuilder.defaultProps = defaultProps;
+
 export default NavBuilder;

--- a/client/containers/DashboardSettings/NavBuilderList.tsx
+++ b/client/containers/DashboardSettings/NavBuilderList.tsx
@@ -1,26 +1,23 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Droppable, Draggable } from 'react-beautiful-dnd';
 import { Button } from '@blueprintjs/core';
+
 import Icon from 'components/Icon/Icon';
+
+import { CommunityNavigationEntry } from 'client/utils/navigation';
+
+import { NavBuilderContext } from './navBuilderContext';
 import NavBuilderRow from './NavBuilderRow';
 
-type OwnProps = {
+type Props = {
 	id: string;
-	items?: any[];
-	removeItem: (...args: any[]) => any;
-	updateItem: (...args: any[]) => any;
-	pages: any[];
+	items?: CommunityNavigationEntry[];
 	newLink: any;
 };
 
-const defaultProps = {
-	items: [],
-};
-
-type Props = OwnProps & typeof defaultProps;
-
 const NavBuilderList = (props: Props) => {
-	const { id, items, updateItem, pages, newLink, removeItem } = props;
+	const { id, items = [], newLink } = props;
+	const { removeItem } = useContext(NavBuilderContext);
 
 	return (
 		<Droppable droppableId={id} type={id}>
@@ -57,25 +54,17 @@ const NavBuilderList = (props: Props) => {
 												/>
 											</span>
 											<NavBuilderRow
-												// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'undefined... Remove this comment to see the full error message
 												dropdownId={id}
-												// @ts-expect-error ts-migrate(2322) FIXME: Type 'number' is not assignable to type 'undefined... Remove this comment to see the full error message
 												index={index}
 												item={item}
-												removeItem={removeItem}
-												updateItem={updateItem}
-												pages={pages}
 												newLink={newLink}
-												// @ts-expect-error ts-migrate(2322) FIXME: Type '{ (props: Props): JSX.Element; defaultProps:... Remove this comment to see the full error message
 												NavBuilderList={NavBuilderList}
 											/>
 											<Button
 												icon="small-cross"
 												minimal
 												small
-												onClick={() => {
-													removeItem(itemId, id);
-												}}
+												onClick={() => removeItem(itemId, id)}
 											/>
 										</div>
 									</div>
@@ -89,5 +78,5 @@ const NavBuilderList = (props: Props) => {
 		</Droppable>
 	);
 };
-NavBuilderList.defaultProps = defaultProps;
+
 export default NavBuilderList;

--- a/client/containers/DashboardSettings/NavBuilderRow.tsx
+++ b/client/containers/DashboardSettings/NavBuilderRow.tsx
@@ -1,123 +1,164 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import classNames from 'classnames';
 import { Button, InputGroup } from '@blueprintjs/core';
-import PageAutocomplete from './PageAutocomplete';
 
-type OwnProps = {
-	dropdownId?: string;
-	index?: number;
-	item: string | any;
-	updateItem?: (...args: any[]) => any;
-	removeItem?: (...args: any[]) => any;
-	pages: any[];
+import { Icon } from 'components';
+import { getSchemaForKind } from 'utils/collections/schemas';
+import { CommunityNavigationEntry } from 'client/utils/navigation';
+
+import PageCollectionAutocomplete from './PageCollectionAutocomplete';
+import { NavBuilderContext } from './navBuilderContext';
+
+type Props = {
+	dropdownId: string;
+	index: number;
+	item: CommunityNavigationEntry;
 	newLink?: any;
 	isStatic?: boolean;
 	NavBuilderList?: (...args: any[]) => any;
 };
 
-const defaultProps = {
-	dropdownId: undefined,
-	NavBuilderList: undefined,
-	isStatic: false,
-	newLink: undefined,
-	updateItem: () => {},
-	removeItem: () => {},
-	index: undefined,
-};
-
-type Props = OwnProps & typeof defaultProps;
-
 const NavBuilderRow = (props: Props) => {
-	const {
-		dropdownId,
-		NavBuilderList,
-		index,
-		item,
-		pages,
-		updateItem,
-		removeItem,
-		newLink,
-		isStatic,
-	} = props;
-	const data = typeof item === 'string' ? pages.find((page) => page.id === item) : item;
-	if (!data) {
-		return null;
-	}
-	let type = 'page';
-	if (typeof data.href === 'string' && !isStatic) {
-		type = 'link';
-	}
-	if (data.children) {
-		type = 'dropdown';
-	}
+	const { dropdownId, NavBuilderList, index, item, newLink, isStatic = false } = props;
+	const { updateItem, pages, collections } = useContext(NavBuilderContext);
 
-	return (
-		<div className={classNames({ 'nav-builder-row-component': true, static: isStatic })}>
-			<div className="top">
-				{type === 'page' && <div className="nav-title">{data.title}</div>}
-				{type !== 'page' && (
+	const renderForPageOrCollection = (title: string, icon: null | string) => {
+		return (
+			<>
+				{icon && <Icon icon={icon} />}
+				{title}
+			</>
+		);
+	};
+
+	const renderEditableTitle = (title: string) => {
+		return (
+			<InputGroup
+				small
+				placeholder="Title"
+				onChange={(evt) => {
+					updateItem(dropdownId, index, { title: evt.target.value });
+				}}
+				value={title}
+			/>
+		);
+	};
+
+	const renderTop = () => {
+		// TODO(ian): Remove this branch after migration
+		if (typeof item === 'string') {
+			const page = pages.find((pg) => pg.id === item);
+			if (page) {
+				return renderForPageOrCollection(page.title, 'page-layout');
+			}
+			return null;
+		}
+		if ('type' in item) {
+			if (item.type === 'collection') {
+				const collection = collections.find((c) => c.id === item.id);
+				if (collection) {
+					const schema = getSchemaForKind(collection.kind);
+					return renderForPageOrCollection(
+						collection.title,
+						schema && schema.bpDisplayIcon,
+					);
+				}
+			} else if (item.type === 'page') {
+				const page = pages.find((pg) => pg.id === item.id);
+				if (page) {
+					return renderForPageOrCollection(page.title, 'page-layout');
+				}
+			}
+			return null;
+		}
+		if ('href' in item) {
+			return (
+				<>
+					<Icon icon="link" />
+					{renderEditableTitle(item.title)}
 					<InputGroup
 						small
-						placeholder="Title"
-						onChange={(evt) => {
-							updateItem(dropdownId, index, { title: evt.target.value });
-						}}
-						value={data.title}
-					/>
-				)}
-				{type === 'link' && (
-					<InputGroup
-						small
+						className="href-input"
 						placeholder="https://www.example.com"
 						onChange={(evt) => {
 							updateItem(dropdownId, index, { href: evt.target.value });
 						}}
-						value={data.href}
+						value={item.href}
 					/>
-				)}
-				{type === 'dropdown' && (
-					<React.Fragment>
-						<PageAutocomplete
-							pages={pages}
-							placeholder="Add Page"
-							// @ts-expect-error ts-migrate(2322) FIXME: Type 'any' is not assignable to type 'never'.
-							usedItems={pages.filter((page) => {
-								return data.children.includes(page.id);
-							})}
-							// @ts-expect-error ts-migrate(2322) FIXME: Type '(newItem: any) => void' is not assignable to... Remove this comment to see the full error message
-							onSelect={(newItem) => {
-								updateItem(dropdownId, index, {
-									children: [newItem.id, ...item.children],
-								});
-							}}
-						/>
-						<Button
-							small
-							text="Add Link"
-							onClick={() => {
-								updateItem(dropdownId, index, {
-									children: [newLink, ...item.children],
-								});
-							}}
-						/>
-					</React.Fragment>
-				)}
-			</div>
-			{type === 'dropdown' && (
+				</>
+			);
+		}
+		if ('children' in item) {
+			return (
+				<>
+					<PageCollectionAutocomplete
+						items={pages}
+						placeholder="Add Page"
+						usedItems={pages.filter((page) =>
+							// TODO(ian): Remove these any casts after completing migration
+							item.children.some(
+								(current: any) => current === page.id || current.id === page.id,
+							),
+						)}
+						onSelect={(page) => {
+							const newItem = { type: 'page' as const, id: page.id };
+							updateItem(dropdownId, index, {
+								children: [newItem, ...item.children],
+							});
+						}}
+					/>
+					<PageCollectionAutocomplete
+						items={collections}
+						placeholder="Add Collection"
+						usedItems={collections.filter((collection) =>
+							// TODO(ian): Remove these any casts after completing migration
+							item.children.some((current: any) => current.id === collection.id),
+						)}
+						onSelect={(collection) => {
+							const newItem = { type: 'collection' as const, id: collection.id };
+							updateItem(dropdownId, index, {
+								children: [newItem, ...item.children],
+							});
+						}}
+					/>
+					<Button
+						small
+						text="Add Link"
+						onClick={() => {
+							updateItem(dropdownId, index, {
+								children: [newLink, ...item.children],
+							});
+						}}
+					/>
+				</>
+			);
+		}
+		return null;
+	};
+
+	const renderChildren = () => {
+		if (typeof item === 'object' && 'children' in item) {
+			return (
 				<div className="children">
 					{/* @ts-expect-error ts-migrate(2604) FIXME: JSX element type 'NavBuilderList' does not have an... Remove this comment to see the full error message */}
 					<NavBuilderList
 						id={item.id}
 						items={item.children}
-						removeItem={removeItem}
-						updateItem={updateItem}
 						pages={pages}
 						newLink={newLink}
 					/>
 				</div>
-			)}
+			);
+		}
+		return null;
+	};
+
+	return (
+		<div className={classNames({ 'nav-builder-row-component': true, static: isStatic })}>
+			<div className="top">{renderTop()}</div>
+			{renderChildren()}
 		</div>
 	);
 };
-NavBuilderRow.defaultProps = defaultProps;
+
 export default NavBuilderRow;

--- a/client/containers/DashboardSettings/NavBuilderRow.tsx
+++ b/client/containers/DashboardSettings/NavBuilderRow.tsx
@@ -4,7 +4,7 @@ import { Button, InputGroup } from '@blueprintjs/core';
 
 import { Icon } from 'components';
 import { getSchemaForKind } from 'utils/collections/schemas';
-import { CommunityNavigationEntry } from 'client/utils/navigation';
+import { CommunityNavigationEntry, isCommunityNavigationMenu } from 'client/utils/navigation';
 
 import PageCollectionAutocomplete from './PageCollectionAutocomplete';
 import { NavBuilderContext } from './navBuilderContext';
@@ -88,7 +88,7 @@ const NavBuilderRow = (props: Props) => {
 				</>
 			);
 		}
-		if ('children' in item) {
+		if (isCommunityNavigationMenu(item)) {
 			return (
 				<>
 					<PageCollectionAutocomplete
@@ -137,7 +137,7 @@ const NavBuilderRow = (props: Props) => {
 	};
 
 	const renderChildren = () => {
-		if (typeof item === 'object' && 'children' in item) {
+		if (isCommunityNavigationMenu(item)) {
 			return (
 				<div className="children">
 					{/* @ts-expect-error ts-migrate(2604) FIXME: JSX element type 'NavBuilderList' does not have an... Remove this comment to see the full error message */}

--- a/client/containers/DashboardSettings/navBuilder.scss
+++ b/client/containers/DashboardSettings/navBuilder.scss
@@ -2,23 +2,24 @@
     .new-items {
         padding: 10px;
         outline: 1px dashed #666;
-        margin: 1em 0em;
+        margin: 1em 0;
         background: #f7f7f9;
-        .page-autocomplete-component {
-            display: inline-block;
-            width: 200px;
-            margin-right: 2em;
-            .bp3-popover-target .bp3-icon {
-                opacity: 0.5;
-                margin-left: 7px;
-                font-size: 14px;
-                padding-top: 2px;
-            }
-        }
-        button {
-            margin-right: 2em;
+        & > * {
+            margin-right: 10px;
         }
     }
+
+    .page-autocomplete-component {
+        display: inline-block;
+        width: 200px;
+        .bp3-popover-target .bp3-icon {
+            opacity: 0.5;
+            margin-left: 7px;
+            font-size: 14px;
+            padding-top: 2px;
+        }
+    }
+
     .nav-builder-row {
         padding: 0.5em 0em;
 
@@ -43,20 +44,24 @@
         }
         .top {
             display: flex;
+            align-items: center;
             line-height: 22px;
             & > * {
-                margin-right: 1em;
+                margin-right: 10px;
             }
+        }
+        .href-input {
+            flex-grow: 1;
         }
         .children {
             padding-left: 30px;
         }
     }
+
     .nav-builder-row-component {
         flex: 1 1 auto;
         &.static {
             padding: calc(8px) calc(34px + 0.5em);
-            // margin: 0.5em 0em;
             box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
         }
     }

--- a/client/containers/DashboardSettings/navBuilderContext.ts
+++ b/client/containers/DashboardSettings/navBuilderContext.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { Collection, Page, CommunityNavigationEntry } from 'client/utils/navigation';
+
+type NavBuilderContext = {
+	pages: Page[];
+	collections: Collection[];
+	updateItem: (
+		dropdownId: string,
+		index: number,
+		update: Partial<CommunityNavigationEntry>,
+	) => any;
+	removeItem: (itemId: string, dropdownId: string) => any;
+};
+
+export const NavBuilderContext = React.createContext<NavBuilderContext>({} as NavBuilderContext);

--- a/client/utils/__tests__/navigation.test.ts
+++ b/client/utils/__tests__/navigation.test.ts
@@ -8,9 +8,27 @@ const pages = [
 ];
 
 const collections = [
-	{ title: 'Collection One', slug: 'collection1', id: 'collection-id-1', isPublic: true },
-	{ title: 'Collection Two', slug: 'collection2', id: 'collection-id-2', isPublic: true },
-	{ title: 'Collection Three', slug: 'collection3', id: 'collection-id-3', isPublic: false },
+	{
+		title: 'Collection One',
+		slug: 'collection1',
+		id: 'collection-id-1',
+		isPublic: true,
+		kind: 'book',
+	},
+	{
+		title: 'Collection Two',
+		slug: 'collection2',
+		id: 'collection-id-2',
+		isPublic: true,
+		kind: 'tag',
+	},
+	{
+		title: 'Collection Three',
+		slug: 'collection3',
+		id: 'collection-id-3',
+		isPublic: false,
+		kind: 'issue',
+	},
 ];
 
 describe('getNavItemsForCommunityNavigation', () => {

--- a/client/utils/navigation.ts
+++ b/client/utils/navigation.ts
@@ -5,14 +5,15 @@ type Community = {
 	twitter: string;
 };
 
-type Collection = {
+export type Collection = {
 	id: string;
 	title: string;
 	slug: string;
+	kind: string;
 	isPublic: boolean;
 };
 
-type Page = {
+export type Page = {
 	id: string;
 	title: string;
 	slug: string;
@@ -29,7 +30,7 @@ type CommunityNavigationChild =
 	| { id: string; type: 'page' | 'collection' }
 	| { id: string; title: string; href: string };
 
-type CommunityNavigationEntry =
+export type CommunityNavigationEntry =
 	| CommunityNavigationChild
 	| { id: string; title: string; children: CommunityNavigationChild[] };
 

--- a/client/utils/navigation.ts
+++ b/client/utils/navigation.ts
@@ -25,14 +25,16 @@ type NavBuildContext = {
 	collections: Collection[];
 };
 
+type CommunityNavigationMenu = { id: string; title: string; children: CommunityNavigationChild[] };
 type CommunityNavigationChild =
 	| string // TODO(ian): We should be able to remove this after late-2020 nav refactor
 	| { id: string; type: 'page' | 'collection' }
 	| { id: string; title: string; href: string };
 
-export type CommunityNavigationEntry =
-	| CommunityNavigationChild
-	| { id: string; title: string; children: CommunityNavigationChild[] };
+export type CommunityNavigationEntry = CommunityNavigationChild | CommunityNavigationMenu;
+export const isCommunityNavigationMenu = (
+	item: CommunityNavigationEntry,
+): item is CommunityNavigationMenu => typeof item === 'object' && 'children' in item;
 
 type NavbarChild = {
 	title: string;
@@ -44,7 +46,6 @@ type NavbarChild = {
 
 export type NavbarMenu = { title: string; id: string; children: NavbarChild[] };
 export type NavbarItem = NavbarChild | NavbarMenu;
-
 export const isNavbarMenu = (item: NavbarItem): item is NavbarMenu => 'children' in item;
 
 export const defaultFooterLinks: CommunityNavigationEntry[] = [
@@ -132,7 +133,7 @@ const getNavbarItemForCommunityNavigationEntry = (
 	navEntry: CommunityNavigationEntry,
 	ctx: NavBuildContext,
 ): null | NavbarItem => {
-	if (typeof navEntry === 'object' && 'children' in navEntry) {
+	if (isCommunityNavigationMenu(navEntry)) {
 		const { title, children, id } = navEntry;
 		return {
 			title: title,

--- a/server/community/queries.js
+++ b/server/community/queries.js
@@ -55,7 +55,7 @@ export const createCommunity = (inputValues, userData, alertAndSubscribe = true)
 				heroText: description,
 				accentColorLight: inputValues.accentColorLight,
 				accentColorDark: inputValues.accentColorDark,
-				navigation: [homePageId],
+				navigation: [{ type: 'page', id: homePageId }],
 				hideCreatePubButton: true,
 			});
 		})

--- a/server/page/queries.js
+++ b/server/page/queries.js
@@ -26,7 +26,7 @@ export const createPage = (inputValues) => {
 			const oldNavigation = communityData.toJSON().navigation;
 			const newNavigationOutput = [
 				oldNavigation[0],
-				newPage.id,
+				{ type: 'page', id: newPage.id },
 				...oldNavigation.slice(1, oldNavigation.length),
 			];
 			const updateCommunity = Community.update(


### PR DESCRIPTION
More progress on #1058 

Since Collections will no longer by represented by linked Pages, we need a way to add them to the Community navigation. This PR does that, with a new "Add Collection" dropdown joining the "Add Page" one.

There are quite a few weird TypeScript casts in here to deal with the fact that a `CommunityNavigationEntry` can be a `string` right now (representing a Page ID). Once I have migrated all of those to objects, we can remove these casts, and I've left some TODOs reminding me where to do that.

![Screen Shot 2020-09-30 at 4 12 20 PM](https://user-images.githubusercontent.com/2208769/94735660-1aa56c00-0339-11eb-8081-ffffe0132289.png)

_Test plan:_
In the demo community, verify that you can add and remove Pages, Collections, links, and submenus without crashing the editor, and that any changes are persisted. Create a new Community and verify that it has a valid `navigation` field.