### PR TITLE
feature: add node label editor; exclude disabled node types from labeling

### DIFF
--- a/client/components/Editor/Editor.tsx
+++ b/client/components/Editor/Editor.tsx
@@ -14,11 +14,12 @@ import { collabDocPluginKey } from './plugins/collaborative';
 import { getChangeObject } from './plugins/onChange';
 import { renderStatic, buildSchema, NodeReference } from './utils';
 import nodeViews from './views';
+import { NodeLabelMap } from './types';
 
 require('./styles/base.scss');
 
 export type EditorProps = {
-	blockNames?: { [key: string]: string };
+	nodeLabels: NodeLabelMap;
 	citationManager?: any;
 	customNodes?: any;
 	customMarks?: any;
@@ -37,7 +38,7 @@ export type EditorProps = {
 };
 
 const defaultProps = {
-	blockNames: {},
+	nodeLabels: {},
 	citationManager: null,
 	collaborativeOptions: {},
 	customMarks: {}, // defaults: 'em', 'strong', 'link', 'sub', 'sup', 'strike', 'code'
@@ -57,7 +58,7 @@ const defaultProps = {
 
 const getInitialArguments = (props) => {
 	const {
-		blockNames,
+		nodeLabels,
 		citationManager,
 		customMarks,
 		customNodes,
@@ -72,7 +73,7 @@ const getInitialArguments = (props) => {
 	const staticContent = renderStatic({
 		schema: schema,
 		doc: props.initialContent,
-		blockNames: blockNames,
+		nodeLabels: nodeLabels,
 		citationManager: citationManager,
 	});
 	return { schema: schema, initialDoc: initialDoc, staticContent: staticContent };
@@ -104,7 +105,6 @@ const Editor = (props: Props) => {
 			doc: initialDoc,
 			schema: schema,
 			plugins: getPlugins(schema, {
-				blockNames: props.blockNames,
 				citationManager: props.citationManager,
 				collaborativeOptions: props.collaborativeOptions,
 				customPlugins: props.customPlugins,
@@ -113,6 +113,7 @@ const Editor = (props: Props) => {
 				onError: props.onError,
 				placeholder: props.placeholder,
 				suggestionManager: suggestionManager,
+				nodeLabels: props.nodeLabels,
 			}),
 		});
 
@@ -192,7 +193,7 @@ const Editor = (props: Props) => {
 					}}
 				>
 					<ReferenceFinder
-						blockNames={props.blockNames}
+						nodeLabels={props.nodeLabels}
 						references={suggesting.items}
 						activeReference={suggestionManager.getSelectedValue()}
 						onReferenceSelect={(reference) => suggestionManager.select(reference)}

--- a/client/components/Editor/Editor.tsx
+++ b/client/components/Editor/Editor.tsx
@@ -195,7 +195,7 @@ const Editor = (props: Props) => {
 					<ReferenceFinder
 						nodeLabels={props.nodeLabels}
 						references={suggesting.items}
-						activeReference={suggestionManager.getSelectedValue()}
+						activeReference={suggestionManager.getSelectedValue() || undefined}
 						onReferenceSelect={(reference) => suggestionManager.select(reference)}
 					/>
 				</div>

--- a/client/components/Editor/ReferenceFinder.tsx
+++ b/client/components/Editor/ReferenceFinder.tsx
@@ -1,23 +1,20 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { Menu, MenuItem } from '@blueprintjs/core';
 
-import SuggestionManager, {
-	SuggestionManagerSuggesting,
-} from 'client/utils/suggestions/suggestionManager';
-
-import { buildLabel, NodeReference } from './utils';
+import { buildLabel, getNodeLabelText, NodeReference } from './utils';
+import { NodeLabelMap } from './types';
 
 require('./referenceFinder.scss');
 
 export type ReferenceFinderProps = {
-	blockNames: { [key: string]: string };
+	nodeLabels: NodeLabelMap;
 	references: ReadonlyArray<NodeReference>;
 	activeReference?: NodeReference;
 	onReferenceSelect: (reference: NodeReference) => unknown;
 };
 
 const ReferenceFinder = (props: ReferenceFinderProps) => {
-	const { blockNames, references, activeReference, onReferenceSelect } = props;
+	const { nodeLabels, references, activeReference, onReferenceSelect } = props;
 	const menuItems = useMemo(
 		() =>
 			references.map((reference) => (
@@ -25,7 +22,7 @@ const ReferenceFinder = (props: ReferenceFinderProps) => {
 					key={reference.node.attrs.id}
 					onClick={() => onReferenceSelect(reference)}
 					icon={reference.icon}
-					text={buildLabel(reference.node, blockNames[reference.node.type.name])}
+					text={buildLabel(reference.node, getNodeLabelText(reference.node, nodeLabels))}
 					active={reference === activeReference}
 				/>
 			)),

--- a/client/components/Editor/plugins/reactive.ts
+++ b/client/components/Editor/plugins/reactive.ts
@@ -4,7 +4,7 @@ export default (schema, props) => {
 	return createReactivePlugin({
 		schema: schema,
 		documentState: {
-			blockNames: props.blockNames,
+			nodeLabels: props.nodeLabels,
 			citationManager: props.citationManager,
 		},
 	});

--- a/client/components/Editor/plugins/suggest.ts
+++ b/client/components/Editor/plugins/suggest.ts
@@ -2,28 +2,34 @@ import { suggest, Suggester } from 'prosemirror-suggest';
 import { EditorView } from 'prosemirror-view';
 
 import SuggestionManager from 'client/utils/suggestions/suggestionManager';
-import { getReferenceableNodes, buildLabel, NodeReference } from 'components/Editor/utils';
+import {
+	getReferenceableNodes,
+	buildLabel,
+	NodeReference,
+	getNodeLabelText,
+} from 'components/Editor/utils';
 import { Schema } from 'prosemirror-model';
+import { NodeLabelMap, ReferenceableNodeType } from '../types';
 
 type SuggestPluginProps = {
-	blockNames: { [key: string]: string };
+	nodeLabels: NodeLabelMap;
 	suggestionManager: SuggestionManager<NodeReference>;
 };
 
 const normalizeQuery = (text: string) => text.toLowerCase().replace(/\s+/g, '');
 
 export default (schema: Schema, props: SuggestPluginProps) => {
-	const { blockNames, suggestionManager } = props;
+	const { nodeLabels, suggestionManager } = props;
 
 	function getNodeReferences(view: EditorView, query: string) {
-		const referenceableNodes = getReferenceableNodes(view.state);
+		const referenceableNodes = getReferenceableNodes(view.state, nodeLabels);
 
 		if (query === '') {
 			return referenceableNodes;
 		}
 
 		return referenceableNodes.filter((target) => {
-			const label = buildLabel(target.node, blockNames[target.node.type.name]);
+			const label = buildLabel(target.node, getNodeLabelText(target.node, nodeLabels));
 
 			if (label === null) {
 				return false;

--- a/client/components/Editor/schemas/audio.ts
+++ b/client/components/Editor/schemas/audio.ts
@@ -19,7 +19,7 @@ export default {
 			caption: { default: '' },
 		},
 		reactiveAttrs: {
-			count: counter('audio'),
+			count: counter(),
 			label: label(),
 		},
 		parseDOM: [
@@ -63,7 +63,11 @@ export default {
 					{},
 					pruneFalsyValues([
 						'div',
-						withValue(buildLabel(node), (label) => ['strong', label]),
+						withValue(buildLabel(node), (label) => [
+							'strong',
+							{ spellcheck: false },
+							label,
+						]),
 						renderHtmlChildren(isReact, node.attrs.caption, 'div'),
 					]),
 				],

--- a/client/components/Editor/schemas/audio.ts
+++ b/client/components/Editor/schemas/audio.ts
@@ -1,4 +1,7 @@
 import { DOMOutputSpec } from 'prosemirror-model';
+import { pruneFalsyValues } from 'utils/arrays';
+import { withValue } from 'utils/fp';
+
 import { buildLabel } from '../utils/references';
 import { renderHtmlChildren } from '../utils/renderHtml';
 import { counter } from './reactive/counter';
@@ -58,11 +61,11 @@ export default {
 				[
 					'figcaption',
 					{},
-					[
+					pruneFalsyValues([
 						'div',
-						['strong', buildLabel(node)],
+						withValue(buildLabel(node), (label) => ['strong', label]),
 						renderHtmlChildren(isReact, node.attrs.caption, 'div'),
-					],
+					]),
 				],
 			] as DOMOutputSpec;
 		},

--- a/client/components/Editor/schemas/equation.tsx
+++ b/client/components/Editor/schemas/equation.tsx
@@ -75,7 +75,7 @@ export default {
 			renderForPandoc: { default: false },
 		},
 		reactiveAttrs: {
-			count: counter('equation'),
+			count: counter(),
 		},
 		parseDOM: [
 			{
@@ -115,7 +115,7 @@ export default {
 				renderHtmlChildren(isReact, node.attrs.html),
 				withValue(node.attrs.count, (count) => [
 					'span',
-					{ class: 'equation-label' },
+					{ class: 'equation-label', spellcheck: false },
 					`(${count})`,
 				]),
 			]) as DOMOutputSpec;

--- a/client/components/Editor/schemas/equation.tsx
+++ b/client/components/Editor/schemas/equation.tsx
@@ -1,4 +1,4 @@
-import { DOMOutputSpec } from 'prosemirror-model';
+import { DOMOutputSpec, Node } from 'prosemirror-model';
 import React from 'react';
 import { pruneFalsyValues } from 'utils/arrays';
 import { withValue } from 'utils/fp';
@@ -94,7 +94,7 @@ export default {
 			},
 		],
 		// @ts-expect-error ts-migrate(2525) FIXME: Initializer provides no value for this binding ele... Remove this comment to see the full error message
-		toDOM: (node, { isReact } = {}) => {
+		toDOM: (node: Node, { isReact } = {}) => {
 			if (node.attrs.renderForPandoc) {
 				return (
 					<script
@@ -113,7 +113,7 @@ export default {
 				},
 				['span'],
 				renderHtmlChildren(isReact, node.attrs.html),
-				withValue(node.atts.count, (count) => [
+				withValue(node.attrs.count, (count) => [
 					'span',
 					{ class: 'equation-label' },
 					`(${count})`,

--- a/client/components/Editor/schemas/equation.tsx
+++ b/client/components/Editor/schemas/equation.tsx
@@ -1,5 +1,7 @@
 import { DOMOutputSpec } from 'prosemirror-model';
 import React from 'react';
+import { pruneFalsyValues } from 'utils/arrays';
+import { withValue } from 'utils/fp';
 
 import { renderHtmlChildren } from '../utils/renderHtml';
 import { counter } from './reactive/counter';
@@ -102,7 +104,7 @@ export default {
 					/>
 				) as any;
 			}
-			return [
+			return pruneFalsyValues([
 				'div',
 				{
 					...(node.attrs.id && { id: node.attrs.id }),
@@ -111,8 +113,12 @@ export default {
 				},
 				['span'],
 				renderHtmlChildren(isReact, node.attrs.html),
-				['span', { class: 'equation-label' }, `(${node.attrs.count})`],
-			] as DOMOutputSpec;
+				withValue(node.atts.count, (count) => [
+					'span',
+					{ class: 'equation-label' },
+					`(${count})`,
+				]),
+			]) as DOMOutputSpec;
 		},
 
 		inline: false,

--- a/client/components/Editor/schemas/footnote.ts
+++ b/client/components/Editor/schemas/footnote.ts
@@ -13,7 +13,7 @@ export default {
 			structuredValue: { default: '' },
 		},
 		reactiveAttrs: {
-			count: counter('footnote'),
+			count: counter(),
 			citation: structuredCitation('structuredValue'),
 		},
 		parseDOM: [

--- a/client/components/Editor/schemas/image.ts
+++ b/client/components/Editor/schemas/image.ts
@@ -18,7 +18,7 @@ export default {
 			caption: { default: '' },
 		},
 		reactiveAttrs: {
-			count: counter('image'),
+			count: counter(),
 			label: label(),
 		},
 		parseDOM: [
@@ -63,7 +63,11 @@ export default {
 					{},
 					pruneFalsyValues([
 						'div',
-						withValue(buildLabel(node), (label) => ['strong', label]),
+						withValue(buildLabel(node), (label) => [
+							'strong',
+							{ spellcheck: false },
+							label,
+						]),
 						renderHtmlChildren(isReact, node.attrs.caption, 'div'),
 					]),
 				],

--- a/client/components/Editor/schemas/image.ts
+++ b/client/components/Editor/schemas/image.ts
@@ -1,4 +1,6 @@
 import { DOMOutputSpec } from 'prosemirror-model';
+import { pruneFalsyValues } from 'utils/arrays';
+import { withValue } from 'utils/fp';
 import { buildLabel } from '../utils/references';
 import { renderHtmlChildren } from '../utils/renderHtml';
 import { counter } from './reactive/counter';
@@ -59,11 +61,11 @@ export default {
 				[
 					'figcaption',
 					{},
-					[
+					pruneFalsyValues([
 						'div',
-						['strong', buildLabel(node)],
+						withValue(buildLabel(node), (label) => ['strong', label]),
 						renderHtmlChildren(isReact, node.attrs.caption, 'div'),
-					],
+					]),
 				],
 			] as DOMOutputSpec;
 		},

--- a/client/components/Editor/schemas/reactive/counter.ts
+++ b/client/components/Editor/schemas/reactive/counter.ts
@@ -1,8 +1,13 @@
+import { Hooks } from '@pubpub/prosemirror-reactive/dist/store/types';
+import { Node } from 'prosemirror-model';
+
+import { isNodeLabelEnabled } from '../../utils';
+
 export const counter = (counterType: string, nodeFingerprintFn?) => {
 	const hasFingerprint = !!nodeFingerprintFn;
 
-	return function(node) {
-		// @ts-expect-error ts-migrate(2683) FIXME: 'this' implicitly has type 'any' because it does n... Remove this comment to see the full error message
+	return function(this: Hooks, node: Node) {
+		const { nodeLabels } = this.useDocumentState();
 		const counterState = this.useTransactionState(['counter', counterType], {
 			countsMap: {},
 			maxCount: 0,
@@ -17,7 +22,12 @@ export const counter = (counterType: string, nodeFingerprintFn?) => {
 			return counterState.countsMap[fingerprint];
 		}
 
+		if (!isNodeLabelEnabled(node, nodeLabels)) {
+			return null;
+		}
+
 		counterState.maxCount++;
+
 		return counterState.maxCount;
 	};
 };

--- a/client/components/Editor/schemas/reactive/counter.ts
+++ b/client/components/Editor/schemas/reactive/counter.ts
@@ -1,17 +1,25 @@
 import { Hooks } from '@pubpub/prosemirror-reactive/dist/store/types';
 import { Node } from 'prosemirror-model';
+import { NodeLabelMap, ReferenceableNodeType } from '../../types';
 
 import { isNodeLabelEnabled } from '../../utils';
 
-export const counter = (counterType: string, nodeFingerprintFn?) => {
+export const counter = (counterType?: string, nodeFingerprintFn?) => {
 	const hasFingerprint = !!nodeFingerprintFn;
 
 	return function(this: Hooks, node: Node) {
 		const { nodeLabels } = this.useDocumentState();
-		const counterState = this.useTransactionState(['counter', counterType], {
-			countsMap: {},
-			maxCount: 0,
-		});
+		const counterState = this.useTransactionState(
+			[
+				'counter',
+				counterType ||
+					(nodeLabels as NodeLabelMap)[node.type.name as ReferenceableNodeType].text,
+			],
+			{
+				countsMap: {},
+				maxCount: 0,
+			},
+		);
 
 		if (hasFingerprint) {
 			const fingerprint = JSON.stringify(nodeFingerprintFn(node));

--- a/client/components/Editor/schemas/reactive/label.ts
+++ b/client/components/Editor/schemas/reactive/label.ts
@@ -1,6 +1,11 @@
+import { Hooks } from '@pubpub/prosemirror-reactive/dist/store/types';
+import { Node } from 'prosemirror-model';
+
+import { isNodeLabelEnabled, getNodeLabelText } from '../../utils';
+
 export const label = () =>
-	function(node) {
-		// @ts-expect-error
-		const { blockNames } = this.useDocumentState();
-		return blockNames[node.type.name];
+	function(this: Hooks, node: Node) {
+		const { nodeLabels } = this.useDocumentState();
+
+		return isNodeLabelEnabled(node, nodeLabels) ? getNodeLabelText(node, nodeLabels) : null;
 	};

--- a/client/components/Editor/schemas/reference.ts
+++ b/client/components/Editor/schemas/reference.ts
@@ -3,6 +3,7 @@ import { DOMOutputSpec } from 'prosemirror-model';
 import { Hooks } from '@pubpub/prosemirror-reactive/src/store/types';
 
 import { buildLabel } from '../utils/references';
+import { NodeLabelMap, ReferenceableNodeType } from '../types';
 
 export default {
 	reference: {
@@ -19,11 +20,24 @@ export default {
 		reactiveAttrs: {
 			label: function(this: Hooks, node) {
 				const { targetId } = node.attrs;
-				const { blockNames } = this.useDocumentState();
+				const { nodeLabels } = this.useDocumentState();
 
 				if (targetId) {
 					return this.useDeferredNode(targetId, (target) => {
-						return target ? buildLabel(target, blockNames[target.type.name]) : null;
+						if (!target) {
+							return null;
+						}
+
+						const nodeType = target.type.name;
+						const label = (nodeLabels as NodeLabelMap)[
+							nodeType as ReferenceableNodeType
+						];
+
+						if (!(label && label.enabled)) {
+							return null;
+						}
+
+						return buildLabel(target, label?.text);
 					});
 				}
 

--- a/client/components/Editor/schemas/table.ts
+++ b/client/components/Editor/schemas/table.ts
@@ -3,6 +3,8 @@ import { DOMOutputSpec, Fragment, Node as ProsemirrorNode } from 'prosemirror-mo
 import { counter } from './reactive/counter';
 import { label } from './reactive/label';
 import { buildLabel } from '../utils/references';
+import { pruneFalsyValues } from 'utils/arrays';
+import { withValue } from 'utils/fp';
 
 const pmTableNodes = tableNodes({
 	tableGroup: 'block',
@@ -65,12 +67,12 @@ table.parseDOM![0].getAttrs = (node) => {
 table.toDOM = (node: ProsemirrorNode) => {
 	const spec = tableToDOM!(node);
 
-	return [
+	return pruneFalsyValues([
 		spec[0],
 		{ id: node.attrs.id },
-		['caption', buildLabel(node)],
+		withValue(buildLabel(node), (label) => ['caption', label]),
 		spec[1],
-	] as DOMOutputSpec;
+	]) as DOMOutputSpec;
 };
 
 export default pmTableNodes;

--- a/client/components/Editor/schemas/table.ts
+++ b/client/components/Editor/schemas/table.ts
@@ -54,7 +54,7 @@ const { toDOM: tableToDOM } = table;
 table.attrs = { ...table.attrs, id: { default: null } };
 table.reactive = true;
 table.reactiveAttrs = {
-	count: counter('table'),
+	count: counter(),
 	label: label(),
 };
 
@@ -70,7 +70,7 @@ table.toDOM = (node: ProsemirrorNode) => {
 	return pruneFalsyValues([
 		spec[0],
 		{ id: node.attrs.id },
-		withValue(buildLabel(node), (label) => ['caption', label]),
+		withValue(buildLabel(node), (label) => ['caption', { spellcheck: false }, label]),
 		spec[1],
 	]) as DOMOutputSpec;
 };

--- a/client/components/Editor/schemas/video.ts
+++ b/client/components/Editor/schemas/video.ts
@@ -18,7 +18,7 @@ export default {
 			caption: { default: '' },
 		},
 		reactiveAttrs: {
-			count: counter('video'),
+			count: counter(),
 			label: label(),
 		},
 		parseDOM: [
@@ -62,7 +62,11 @@ export default {
 					{},
 					pruneFalsyValues([
 						'div',
-						withValue(buildLabel(node), (label) => ['strong', label]),
+						withValue(buildLabel(node), (label) => [
+							'strong',
+							{ spellcheck: false },
+							label,
+						]),
 						renderHtmlChildren(isReact, node.attrs.caption, 'div'),
 					]),
 				],

--- a/client/components/Editor/schemas/video.ts
+++ b/client/components/Editor/schemas/video.ts
@@ -3,6 +3,8 @@ import { counter } from './reactive/counter';
 import { label } from './reactive/label';
 import { buildLabel } from '../utils/references';
 import { DOMOutputSpec } from 'prosemirror-model';
+import { pruneFalsyValues } from 'utils/arrays';
+import { withValue } from 'utils/fp';
 
 export default {
 	video: {
@@ -58,11 +60,11 @@ export default {
 				[
 					'figcaption',
 					{},
-					[
+					pruneFalsyValues([
 						'div',
-						['strong', buildLabel(node)],
+						withValue(buildLabel(node), (label) => ['strong', label]),
 						renderHtmlChildren(isReact, node.attrs.caption, 'div'),
-					],
+					]),
 				],
 			] as DOMOutputSpec;
 		},

--- a/client/components/Editor/styles/main.scss
+++ b/client/components/Editor/styles/main.scss
@@ -42,12 +42,8 @@ span.citation {
 	font-weight: bold;
 }
 
-a.reference {
-	font-weight: bold;
-	text-decoration: none;
-	&.missing {
-		color: darkred;
-	}
+a.reference.missing {
+	color: darkred;
 }
 
 table {

--- a/client/components/Editor/types.ts
+++ b/client/components/Editor/types.ts
@@ -1,0 +1,18 @@
+export enum ReferenceableNodeType {
+	Image = 'image',
+	Video = 'video',
+	Audio = 'audio',
+	Table = 'table',
+	BlockEquation = 'block_equation',
+}
+
+export const referenceableNodeTypes = Object.values(ReferenceableNodeType);
+
+export type NodeLabel = {
+	enabled: boolean;
+	text: string;
+};
+
+export type NodeLabelMap = {
+	[nodeType in ReferenceableNodeType]: NodeLabel;
+};

--- a/client/components/Editor/utils/renderStatic.ts
+++ b/client/components/Editor/utils/renderStatic.ts
@@ -140,12 +140,12 @@ const createOutputSpecFromNode = (node, schema, context) => {
 	return marks ? wrapOutputSpecInMarks(outputSpec, marks, schema) : outputSpec;
 };
 
-export const getReactedDocFromJson = (doc, schema, citationManager, blockNames) => {
+export const getReactedDocFromJson = (doc, schema, citationManager, nodeLabels) => {
 	const hydratedDoc = Node.fromJSON(schema, doc);
 	const reactedDoc = getReactedDoc(hydratedDoc, {
 		documentState: {
 			citationManager: citationManager,
-			blockNames: blockNames,
+			nodeLabels: nodeLabels,
 		},
 	});
 	return reactedDoc.toJSON();
@@ -156,10 +156,10 @@ export const renderStatic = ({
 	doc,
 	reactedDoc,
 	citationManager,
-	blockNames = {},
+	nodeLabels = {},
 	context = {},
 }) => {
-	const finalDoc = reactedDoc || getReactedDocFromJson(doc, schema, citationManager, blockNames);
+	const finalDoc = reactedDoc || getReactedDocFromJson(doc, schema, citationManager, nodeLabels);
 	return finalDoc.content.map((node, index) => {
 		const outputSpec = createOutputSpecFromNode(node, schema, context);
 		return createReactFromOutputSpec(outputSpec, index);

--- a/client/components/FormattingBar/controlComponents/ControlsReference.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsReference.tsx
@@ -6,7 +6,6 @@ import { EditorChangeObject } from 'client/types';
 import { usePubContext } from 'client/containers/Pub/pubHooks';
 
 export type ControlsReferenceProps = {
-	blockNames: { [key: string]: string };
 	editorChangeObject: EditorChangeObject;
 };
 
@@ -21,9 +20,11 @@ const ControlsReference = (props: ControlsReferenceProps) => {
 	const {
 		editorChangeObject: { updateNode, selectedNode, view },
 	} = props;
-	const { blockNames } = usePubContext();
-	const possibleTargets = useMemo(() => getReferenceableNodes(view.state), [view.state]);
-	const [target, setTarget] = useState(() => matchInitialTarget(selectedNode, possibleTargets));
+	const { pubData } = usePubContext();
+	const nodeReferences = useMemo(() => getReferenceableNodes(view.state, pubData.nodeLabels), [
+		view.state,
+	]);
+	const [target, setTarget] = useState(() => matchInitialTarget(selectedNode, nodeReferences));
 	const targetId = target && target.node && target.node.attrs.id;
 	const changed = useRef(false);
 
@@ -44,9 +45,8 @@ const ControlsReference = (props: ControlsReferenceProps) => {
 
 	return (
 		<ReferencesDropdown
-			references={possibleTargets}
+			references={nodeReferences}
 			selectedReference={target}
-			blockNames={blockNames}
 			onSelect={onSelect}
 		/>
 	);

--- a/client/components/FormattingBar/controlComponents/ControlsReference.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsReference.tsx
@@ -21,9 +21,10 @@ const ControlsReference = (props: ControlsReferenceProps) => {
 		editorChangeObject: { updateNode, selectedNode, view },
 	} = props;
 	const { pubData } = usePubContext();
-	const nodeReferences = useMemo(() => getReferenceableNodes(view.state, pubData.nodeLabels), [
-		view.state,
-	]);
+	const nodeReferences = useMemo(
+		() => (pubData.nodeLabels ? getReferenceableNodes(view.state, pubData.nodeLabels) : []),
+		[view.state],
+	);
 	const [target, setTarget] = useState(() => matchInitialTarget(selectedNode, nodeReferences));
 	const targetId = target && target.node && target.node.attrs.id;
 	const changed = useRef(false);

--- a/client/components/ReferencesDropdown/ReferencesDropdown.tsx
+++ b/client/components/ReferencesDropdown/ReferencesDropdown.tsx
@@ -1,23 +1,24 @@
 import React from 'react';
 
-import { buildLabel, NodeReference } from '../Editor/utils/references';
+import { NodeReference } from '../Editor/utils/references';
 import { MenuButton, MenuItem } from '../Menu';
 
 export type ReferencesDropdownProps = {
 	references: ReadonlyArray<NodeReference>;
-	blockNames: { [key: string]: string };
 	selectedReference?: NodeReference | null;
 	onSelect: (reference: NodeReference) => unknown;
 };
 
 const ReferencesDropdown = (props: ReferencesDropdownProps) => {
-	const { blockNames, references, selectedReference, onSelect } = props;
+	const { references, selectedReference, onSelect } = props;
 	const currentIcon = selectedReference ? selectedReference.icon : 'disable';
 	const currentLabel = selectedReference
-		? buildLabel(selectedReference.node, blockNames[selectedReference.node.type.name])
+		? selectedReference.label
 		: references.length
 		? 'No referenced item'
 		: 'No items to reference';
+
+	console.log(references);
 
 	return (
 		<div className="controls-link-component">
@@ -32,7 +33,7 @@ const ReferencesDropdown = (props: ReferencesDropdownProps) => {
 				}}
 			>
 				{references.map((possibleTarget) => {
-					const { icon, node } = possibleTarget;
+					const { icon, node, label } = possibleTarget;
 					return (
 						<MenuItem
 							onClick={() => {
@@ -40,7 +41,7 @@ const ReferencesDropdown = (props: ReferencesDropdownProps) => {
 							}}
 							key={node.attrs.id}
 							active={Boolean(selectedReference && selectedReference.node === node)}
-							text={buildLabel(node, blockNames[node.type.name])}
+							text={label}
 							icon={icon}
 						/>
 					);

--- a/client/containers/DashboardSettings/PubSettings/NodeLabelEditor.tsx
+++ b/client/containers/DashboardSettings/PubSettings/NodeLabelEditor.tsx
@@ -1,0 +1,141 @@
+import { Checkbox } from '@blueprintjs/core';
+import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
+import { useDebounce } from 'use-debounce';
+import classNames from 'classnames';
+
+import { InputField } from 'client/components';
+import { getDefaultNodeLabels } from 'client/components/Editor/utils/references';
+import { NodeLabelMap, referenceableNodeTypes } from 'client/components/Editor/types';
+
+require('./nodeLabelEditor.scss');
+
+export type NodeLabelEditorRowProps = {
+	type: string;
+	enabled: boolean;
+	text: string;
+	onTextChange: (label: string) => unknown;
+	onToggle: (enabled: boolean) => unknown;
+};
+
+const NodeLabelEditorRow = (props: NodeLabelEditorRowProps) => {
+	const { enabled, type, text, onTextChange, onToggle } = props;
+
+	return (
+		<tr className={classNames(!enabled && 'disabled')}>
+			<td>{type}</td>
+			<td>
+				<Checkbox
+					checked={enabled}
+					onChange={(e) => onToggle((e.target as HTMLInputElement).checked)}
+				/>
+			</td>
+			<td>
+				<InputField
+					type="text"
+					onChange={(e) => onTextChange(e.target.value)}
+					value={text}
+					isDisabled={!enabled}
+				/>
+			</td>
+		</tr>
+	);
+};
+
+export type NodeLabelEditorProps = {
+	pubData: any;
+	updatePubData: (values: any) => void;
+};
+
+enum NodeLabelEditorActionType {
+	Toggle = 'toggle',
+	UpdateLabel = 'update_label',
+}
+
+type NodeLabelEditorAction =
+	| {
+			type: NodeLabelEditorActionType.Toggle;
+			payload: { nodeType: string; enabled: boolean };
+	  }
+	| { type: NodeLabelEditorActionType.UpdateLabel; payload: { nodeType: string; text: string } };
+
+const nodeLabelEditorReducer = (state: NodeLabelMap, action: NodeLabelEditorAction) => {
+	switch (action.type) {
+		case NodeLabelEditorActionType.Toggle: {
+			const { nodeType, enabled } = action.payload;
+			return {
+				...state,
+				[nodeType]: { ...state[nodeType], enabled: enabled },
+			};
+		}
+		case NodeLabelEditorActionType.UpdateLabel: {
+			const { nodeType, text } = action.payload;
+			return {
+				...state,
+				[nodeType]: { ...state[nodeType], text: text },
+			};
+		}
+	}
+};
+
+const useNodeLabelEditorState = (pub: any) => {
+	const initialState = useMemo(() => getDefaultNodeLabels(pub), []);
+	const [state, dispatch] = useReducer(nodeLabelEditorReducer, initialState);
+	const toggleNode = useCallback(
+		(nodeType: string, enabled: boolean) =>
+			dispatch({ type: NodeLabelEditorActionType.Toggle, payload: { nodeType, enabled } }),
+		[],
+	);
+	const updateLabel = useCallback(
+		(nodeType: string, text: string) =>
+			dispatch({ type: NodeLabelEditorActionType.UpdateLabel, payload: { nodeType, text } }),
+		[],
+	);
+
+	return { state, toggleNode, updateLabel };
+};
+
+const NodeLabelEditor = (props: NodeLabelEditorProps) => {
+	const { pubData, updatePubData } = props;
+	const { state, toggleNode, updateLabel } = useNodeLabelEditorState(pubData);
+	const [stateToPersist] = useDebounce(state, 500);
+	const initialState = useMemo(() => state, []);
+
+	useEffect(() => {
+		if (stateToPersist !== initialState) {
+			updatePubData({
+				nodeLabels: stateToPersist,
+			});
+		}
+	}, [stateToPersist]);
+
+	return (
+		<div className="node-label-editor-component">
+			<table className="bp3-html-table bp3-small">
+				<thead>
+					<tr>
+						<th>Type</th>
+						<th>Enabled</th>
+						<th>Label</th>
+					</tr>
+				</thead>
+				<tbody>
+					{referenceableNodeTypes.map((nodeType) => {
+						const { enabled, text } = state[nodeType];
+						return (
+							<NodeLabelEditorRow
+								key={nodeType}
+								type={nodeType}
+								enabled={enabled}
+								text={text}
+								onTextChange={(text) => updateLabel(nodeType, text)}
+								onToggle={(enabled) => toggleNode(nodeType, enabled)}
+							/>
+						);
+					})}
+				</tbody>
+			</table>
+		</div>
+	);
+};
+
+export default NodeLabelEditor;

--- a/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
+++ b/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
@@ -24,6 +24,7 @@ import DeletePub from './DeletePub';
 import Collections from './Collections';
 import Doi from './Doi';
 import CitationChooser from './CitationChooser';
+import NodeLabelEditor from './NodeLabelEditor';
 
 type Props = {
 	settingsData: {
@@ -295,6 +296,18 @@ const PubSettings = (props: Props) => {
 		);
 	};
 
+	const renderNodeLabelEditor = () => {
+		return (
+			<SettingsSection title="Block Labels">
+				<NodeLabelEditor
+					pubData={persistedPubData}
+					// communityData={activeCommunity}
+					updatePubData={updatePubData}
+				/>
+			</SettingsSection>
+		);
+	};
+
 	return (
 		// @ts-expect-error ts-migrate(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message
 		<DashboardFrame
@@ -313,6 +326,7 @@ const PubSettings = (props: Props) => {
 			{renderAttributions()}
 			{renderFormattedDownload()}
 			{renderCollections()}
+			{renderNodeLabelEditor()}
 			{renderDelete()}
 		</DashboardFrame>
 	);

--- a/client/containers/DashboardSettings/PubSettings/nodeLabelEditor.scss
+++ b/client/containers/DashboardSettings/PubSettings/nodeLabelEditor.scss
@@ -1,0 +1,20 @@
+.node-label-editor-component {
+	> table {
+		tr.disabled td {
+			color: #ccc;
+		}
+
+		td:nth-child(2) {
+			text-align: center;
+		}
+
+		td {
+			line-height: 30px;
+
+			.bp3-checkbox {
+				position: relative;
+				top: 10px;
+			}
+		}
+	}
+}

--- a/client/containers/DashboardSettings/PubSettings/nodeLabelEditor.scss
+++ b/client/containers/DashboardSettings/PubSettings/nodeLabelEditor.scss
@@ -17,4 +17,8 @@
 			}
 		}
 	}
+
+	.toggle-all {
+		margin: 1em 0;
+	}
 }

--- a/client/containers/Pub/PubDocument/PubBody.tsx
+++ b/client/containers/Pub/PubDocument/PubBody.tsx
@@ -15,6 +15,7 @@ import { usePubContext } from '../pubHooks';
 import { PubSuspendWhileTypingContext } from '../PubSuspendWhileTyping';
 import discussionSchema from './DiscussionAddon/discussionSchema';
 import Discussion from './PubDiscussions/Discussion';
+import { NodeLabelMap } from 'client/components/Editor/types';
 
 require('./pubBody.scss');
 
@@ -145,7 +146,7 @@ const PubBody = (props: Props) => {
 						},
 					},
 				}}
-				nodeLabels={pubData.nodeLabels}
+				nodeLabels={pubData.nodeLabels || ({} as NodeLabelMap)}
 				citationManager={citationManager}
 				placeholder={pubData.isReadOnly ? undefined : 'Begin writing here...'}
 				initialContent={initialContent}

--- a/client/containers/Pub/PubDocument/PubBody.tsx
+++ b/client/containers/Pub/PubDocument/PubBody.tsx
@@ -52,7 +52,7 @@ const PubBody = (props: Props) => {
 		editorWrapperRef,
 	} = props;
 	const { communityData } = usePageContext();
-	const { blockNames, citationManager } = usePubContext();
+	const { citationManager } = usePubContext();
 	const { isViewingHistory } = historyData;
 	const prevStatusRef = useRef(null);
 	const embedDiscussions = useRef({});
@@ -145,7 +145,7 @@ const PubBody = (props: Props) => {
 						},
 					},
 				}}
-				blockNames={blockNames}
+				nodeLabels={pubData.nodeLabels}
 				citationManager={citationManager}
 				placeholder={pubData.isReadOnly ? undefined : 'Begin writing here...'}
 				initialContent={initialContent}

--- a/client/containers/Pub/PubSyncManager.tsx
+++ b/client/containers/Pub/PubSyncManager.tsx
@@ -8,14 +8,16 @@ import { getPubPageTitle } from 'utils/pubPageTitle';
 import { CitationManager } from 'client/utils/citations/citationManager';
 import { initFirebase } from 'client/utils/firebaseClient';
 import { apiFetch } from 'client/utils/apiFetch';
+import { NodeLabelMap } from 'client/components/Editor/types';
 
 export const PubContext = React.createContext({
-	pubData: {},
+	pubData: {
+		nodeLabels: {} as NodeLabelMap | undefined,
+	},
 	collabData: { editorChangeObject: {} },
 	historyData: {},
 	firebaseBranchRef: null,
 	updateLocalData: null,
-	blockNames: {} as { [key: string]: string },
 	// @ts-expect-error ts-migrate(2554) FIXME: Expected 2-3 arguments, but got 0.
 	citationManager: new CitationManager(),
 });
@@ -132,11 +134,6 @@ class PubSyncManager extends React.Component<Props, State> {
 				isViewingHistory: isViewingHistory,
 				loadedIntoHistory: isViewingHistory,
 				historyDocKey: `history-${historyData.currentKey}`,
-			},
-			blockNames: {
-				image: 'Figure',
-				video: 'Video',
-				table: 'Table',
 			},
 			citationManager: new CitationManager(
 				pubData.citationStyle,
@@ -421,7 +418,6 @@ class PubSyncManager extends React.Component<Props, State> {
 			pubData: this.state.pubData,
 			collabData: this.state.collabData,
 			historyData: this.state.historyData,
-			blockNames: this.state.blockNames,
 			citationManager: this.state.citationManager,
 			firebaseBranchRef: this.state.firebaseBranchRef,
 			updateLocalData: this.updateLocalData,

--- a/client/types/editor.ts
+++ b/client/types/editor.ts
@@ -1,3 +1,5 @@
+import { EditorView } from 'prosemirror-view';
+
 export type EditorChangeObject = {
 	selectedNode?: {
 		attrs?: {
@@ -5,7 +7,5 @@ export type EditorChangeObject = {
 		};
 	};
 	updateNode: (...args: unknown[]) => unknown;
-	view: {
-		state: Object;
-	};
+	view: EditorView;
 };

--- a/client/utils/suggestions/suggestionManager.ts
+++ b/client/utils/suggestions/suggestionManager.ts
@@ -98,7 +98,7 @@ export default class SuggestionManager<T> {
 		return this.state.status === SuggestionManagerStatus.Suggesting;
 	}
 
-	getSelectedValue() {
+	getSelectedValue(): T | null {
 		if (this.isSuggesting()) {
 			const { items, index } = this.state;
 			return items[modFloor(index, items.length)];

--- a/server/pub/model.js
+++ b/server/pub/model.js
@@ -43,6 +43,7 @@ export default (sequelize, dataTypes) => {
 			// isPublicReviews: { type: dataTypes.BOOLEAN },
 			viewHash: { type: dataTypes.STRING },
 			editHash: { type: dataTypes.STRING },
+			nodeLabels: { type: dataTypes.JSONB },
 
 			/* Set by Associations */
 			communityId: { type: dataTypes.UUID, allowNull: false },

--- a/server/pub/permissions.js
+++ b/server/pub/permissions.js
@@ -18,6 +18,7 @@ const managerUpdatableFields = [
 	'licenseSlug',
 	'slug',
 	'title',
+	'nodeLabels',
 ];
 
 const adminUpdatableFields = ['doi'];

--- a/tools/migrations/2020_10_06_addPubNodeLabels.js
+++ b/tools/migrations/2020_10_06_addPubNodeLabels.js
@@ -1,0 +1,5 @@
+module.exports = async ({ Sequelize, sequelize }) => {
+	await sequelize.queryInterface.addColumn('Pubs', 'nodeLabels', {
+		type: Sequelize.JSONB,
+	});
+};

--- a/utils/arrays.js
+++ b/utils/arrays.js
@@ -9,3 +9,5 @@ export const intersperse = (arr, val) => {
 	});
 	return res;
 };
+
+export const pruneFalsyValues = (arr) => arr.filter(Boolean);

--- a/utils/fp.ts
+++ b/utils/fp.ts
@@ -1,0 +1,10 @@
+export const withValue = <T, R>(
+	value: T | null | undefined,
+	callback: (value: T) => R,
+): R | null => {
+	if (value) {
+		return callback(value);
+	}
+
+	return null;
+};


### PR DESCRIPTION
This PR adds a new section to Pub settings that allows managers/admins to enable/disable labeling of nodes by node type, and to customize the labels of enabled node groups. Labeling is disabled by default, and custom label configuration is stored in a new column `Pubs.nodeLabels` in the database.

Disabled node groups are excluded from both the reference shortcut (currently `@`) suggestion dropdown and the reference controls menu.

_Test Plan_

1. Open the settings dashboard page for a Pub.
2. Scroll to the Block Labels section of the settings page. Labeling of all node types should be disabled/greyed out by default.
3. Enable a node group by clicking on a checkbox. Change the default label value to something unique.
4. Open the pub. Create a node of the same type of the node group you enabled, and a node of a type that remained disabled.
5. Create a reference, either by using the `@` shortcut, or the editor control bar.
6. In the dropdown, you should see **only** the node of the type you enabled in step #3. The other node should not be visible.