### PR TITLE
update: Use Pub citation style preference for Pub cite

### DIFF
--- a/client/containers/DashboardSettings/PubSettings/CitationChooser.tsx
+++ b/client/containers/DashboardSettings/PubSettings/CitationChooser.tsx
@@ -4,6 +4,7 @@ import { Select } from '@blueprintjs/select';
 
 import { InputField } from 'components';
 import { apiFetch } from 'client/utils/apiFetch';
+import { citationStyles as citationStyleItems } from 'utils/citations';
 
 require('./citationChooser.scss');
 
@@ -33,19 +34,6 @@ const CitationChooser = (props: Props) => {
 		}).catch((err) => console.error('Error Saving Pub Citation Style: ', err));
 	};
 
-	const citationStyleItems = [
-		{ key: 'acm-siggraph', title: 'ACM SIGGRAPH' },
-		{ key: 'american-anthro', title: 'American Anthropological Association' },
-		{ key: 'apa', title: 'APA 6th Edition' },
-		{ key: 'apa-7', title: 'APA 7th Edition' },
-		{ key: 'cell', title: 'Cell' },
-		{ key: 'chicago', title: 'Chicago' },
-		{ key: 'harvard', title: 'Harvard' },
-		{ key: 'elife', title: 'ELife' },
-		{ key: 'frontiers', title: 'Frontiers' },
-		{ key: 'mla', title: 'MLA' },
-		{ key: 'vancouver', title: 'Vancouver' },
-	];
 	const citationInlineStyleItems = [
 		{ key: 'count', title: 'Count', example: '[1]' },
 		{ key: 'authorYear', title: 'Author-Year', example: '(Goodall, 1995)' },
@@ -70,7 +58,7 @@ const CitationChooser = (props: Props) => {
 							key={item.key}
 							// @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
 							active={item.key === activeCitationStyle.key}
-							text={item.title}
+							text={item.name}
 						/>
 					)}
 					filterable={false}
@@ -80,7 +68,7 @@ const CitationChooser = (props: Props) => {
 					}}
 				>
 					{/* @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'. */}
-					<Button text={activeCitationStyle.title} rightIcon="caret-down" />
+					<Button text={activeCitationStyle.name} rightIcon="caret-down" />
 				</Select>
 			</InputField>
 

--- a/client/containers/Pub/PubHeader/CitationsModal.tsx
+++ b/client/containers/Pub/PubHeader/CitationsModal.tsx
@@ -1,24 +1,31 @@
 /* eslint-disable react/no-danger */
 import React from 'react';
 import { Classes, Dialog } from '@blueprintjs/core';
+import { citationStyles } from 'utils/citations';
 
 require('./citationsModal.scss');
 
 type Props = {
 	citationData: {
 		pub?: {
+			default?: string;
 			apa?: string;
 			harvard?: string;
 			vancouver?: string;
 			bibtex?: string;
 		};
 	};
+	citationStyle: string;
 	isOpen: boolean;
 	onClose: (...args: any[]) => any;
 };
 
 const CitationsModal = (props: Props) => {
-	const { citationData, isOpen, onClose } = props;
+	const { citationData, citationStyle, isOpen, onClose } = props;
+	let defaultCitationName = '';
+	citationStyles.forEach((style) => {
+		if (style.key === citationStyle) defaultCitationName = style.name;
+	});
 	return (
 		<Dialog
 			className="citations-modal-component"
@@ -28,29 +35,43 @@ const CitationsModal = (props: Props) => {
 		>
 			<div className={Classes.DIALOG_BODY}>
 				<div className="style-wrapper">
-					<div className="style-title">APA</div>
+					<div className="style-title">{defaultCitationName} (Default)</div>
 					<div
 						className="style-content"
 						// @ts-expect-error ts-migrate(2322) FIXME: Type 'undefined' is not assignable to type 'string... Remove this comment to see the full error message
-						dangerouslySetInnerHTML={{ __html: citationData.pub.apa }}
+						dangerouslySetInnerHTML={{ __html: citationData.pub.default }}
 					/>
 				</div>
-				<div className="style-wrapper">
-					<div className="style-title">Harvard</div>
-					<div
-						className="style-content"
-						// @ts-expect-error ts-migrate(2322) FIXME: Type 'undefined' is not assignable to type 'string... Remove this comment to see the full error message
-						dangerouslySetInnerHTML={{ __html: citationData.pub.harvard }}
-					/>
-				</div>
-				<div className="style-wrapper">
-					<div className="style-title">Vancouver</div>
-					<div
-						className="style-content"
-						// @ts-expect-error ts-migrate(2322) FIXME: Type 'undefined' is not assignable to type 'string... Remove this comment to see the full error message
-						dangerouslySetInnerHTML={{ __html: citationData.pub.vancouver }}
-					/>
-				</div>
+				{citationStyle !== 'apa' && (
+					<div className="style-wrapper">
+						<div className="style-title">APA 6th Edition</div>
+						<div
+							className="style-content"
+							// @ts-expect-error ts-migrate(2322) FIXME: Type 'undefined' is not assignable to type 'string... Remove this comment to see the full error message
+							dangerouslySetInnerHTML={{ __html: citationData.pub.apa }}
+						/>
+					</div>
+				)}
+				{citationStyle !== 'harvard' && (
+					<div className="style-wrapper">
+						<div className="style-title">Harvard</div>
+						<div
+							className="style-content"
+							// @ts-expect-error ts-migrate(2322) FIXME: Type 'undefined' is not assignable to type 'string... Remove this comment to see the full error message
+							dangerouslySetInnerHTML={{ __html: citationData.pub.harvard }}
+						/>
+					</div>
+				)}
+				{citationStyle !== 'vancouver' && (
+					<div className="style-wrapper">
+						<div className="style-title">Vancouver</div>
+						<div
+							className="style-content"
+							// @ts-expect-error ts-migrate(2322) FIXME: Type 'undefined' is not assignable to type 'string... Remove this comment to see the full error message
+							dangerouslySetInnerHTML={{ __html: citationData.pub.vancouver }}
+						/>
+					</div>
+				)}
 				<div className="style-wrapper">
 					<div className="style-title">Bibtex</div>
 					<div

--- a/client/containers/Pub/PubHeader/CitationsPreview.tsx
+++ b/client/containers/Pub/PubHeader/CitationsPreview.tsx
@@ -32,7 +32,7 @@ const CitationsPreview = (props: Props) => {
 				ref={copyableCitationRef}
 				// eslint-disable-next-line react/no-danger
 				dangerouslySetInnerHTML={{
-					__html: pubData.citationData.pub.apa,
+					__html: pubData.citationData.pub.default,
 				}}
 			/>
 			<ButtonGroup>
@@ -61,6 +61,7 @@ const CitationsPreview = (props: Props) => {
 			<CitationsModal
 				isOpen={isCitationModalOpen}
 				citationData={pubData.citationData}
+				citationStyle={pubData.citationStyle}
 				onClose={() => setCitationModalOpen(false)}
 			/>
 		</div>

--- a/server/utils/citations/generateCitationHtml.js
+++ b/server/utils/citations/generateCitationHtml.js
@@ -75,7 +75,6 @@ export const generateCitationHtml = async (pubData, communityData) => {
 		note: pubLink,
 		URL: pubLink,
 	});
-	console.log(pubCiteObject);
 	return {
 		pub: {
 			default: pubCiteObject

--- a/server/utils/citations/generateCitationHtml.js
+++ b/server/utils/citations/generateCitationHtml.js
@@ -26,7 +26,7 @@ const getCollectionLevelData = (primaryCollectionPub) => {
 	return {
 		type: collectionKindToCitationJSPart(kind),
 		...(useCollectionTitle && { 'container-title': title }),
-		containerDoi: metadata.doi,
+		containerDoi: metadata.doi || collection.doi,
 		ISBN: metadata.isbn,
 		ISSN: metadata.issn || metadata.printIssn || metadata.electronicIssn,
 		edition: metadata.edition,

--- a/server/utils/citations/generateCitationHtml.js
+++ b/server/utils/citations/generateCitationHtml.js
@@ -26,6 +26,7 @@ const getCollectionLevelData = (primaryCollectionPub) => {
 	return {
 		type: collectionKindToCitationJSPart(kind),
 		...(useCollectionTitle && { 'container-title': title }),
+		containerDoi: metadata.doi,
 		ISBN: metadata.isbn,
 		ISSN: metadata.issn || metadata.printIssn || metadata.electronicIssn,
 		edition: metadata.edition,
@@ -68,13 +69,13 @@ export const generateCitationHtml = async (pubData, communityData) => {
 	};
 	const pubCiteObject = await Cite.async({
 		...commonData,
-		DOI: pubData.doi,
+		DOI: pubData.doi || commonData.containerDoi,
 		ISSN: pubData.doi ? communityData.issn : null,
 		issued: pubIssuedDate && [getDatePartsObject(pubIssuedDate)],
 		note: pubLink,
 		URL: pubLink,
 	});
-
+	console.log(pubCiteObject);
 	return {
 		pub: {
 			default: pubCiteObject

--- a/server/utils/citations/generateCitationHtml.js
+++ b/server/utils/citations/generateCitationHtml.js
@@ -2,6 +2,7 @@
 import Cite from 'citation-js';
 
 import { getPubPublishedDate } from 'utils/pub/pubDates';
+import getCollectionDoi from 'utils/collections/getCollectionDoi';
 import { pubUrl } from 'utils/canonicalUrls';
 
 const getDatePartsObject = (date) => ({
@@ -26,7 +27,7 @@ const getCollectionLevelData = (primaryCollectionPub) => {
 	return {
 		type: collectionKindToCitationJSPart(kind),
 		...(useCollectionTitle && { 'container-title': title }),
-		containerDoi: metadata.doi || collection.doi,
+		containerDoi: getCollectionDoi(collection),
 		ISBN: metadata.isbn,
 		ISSN: metadata.issn || metadata.printIssn || metadata.electronicIssn,
 		edition: metadata.edition,

--- a/server/utils/citations/generateCitationHtml.js
+++ b/server/utils/citations/generateCitationHtml.js
@@ -77,6 +77,14 @@ export const generateCitationHtml = async (pubData, communityData) => {
 
 	return {
 		pub: {
+			default: pubCiteObject
+				.get({
+					format: 'string',
+					type: 'html',
+					style: `citation-${pubData.citationStyle}`,
+					lang: 'en-US',
+				})
+				.replace(/\n/gi, ''),
 			apa: pubCiteObject
 				.get({ format: 'string', type: 'html', style: 'citation-apa', lang: 'en-US' })
 				.replace(/\n/gi, ''),

--- a/server/utils/citations/structuredCitations.js
+++ b/server/utils/citations/structuredCitations.js
@@ -2,26 +2,20 @@ import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import Cite from 'citation-js';
-
 import { getNotes } from 'components/Editor';
+import { citationStyles as styles } from 'utils/citations';
 
 /* Different styles available here: */
 /* https://github.com/citation-style-language/styles */
-/* ['apa', 'harvard', 'vancouver'] built-in to citation-js */
-const styles = [
-	{ name: 'acm-siggraph', path: './citeStyles/acm-siggraph.csl' },
-	{ name: 'american-anthro', path: './citeStyles/american-anthropological-association.csl' },
-	{ name: 'cell', path: './citeStyles/cell.csl' },
-	{ name: 'chicago', path: './citeStyles/chicago-author-date.csl' },
-	{ name: 'elife', path: './citeStyles/elife.csl' },
-	{ name: 'frontiers', path: './citeStyles/frontiers.csl' },
-	{ name: 'mla', path: './citeStyles/modern-language-association.csl' },
-	{ name: 'apa-7', path: './citeStyles/apa-7.csl' },
-];
 const config = Cite.plugins.config.get('@csl');
 styles.forEach((style) => {
-	const fileString = fs.readFileSync(path.join(__dirname, style.path), { encoding: 'utf8' });
-	config.templates.add(style.name, fileString);
+	/* ['apa', 'harvard', 'vancouver'] built-in to citation-js */
+	if (!style.path) return;
+	const fileString = fs.readFileSync(
+		path.join(__dirname, style.path !== '' ? style.path : null),
+		{ encoding: 'utf8' },
+	);
+	config.templates.add(style.key, fileString);
 });
 /* Remove @else/url parser. See Freshdesk ticket #1308. Second term specifies sync/async component.  */
 /* https://github.com/citation-js/citation-js/blob/master/packages/core/src/plugins/input/data.js#L90-L97 */

--- a/server/utils/citations/structuredCitations.js
+++ b/server/utils/citations/structuredCitations.js
@@ -3,14 +3,14 @@ import path from 'path';
 import crypto from 'crypto';
 import Cite from 'citation-js';
 import { getNotes } from 'components/Editor';
-import { citationStyles as styles } from 'utils/citations';
+import { citationStyles } from 'utils/citations';
 
 /* Different styles available here: */
 /* https://github.com/citation-style-language/styles */
 const config = Cite.plugins.config.get('@csl');
-styles.forEach((style) => {
-	/* ['apa', 'harvard', 'vancouver'] built-in to citation-js */
+citationStyles.forEach((style) => {
 	if (!style.path) return;
+	/* ['apa', 'harvard', 'vancouver'] built-in to citation-js */
 	const fileString = fs.readFileSync(
 		path.join(__dirname, style.path !== '' ? style.path : null),
 		{ encoding: 'utf8' },

--- a/utils/citations.ts
+++ b/utils/citations.ts
@@ -1,0 +1,27 @@
+type CitationStyle = {
+	name: string;
+	key: string;
+	path?: string;
+};
+
+export const citationStyles: CitationStyle[] = [
+	{ key: 'acm-siggraph', name: 'ACM SIGGRAPH', path: './citeStyles/acm-siggraph.csl' },
+	{
+		key: 'american-anthro',
+		name: 'American Anthropological Association',
+		path: './citeStyles/american-anthropological-association.csl',
+	},
+	{ key: 'apa', name: 'APA 6th Edition' },
+	{
+		key: 'apa-7',
+		name: 'APA 7th Edition',
+		path: './citeStyles/apa-7.csl',
+	},
+	{ key: 'cell', name: 'Cell', path: './citeStyles/cell.csl' },
+	{ key: 'chicago', name: 'Chicago', path: './citeStyles/chicago-author-date.csl' },
+	{ key: 'harvard', name: 'Harvard' },
+	{ key: 'elife', name: 'ELife', path: './citeStyles/elife.csl' },
+	{ key: 'frontiers', name: 'Frontiers', path: './citeStyles/frontiers.csl' },
+	{ key: 'mla', name: 'MLA', path: './citeStyles/modern-language-association.csl' },
+	{ key: 'vancouver', name: 'Vancouver' },
+];

--- a/utils/crossref/__tests__/data/pub.js
+++ b/utils/crossref/__tests__/data/pub.js
@@ -432,6 +432,8 @@ export default {
 	],
 	citationData: {
 		pub: {
+			default:
+				'<div class="csl-bib-body">  <div data-csl-entry-id="00f9aaaf-0468-4590-9b86-1a2bff4ffe57" class="csl-entry">Hsu, W., &#38; Dubberly, H. (2019). Defining the Dimensions of the “Space” of Computing. <i>JoDS V6 Dev</i>. Retrieved from https://jods.mitpress.mit.edu/pub/6pewbpry</div></div>',
 			apa:
 				'<div class="csl-bib-body">  <div data-csl-entry-id="1519656b-cc26-43ad-83f2-dbf5b828a8c7" class="csl-entry">Reynolds, I. (2019). In Which Ian Makes A Pub. In <i>Collection with an Extremely Long Name That Ought To Wrap Onto The Next Line</i>. https://doi.org/10.21428/eea8ec7d.1519656b</div></div>',
 			harvard:

--- a/utils/storybook/data/dataPub.js
+++ b/utils/storybook/data/dataPub.js
@@ -674,6 +674,8 @@ export default {
 	isStaticDoc: false,
 	citationData: {
 		pub: {
+			default: 
+				'<div class="csl-bib-body">  <div data-csl-entry-id="00f9aaaf-0468-4590-9b86-1a2bff4ffe57" class="csl-entry">Hsu, W., &#38; Dubberly, H. (2019). Defining the Dimensions of the “Space” of Computing. <i>JoDS V6 Dev</i>. Retrieved from https://jods.mitpress.mit.edu/pub/6pewbpry</div></div>',
 			apa:
 				'<div class="csl-bib-body">  <div data-csl-entry-id="00f9aaaf-0468-4590-9b86-1a2bff4ffe57" class="csl-entry">Hsu, W., &#38; Dubberly, H. (2019). Defining the Dimensions of the “Space” of Computing. <i>JoDS V6 Dev</i>. Retrieved from https://jods.mitpress.mit.edu/pub/6pewbpry</div></div>',
 			harvard:


### PR DESCRIPTION
Resolves #1075 

- Adds "default" citation HTML to the enriched pub object and displays that in the cite menu rather than always defaulting to APA.
- Refactors how we generate both pub citations (in the cite menu) and inline citations slightly by moving the list of supported citations into a shared util consumed by both
- Updates the citation 'more options' modal to show the default citation along with the most common ones (labeling the common one as default if it exists)
- Modifies generateCiteHtml to fall back to a collection-level DOI if there is no DOI for the pub itself but there is for the collection.

_Test plan_

General cites:
1. Visit a pub, add some inline cites in various formats (doi, bibtex, etc.)
1. Make sure they display properly
1. Make sure the pub cite displays properly
1. Switch the cite type and go back to the pub
1. Make sure the cites still display, in the format selected
1. Make sure the pub cite displays

Default cite:
1. Visit any pub and, in settings, change the citation style.
1. Visit the front-end of the pub, click cite, and verify that it's using the selected citation style
1. Click 'more options' in the cite menu, make sure default shows correctly style

Doi defaults:
1. Visit a pub in a book or issue collection with a doi, but which does not itself have a doi
1. Verify that the citation lists the collection-level doi
1. Visit a pub that has a doi in a collection that also has a doi
1. Verify that the pub's citation uses the pub-level doi