### PR TITLE
update: toggle referencing of media, equations, and tables

### DIFF
--- a/client/components/Editor/Editor.tsx
+++ b/client/components/Editor/Editor.tsx
@@ -164,7 +164,7 @@ const Editor = (props: Props) => {
 			},
 		});
 
-		props.onChange(getChangeObject(view));
+		props.onChange(getChangeObject(view, props));
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 
 		return suggestionManager.transitioned.subscribe(onSuggestionManagerTransition);

--- a/client/components/Editor/plugins/onChange.ts
+++ b/client/components/Editor/plugins/onChange.ts
@@ -46,7 +46,7 @@ const getInsertFunctions = (editorView) => {
 };
 
 const toggleTableLabel = (editorView: EditorView, editorProps: EditorProps, dryRun = false) => {
-	if (!editorProps.nodeLabels[ReferenceableNodeType.Table].enabled) {
+	if (!editorProps.nodeLabels[ReferenceableNodeType.Table]?.enabled) {
 		return false;
 	}
 

--- a/client/components/Editor/plugins/onChange.ts
+++ b/client/components/Editor/plugins/onChange.ts
@@ -23,6 +23,7 @@ import { domEventsPluginKey } from './domEvents';
 import { findParentNodeClosestToPos } from '../utils';
 import { EditorView } from 'prosemirror-view';
 import { ReferenceableNodeType } from '../types';
+import { EditorProps } from '../Editor';
 // import { collaborativePluginKey } from './plugins/collaborative';
 
 const getInsertFunctions = (editorView) => {
@@ -44,7 +45,7 @@ const getInsertFunctions = (editorView) => {
 		}, {});
 };
 
-const toggleTableLabel = (editorView: EditorView, editorProps: any, dryRun = false) => {
+const toggleTableLabel = (editorView: EditorView, editorProps: EditorProps, dryRun = false) => {
 	if (!editorProps.nodeLabels[ReferenceableNodeType.Table].enabled) {
 		return false;
 	}
@@ -70,7 +71,7 @@ const toggleTableLabel = (editorView: EditorView, editorProps: any, dryRun = fal
 	return false;
 };
 
-const getMenuItems = (editorView: EditorView, editorProps) => {
+const getMenuItems = (editorView: EditorView, editorProps: EditorProps) => {
 	const schema = editorView.state.schema;
 
 	/* Marks */
@@ -593,8 +594,8 @@ const getSelectedNode = (editorState) => {
 	return getReactedCopyOfNode(node, editorState) || node;
 };
 
-export const getChangeObject = (editorView, editorProps) => {
-	const isNode = !!editorView.state.selection.node;
+export const getChangeObject = (editorView: EditorView, editorProps: EditorProps) => {
+	const isNode = !!(editorView.state.selection as any).node;
 	const collaborativePluginState = collabDocPluginKey.getState(editorView.state) || {};
 	const { latestDomEvent } = domEventsPluginKey.getState(editorView.state);
 	// const hasFocus = editorView.hasFocus();

--- a/client/components/Editor/plugins/onChange.ts
+++ b/client/components/Editor/plugins/onChange.ts
@@ -1,6 +1,7 @@
 import { Plugin, NodeSelection, TextSelection } from 'prosemirror-state';
 import { lift, setBlockType, toggleMark, wrapIn } from 'prosemirror-commands';
 import { wrapInList } from 'prosemirror-schema-list';
+import { EditorView } from 'prosemirror-view';
 import {
 	isInTable,
 	deleteTable,
@@ -21,7 +22,6 @@ import { getReactedCopyOfNode } from '@pubpub/prosemirror-reactive';
 import { collabDocPluginKey } from './collaborative';
 import { domEventsPluginKey } from './domEvents';
 import { findParentNodeClosestToPos } from '../utils';
-import { EditorView } from 'prosemirror-view';
 import { ReferenceableNodeType } from '../types';
 import { EditorProps } from '../Editor';
 // import { collaborativePluginKey } from './plugins/collaborative';

--- a/client/components/Editor/schemas/audio.ts
+++ b/client/components/Editor/schemas/audio.ts
@@ -17,6 +17,7 @@ export default {
 			size: { default: 50 }, // number as percentage
 			align: { default: 'center' },
 			caption: { default: '' },
+			hideLabel: { default: false },
 		},
 		reactiveAttrs: {
 			count: counter(),
@@ -65,7 +66,7 @@ export default {
 						'div',
 						withValue(buildLabel(node), (label) => [
 							'strong',
-							{ spellcheck: false },
+							{ spellcheck: 'false' },
 							label,
 						]),
 						renderHtmlChildren(isReact, node.attrs.caption, 'div'),

--- a/client/components/Editor/schemas/equation.tsx
+++ b/client/components/Editor/schemas/equation.tsx
@@ -73,6 +73,7 @@ export default {
 			value: { default: '' },
 			html: { default: '' },
 			renderForPandoc: { default: false },
+			hideLabel: { default: false },
 		},
 		reactiveAttrs: {
 			count: counter(),
@@ -104,7 +105,7 @@ export default {
 					/>
 				) as any;
 			}
-			return pruneFalsyValues([
+			return [
 				'div',
 				{
 					...(node.attrs.id && { id: node.attrs.id }),
@@ -113,12 +114,12 @@ export default {
 				},
 				['span'],
 				renderHtmlChildren(isReact, node.attrs.html),
-				withValue(node.attrs.count, (count) => [
+				[
 					'span',
-					{ class: 'equation-label', spellcheck: false },
-					`(${count})`,
-				]),
-			]) as DOMOutputSpec;
+					{ class: 'equation-label', spellcheck: 'false' },
+					node.attrs.count ? `(${node.attrs.count})` : '',
+				],
+			] as DOMOutputSpec;
 		},
 
 		inline: false,

--- a/client/components/Editor/schemas/image.ts
+++ b/client/components/Editor/schemas/image.ts
@@ -16,6 +16,7 @@ export default {
 			size: { default: 50 }, // number as percentage
 			align: { default: 'center' },
 			caption: { default: '' },
+			hideLabel: { default: false },
 		},
 		reactiveAttrs: {
 			count: counter(),
@@ -65,7 +66,7 @@ export default {
 						'div',
 						withValue(buildLabel(node), (label) => [
 							'strong',
-							{ spellcheck: false },
+							{ spellcheck: 'false' },
 							label,
 						]),
 						renderHtmlChildren(isReact, node.attrs.caption, 'div'),

--- a/client/components/Editor/schemas/reactive/counter.ts
+++ b/client/components/Editor/schemas/reactive/counter.ts
@@ -9,12 +9,10 @@ export const counter = (counterType?: string, nodeFingerprintFn?) => {
 
 	return function(this: Hooks, node: Node) {
 		const { nodeLabels } = this.useDocumentState();
+		const nodeLabel = (nodeLabels as NodeLabelMap)[node.type.name as ReferenceableNodeType];
+		const resolvedCounterType = counterType || nodeLabel?.text;
 		const counterState = this.useTransactionState(
-			[
-				'counter',
-				counterType ||
-					(nodeLabels as NodeLabelMap)[node.type.name as ReferenceableNodeType].text,
-			],
+			resolvedCounterType ? ['counter', resolvedCounterType] : ['counter'],
 			{
 				countsMap: {},
 				maxCount: 0,

--- a/client/components/Editor/schemas/table.ts
+++ b/client/components/Editor/schemas/table.ts
@@ -70,7 +70,7 @@ table.toDOM = (node: ProsemirrorNode) => {
 	return pruneFalsyValues([
 		spec[0],
 		{ id: node.attrs.id },
-		withValue(buildLabel(node), (label) => ['caption', { spellcheck: false }, label]),
+		withValue(buildLabel(node), (label) => ['caption', { spellcheck: 'false' }, label]),
 		spec[1],
 	]) as DOMOutputSpec;
 };

--- a/client/components/Editor/schemas/table.ts
+++ b/client/components/Editor/schemas/table.ts
@@ -51,7 +51,7 @@ table.onInsert = (view) => {
 // Enhance table node with reactive attributes.
 const { toDOM: tableToDOM } = table;
 
-table.attrs = { ...table.attrs, id: { default: null } };
+table.attrs = { ...table.attrs, id: { default: null }, hideLabel: { default: false } };
 table.reactive = true;
 table.reactiveAttrs = {
 	count: counter(),

--- a/client/components/Editor/schemas/video.ts
+++ b/client/components/Editor/schemas/video.ts
@@ -16,6 +16,7 @@ export default {
 			size: { default: 50 }, // number as percentage
 			align: { default: 'center' },
 			caption: { default: '' },
+			hideLabel: { default: false },
 		},
 		reactiveAttrs: {
 			count: counter(),
@@ -64,7 +65,7 @@ export default {
 						'div',
 						withValue(buildLabel(node), (label) => [
 							'strong',
-							{ spellcheck: false },
+							{ spellcheck: 'false' },
 							label,
 						]),
 						renderHtmlChildren(isReact, node.attrs.caption, 'div'),

--- a/client/components/Editor/utils/references.ts
+++ b/client/components/Editor/utils/references.ts
@@ -113,4 +113,4 @@ export const getNodeLabelText = (node: Node, nodeLabels: NodeLabelMap) =>
 	nodeLabels[node.type.name as ReferenceableNodeType]?.text;
 
 export const isNodeLabelEnabled = (node: Node, nodeLabels: NodeLabelMap) =>
-	Boolean(nodeLabels[node.type.name as ReferenceableNodeType]?.enabled);
+	Boolean(nodeLabels[node.type.name as ReferenceableNodeType]?.enabled) && !node.attrs.hideLabel;

--- a/client/components/Editor/utils/selection.ts
+++ b/client/components/Editor/utils/selection.ts
@@ -1,3 +1,4 @@
+import { Node, ResolvedPos } from 'prosemirror-model';
 import { NodeSelection, Selection, TextSelection } from 'prosemirror-state';
 
 export const moveSelectionToStart = (editorView) => {
@@ -51,5 +52,24 @@ export const setEditorSelectionFromClick = (editorView, clickEvent) => {
 		}
 		txn.setMeta('latestDomEvent', clickEvent);
 		editorView.dispatch(txn);
+	}
+};
+
+type NodePredicate = (node: Node) => boolean;
+
+export const findParentNode = (predicate: NodePredicate) => ({ $from }: Selection) =>
+	findParentNodeClosestToPos($from, predicate);
+
+export const findParentNodeClosestToPos = ($pos: ResolvedPos, predicate: NodePredicate) => {
+	for (let i = $pos.depth; i > 0; i--) {
+		const node = $pos.node(i);
+		if (predicate(node)) {
+			return {
+				pos: i > 0 ? $pos.before(i) : 0,
+				start: $pos.start(i),
+				depth: i,
+				node,
+			};
+		}
 	}
 };

--- a/client/components/FormattingBar/controlComponents/ControlsEquation.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsEquation.tsx
@@ -1,11 +1,15 @@
 /* eslint-disable react/no-danger */
 import React, { useRef, useEffect, useCallback } from 'react';
+import { Checkbox } from '@blueprintjs/core';
 import { useDebounce } from 'use-debounce';
+import { Node } from 'prosemirror-model';
 
 import { renderLatexString } from 'client/utils/editor';
 
 import { ControlsButton, ControlsButtonGroup } from './ControlsButton';
-import { Checkbox } from '@blueprintjs/core';
+
+import { usePubData } from 'client/containers/Pub/pubHooks';
+import { NodeLabelMap, ReferenceableNodeType } from 'client/components/Editor/types';
 
 require('./controls.scss');
 
@@ -15,15 +19,10 @@ type Props = {
 	editorChangeObject: {
 		changeNode: (...args: any[]) => any;
 		updateNode: (...args: any[]) => any;
-		selectedNode?: {
-			type?: {
-				name?: string;
-			};
-			attrs?: {
-				value: string;
-				html?: string;
-				hideLabel: boolean;
-			};
+		selectedNode: Node & {
+			value: string;
+			html?: string;
+			hideLabel: boolean;
 		};
 	};
 };
@@ -47,8 +46,11 @@ const ControlsEquation = (props: Props) => {
 		(e: React.MouseEvent) => updateNode({ hideLabel: (e.target as HTMLInputElement).checked }),
 		[updateNode],
 	);
-	// @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
 	const isBlock = selectedNode.type.name === 'block_equation';
+	const { nodeLabels } = usePubData();
+	const canHideLabel =
+		nodeLabels &&
+		(nodeLabels as NodeLabelMap)[selectedNode.type.name as ReferenceableNodeType]?.enabled;
 
 	useEffect(() => {
 		// Avoid an initial call to the server's LaTeX renderer on mount
@@ -92,7 +94,7 @@ const ControlsEquation = (props: Props) => {
 				<div className="section">
 					<div className="title">Preview</div>
 					<div className="preview" dangerouslySetInnerHTML={{ __html: html }} />
-					{isBlock && (
+					{isBlock && canHideLabel && (
 						<div className="controls-row">
 							<Checkbox
 								onClick={toggleLabel}

--- a/client/components/FormattingBar/controlComponents/ControlsEquation.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsEquation.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-danger */
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 import { useDebounce } from 'use-debounce';
 
 import { renderLatexString } from 'client/utils/editor';
@@ -43,11 +43,10 @@ const ControlsEquation = (props: Props) => {
 	} = pendingAttrs;
 	const [debouncedValue] = useDebounce(value, 250);
 	const hasMountedRef = useRef(false);
-	const toggleLabel = (e: React.MouseEvent) => {
-		// @ts-ignore
-		console.log(e.target.checked);
-		updateNode({ hideLabel: (e.target as HTMLInputElement).checked });
-	};
+	const toggleLabel = (e: React.MouseEvent) =>
+		useCallback(() => updateNode({ hideLabel: (e.target as HTMLInputElement).checked }), [
+			updateNode,
+		]);
 	// @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
 	const isBlock = selectedNode.type.name === 'block_equation';
 

--- a/client/components/FormattingBar/controlComponents/ControlsEquation.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsEquation.tsx
@@ -43,10 +43,10 @@ const ControlsEquation = (props: Props) => {
 	} = pendingAttrs;
 	const [debouncedValue] = useDebounce(value, 250);
 	const hasMountedRef = useRef(false);
-	const toggleLabel = (e: React.MouseEvent) =>
-		useCallback(() => updateNode({ hideLabel: (e.target as HTMLInputElement).checked }), [
-			updateNode,
-		]);
+	const toggleLabel = useCallback(
+		(e: React.MouseEvent) => updateNode({ hideLabel: (e.target as HTMLInputElement).checked }),
+		[updateNode],
+	);
 	// @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
 	const isBlock = selectedNode.type.name === 'block_equation';
 

--- a/client/components/FormattingBar/controlComponents/ControlsEquation.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsEquation.tsx
@@ -5,6 +5,7 @@ import { useDebounce } from 'use-debounce';
 import { renderLatexString } from 'client/utils/editor';
 
 import { ControlsButton, ControlsButtonGroup } from './ControlsButton';
+import { Checkbox } from '@blueprintjs/core';
 
 require('./controls.scss');
 
@@ -21,6 +22,7 @@ type Props = {
 			attrs?: {
 				value: string;
 				html?: string;
+				hideLabel: boolean;
 			};
 		};
 	};
@@ -32,7 +34,7 @@ const getSchemaDefinitionForNodeType = (editorChangeObject, nodeTypeName) => {
 
 const ControlsEquation = (props: Props) => {
 	const { editorChangeObject, pendingAttrs, onClose } = props;
-	const { changeNode, selectedNode } = editorChangeObject;
+	const { changeNode, updateNode, selectedNode } = editorChangeObject;
 	const {
 		commitChanges,
 		hasPendingChanges,
@@ -41,6 +43,11 @@ const ControlsEquation = (props: Props) => {
 	} = pendingAttrs;
 	const [debouncedValue] = useDebounce(value, 250);
 	const hasMountedRef = useRef(false);
+	const toggleLabel = (e: React.MouseEvent) => {
+		// @ts-ignore
+		console.log(e.target.checked);
+		updateNode({ hideLabel: (e.target as HTMLInputElement).checked });
+	};
 	// @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
 	const isBlock = selectedNode.type.name === 'block_equation';
 
@@ -86,6 +93,16 @@ const ControlsEquation = (props: Props) => {
 				<div className="section">
 					<div className="title">Preview</div>
 					<div className="preview" dangerouslySetInnerHTML={{ __html: html }} />
+					{isBlock && (
+						<div className="controls-row">
+							<Checkbox
+								onClick={toggleLabel}
+								alignIndicator="right"
+								label="Hide label"
+								checked={selectedNode?.attrs?.hideLabel}
+							/>
+						</div>
+					)}
 					<ControlsButtonGroup>
 						<ControlsButton onClick={handleChangeNodeType}>
 							Change to {isBlock ? 'inline' : 'block'}

--- a/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import { Checkbox } from '@blueprintjs/core';
+import { Node } from 'prosemirror-model';
 
 import { SimpleEditor } from 'components';
 
@@ -7,18 +8,20 @@ import { ControlsButton, ControlsButtonGroup } from '../ControlsButton';
 import AlignmentControl from './AlignmentControl';
 import SliderInputControl from './SliderInputControl';
 import SourceControls from './SourceControls';
+import { usePubData } from 'client/containers/Pub/pubHooks';
+import { NodeLabelMap, ReferenceableNodeType } from 'client/components/Editor/types';
 
 type Props = {
 	isSmall: boolean;
 	pendingAttrs: any;
 	editorChangeObject: {
 		updateNode: (...args: any[]) => any;
-		selectedNode: {
+		selectedNode: Node & {
 			attrs?: {
-				size?: number;
-				align?: string;
-				height?: number;
-				caption?: string;
+				size: number;
+				align: string;
+				height: number;
+				caption: string;
 				hideLabel: boolean;
 			};
 		};
@@ -39,7 +42,6 @@ const ControlsMedia = (props: Props) => {
 	const { isSmall, editorChangeObject, pendingAttrs } = props;
 	const { updateNode, selectedNode } = editorChangeObject;
 	const { hasPendingChanges, commitChanges, updateAttrs } = pendingAttrs;
-	// @ts-expect-error ts-migrate(2339) FIXME: Property 'size' does not exist on type '{ size?: n... Remove this comment to see the full error message
 	const { size, align, height, caption, hideLabel } = selectedNode.attrs;
 	const canEditHeight = getCanEditNodeHeight(selectedNode);
 	const itemName = getItemName(selectedNode);
@@ -47,6 +49,10 @@ const ControlsMedia = (props: Props) => {
 		(e: React.MouseEvent) => updateNode({ hideLabel: (e.target as HTMLInputElement).checked }),
 		[updateNode],
 	);
+	const { nodeLabels } = usePubData();
+	const canHideLabel =
+		nodeLabels &&
+		(nodeLabels as NodeLabelMap)[selectedNode.type.name as ReferenceableNodeType]?.enabled;
 
 	return (
 		<div className="controls-media-component">
@@ -84,14 +90,16 @@ const ControlsMedia = (props: Props) => {
 					updateNode={updateNode}
 					isSmall={isSmall}
 				/>
-				<div className="controls-row">
-					<Checkbox
-						onClick={toggleLabel}
-						alignIndicator="right"
-						label="Hide label"
-						checked={hideLabel}
-					/>
-				</div>
+				{canHideLabel && (
+					<div className="controls-row">
+						<Checkbox
+							onClick={toggleLabel}
+							alignIndicator="right"
+							label="Hide label"
+							checked={hideLabel}
+						/>
+					</div>
+				)}
 			</div>
 			<div className="section hide-overflow">
 				<SimpleEditor

--- a/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback } from 'react';
+import { Checkbox } from '@blueprintjs/core';
 
 import { SimpleEditor } from 'components';
-import { ControlsButton, ControlsButtonGroup } from '../ControlsButton';
 
+import { ControlsButton, ControlsButtonGroup } from '../ControlsButton';
 import AlignmentControl from './AlignmentControl';
 import SliderInputControl from './SliderInputControl';
 import SourceControls from './SourceControls';
-import { Checkbox } from '@blueprintjs/core';
 
 type Props = {
 	isSmall: boolean;

--- a/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
@@ -6,6 +6,7 @@ import { ControlsButton, ControlsButtonGroup } from '../ControlsButton';
 import AlignmentControl from './AlignmentControl';
 import SliderInputControl from './SliderInputControl';
 import SourceControls from './SourceControls';
+import { Checkbox } from '@blueprintjs/core';
 
 type Props = {
 	isSmall: boolean;
@@ -18,6 +19,7 @@ type Props = {
 				align?: string;
 				height?: number;
 				caption?: string;
+				hideLabel: boolean;
 			};
 		};
 	};
@@ -38,9 +40,11 @@ const ControlsMedia = (props: Props) => {
 	const { updateNode, selectedNode } = editorChangeObject;
 	const { hasPendingChanges, commitChanges, updateAttrs } = pendingAttrs;
 	// @ts-expect-error ts-migrate(2339) FIXME: Property 'size' does not exist on type '{ size?: n... Remove this comment to see the full error message
-	const { size, align, height, caption } = selectedNode.attrs;
+	const { size, align, height, caption, hideLabel } = selectedNode.attrs;
 	const canEditHeight = getCanEditNodeHeight(selectedNode);
 	const itemName = getItemName(selectedNode);
+	const toggleLabel = (e: React.MouseEvent) =>
+		updateNode({ hideLabel: (e.target as HTMLInputElement).checked });
 
 	return (
 		<div className="controls-media-component">
@@ -78,6 +82,14 @@ const ControlsMedia = (props: Props) => {
 					updateNode={updateNode}
 					isSmall={isSmall}
 				/>
+				<div className="controls-row">
+					<Checkbox
+						onClick={toggleLabel}
+						alignIndicator="right"
+						label="Hide label"
+						checked={hideLabel}
+					/>
+				</div>
 			</div>
 			<div className="section hide-overflow">
 				<SimpleEditor

--- a/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { SimpleEditor } from 'components';
 import { ControlsButton, ControlsButtonGroup } from '../ControlsButton';
@@ -43,8 +43,10 @@ const ControlsMedia = (props: Props) => {
 	const { size, align, height, caption, hideLabel } = selectedNode.attrs;
 	const canEditHeight = getCanEditNodeHeight(selectedNode);
 	const itemName = getItemName(selectedNode);
-	const toggleLabel = (e: React.MouseEvent) =>
-		updateNode({ hideLabel: (e.target as HTMLInputElement).checked });
+	const toggleLabel = useCallback(
+		(e: React.MouseEvent) => updateNode({ hideLabel: (e.target as HTMLInputElement).checked }),
+		[updateNode],
+	);
 
 	return (
 		<div className="controls-media-component">

--- a/client/components/FormattingBar/controlComponents/ControlsTable.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsTable.tsx
@@ -1,14 +1,13 @@
 import React, { useEffect } from 'react';
 import { Toolbar, ToolbarItem, useToolbarState } from 'reakit';
 import { Button } from '@blueprintjs/core';
+import { EditorView } from 'prosemirror-view';
 
 import CommandMenu from '../CommandMenu';
 
 type Props = {
 	editorChangeObject: {
-		view?: {
-			dom?: any;
-		};
+		view?: EditorView;
 	};
 	onClose: (...args: any[]) => any;
 };
@@ -32,6 +31,7 @@ const buttonCommands = [
 	{ key: 'table-split-cell', title: 'Split cells', icon: 'split-columns' },
 	{ key: 'toggle-header-cell', title: 'Toggle header cells', icon: 'header' },
 	{ key: 'table-delete', title: 'Remove table', icon: 'trash' },
+	{ key: 'table-toggle-label', title: 'Toggle label', icon: 'tag' },
 ];
 
 const ControlsTable = (props: Props) => {


### PR DESCRIPTION
This PR adds the ability to toggle labeling of specific nodes via the editor controls of block equations, media, and tables. Hiding the label of a node should decrement the counter on labels of subsequent, labeled nodes. Nodes with hidden labels will no longer be referenceable, and any existing references will fall back to the **(ref?)** placeholder.

I also snuck in a change to group nodes with shared custom labels into the same reactive counter state. e.g. if both images and audio are labeled "Figure", they will share the same list of potential counter values.

_Screenshots_

Standard block editor controls
<img width="505" alt="Screen Shot 2020-10-14 at 10 20 13 AM" src="https://user-images.githubusercontent.com/6402908/96002779-7e369b80-0e07-11eb-996b-6b74c7dfbab0.png">

Table controls
<img width="619" alt="Screen Shot 2020-10-14 at 10 24 00 AM" src="https://user-images.githubusercontent.com/6402908/96002732-737c0680-0e07-11eb-8cb7-e3ed2c521afd.png">

_Test Plan_

1. Create a Pub and enable labeling of images and tables.
2. Update the custom of images and tables to "Figure".
3. Add an image and a table to the Pub.
4. Note that it should have a label and counter by default. The image should be labeled **Figure 1** and the table should be labeled **Figure 2**.
5. Create a reference to **Figure 1** either with the trigger character `@` or editor toolbar.
6. Select the image (Figure 1) and check the Hide Label option in the editor controls.
7. Ensure the following things happen:
    - The image's label is hidden.
    - The table's label is updated to read **Figure 1**.
    - The reference you created in step 5 is reverted to the **(ref?)** placeholder.
    - The image is no longer referenceable via the trigger character or editor toolbar.