### PR TITLE
new: Twitter embed

### DIFF
--- a/client/components/FormattingBar/media/Media.tsx
+++ b/client/components/FormattingBar/media/Media.tsx
@@ -13,6 +13,7 @@ import MediaCodepen from './MediaCodepen';
 import MediaVimeo from './MediaVimeo';
 import MediaSoundcloud from './MediaSoundcloud';
 import MediaGithub from './MediaGithub';
+import MediaTwitter from './MediaTwitter';
 
 require('./media.scss');
 
@@ -49,6 +50,7 @@ class Media extends Component<Props, State> {
 		const apps = [
 			{ text: 'Iframe', icon: 'application' },
 			{ text: 'YouTube', icon: 'youtube' },
+			{ text: 'Twitter', icon: 'twitter' },
 			{ text: 'Codepen', icon: 'codepen' },
 			{ text: 'Vimeo', icon: 'vimeo' },
 			{ text: 'SoundCloud', icon: 'soundcloud' },
@@ -105,6 +107,7 @@ class Media extends Component<Props, State> {
 				{activeItem === 'Other' && <MediaFile {...componentProps} />}
 				{activeItem === 'Iframe' && <MediaIframe {...componentProps} />}
 				{activeItem === 'YouTube' && <MediaYoutube {...componentProps} />}
+				{activeItem === 'Twitter' && <MediaTwitter {...componentProps} />}
 				{activeItem === 'Codepen' && <MediaCodepen {...componentProps} />}
 				{activeItem === 'Vimeo' && <MediaVimeo {...componentProps} />}
 				{activeItem === 'SoundCloud' && <MediaSoundcloud {...componentProps} />}

--- a/client/components/FormattingBar/media/MediaTwitter.tsx
+++ b/client/components/FormattingBar/media/MediaTwitter.tsx
@@ -1,0 +1,117 @@
+import React, { Component } from 'react';
+import { InputGroup, Button, Intent, NonIdealState } from '@blueprintjs/core';
+import { isHttpsUri } from 'valid-url';
+
+import Icon from 'components/Icon/Icon';
+import { apiFetch } from 'client/utils/apiFetch';
+import { getIframeSrc, getEmbedType } from 'client/utils/editor';
+
+type Props = {
+	onInsert: (...args: any[]) => any;
+};
+
+const sampleUrl =
+	process.env.NODE_ENV === 'production'
+		? 'https://twitter.com/pubpub'
+		: 'https://twitter.com/kfutures';
+
+type State = any;
+
+class MediaTwitter extends Component<Props, State> {
+	constructor(props: Props) {
+		super(props);
+		this.state = {
+			isValid: false,
+			input: '',
+			embedUrl: '',
+			embedTitle: '',
+		};
+		this.handleInput = this.handleInput.bind(this);
+		this.handleInsert = this.handleInsert.bind(this);
+	}
+
+	handleInput(url) {
+		const input = url;
+		const isValid = isHttpsUri(input) && getEmbedType(input) === 'twitter';
+		this.setState(
+			{
+				input: input,
+				isValid: isValid,
+			},
+			() => {
+				if (!this.state.isValid) {
+					return this.setState({ embedUrl: '', embedTitle: '' });
+				}
+
+				const queryParams = `?type=${getEmbedType(input)}&input=${input}`;
+				// @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
+				return apiFetch(`/api/editor/embed${queryParams}`).then((result) => {
+					this.setState({
+						embedUrl: result.html,
+						embedTitle: result.title,
+					});
+				});
+			},
+		);
+	}
+
+	handleInsert() {
+		this.props.onInsert('iframe', {
+			url: `data:text/html;charset=utf-8,${encodeURI(this.state.embedUrl)}`,
+			caption: this.state.embedTitle,
+			align: 'full',
+		});
+	}
+
+	render() {
+		return (
+			<div className="formatting-bar_media-component-content">
+				<InputGroup
+					className="top-input"
+					fill={true}
+					placeholder="Enter Twitter URL"
+					large={true}
+					value={this.state.input}
+					onChange={(evt) => {
+						this.handleInput(evt.target.value);
+					}}
+					rightElement={
+						<Button
+							text="Insert"
+							intent={Intent.PRIMARY}
+							disabled={!this.state.embedUrl}
+							large={true}
+							onClick={this.handleInsert}
+						/>
+					}
+				/>
+				{this.state.isValid && (
+					<div className="preview-wrapper">
+						<iframe
+							frameBorder="none"
+							src={`data:text/html;charset=utf-8,${encodeURI(this.state.embedUrl)}`}
+							title="URL preview"
+						/>
+					</div>
+				)}
+				{!this.state.isValid && (
+					<div className="preview-wrapper">
+						<NonIdealState
+							title="Paste a Twitter URL above. You can embed a tweet, timline, list or search."
+							icon={<Icon icon="twitter" iconSize={60} useColor={true} />}
+							action={
+								<Button
+									text="Load Sample URL"
+									onClick={() => {
+										this.handleInput(sampleUrl);
+									}}
+								/>
+							}
+						/>
+					</div>
+				)}
+			</div>
+		);
+	}
+}
+export default MediaTwitter;

--- a/client/components/FormattingBar/media/MediaTwitter.tsx
+++ b/client/components/FormattingBar/media/MediaTwitter.tsx
@@ -99,7 +99,7 @@ class MediaTwitter extends Component<Props, State> {
 				{!this.state.isValid && (
 					<div className="preview-wrapper">
 						<NonIdealState
-							title="Paste a Twitter URL above. You can embed a tweet, timline, list or search."
+							title="Paste a Twitter URL above. You can embed a tweet, profile, list, collection, or likes timeline."
 							icon={<Icon icon="twitter" iconSize={60} useColor={true} />}
 							action={
 								<Button

--- a/client/components/FormattingBar/media/MediaTwitter.tsx
+++ b/client/components/FormattingBar/media/MediaTwitter.tsx
@@ -57,7 +57,7 @@ class MediaTwitter extends Component<Props, State> {
 
 	handleInsert() {
 		this.props.onInsert('iframe', {
-			url: `data:text/html;charset=utf-8,${encodeURI(this.state.embedUrl)}`,
+			url: `data:text/html;charset=utf-8,${encodeURIComponent(this.state.embedUrl)}`,
 			caption: this.state.embedTitle,
 			align: 'full',
 		});
@@ -89,7 +89,9 @@ class MediaTwitter extends Component<Props, State> {
 					<div className="preview-wrapper">
 						<iframe
 							frameBorder="none"
-							src={`data:text/html;charset=utf-8,${encodeURI(this.state.embedUrl)}`}
+							src={`data:text/html;charset=utf-8,${encodeURIComponent(
+								this.state.embedUrl,
+							)}`}
 							title="URL preview"
 						/>
 					</div>

--- a/client/utils/editor.ts
+++ b/client/utils/editor.ts
@@ -11,6 +11,7 @@ export const getEmbedType = (input) => {
 		vimeo: ['https://vimeo.com', 'https://player.vimeo.com'],
 		soundcloud: ['https://soundcloud.com'],
 		github: ['https://gist.github.com'],
+		twitter: ['https://twitter.com', 'https://publish.twitter.com'],
 	};
 
 	// @ts-expect-error ts-migrate(2769) FIXME: Type 'string' is not assignable to type 'null'.

--- a/server/editor/api.js
+++ b/server/editor/api.js
@@ -31,9 +31,9 @@ app.get('/api/editor/embed', (req, res) => {
 		codepen: `https://codepen.io/api/oembed?url=${input}&format=json`,
 		vimeo: `https://vimeo.com/api/oembed.json?url=${input}`,
 		soundcloud: `https://soundcloud.com/oembed?url=${input}&format=json`,
+		twitter: `https://publish.twitter.com/oembed?url=${input}&format=json`,
 	};
 	const oembedUrl = oembedUrls[type];
-
 	if (!oembedUrl) {
 		if (type === 'github') {
 			const githubParts = input.split('/');


### PR DESCRIPTION
Someone recently asked for better social embedding. It turns out Twitter has recently updated their [oembed](https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/overview) [capabilities](https://developer.twitter.com/en/docs/twitter-for-websites/timelines/overview) to make this quite easy, so, I went ahead and added it. Because Twitter returns "rich" oembeds (ie, not iFrames), it uses the same "hack" as Gists, encoding the html and using a data uri to render it into the iFrame. (As a sidenote, I think we should eventually use this approach – well, in fact, srcdoc because we won't be able to validate the content – to allow people to create arbitrary embeds of html code of their choosing. But that needs a bit more work).

<img width="645" alt="Screen Shot 2020-10-16 at 14 58 27" src="https://user-images.githubusercontent.com/639110/96298201-14152680-0fc0-11eb-9f9a-9b8595deec98.png">

_Test Plan_
1. Embed a Tweet (e.g. https://twitter.com/pubpub/status/1316132973255766017)
1. Embed a "timeline" (e.g. https://twitter.com/pubpub)