### PR TITLE
update: references feature discoverability and conditional disabling

### DIFF
--- a/client/components/Editor/ReferenceFinder.tsx
+++ b/client/components/Editor/ReferenceFinder.tsx
@@ -31,7 +31,7 @@ const ReferenceFinder = (props: ReferenceFinderProps) => {
 
 	return (
 		<Menu className="reference-finder-component bp3-elevation-1">
-			{menuItems.length > 0 ? menuItems : <MenuItem text="No references found" disabled />}
+			{menuItems.length > 0 ? menuItems : <MenuItem text="No items to reference" disabled />}
 		</Menu>
 	);
 };

--- a/client/components/FormattingBar/FormattingBar.tsx
+++ b/client/components/FormattingBar/FormattingBar.tsx
@@ -236,7 +236,6 @@ const FormattingBar = (props: Props) => {
 				accentColor={communityData.accentColorDark}
 				// @ts-expect-error ts-migrate(2554) FIXME: Expected 1 arguments, but got 2.
 				onClick={(evt) => handleButtonClick(button, evt)}
-				pubData={pubData}
 				{...maybeEditorChangeObject}
 			/>
 		);
@@ -308,6 +307,7 @@ const FormattingBar = (props: Props) => {
 							onClose={onClose}
 							isSmall={isSmall}
 							citationStyle={citationStyle}
+							pubData={pubData}
 						/>
 					)}
 				</FormattingBarPopover>

--- a/client/components/FormattingBar/FormattingBar.tsx
+++ b/client/components/FormattingBar/FormattingBar.tsx
@@ -235,7 +235,7 @@ const FormattingBar = (props: Props) => {
 				isOpen={isOpen}
 				isDetached={isOpen && !!controlsPosition}
 				isSmall={isSmall}
-				renderPopover={button.renderPopover}
+				PopoverComponent={button.PopoverComponent}
 				accentColor={communityData.accentColorDark}
 				// @ts-expect-error ts-migrate(2554) FIXME: Expected 1 arguments, but got 2.
 				onClick={(evt) => handleButtonClick(button, evt)}

--- a/client/components/FormattingBar/FormattingBar.tsx
+++ b/client/components/FormattingBar/FormattingBar.tsx
@@ -9,6 +9,7 @@ import BlockTypeSelector from './BlockTypeSelector';
 import FormattingBarButton from './FormattingBarButton';
 import FormattingBarPopover from './FormattingBarPopover';
 import { positionNearSelection } from './positioning';
+import { usePubData } from 'client/containers/Pub/pubHooks';
 
 require('./formattingBar.scss');
 
@@ -127,6 +128,7 @@ const FormattingBar = (props: Props) => {
 	} = props;
 	const { menuItems, insertFunctions, view } = editorChangeObject;
 	const { communityData } = usePageContext();
+	const pubData = usePubData();
 	const buttonElementRefs = useRefMap();
 	const toolbar = useToolbarState({ loop: true });
 	const {
@@ -212,10 +214,14 @@ const FormattingBar = (props: Props) => {
 		const isIndicated = indicatedButtons.includes(button) && !isOpen;
 		// @ts-expect-error ts-migrate(2339) FIXME: Property 'isActive' does not exist on type '{}'.
 		const isActive = !isOpen && !isIndicated && !!matchingMenuItem && matchingMenuItem.isActive;
-		const isDisabled =
-			noFunction || (openedButton && !isOpen && !isIndicated && !controlsPosition);
+		const isDisabled = Boolean(
+			(typeof button.isDisabled === 'function' && button.isDisabled(pubData)) ||
+				noFunction ||
+				(openedButton && !isOpen && !isIndicated && !controlsPosition),
+		);
 		const maybeEditorChangeObject =
 			button.key === 'media' ? { editorChangeObject: editorChangeObject } : {};
+
 		return (
 			<ToolbarItem
 				{...toolbar}
@@ -223,16 +229,17 @@ const FormattingBar = (props: Props) => {
 				as={button.component || FormattingBarButton}
 				key={button.key}
 				formattingItem={button}
-				// @ts-expect-error ts-migrate(2769) FIXME: Type 'null' is not assignable to type 'boolean | u... Remove this comment to see the full error message
 				disabled={isDisabled}
 				isActive={isActive}
 				isIndicated={isIndicated && !isOpen}
 				isOpen={isOpen}
 				isDetached={isOpen && !!controlsPosition}
 				isSmall={isSmall}
+				renderPopover={button.renderPopover}
 				accentColor={communityData.accentColorDark}
 				// @ts-expect-error ts-migrate(2554) FIXME: Expected 1 arguments, but got 2.
 				onClick={(evt) => handleButtonClick(button, evt)}
+				pubData={pubData}
 				{...maybeEditorChangeObject}
 			/>
 		);

--- a/client/components/FormattingBar/FormattingBar.tsx
+++ b/client/components/FormattingBar/FormattingBar.tsx
@@ -4,12 +4,12 @@ import { Toolbar, ToolbarItem, useToolbarState } from 'reakit';
 
 import { usePageContext } from 'utils/hooks';
 import { useRefMap } from 'client/utils/useRefMap';
+import { usePubData } from 'client/containers/Pub/pubHooks';
 
 import BlockTypeSelector from './BlockTypeSelector';
 import FormattingBarButton from './FormattingBarButton';
 import FormattingBarPopover from './FormattingBarPopover';
 import { positionNearSelection } from './positioning';
-import { usePubData } from 'client/containers/Pub/pubHooks';
 import { FormattingBarButtonData } from './types';
 import { getButtonPopoverComponent } from './utils';
 

--- a/client/components/FormattingBar/FormattingBar.tsx
+++ b/client/components/FormattingBar/FormattingBar.tsx
@@ -10,6 +10,8 @@ import FormattingBarButton from './FormattingBarButton';
 import FormattingBarPopover from './FormattingBarPopover';
 import { positionNearSelection } from './positioning';
 import { usePubData } from 'client/containers/Pub/pubHooks';
+import { FormattingBarButtonData } from './types';
+import { getButtonPopoverComponent } from './utils';
 
 require('./formattingBar.scss');
 
@@ -26,13 +28,7 @@ type OwnProps = {
 			attrs?: any;
 		};
 	};
-	buttons: {
-		key: string;
-		title: string;
-		ariaTitle?: string;
-		icon: string;
-		isToggle?: boolean;
-	}[];
+	buttons: FormattingBarButtonData[];
 	showBlockTypes?: boolean;
 	isSmall?: boolean;
 	isTranslucent?: boolean;
@@ -205,7 +201,7 @@ const FormattingBar = (props: Props) => {
 		setOpenedButton(null);
 	}, [setOpenedButton]);
 
-	const renderButton = (button) => {
+	const renderButton = (button: FormattingBarButtonData) => {
 		const matchingMenuItem = menuItemByKey(button.key);
 		const insertFunction = insertFunctions && insertFunctions[button.key];
 		// @ts-expect-error ts-migrate(2339) FIXME: Property 'canRun' does not exist on type '{}'.
@@ -221,6 +217,7 @@ const FormattingBar = (props: Props) => {
 		);
 		const maybeEditorChangeObject =
 			button.key === 'media' ? { editorChangeObject: editorChangeObject } : {};
+		const PopoverComponent = getButtonPopoverComponent(button, isDisabled);
 
 		return (
 			<ToolbarItem
@@ -235,7 +232,7 @@ const FormattingBar = (props: Props) => {
 				isOpen={isOpen}
 				isDetached={isOpen && !!controlsPosition}
 				isSmall={isSmall}
-				PopoverComponent={button.PopoverComponent}
+				popoverContent={PopoverComponent && <PopoverComponent />}
 				accentColor={communityData.accentColorDark}
 				// @ts-expect-error ts-migrate(2554) FIXME: Expected 1 arguments, but got 2.
 				onClick={(evt) => handleButtonClick(button, evt)}

--- a/client/components/FormattingBar/FormattingBarButton.tsx
+++ b/client/components/FormattingBar/FormattingBarButton.tsx
@@ -14,8 +14,8 @@ export type FormattingItem = {
 
 export type FormattingBarButtonProps = {
 	accentColor: string;
-	formattingItem: FormattingItem;
 	disabled?: boolean;
+	formattingItem: FormattingItem;
 	isActive?: boolean;
 	isDetached?: boolean;
 	isIndicated?: boolean;
@@ -52,6 +52,8 @@ const getIndicatorStyle = (accentColor) => {
 		background: accentColor,
 	};
 };
+
+const popoverModifiers = { preventOverflow: { enabled: false }, flip: { enabled: false } };
 
 const FormattingBarButton = React.forwardRef<unknown, FormattingBarButtonProps>((props, ref) => {
 	const {
@@ -101,10 +103,10 @@ const FormattingBarButton = React.forwardRef<unknown, FormattingBarButtonProps>(
 		button = (
 			<Popover
 				content={<PopoverComponent pubData={pubData} />}
-				position={Position.BOTTOM}
-				modifiers={{ preventOverflow: { enabled: false }, flip: { enabled: false } }}
-				openOnTargetFocus={true}
 				interactionKind={PopoverInteractionKind.HOVER}
+				modifiers={popoverModifiers}
+				openOnTargetFocus
+				position={Position.BOTTOM}
 			>
 				{button}
 			</Popover>

--- a/client/components/FormattingBar/FormattingBarButton.tsx
+++ b/client/components/FormattingBar/FormattingBarButton.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { Button } from 'reakit';
 
 import { Icon } from 'components';
+import { Popover, PopoverInteractionKind, Position, Tooltip } from '@blueprintjs/core';
 
 const propTypes = {
 	accentColor: PropTypes.string,
@@ -22,6 +23,7 @@ const propTypes = {
 	label: PropTypes.string,
 	onClick: PropTypes.func.isRequired,
 	outerRef: PropTypes.any,
+	pubData: PropTypes.object,
 };
 
 const defaultProps = {
@@ -61,45 +63,43 @@ const getIndicatorStyle = (accentColor) => {
 	};
 };
 
-const FormattingBarButton = React.forwardRef((props, ref) => {
-	const {
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'disabled' does not exist on type '{ chil... Remove this comment to see the full error message
-		disabled,
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'formattingItem' does not exist on type '... Remove this comment to see the full error message
-		formattingItem,
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'isActive' does not exist on type '{ chil... Remove this comment to see the full error message
-		isActive,
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'isIndicated' does not exist on type '{ c... Remove this comment to see the full error message
-		isIndicated,
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'isDetached' does not exist on type '{ ch... Remove this comment to see the full error message
-		isDetached,
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'isOpen' does not exist on type '{ childr... Remove this comment to see the full error message
-		isOpen,
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'isSmall' does not exist on type '{ child... Remove this comment to see the full error message
-		isSmall,
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'label' does not exist on type '{ childre... Remove this comment to see the full error message
-		label,
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'onClick' does not exist on type '{ child... Remove this comment to see the full error message
-		onClick,
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'accentColor' does not exist on type '{ c... Remove this comment to see the full error message
-		accentColor,
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'outerRef' does not exist on type '{ chil... Remove this comment to see the full error message
-		outerRef,
-		...restProps
-	} = props;
+type FormattingBarButtonProps = {
+	renderPopover?: (pubData: any) => string;
+	pubData: any;
+};
 
-	return (
-		<span
-			ref={outerRef}
-			className={classNames(
-				'formatting-bar-button',
-				isOpen && 'open',
-				isDetached && 'detached',
-				!!label && 'has-label',
-			)}
-			style={getOuterStyle(accentColor, isOpen, isDetached)}
-		>
-			{/* @ts-expect-error ts-migrate(2769) FIXME: Type 'unknown' is not assignable to type 'HTMLButt... Remove this comment to see the full error message */}
+const FormattingBarButton = React.forwardRef<typeof Button, FormattingBarButtonProps>(
+	(props, ref) => {
+		const {
+			// @ts-expect-error ts-migrate(2339) FIXME: Property 'disabled' does not exist on type '{ chil... Remove this comment to see the full error message
+			disabled,
+			// @ts-expect-error ts-migrate(2339) FIXME: Property 'formattingItem' does not exist on type '... Remove this comment to see the full error message
+			formattingItem,
+			// @ts-expect-error ts-migrate(2339) FIXME: Property 'isActive' does not exist on type '{ chil... Remove this comment to see the full error message
+			isActive,
+			// @ts-expect-error ts-migrate(2339) FIXME: Property 'isIndicated' does not exist on type '{ c... Remove this comment to see the full error message
+			isIndicated,
+			// @ts-expect-error ts-migrate(2339) FIXME: Property 'isDetached' does not exist on type '{ ch... Remove this comment to see the full error message
+			isDetached,
+			// @ts-expect-error ts-migrate(2339) FIXME: Property 'isOpen' does not exist on type '{ childr... Remove this comment to see the full error message
+			isOpen,
+			// @ts-expect-error ts-migrate(2339) FIXME: Property 'isSmall' does not exist on type '{ child... Remove this comment to see the full error message
+			isSmall,
+			// @ts-expect-error ts-migrate(2339) FIXME: Property 'label' does not exist on type '{ childre... Remove this comment to see the full error message
+			label,
+			// @ts-expect-error ts-migrate(2339) FIXME: Property 'onClick' does not exist on type '{ child... Remove this comment to see the full error message
+			onClick,
+			// @ts-expect-error ts-migrate(2339) FIXME: Property 'accentColor' does not exist on type '{ c... Remove this comment to see the full error message
+			accentColor,
+			// @ts-expect-error ts-migrate(2339) FIXME: Property 'outerRef' does not exist on type '{ chil... Remove this comment to see the full error message
+			outerRef,
+			renderPopover,
+			pubData,
+			...restProps
+		} = props;
+
+		let button = (
+			/* @ts-expect-error ts-migrate(2769) FIXME: Type 'unknown' is not assignable to type 'HTMLButt... Remove this comment to see the full error message */
 			<Button
 				ref={ref}
 				{...restProps}
@@ -122,12 +122,44 @@ const FormattingBarButton = React.forwardRef((props, ref) => {
 				<Icon icon={formattingItem.icon} iconSize={isSmall ? 12 : 16} />
 				{label}
 			</Button>
-			{isIndicated && <div className="indicator" style={getIndicatorStyle(accentColor)} />}
-		</span>
-	);
-});
+		);
 
-// @ts-expect-error ts-migrate(2559) FIXME: Type '{ accentColor: Requireable<string>; formatti... Remove this comment to see the full error message
+		const popoverContent = renderPopover && renderPopover(pubData);
+
+		if (popoverContent) {
+			button = (
+				<Popover
+					content={popoverContent}
+					position={Position.BOTTOM}
+					modifiers={{ preventOverflow: { enabled: false }, flip: { enabled: false } }}
+					openOnTargetFocus={true}
+					interactionKind={PopoverInteractionKind.HOVER}
+				>
+					{button}
+				</Popover>
+			);
+		}
+
+		return (
+			<span
+				ref={outerRef}
+				className={classNames(
+					'formatting-bar-button',
+					isOpen && 'open',
+					isDetached && 'detached',
+					!!label && 'has-label',
+				)}
+				style={getOuterStyle(accentColor, isOpen, isDetached)}
+			>
+				{button}
+				{isIndicated && (
+					<div className="indicator" style={getIndicatorStyle(accentColor)} />
+				)}
+			</span>
+		);
+	},
+);
+
 FormattingBarButton.propTypes = propTypes;
 // @ts-expect-error ts-migrate(2559) FIXME: Type '{ accentColor: string; disabled: boolean; la... Remove this comment to see the full error message
 FormattingBarButton.defaultProps = defaultProps;

--- a/client/components/FormattingBar/FormattingBarButton.tsx
+++ b/client/components/FormattingBar/FormattingBarButton.tsx
@@ -104,6 +104,7 @@ const FormattingBarButton = React.forwardRef<unknown, FormattingBarButtonProps>(
 				interactionKind={PopoverInteractionKind.HOVER}
 				modifiers={popoverModifiers}
 				openOnTargetFocus
+				minimal
 				position={Position.BOTTOM}
 			>
 				{button}

--- a/client/components/FormattingBar/FormattingBarButton.tsx
+++ b/client/components/FormattingBar/FormattingBarButton.tsx
@@ -1,41 +1,31 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Button } from 'reakit';
+import { Popover, PopoverInteractionKind, Position } from '@blueprintjs/core';
 
 import { Icon } from 'components';
-import { Popover, PopoverInteractionKind, Position, Tooltip } from '@blueprintjs/core';
 
-const propTypes = {
-	accentColor: PropTypes.string,
-	formattingItem: PropTypes.shape({
-		ariaTitle: PropTypes.string,
-		title: PropTypes.string.isRequired,
-		isToggle: PropTypes.bool,
-		icon: PropTypes.string.isRequired,
-	}).isRequired,
-	disabled: PropTypes.bool,
-	isActive: PropTypes.bool,
-	isDetached: PropTypes.bool,
-	isIndicated: PropTypes.bool,
-	isOpen: PropTypes.bool,
-	isSmall: PropTypes.bool,
-	label: PropTypes.string,
-	onClick: PropTypes.func.isRequired,
-	outerRef: PropTypes.any,
-	pubData: PropTypes.object,
+type FormattingItem = {
+	ariaTitle?: string;
+	title: string;
+	isToggle?: string;
+	icon: string;
 };
 
-const defaultProps = {
-	accentColor: 'white',
-	disabled: false,
-	label: null,
-	isActive: false,
-	isIndicated: false,
-	isOpen: false,
-	isSmall: false,
-	isDetached: false,
-	outerRef: undefined,
+type FormattingBarButtonProps = {
+	accentColor: string;
+	formattingItem: FormattingItem;
+	disabled?: boolean;
+	isActive?: boolean;
+	isDetached?: boolean;
+	isIndicated?: boolean;
+	isOpen?: boolean;
+	isSmall?: boolean;
+	label: string;
+	onClick: (formattingItem: FormattingItem) => unknown;
+	outerRef: React.RefObject<any>;
+	renderPopover?: (pubData: any) => string;
+	pubData: any;
 };
 
 const getOuterStyle = (accentColor, isOpen, isDetached) => {
@@ -63,104 +53,84 @@ const getIndicatorStyle = (accentColor) => {
 	};
 };
 
-type FormattingBarButtonProps = {
-	renderPopover?: (pubData: any) => string;
-	pubData: any;
-};
+const FormattingBarButton = React.forwardRef<unknown, FormattingBarButtonProps>((props, ref) => {
+	const {
+		disabled = false,
+		formattingItem,
+		isActive = false,
+		isIndicated = false,
+		isDetached = false,
+		isOpen = false,
+		isSmall = false,
+		label = null,
+		onClick,
+		accentColor = 'white',
+		outerRef,
+		renderPopover,
+		pubData,
+		...restProps
+	} = props;
 
-const FormattingBarButton = React.forwardRef<typeof Button, FormattingBarButtonProps>(
-	(props, ref) => {
-		const {
-			// @ts-expect-error ts-migrate(2339) FIXME: Property 'disabled' does not exist on type '{ chil... Remove this comment to see the full error message
-			disabled,
-			// @ts-expect-error ts-migrate(2339) FIXME: Property 'formattingItem' does not exist on type '... Remove this comment to see the full error message
-			formattingItem,
-			// @ts-expect-error ts-migrate(2339) FIXME: Property 'isActive' does not exist on type '{ chil... Remove this comment to see the full error message
-			isActive,
-			// @ts-expect-error ts-migrate(2339) FIXME: Property 'isIndicated' does not exist on type '{ c... Remove this comment to see the full error message
-			isIndicated,
-			// @ts-expect-error ts-migrate(2339) FIXME: Property 'isDetached' does not exist on type '{ ch... Remove this comment to see the full error message
-			isDetached,
-			// @ts-expect-error ts-migrate(2339) FIXME: Property 'isOpen' does not exist on type '{ childr... Remove this comment to see the full error message
-			isOpen,
-			// @ts-expect-error ts-migrate(2339) FIXME: Property 'isSmall' does not exist on type '{ child... Remove this comment to see the full error message
-			isSmall,
-			// @ts-expect-error ts-migrate(2339) FIXME: Property 'label' does not exist on type '{ childre... Remove this comment to see the full error message
-			label,
-			// @ts-expect-error ts-migrate(2339) FIXME: Property 'onClick' does not exist on type '{ child... Remove this comment to see the full error message
-			onClick,
-			// @ts-expect-error ts-migrate(2339) FIXME: Property 'accentColor' does not exist on type '{ c... Remove this comment to see the full error message
-			accentColor,
-			// @ts-expect-error ts-migrate(2339) FIXME: Property 'outerRef' does not exist on type '{ chil... Remove this comment to see the full error message
-			outerRef,
-			renderPopover,
-			pubData,
-			...restProps
-		} = props;
+	let button = (
+		/* @ts-expect-error ts-migrate(2769) FIXME: Type 'unknown' is not assignable to type 'HTMLButt... Remove this comment to see the full error message */
+		<Button
+			ref={ref}
+			{...restProps}
+			role="button"
+			disabled={disabled}
+			focusable
+			title={formattingItem.title}
+			aria-label={formattingItem.ariaTitle || formattingItem.title}
+			aria-pressed={formattingItem.isToggle ? isActive : undefined}
+			className={classNames(
+				'bp3-button',
+				'bp3-minimal',
+				isActive && 'bp3-active',
+				isSmall && 'bp3-small',
+				disabled && 'bp3-disabled',
+			)}
+			style={getInnerStyle(accentColor, isOpen, isDetached)}
+			onClick={() => onClick(formattingItem)}
+		>
+			<Icon icon={formattingItem.icon} iconSize={isSmall ? 12 : 16} />
+			{label}
+		</Button>
+	);
 
-		let button = (
-			/* @ts-expect-error ts-migrate(2769) FIXME: Type 'unknown' is not assignable to type 'HTMLButt... Remove this comment to see the full error message */
-			<Button
-				ref={ref}
-				{...restProps}
-				role="button"
-				disabled={disabled}
-				focusable
-				title={formattingItem.title}
-				aria-label={formattingItem.ariaTitle || formattingItem.title}
-				aria-pressed={formattingItem.isToggle ? isActive : undefined}
-				className={classNames(
-					'bp3-button',
-					'bp3-minimal',
-					isActive && 'bp3-active',
-					isSmall && 'bp3-small',
-					disabled && 'bp3-disabled',
-				)}
-				style={getInnerStyle(accentColor, isOpen, isDetached)}
-				onClick={() => onClick(formattingItem)}
-			>
-				<Icon icon={formattingItem.icon} iconSize={isSmall ? 12 : 16} />
-				{label}
-			</Button>
-		);
+	const popoverContent = renderPopover && renderPopover(pubData);
 
-		const popoverContent = renderPopover && renderPopover(pubData);
-
-		if (popoverContent) {
-			button = (
-				<Popover
-					content={popoverContent}
-					position={Position.BOTTOM}
-					modifiers={{ preventOverflow: { enabled: false }, flip: { enabled: false } }}
-					openOnTargetFocus={true}
-					interactionKind={PopoverInteractionKind.HOVER}
-				>
-					{button}
-				</Popover>
-			);
-		}
-
-		return (
-			<span
-				ref={outerRef}
-				className={classNames(
-					'formatting-bar-button',
-					isOpen && 'open',
-					isDetached && 'detached',
-					!!label && 'has-label',
-				)}
-				style={getOuterStyle(accentColor, isOpen, isDetached)}
+	if (popoverContent) {
+		button = (
+			<Popover
+				content={popoverContent}
+				position={Position.BOTTOM}
+				modifiers={{ preventOverflow: { enabled: false }, flip: { enabled: false } }}
+				openOnTargetFocus={true}
+				interactionKind={PopoverInteractionKind.HOVER}
 			>
 				{button}
-				{isIndicated && (
-					<div className="indicator" style={getIndicatorStyle(accentColor)} />
-				)}
-			</span>
+			</Popover>
 		);
-	},
-);
+	}
 
-FormattingBarButton.propTypes = propTypes;
+	return (
+		<span
+			ref={outerRef}
+			className={classNames(
+				'formatting-bar-button',
+				isOpen && 'open',
+				isDetached && 'detached',
+				!!label && 'has-label',
+			)}
+			style={getOuterStyle(accentColor, isOpen, isDetached)}
+		>
+			{button}
+			{isIndicated && <div className="indicator" style={getIndicatorStyle(accentColor)} />}
+		</span>
+	);
+});
+
 // @ts-expect-error ts-migrate(2559) FIXME: Type '{ accentColor: string; disabled: boolean; la... Remove this comment to see the full error message
 FormattingBarButton.defaultProps = defaultProps;
+
 export default FormattingBarButton;

--- a/client/components/FormattingBar/FormattingBarButton.tsx
+++ b/client/components/FormattingBar/FormattingBarButton.tsx
@@ -5,14 +5,14 @@ import { Popover, PopoverInteractionKind, Position } from '@blueprintjs/core';
 
 import { Icon } from 'components';
 
-type FormattingItem = {
+export type FormattingItem = {
 	ariaTitle?: string;
 	title: string;
 	isToggle?: string;
 	icon: string;
 };
 
-type FormattingBarButtonProps = {
+export type FormattingBarButtonProps = {
 	accentColor: string;
 	formattingItem: FormattingItem;
 	disabled?: boolean;
@@ -24,7 +24,7 @@ type FormattingBarButtonProps = {
 	label: string;
 	onClick: (formattingItem: FormattingItem) => unknown;
 	outerRef: React.RefObject<any>;
-	renderPopover?: (pubData: any) => string;
+	PopoverComponent?: React.ComponentType<{ pubData: any }>;
 	pubData: any;
 };
 
@@ -66,7 +66,7 @@ const FormattingBarButton = React.forwardRef<unknown, FormattingBarButtonProps>(
 		onClick,
 		accentColor = 'white',
 		outerRef,
-		renderPopover,
+		PopoverComponent,
 		pubData,
 		...restProps
 	} = props;
@@ -97,12 +97,10 @@ const FormattingBarButton = React.forwardRef<unknown, FormattingBarButtonProps>(
 		</Button>
 	);
 
-	const popoverContent = renderPopover && renderPopover(pubData);
-
-	if (popoverContent) {
+	if (PopoverComponent) {
 		button = (
 			<Popover
-				content={popoverContent}
+				content={<PopoverComponent pubData={pubData} />}
 				position={Position.BOTTOM}
 				modifiers={{ preventOverflow: { enabled: false }, flip: { enabled: false } }}
 				openOnTargetFocus={true}
@@ -129,8 +127,5 @@ const FormattingBarButton = React.forwardRef<unknown, FormattingBarButtonProps>(
 		</span>
 	);
 });
-
-// @ts-expect-error ts-migrate(2559) FIXME: Type '{ accentColor: string; disabled: boolean; la... Remove this comment to see the full error message
-FormattingBarButton.defaultProps = defaultProps;
 
 export default FormattingBarButton;

--- a/client/components/FormattingBar/FormattingBarButton.tsx
+++ b/client/components/FormattingBar/FormattingBarButton.tsx
@@ -25,7 +25,6 @@ export type FormattingBarButtonProps = {
 	onClick: (formattingItem: FormattingItem) => unknown;
 	outerRef: React.RefObject<any>;
 	popoverContent?: JSX.Element;
-	pubData: any;
 };
 
 const getOuterStyle = (accentColor, isOpen, isDetached) => {
@@ -69,7 +68,6 @@ const FormattingBarButton = React.forwardRef<unknown, FormattingBarButtonProps>(
 		accentColor = 'white',
 		outerRef,
 		popoverContent,
-		pubData,
 		...restProps
 	} = props;
 

--- a/client/components/FormattingBar/FormattingBarButton.tsx
+++ b/client/components/FormattingBar/FormattingBarButton.tsx
@@ -24,7 +24,7 @@ export type FormattingBarButtonProps = {
 	label: string;
 	onClick: (formattingItem: FormattingItem) => unknown;
 	outerRef: React.RefObject<any>;
-	PopoverComponent?: React.ComponentType<{ pubData: any }>;
+	popoverContent?: JSX.Element;
 	pubData: any;
 };
 
@@ -68,7 +68,7 @@ const FormattingBarButton = React.forwardRef<unknown, FormattingBarButtonProps>(
 		onClick,
 		accentColor = 'white',
 		outerRef,
-		PopoverComponent,
+		popoverContent,
 		pubData,
 		...restProps
 	} = props;
@@ -99,10 +99,10 @@ const FormattingBarButton = React.forwardRef<unknown, FormattingBarButtonProps>(
 		</Button>
 	);
 
-	if (PopoverComponent) {
+	if (popoverContent) {
 		button = (
 			<Popover
-				content={<PopoverComponent pubData={pubData} />}
+				content={popoverContent}
 				interactionKind={PopoverInteractionKind.HOVER}
 				modifiers={popoverModifiers}
 				openOnTargetFocus

--- a/client/components/FormattingBar/FormattingBarMediaButton.tsx
+++ b/client/components/FormattingBar/FormattingBarMediaButton.tsx
@@ -42,7 +42,6 @@ const FormattingBarMediaButton = React.forwardRef<unknown, FormattingBarMediaBut
 					isSmall={isSmall}
 					label="Media"
 					onClick={isIndicated || isOpen ? onClick : () => setModalOpen(true)}
-					pubData={pubData}
 				/>
 			</>
 		);

--- a/client/components/FormattingBar/FormattingBarMediaButton.tsx
+++ b/client/components/FormattingBar/FormattingBarMediaButton.tsx
@@ -41,7 +41,6 @@ const FormattingBarMediaButton = React.forwardRef((props, ref) => {
 			<FormattingBarButton
 				{...restProps}
 				ref={ref}
-				// @ts-expect-error ts-migrate(2322) FIXME: Property 'isIndicated' does not exist on type 'Int... Remove this comment to see the full error message
 				isIndicated={isIndicated}
 				isOpen={isOpen}
 				isSmall={isSmall}

--- a/client/components/FormattingBar/FormattingBarMediaButton.tsx
+++ b/client/components/FormattingBar/FormattingBarMediaButton.tsx
@@ -1,56 +1,52 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 
 import { Overlay } from 'components';
+import { usePubData } from 'client/containers/Pub/pubHooks';
+import { EditorChangeObject } from 'client/types';
 
-import FormattingBarButton from './FormattingBarButton';
+import FormattingBarButton, { FormattingBarButtonProps } from './FormattingBarButton';
 import Media from './media/Media';
 
-const propTypes = {
-	editorChangeObject: PropTypes.shape({
-		insertFunctions: PropTypes.object,
-	}).isRequired,
-	isIndicated: PropTypes.bool.isRequired,
-	isSmall: PropTypes.bool.isRequired,
-	isOpen: PropTypes.bool.isRequired,
-	onClick: PropTypes.func.isRequired,
+type FormattingBarMediaButtonProps = FormattingBarButtonProps & {
+	editorChangeObject: EditorChangeObject;
 };
 
-const FormattingBarMediaButton = React.forwardRef((props, ref) => {
-	// @ts-expect-error ts-migrate(2339) FIXME: Property 'editorChangeObject' does not exist on ty... Remove this comment to see the full error message
-	const { editorChangeObject, isSmall, onClick, isIndicated, isOpen, ...restProps } = props;
-	const [isModalOpen, setModalOpen] = useState(false);
+const FormattingBarMediaButton = React.forwardRef<unknown, FormattingBarMediaButtonProps>(
+	(props, ref) => {
+		const { editorChangeObject, isSmall, onClick, isIndicated, isOpen, ...restProps } = props;
+		const pubData = usePubData();
+		const [isModalOpen, setModalOpen] = useState(false);
+		const handleInsert = (insertType, insertData) => {
+			const { insertFunctions } = editorChangeObject;
+			if (insertFunctions) {
+				insertFunctions[insertType](insertData);
+			}
+			setModalOpen(false);
+		};
 
-	const handleInsert = (insertType, insertData) => {
-		const { insertFunctions } = editorChangeObject;
-		if (insertFunctions) {
-			insertFunctions[insertType](insertData);
-		}
-		setModalOpen(false);
-	};
-	return (
-		<>
-			<Overlay isOpen={isModalOpen} onClose={() => setModalOpen(false)} maxWidth={750}>
-				<Media
-					editorChangeObject={editorChangeObject}
-					onInsert={handleInsert}
+		return (
+			<>
+				<Overlay isOpen={isModalOpen} onClose={() => setModalOpen(false)} maxWidth={750}>
+					<Media
+						editorChangeObject={editorChangeObject}
+						onInsert={handleInsert}
+						isSmall={Boolean(isSmall)}
+					/>
+				</Overlay>
+				<div className="separator" />
+				<FormattingBarButton
+					{...restProps}
+					ref={ref}
+					isIndicated={isIndicated}
+					isOpen={isOpen}
 					isSmall={isSmall}
+					label="Media"
+					onClick={isIndicated || isOpen ? onClick : () => setModalOpen(true)}
+					pubData={pubData}
 				/>
-			</Overlay>
-			<div className="separator" />
-			<FormattingBarButton
-				{...restProps}
-				ref={ref}
-				isIndicated={isIndicated}
-				isOpen={isOpen}
-				isSmall={isSmall}
-				label="Media"
-				onClick={isIndicated || isOpen ? onClick : () => setModalOpen(true)}
-			/>
-		</>
-	);
-});
+			</>
+		);
+	},
+);
 
-// @ts-expect-error ts-migrate(2559) FIXME: Type '{ editorChangeObject: Validator<InferProps<{... Remove this comment to see the full error message
-FormattingBarMediaButton.propTypes = propTypes;
 export default FormattingBarMediaButton;

--- a/client/components/FormattingBar/buttons.tsx
+++ b/client/components/FormattingBar/buttons.tsx
@@ -4,7 +4,7 @@ import { getDashUrl } from 'utils/dashboard';
 import ControlsEquation from './controlComponents/ControlsEquation';
 import ControlsFootnoteCitation from './controlComponents/ControlsFootnoteCitation/ControlsFootnoteCitation';
 import ControlsLink from './controlComponents/ControlsLink';
-import ControlsReference from './controlComponents/ControlsReference';
+import ControlsReference, { ControlsReferencePopover } from './controlComponents/ControlsReference';
 
 import ControlsMedia from './controlComponents/ControlsMedia/ControlsMedia';
 import ControlsTable from './controlComponents/ControlsTable';
@@ -140,6 +140,7 @@ const canInsertReference = (pubData: any) => {
 	);
 };
 
+const referencePopoverStyles = { maxWidth: 150, padding: '12 12 0' };
 export const reference = {
 	key: 'reference',
 	title: 'Reference',
@@ -149,27 +150,7 @@ export const reference = {
 		showCloseButton: false,
 	}),
 	isDisabled: canInsertReference,
-	renderPopover: (pubData: any) => {
-		if (!canInsertReference(pubData)) {
-			return null;
-		}
-
-		return (
-			<p style={{ maxWidth: 150, padding: '12 12 0' }}>
-				Visit{' '}
-				<a
-					href={getDashUrl({
-						pubSlug: pubData.slug,
-						mode: 'settings',
-						section: 'block-labels',
-					})}
-				>
-					Pub Settings
-				</a>{' '}
-				to turn on labeling and enable references.
-			</p>
-		);
-	},
+	PopoverComponent: ControlsReferencePopover,
 };
 
 export const equation = {

--- a/client/components/FormattingBar/buttons.tsx
+++ b/client/components/FormattingBar/buttons.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getDashUrl } from 'utils/dashboard';
 
 import ControlsEquation from './controlComponents/ControlsEquation';
 import ControlsFootnoteCitation from './controlComponents/ControlsFootnoteCitation/ControlsFootnoteCitation';
@@ -9,8 +10,6 @@ import ControlsMedia from './controlComponents/ControlsMedia/ControlsMedia';
 import ControlsTable from './controlComponents/ControlsTable';
 import MediaButton from './FormattingBarMediaButton';
 import { positionNearSelection, positionNearLink } from './positioning';
-import { usePubData } from 'client/containers/Pub/pubHooks';
-import { getDashUrl } from 'utils/dashboard';
 import { NodeLabelMap } from '../Editor/types';
 
 const triggerOnClick = (changeObject) => {

--- a/client/components/FormattingBar/buttons.tsx
+++ b/client/components/FormattingBar/buttons.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import ControlsEquation from './controlComponents/ControlsEquation';
 import ControlsFootnoteCitation from './controlComponents/ControlsFootnoteCitation/ControlsFootnoteCitation';
 import ControlsLink from './controlComponents/ControlsLink';
@@ -7,6 +9,9 @@ import ControlsMedia from './controlComponents/ControlsMedia/ControlsMedia';
 import ControlsTable from './controlComponents/ControlsTable';
 import MediaButton from './FormattingBarMediaButton';
 import { positionNearSelection, positionNearLink } from './positioning';
+import { usePubData } from 'client/containers/Pub/pubHooks';
+import { getDashUrl } from 'utils/dashboard';
+import { NodeLabelMap } from '../Editor/types';
 
 const triggerOnClick = (changeObject) => {
 	const { latestDomEvent } = changeObject;
@@ -129,6 +134,13 @@ export const citation = {
 	controls: nodeControls(ControlsFootnoteCitation, 'citation'),
 };
 
+const canInsertReference = (pubData: any) => {
+	return (
+		!pubData.nodeLabels ||
+		!Object.values(pubData.nodeLabels as NodeLabelMap).some((nodeLabel) => nodeLabel.enabled)
+	);
+};
+
 export const reference = {
 	key: 'reference',
 	title: 'Reference',
@@ -137,6 +149,28 @@ export const reference = {
 		position: positionNearSelection,
 		showCloseButton: false,
 	}),
+	isDisabled: canInsertReference,
+	renderPopover: (pubData: any) => {
+		if (!canInsertReference(pubData)) {
+			return null;
+		}
+
+		return (
+			<p style={{ maxWidth: 150, padding: '12 12 0' }}>
+				Visit{' '}
+				<a
+					href={getDashUrl({
+						pubSlug: pubData.slug,
+						mode: 'settings',
+						section: 'block-labels',
+					})}
+				>
+					Pub Settings
+				</a>{' '}
+				to turn on labeling and enable references.
+			</p>
+		);
+	},
 };
 
 export const equation = {

--- a/client/components/FormattingBar/buttons.tsx
+++ b/client/components/FormattingBar/buttons.tsx
@@ -140,7 +140,6 @@ const canInsertReference = (pubData: any) => {
 	);
 };
 
-const referencePopoverStyles = { maxWidth: 150, padding: '12 12 0' };
 export const reference = {
 	key: 'reference',
 	title: 'Reference',

--- a/client/components/FormattingBar/buttons.tsx
+++ b/client/components/FormattingBar/buttons.tsx
@@ -11,6 +11,7 @@ import ControlsTable from './controlComponents/ControlsTable';
 import MediaButton from './FormattingBarMediaButton';
 import { positionNearSelection, positionNearLink } from './positioning';
 import { NodeLabelMap } from '../Editor/types';
+import { FormattingBarButtonData, FormattingBarPopoverCondition } from './types';
 
 const triggerOnClick = (changeObject) => {
 	const { latestDomEvent } = changeObject;
@@ -45,21 +46,21 @@ const showOrTriggerTable = (editorChangeObject) => {
 	);
 };
 
-export const strong = {
+export const strong: FormattingBarButtonData = {
 	key: 'strong',
 	title: 'Bold',
 	icon: 'bold',
 	isToggle: true,
 };
 
-export const em = {
+export const em: FormattingBarButtonData = {
 	key: 'em',
 	title: 'Italic',
 	icon: 'italic',
 	isToggle: true,
 };
 
-export const link = {
+export const link: FormattingBarButtonData = {
 	key: 'link',
 	title: 'Link',
 	icon: 'link',
@@ -79,46 +80,46 @@ export const link = {
 	},
 };
 
-export const bulletList = {
+export const bulletList: FormattingBarButtonData = {
 	key: 'bullet-list',
 	title: 'Bullet List',
 	icon: 'list-ul',
 };
 
-export const numberedList = {
+export const numberedList: FormattingBarButtonData = {
 	key: 'numbered-list',
 	title: 'Numbered List',
 	icon: 'list-ol',
 };
 
-export const blockquote = {
+export const blockquote: FormattingBarButtonData = {
 	key: 'blockquote',
 	title: 'Blockquote',
 	icon: 'citation',
 };
 
-export const code = {
+export const code: FormattingBarButtonData = {
 	key: 'code',
 	title: 'Code',
 	icon: 'code',
 	isToggle: true,
 };
 
-export const subscript = {
+export const subscript: FormattingBarButtonData = {
 	key: 'subscript',
 	title: 'Subscript',
 	icon: 'subscript',
 	isToggle: true,
 };
 
-export const superscript = {
+export const superscript: FormattingBarButtonData = {
 	key: 'superscript',
 	title: 'Superscript',
 	icon: 'superscript',
 	isToggle: true,
 };
 
-export const strikethrough = {
+export const strikethrough: FormattingBarButtonData = {
 	key: 'strikethrough',
 	title: 'Strikethrough',
 	ariaTitle: 'strike through',
@@ -126,7 +127,7 @@ export const strikethrough = {
 	isToggle: true,
 };
 
-export const citation = {
+export const citation: FormattingBarButtonData = {
 	key: 'citation',
 	title: 'Citation',
 	icon: 'bookmark',
@@ -135,12 +136,12 @@ export const citation = {
 
 const canInsertReference = (pubData: any) => {
 	return (
-		!pubData.nodeLabels ||
-		!Object.values(pubData.nodeLabels as NodeLabelMap).some((nodeLabel) => nodeLabel.enabled)
+		pubData.nodeLabels &&
+		Object.values(pubData.nodeLabels as NodeLabelMap).some((nodeLabel) => nodeLabel.enabled)
 	);
 };
 
-export const reference = {
+export const reference: FormattingBarButtonData = {
 	key: 'reference',
 	title: 'Reference',
 	icon: 'at',
@@ -148,31 +149,34 @@ export const reference = {
 		position: positionNearSelection,
 		showCloseButton: false,
 	}),
-	isDisabled: canInsertReference,
-	PopoverComponent: ControlsReferencePopover,
+	isDisabled: (pubData: any) => !canInsertReference(pubData),
+	popover: {
+		condition: FormattingBarPopoverCondition.Disabled,
+		component: ControlsReferencePopover,
+	},
 };
 
-export const equation = {
+export const equation: FormattingBarButtonData = {
 	key: 'equation',
 	title: 'Equation',
 	icon: 'function',
 	controls: nodeControls(ControlsEquation, ['equation', 'block_equation']),
 };
 
-export const footnote = {
+export const footnote: FormattingBarButtonData = {
 	key: 'footnote',
 	title: 'Footnote',
 	icon: 'asterisk',
 	controls: nodeControls(ControlsFootnoteCitation, 'footnote'),
 };
 
-export const horizontalRule = {
+export const horizontalRule: FormattingBarButtonData = {
 	key: 'horizontal_rule',
 	title: 'Horizontal Line',
 	icon: 'minus',
 };
 
-export const table = {
+export const table: FormattingBarButtonData = {
 	key: 'table',
 	title: 'Table',
 	icon: 'th',
@@ -187,7 +191,7 @@ export const table = {
 	},
 };
 
-export const media = {
+export const media: FormattingBarButtonData = {
 	key: 'media',
 	title: 'Media',
 	icon: 'media',

--- a/client/components/FormattingBar/controlComponents/ControlsEquation.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsEquation.tsx
@@ -5,11 +5,11 @@ import { useDebounce } from 'use-debounce';
 import { Node } from 'prosemirror-model';
 
 import { renderLatexString } from 'client/utils/editor';
-
-import { ControlsButton, ControlsButtonGroup } from './ControlsButton';
-
 import { usePubData } from 'client/containers/Pub/pubHooks';
 import { NodeLabelMap, ReferenceableNodeType } from 'client/components/Editor/types';
+
+import { ControlsButton, ControlsButtonGroup } from './ControlsButton';
+import { ControlsReferenceSettingsLink } from './ControlsReference';
 
 require('./controls.scss');
 
@@ -25,6 +25,7 @@ type Props = {
 			hideLabel: boolean;
 		};
 	};
+	pubData: any;
 };
 
 const getSchemaDefinitionForNodeType = (editorChangeObject, nodeTypeName) => {
@@ -32,7 +33,7 @@ const getSchemaDefinitionForNodeType = (editorChangeObject, nodeTypeName) => {
 };
 
 const ControlsEquation = (props: Props) => {
-	const { editorChangeObject, pendingAttrs, onClose } = props;
+	const { editorChangeObject, pendingAttrs, onClose, pubData } = props;
 	const { changeNode, updateNode, selectedNode } = editorChangeObject;
 	const {
 		commitChanges,
@@ -94,15 +95,22 @@ const ControlsEquation = (props: Props) => {
 				<div className="section">
 					<div className="title">Preview</div>
 					<div className="preview" dangerouslySetInnerHTML={{ __html: html }} />
-					{isBlock && canHideLabel && (
-						<div className="controls-row">
-							<Checkbox
-								onClick={toggleLabel}
-								alignIndicator="right"
-								label="Hide label"
-								checked={selectedNode?.attrs?.hideLabel}
-							/>
-						</div>
+					{isBlock && (
+						<Checkbox
+							disabled={!canHideLabel}
+							onClick={toggleLabel}
+							alignIndicator="right"
+							label="Hide label"
+							checked={selectedNode?.attrs?.hideLabel}
+						>
+							{!canHideLabel && (
+								<>
+									{' '}
+									(
+									<ControlsReferenceSettingsLink dark small pubData={pubData} />)
+								</>
+							)}
+						</Checkbox>
 					)}
 					<ControlsButtonGroup>
 						<ControlsButton onClick={handleChangeNodeType}>

--- a/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
@@ -10,6 +10,7 @@ import SliderInputControl from './SliderInputControl';
 import SourceControls from './SourceControls';
 import { usePubData } from 'client/containers/Pub/pubHooks';
 import { NodeLabelMap, ReferenceableNodeType } from 'client/components/Editor/types';
+import { ControlsReferenceSettingsLink } from '../ControlsReference';
 
 type Props = {
 	isSmall: boolean;
@@ -26,6 +27,7 @@ type Props = {
 			};
 		};
 	};
+	pubData: any;
 };
 
 const getCanEditNodeHeight = (selectedNode) => selectedNode.type.name === 'iframe';
@@ -39,7 +41,7 @@ const getItemName = (selectedNode) => {
 };
 
 const ControlsMedia = (props: Props) => {
-	const { isSmall, editorChangeObject, pendingAttrs } = props;
+	const { isSmall, editorChangeObject, pendingAttrs, pubData } = props;
 	const { updateNode, selectedNode } = editorChangeObject;
 	const { hasPendingChanges, commitChanges, updateAttrs } = pendingAttrs;
 	const { size, align, height, caption, hideLabel } = selectedNode.attrs;
@@ -90,16 +92,23 @@ const ControlsMedia = (props: Props) => {
 					updateNode={updateNode}
 					isSmall={isSmall}
 				/>
-				{canHideLabel && (
-					<div className="controls-row">
-						<Checkbox
-							onClick={toggleLabel}
-							alignIndicator="right"
-							label="Hide label"
-							checked={hideLabel}
-						/>
-					</div>
-				)}
+				<div className="controls-row">
+					<Checkbox
+						disabled={!canHideLabel}
+						onClick={toggleLabel}
+						alignIndicator="right"
+						label="Hide label"
+						checked={selectedNode?.attrs?.hideLabel}
+					>
+						{!canHideLabel && (
+							<>
+								{' '}
+								(
+								<ControlsReferenceSettingsLink dark small pubData={pubData} />)
+							</>
+						)}
+					</Checkbox>
+				</div>
 			</div>
 			<div className="section hide-overflow">
 				<SimpleEditor

--- a/client/components/FormattingBar/controlComponents/ControlsReference.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsReference.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react';
+import classNames from 'classnames';
 
 import { ReferencesDropdown } from 'components';
 import { getReferenceableNodes, NodeReference } from 'components/Editor/utils/references';
@@ -56,22 +57,42 @@ const ControlsReference = (props: ControlsReferenceProps) => {
 	);
 };
 
+type ControlsReferencePopoverContentProps = {
+	pubData: any;
+	small?: boolean;
+	dark?: boolean;
+};
+
+export const ControlsReferenceSettingsLink = (props: ControlsReferencePopoverContentProps) => {
+	const link = (
+		<a
+			href={getDashUrl({
+				pubSlug: props.pubData.slug,
+				mode: 'settings',
+				section: 'block-labels',
+			})}
+		>
+			Pub Settings
+		</a>
+	);
+
+	return (
+		<span className={classNames('controls-reference-settings-link', props.dark && 'dark')}>
+			{props.small ? (
+				<>Enable block labeling in {link}</>
+			) : (
+				<>Visit {link} to turn on labeling and enable references.</>
+			)}
+		</span>
+	);
+};
+
 export const ControlsReferencePopover = () => {
 	const pubData = usePubData();
 
 	return (
 		<p className="controls-reference-popover-component">
-			Visit{' '}
-			<a
-				href={getDashUrl({
-					pubSlug: pubData.slug,
-					mode: 'settings',
-					section: 'block-labels',
-				})}
-			>
-				Pub Settings
-			</a>{' '}
-			to turn on labeling and enable references.
+			<ControlsReferenceSettingsLink pubData={pubData} />
 		</p>
 	);
 };

--- a/client/components/FormattingBar/controlComponents/ControlsReference.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsReference.tsx
@@ -79,7 +79,7 @@ export const ControlsReferenceSettingsLink = (props: ControlsReferencePopoverCon
 	return (
 		<span className={classNames('controls-reference-settings-link', props.dark && 'dark')}>
 			{props.small ? (
-				<>Enable block labeling in {link}</>
+				<>Enable item labeling in {link}</>
 			) : (
 				<>Visit {link} to turn on labeling and enable references.</>
 			)}

--- a/client/components/FormattingBar/controlComponents/ControlsReference.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsReference.tsx
@@ -4,6 +4,9 @@ import { ReferencesDropdown } from 'components';
 import { getReferenceableNodes, NodeReference } from 'components/Editor/utils/references';
 import { EditorChangeObject } from 'client/types';
 import { usePubContext } from 'client/containers/Pub/pubHooks';
+import { getDashUrl } from 'utils/dashboard';
+
+require('./controlsReference.scss');
 
 export type ControlsReferenceProps = {
 	editorChangeObject: EditorChangeObject;
@@ -50,6 +53,30 @@ const ControlsReference = (props: ControlsReferenceProps) => {
 			selectedReference={target}
 			onSelect={onSelect}
 		/>
+	);
+};
+
+type ControlsReferencePopoverProps = {
+	pubData: any;
+};
+
+export const ControlsReferencePopover = (props: ControlsReferencePopoverProps) => {
+	const { pubData } = props;
+
+	return (
+		<p className="controls-reference-popover-component">
+			Visit{' '}
+			<a
+				href={getDashUrl({
+					pubSlug: pubData.slug,
+					mode: 'settings',
+					section: 'block-labels',
+				})}
+			>
+				Pub Settings
+			</a>{' '}
+			to turn on labeling and enable references.
+		</p>
 	);
 };
 

--- a/client/components/FormattingBar/controlComponents/ControlsReference.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsReference.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState, useMemo, useRef, useCallback } from 'react'
 import { ReferencesDropdown } from 'components';
 import { getReferenceableNodes, NodeReference } from 'components/Editor/utils/references';
 import { EditorChangeObject } from 'client/types';
-import { usePubContext } from 'client/containers/Pub/pubHooks';
+import { usePubContext, usePubData } from 'client/containers/Pub/pubHooks';
 import { getDashUrl } from 'utils/dashboard';
 
 require('./controlsReference.scss');
@@ -56,12 +56,8 @@ const ControlsReference = (props: ControlsReferenceProps) => {
 	);
 };
 
-type ControlsReferencePopoverProps = {
-	pubData: any;
-};
-
-export const ControlsReferencePopover = (props: ControlsReferencePopoverProps) => {
-	const { pubData } = props;
+export const ControlsReferencePopover = () => {
+	const pubData = usePubData();
 
 	return (
 		<p className="controls-reference-popover-component">

--- a/client/components/FormattingBar/controlComponents/controlsReference.scss
+++ b/client/components/FormattingBar/controlComponents/controlsReference.scss
@@ -2,3 +2,13 @@
 	max-width: 150px;
 	padding: 12px 12px 0;
 }
+
+.controls-reference-settings-link {
+	&.dark {
+		color: #545454;
+
+		a {
+			color: #eee;
+		}
+	}
+}

--- a/client/components/FormattingBar/controlComponents/controlsReference.scss
+++ b/client/components/FormattingBar/controlComponents/controlsReference.scss
@@ -1,0 +1,4 @@
+.controls-reference-popover-component {
+	max-width: 150px;
+	padding: 12px 12px 0;
+}

--- a/client/components/FormattingBar/types.ts
+++ b/client/components/FormattingBar/types.ts
@@ -1,0 +1,21 @@
+export enum FormattingBarPopoverCondition {
+	Always,
+	Disabled,
+}
+
+export type FormattingBarPopover = {
+	component: React.ComponentType;
+	condition: FormattingBarPopoverCondition;
+};
+
+export type FormattingBarButtonData = {
+	controls?: any;
+	component?: React.ComponentType<any>;
+	key: string;
+	popover?: FormattingBarPopover;
+	title: string;
+	ariaTitle?: string;
+	icon: string;
+	isToggle?: boolean;
+	isDisabled?: (pubData: any) => boolean;
+};

--- a/client/components/FormattingBar/utils.ts
+++ b/client/components/FormattingBar/utils.ts
@@ -1,0 +1,14 @@
+import {
+	FormattingBarButtonData,
+	FormattingBarPopover,
+	FormattingBarPopoverCondition,
+} from './types';
+
+export const getButtonPopoverComponent = (button: FormattingBarButtonData, isDisabled: boolean) =>
+	button.popover &&
+	Boolean(
+		FormattingBarPopoverCondition.Always ||
+			(button.popover.condition === FormattingBarPopoverCondition.Disabled && isDisabled),
+	)
+		? button.popover.component
+		: null;

--- a/client/components/ReferencesDropdown/ReferencesDropdown.tsx
+++ b/client/components/ReferencesDropdown/ReferencesDropdown.tsx
@@ -18,8 +18,6 @@ const ReferencesDropdown = (props: ReferencesDropdownProps) => {
 		? 'No referenced item'
 		: 'No items to reference';
 
-	console.log(references);
-
 	return (
 		<div className="controls-link-component">
 			<MenuButton

--- a/client/components/SettingsSection/SettingsSection.tsx
+++ b/client/components/SettingsSection/SettingsSection.tsx
@@ -1,33 +1,41 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+import classNames from 'classnames';
 import { slugifyString } from 'utils/strings';
 
 require('./settingsSection.scss');
 
-const propTypes = {
-	className: PropTypes.string,
-	title: PropTypes.string,
-	children: PropTypes.node,
+type Props = {
+	className?: string;
+	title: React.ReactNode;
+	id?: string;
+	children: React.ReactNode;
 };
 
-const defaultProps = {
-	className: '',
-	title: '',
-	children: undefined,
-};
+const SettingsSection = (props: Props) => {
+	const { className, title, id, children } = props;
+	const [emphasized, setEmphasized] = useState(false);
 
-const SettingsSection = function(props) {
+	useEffect(() => {
+		if (window && id && id === window.location.hash.slice(1)) {
+			setEmphasized(true);
+		}
+	}, [id]);
+
 	return (
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div
-			className={`settings-section-component ${props.className}`}
-			id={slugifyString(props.title)}
+			onClick={() => setEmphasized(false)}
+			className={classNames(
+				'settings-section-component',
+				emphasized && 'emphasized',
+				className,
+			)}
+			id={id || slugifyString(props.title)}
 		>
-			<div className="title">{props.title}</div>
-			<div className="content">{props.children}</div>
+			<div className="title">{title}</div>
+			<div className="content">{children}</div>
 		</div>
 	);
 };
 
-SettingsSection.defaultProps = defaultProps;
-SettingsSection.propTypes = propTypes;
 export default SettingsSection;

--- a/client/components/SettingsSection/SettingsSection.tsx
+++ b/client/components/SettingsSection/SettingsSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { slugifyString } from 'utils/strings';
 
 require('./settingsSection.scss');
 
@@ -17,7 +18,10 @@ const defaultProps = {
 
 const SettingsSection = function(props) {
 	return (
-		<div className={`settings-section-component ${props.className}`}>
+		<div
+			className={`settings-section-component ${props.className}`}
+			id={slugifyString(props.title)}
+		>
 			<div className="title">{props.title}</div>
 			<div className="content">{props.children}</div>
 		</div>

--- a/client/components/SettingsSection/settingsSection.scss
+++ b/client/components/SettingsSection/settingsSection.scss
@@ -4,6 +4,9 @@
 		font-size: 16px;
 		padding-bottom: 1em;
 	}
+	&.emphasized {
+		background: cornsilk;
+	}
 }
 
 @media only screen and (min-width: 1250px) {

--- a/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
+++ b/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
@@ -298,7 +298,7 @@ const PubSettings = (props: Props) => {
 
 	const renderNodeLabelEditor = () => {
 		return (
-			<SettingsSection title="Block Labels">
+			<SettingsSection title="Block Labels" id="block-labels">
 				<NodeLabelEditor
 					pubData={persistedPubData}
 					// communityData={activeCommunity}

--- a/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
+++ b/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
@@ -298,7 +298,7 @@ const PubSettings = (props: Props) => {
 
 	const renderNodeLabelEditor = () => {
 		return (
-			<SettingsSection title="Block Labels" id="block-labels">
+			<SettingsSection title="Item Labels" id="block-labels">
 				<NodeLabelEditor
 					pubData={persistedPubData}
 					// communityData={activeCommunity}

--- a/client/containers/Pub/PubSyncManager.tsx
+++ b/client/containers/Pub/PubSyncManager.tsx
@@ -13,6 +13,7 @@ import { NodeLabelMap } from 'client/components/Editor/types';
 export const PubContext = React.createContext({
 	pubData: {
 		nodeLabels: {} as NodeLabelMap | undefined,
+		slug: '',
 	},
 	collabData: { editorChangeObject: {} },
 	historyData: {},

--- a/client/types/editor.ts
+++ b/client/types/editor.ts
@@ -1,6 +1,7 @@
 import { EditorView } from 'prosemirror-view';
 
 export type EditorChangeObject = {
+	insertFunctions: Record<string, (...args: any[]) => any>;
 	selectedNode?: {
 		attrs?: {
 			targetId?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8714,11 +8714,6 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"circular-dependency-plugin": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.0.tgz",
-			"integrity": "sha512-7p4Kn/gffhQaavNfyDFg7LS5S/UT1JAjyGd4UqR2+jzoYF02eDkj0Ec3+48TsIa4zghjLY87nQHIh/ecK9qLdw=="
-		},
 		"citation-js": {
 			"version": "0.5.0-alpha.5",
 			"resolved": "https://registry.npmjs.org/citation-js/-/citation-js-0.5.0-alpha.5.tgz",

--- a/utils/dashboard.ts
+++ b/utils/dashboard.ts
@@ -33,7 +33,7 @@ export const getDashUrl = ({
 				.replace(/ /gi, '-')}`
 		: '';
 
-	return `${baseHref}${modeString}${subModeString}${section && `#${section}`}${baseQuery}`;
+	return `${baseHref}${modeString}${subModeString}${baseQuery}${section && `#${section}`}`;
 };
 
 export const groupPubs = ({ pubs, collections }) => {

--- a/utils/dashboard.ts
+++ b/utils/dashboard.ts
@@ -2,10 +2,17 @@ type GetDashUrlOptions = {
 	pubSlug?: string;
 	collectionSlug?: string;
 	mode?: string;
+	section?: string;
 	subMode?: string;
 };
 
-export const getDashUrl = ({ collectionSlug, pubSlug, mode, subMode }: GetDashUrlOptions) => {
+export const getDashUrl = ({
+	collectionSlug,
+	pubSlug,
+	mode,
+	subMode,
+	section = '',
+}: GetDashUrlOptions) => {
 	let baseHref = '/dash';
 	if (collectionSlug) {
 		baseHref = `/dash/collection/${collectionSlug}`;
@@ -26,7 +33,7 @@ export const getDashUrl = ({ collectionSlug, pubSlug, mode, subMode }: GetDashUr
 				.replace(/ /gi, '-')}`
 		: '';
 
-	return `${baseHref}${modeString}${subModeString}${baseQuery}`;
+	return `${baseHref}${modeString}${subModeString}${section && `#${section}`}${baseQuery}`;
 };
 
 export const groupPubs = ({ pubs, collections }) => {

--- a/utils/workers/constants.js
+++ b/utils/workers/constants.js
@@ -16,5 +16,3 @@ const prodTaskQueueName = 'pubpubTaskQueue-2020-07-20';
 const localTaskQueueName = isDevelopment() && process.env.PUBPUB_LOCAL_TASK_QUEUE;
 
 export const taskQueueName = localTaskQueueName || prodTaskQueueName;
-
-console.log(process.env.PUBPUB_LOCAL_TASK_QUEUE);

--- a/utils/workers/constants.js
+++ b/utils/workers/constants.js
@@ -16,3 +16,5 @@ const prodTaskQueueName = 'pubpubTaskQueue-2020-07-20';
 const localTaskQueueName = isDevelopment() && process.env.PUBPUB_LOCAL_TASK_QUEUE;
 
 export const taskQueueName = localTaskQueueName || prodTaskQueueName;
+
+console.log(process.env.PUBPUB_LOCAL_TASK_QUEUE);

--- a/workers/tasks/import/rules.js
+++ b/workers/tasks/import/rules.js
@@ -98,11 +98,13 @@ rules.fromPandoc('DefinitionList', definitionListTransformer('bullet_list', 'lis
 // Tranform headers
 rules.transform('Header', 'heading', {
 	fromPandoc: (node, { transform }) => {
+		const id = node.attr.identifier;
 		return {
 			type: 'heading',
 			attrs: {
+				id: id,
 				level: node.level,
-				fixedId: node.attr.identifier,
+				fixedId: id,
 			},
 			content: transform(node.content).asArray(),
 		};
@@ -214,6 +216,7 @@ rules.fromPandoc('Math', (node) => {
 	return {
 		type: prosemirrorType,
 		attrs: {
+			id: node.attr.identifier,
 			value: content,
 			html: katex.renderToString(content, {
 				displayMode: isDisplay,
@@ -229,6 +232,7 @@ rules.fromPandoc('Image', (node, { resource }) => {
 	return {
 		type: 'image',
 		attrs: {
+			id: node.attr.identifier,
 			url: resource(node.target.url, 'image'),
 			caption: pandocInlineToHtmlString(node.content),
 			// TODO(ian): is there anything we can do about the image size here?


### PR DESCRIPTION
This PR improves Pub internal references with the following enhancements:

- The references button is disabled when the Pub has no block nodes enabled for labeling.
- When disabled, the button will show a tooltip that contains a link to the references section of the Pub settings.
- The "Hide label" options in node formatting controls is now disabled instead of hidden when referencing is not allowed.
- Each of the "hide label" buttons now shows the same message from the tooltip to help guide the user to Pub settings.

Tooltip:
<img width="366" alt="Screen Shot 2020-10-22 at 6 36 21 PM" src="https://user-images.githubusercontent.com/6402908/96937152-8345bb80-1495-11eb-8dd2-da684c958820.png">

Disabled "Hide Label" checkbox:
<img width="587" alt="Screen Shot 2020-10-22 at 6 37 23 PM" src="https://user-images.githubusercontent.com/6402908/96937217-a5d7d480-1495-11eb-8c57-d44a7ec4b912.png">

I'm not 100% happy with how the hide label checkbox text came out, but it was the most straightforward way I could come up with using Blueprint's `<Checkbox>` component. I'm looking for some feedback (paging @djagdish) on both the position and formatting of the text.

Test Plan:
TBD

