### PR TITLE
update: Add a notice to Pages and Collections with privacy status and edit button

### DIFF
--- a/client/components/Layout/LayoutManageNotice.tsx
+++ b/client/components/Layout/LayoutManageNotice.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { AnchorButton } from '@blueprintjs/core';
+
+import { GridWrapper, Icon } from 'components';
+
+require('./layoutManageNotice.scss');
+
+type Props = {
+	type: 'page' | 'collection';
+	isPublic: boolean;
+	manageUrl?: string;
+};
+
+const LayoutManageNotice = (props: Props) => {
+	const { type, isPublic, manageUrl } = props;
+	const displayType = type === 'collection' ? 'Collection' : 'Page';
+
+	if (isPublic && !manageUrl) {
+		return null;
+	}
+
+	const renderNotice = () => {
+		if (isPublic) {
+			return (
+				<>
+					This is a preview of a public {displayType} as visitors to this Community will
+					see it.
+				</>
+			);
+		}
+		return (
+			<>
+				This is a preview of a private {displayType}. It will only be visible to Members
+				until it is made public.
+			</>
+		);
+	};
+
+	return (
+		<div className="layout-manage-notice-component">
+			<GridWrapper columnClassName="inner">
+				<div className="notice">
+					<Icon icon={isPublic ? 'globe' : 'lock2'} />
+					{renderNotice()}
+				</div>
+				{manageUrl && (
+					<AnchorButton outlined href={manageUrl} icon="edit">
+						Edit
+					</AnchorButton>
+				)}
+			</GridWrapper>
+		</div>
+	);
+};
+
+export default LayoutManageNotice;

--- a/client/components/Layout/LayoutPubs.tsx
+++ b/client/components/Layout/LayoutPubs.tsx
@@ -41,7 +41,7 @@ const LayoutPubs = (props: Props) => {
 					/>
 				</div>
 				{nextPub && (
-					<div className={isTwoColumn ? 'col-6' : 'col-12'}>
+					<div key={nextPub.id} className={isTwoColumn ? 'col-6' : 'col-12'}>
 						<PubPreview
 							pubData={nextPub}
 							size={pubPreviewType}

--- a/client/components/Layout/index.ts
+++ b/client/components/Layout/index.ts
@@ -4,3 +4,4 @@ export { default as LayoutHtml } from './LayoutHtml';
 export { default as LayoutPagesCollections } from './LayoutPagesCollections';
 export { default as LayoutPubs } from './LayoutPubs';
 export { default as LayoutText } from './LayoutText';
+export { default as LayoutManageNotice } from './LayoutManageNotice';

--- a/client/components/Layout/layoutManageNotice.scss
+++ b/client/components/Layout/layoutManageNotice.scss
@@ -1,0 +1,18 @@
+.layout-manage-notice-component {
+    background: #eee;
+    color: #111;
+    .inner,
+    .inner > .notice {
+        display: flex;
+        align-items: center;
+    }
+    .inner {
+        justify-content: space-between;
+        .notice {
+            .bp3-icon {
+                color: #111;
+                margin-right: 5px;
+            }
+        }
+    }
+}

--- a/client/containers/Collection/Collection.tsx
+++ b/client/containers/Collection/Collection.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
-import { Layout } from 'components';
+import { Layout, LayoutManageNotice } from 'components/Layout';
 import { Pub, Collection as CollectionType } from 'utils/types';
+import { usePageContext } from 'utils/hooks';
+import { getDashUrl } from 'utils/dashboard';
 
 type Props = {
 	pubs: Pub[];
@@ -10,10 +12,29 @@ type Props = {
 
 const Collection = (props: Props) => {
 	const { pubs, collection } = props;
+	const {
+		scopeData: {
+			activePermissions: { canManage },
+		},
+	} = usePageContext();
 	if (collection.layout) {
 		const { blocks, isNarrow } = collection.layout;
 		return (
-			<Layout blocks={blocks} isNarrow={isNarrow} pubs={pubs} collectionId={collection.id} />
+			<>
+				<LayoutManageNotice
+					type="collection"
+					isPublic={collection.isPublic}
+					manageUrl={
+						canManage && getDashUrl({ mode: 'layout', collectionSlug: collection.slug })
+					}
+				/>
+				<Layout
+					blocks={blocks}
+					isNarrow={isNarrow}
+					pubs={pubs}
+					collectionId={collection.id}
+				/>
+			</>
 		);
 	}
 	return null;

--- a/client/containers/Page/Page.tsx
+++ b/client/containers/Page/Page.tsx
@@ -1,21 +1,36 @@
 import React from 'react';
 
-import { Layout } from 'components';
+import { Layout, LayoutManageNotice } from 'components/Layout';
 import { LayoutBlock } from 'utils/layout/types';
 import { getDefaultLayout } from 'utils/pages';
+import { usePageContext } from 'utils/hooks';
+import { getDashUrl } from 'utils/dashboard';
 
 type Props = {
 	pageData: {
 		pubs: any[];
 		isNarrow: boolean;
+		isPublic: boolean;
+		slug: string;
 		layout: LayoutBlock[];
 	};
 };
 
 const Page = (props: Props) => {
 	const { pageData } = props;
+	const {
+		scopeData: {
+			activePermissions: { canManageCommunity },
+		},
+	} = usePageContext();
 	const blocks = pageData.layout || getDefaultLayout();
-	return <Layout blocks={blocks} isNarrow={pageData.isNarrow} pubs={pageData.pubs} />;
+	const manageUrl = canManageCommunity && getDashUrl({ mode: 'pages', subMode: pageData.slug });
+	return (
+		<>
+			<LayoutManageNotice type="page" isPublic={pageData.isPublic} manageUrl={manageUrl} />
+			<Layout blocks={blocks} isNarrow={pageData.isNarrow} pubs={pageData.pubs} />
+		</>
+	);
 };
 
 export default Page;

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -33,7 +33,7 @@ export type Collection = {
 	slug: string;
 	avatar?: string;
 	isRestricted?: string;
-	isPublic?: boolean;
+	isPublic: boolean;
 	viewHash?: string;
 	editHash?: string;
 	metadata?: string;


### PR DESCRIPTION
Related to #1059 

This PR adds a small bar to the top of Collection and Page layouts indicating its visibility and allowing for easy editing:

![image](https://user-images.githubusercontent.com/2208769/96639542-d978fa00-12ef-11eb-80f9-410fd7695be9.png)

It is also visible to Members on public Pages:

![image](https://user-images.githubusercontent.com/2208769/96639699-0decb600-12f0-11eb-89df-53aaa929df66.png)

It will only show the Edit button to users who have permissions to manage the Page or Collection:

![image](https://user-images.githubusercontent.com/2208769/96639839-49878000-12f0-11eb-901f-6f59e2502fbe.png)

_Test plan:_
- As a Community manager, check for this `LayoutManageNotice` on all Pages and Collection layouts. Make sure the Edit link works.
- Make sure the `LayoutManageNotice` displays public/private status correctly
- Make sure the Edit button is not shown to anyone without manage permissions.