### PR TITLE
update: Add the readingCollection URL param to Collection layout PubPreviews

### DIFF
--- a/client/components/Layout/Layout.tsx
+++ b/client/components/Layout/Layout.tsx
@@ -28,9 +28,8 @@ const Layout = (props: Props) => {
 	const renderBlock = (block: LayoutBlock, index: number) => {
 		if (block.type === 'pubs') {
 			return (
-				<div className="layout-pubs-block">
+				<div className="layout-pubs-block" key={index}>
 					<LayoutPubs
-						key={index}
 						content={block.content}
 						pubs={pubBlocksLists[index]}
 						collectionId={collectionId}
@@ -57,9 +56,8 @@ const Layout = (props: Props) => {
 		}
 		if (block.type === 'pages' || block.type === 'collections-pages') {
 			return (
-				<div className="layout-pages-block">
+				<div className="layout-pages-block" key={index}>
 					<LayoutPagesCollections
-						key={index}
 						content={block.content}
 						pages={communityData.pages}
 						collections={communityData.collections}

--- a/client/components/Layout/Layout.tsx
+++ b/client/components/Layout/Layout.tsx
@@ -29,7 +29,12 @@ const Layout = (props: Props) => {
 		if (block.type === 'pubs') {
 			return (
 				<div className="layout-pubs-block">
-					<LayoutPubs key={index} content={block.content} pubs={pubBlocksLists[index]} />
+					<LayoutPubs
+						key={index}
+						content={block.content}
+						pubs={pubBlocksLists[index]}
+						collectionId={collectionId}
+					/>
 				</div>
 			);
 		}

--- a/client/components/Layout/LayoutPubs.tsx
+++ b/client/components/Layout/LayoutPubs.tsx
@@ -3,14 +3,16 @@ import React from 'react';
 import { PubPreview } from 'components';
 import { Pub } from 'utils/types';
 import { LayoutBlockPubs } from 'utils/layout/types';
+import { createReadingParamUrl } from 'client/utils/collections';
 
 type Props = {
 	content: LayoutBlockPubs['content'];
 	pubs: Pub[];
+	collectionId?: string;
 };
 
 const LayoutPubs = (props: Props) => {
-	const { pubs, content } = props;
+	const { pubs, content, collectionId } = props;
 	const {
 		hideByline,
 		hideContributors,
@@ -21,6 +23,10 @@ const LayoutPubs = (props: Props) => {
 		title,
 	} = content;
 	const isTwoColumn = ['medium', 'minimal'].includes(pubPreviewType);
+
+	const customizePubUrlProps = collectionId
+		? { customizePubUrl: (url) => createReadingParamUrl(url, collectionId) }
+		: {};
 
 	const renderPubRow = (currentPub: Pub, index: number, allPubs: Pub[]) => {
 		if (isTwoColumn && index % 2 === 1) {
@@ -38,6 +44,7 @@ const LayoutPubs = (props: Props) => {
 						hideDates={hideDates}
 						hideEdges={hideEdges}
 						hideContributors={hideContributors}
+						{...customizePubUrlProps}
 					/>
 				</div>
 				{nextPub && (
@@ -50,6 +57,7 @@ const LayoutPubs = (props: Props) => {
 							hideDates={hideDates}
 							hideEdges={hideEdges}
 							hideContributors={hideContributors}
+							{...customizePubUrlProps}
 						/>
 					</div>
 				)}

--- a/client/components/PubPreview/PubPreview.tsx
+++ b/client/components/PubPreview/PubPreview.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import classNames from 'classnames';
 import dateFormat from 'dateformat';
 
-import { Pub } from 'utils/types';
+import { Pub, Community } from 'utils/types';
 import { getResizedUrl } from 'utils/images';
 import { getPubPublishedDate } from 'utils/pub/pubDates';
 import { isPubPublic } from 'utils/pub/permissions';
@@ -26,13 +26,25 @@ type Props = {
 	hideDates?: boolean;
 	hideContributors?: boolean;
 	hideEdges?: boolean;
-	customPubUrl?: string;
+	customizePubUrl?: (url: string) => string;
+};
+
+const getPubUrl = (
+	pubData: Pub,
+	communityData: Community,
+	customizePubUrl: Props['customizePubUrl'],
+) => {
+	const proposedPubUrl = bestPubUrl({ pubData: pubData, communityData: communityData });
+	if (customizePubUrl) {
+		return customizePubUrl(proposedPubUrl);
+	}
+	return proposedPubUrl;
 };
 
 const PubPreview = (props: Props) => {
 	const {
 		communityData,
-		customPubUrl = null,
+		customizePubUrl,
 		hideByline = false,
 		hideContributors = false,
 		hideDates = false,
@@ -56,9 +68,7 @@ const PubPreview = (props: Props) => {
 	const showContributors = !hideContributors && ['large', 'medium', 'small'].includes(size);
 	const showDescription = pubData.description && !hideDescription;
 	const showExpandButton = canExpand && ['large', 'medium'].includes(size);
-	const pubLink =
-		customPubUrl ||
-		bestPubUrl({ pubData: pubData, communityData: communityData || localCommunityData });
+	const pubLink = getPubUrl(pubData, communityData || localCommunityData, customizePubUrl);
 
 	const renderByline = () => (
 		<ManyAuthorsByline

--- a/client/containers/Pub/PubDocument/PubBottom/ReadNextSection.tsx
+++ b/client/containers/Pub/PubDocument/PubBottom/ReadNextSection.tsx
@@ -42,7 +42,7 @@ const ReadNextSection = (props: Props) => {
 					<a
 						href={createReadingParamUrl(
 							pubUrl(communityData, nextPub),
-							currentCollection,
+							currentCollection.id,
 						)}
 					>
 						{nextPub.title}

--- a/client/containers/Pub/PubHeader/collections/CollectionBrowser.tsx
+++ b/client/containers/Pub/PubHeader/collections/CollectionBrowser.tsx
@@ -31,7 +31,7 @@ const CollectionBrowser = (props: Props) => {
 	const { pubs, error, isLoading } = useCollectionPubs(updateLocalData, collection);
 	// @ts-expect-error ts-migrate(2339) FIXME: Property 'bpDisplayIcon' does not exist on type '{... Remove this comment to see the full error message
 	const { bpDisplayIcon } = getSchemaForKind(collection.kind);
-	const readingPubUrl = (pub) => createReadingParamUrl(pubUrl(communityData, pub), collection);
+	const readingPubUrl = (pub) => createReadingParamUrl(pubUrl(communityData, pub), collection.id);
 
 	// eslint-disable-next-line react/prop-types
 	const renderDisclosure = ({ ref, ...disclosureProps }) => {

--- a/client/utils/collections.ts
+++ b/client/utils/collections.ts
@@ -24,9 +24,9 @@ export const getNeighborsInCollectionPub = (pubs, currentPub) => {
 	return { previousPub: previousPub, nextPub: nextPub };
 };
 
-export const createReadingParamUrl = (url, collection) => {
+export const createReadingParamUrl = (url, collectionId) => {
 	const urlObject = new URL(url);
-	urlObject.searchParams.append(readingCollectionParam, collection.id.split('-')[0]);
+	urlObject.searchParams.append(readingCollectionParam, collectionId.split('-')[0]);
 	return urlObject.toString();
 };
 


### PR DESCRIPTION
We want to ensure that when a Pub in a Collection layout is clicked, that Pub is loaded in the context of that Collection, meaning it will be shown prominently in the Pub Header and used for Read Next. We accomplish that with the `readingCollection` URL parameter. This PR adds that param where appropriate to links in Pubs blocks in Collection layouts.

_Test plan:_
- Visit a Collection layout and ensure that the `readingCollection` param is specified on Pub hrefs as expected.
- Visit a Page layout and a User profile and ensure the PubPreviews in those views still work.