### PR TITLE
dev: Add pubRanks to CollectionPubs

### DIFF
--- a/server/collectionPub/api.js
+++ b/server/collectionPub/api.js
@@ -1,7 +1,12 @@
 import app, { wrap } from 'server/server';
 import { ForbiddenError } from 'server/utils/errors';
 
-import { getPermissions } from './permissions';
+import {
+	canCreateCollectionPub,
+	canDestroyCollectionPub,
+	getPermissions,
+	getUpdatableFieldsForCollectionPub,
+} from './permissions';
 import {
 	createCollectionPub,
 	updateCollectionPub,
@@ -34,12 +39,13 @@ app.post(
 	wrap(async (req, res) => {
 		const { collectionId, pubId, userId, communityId } = getRequestIds(req);
 		const { rank, moveToTop } = req.body;
-		const permissions = await getPermissions({
+		const canCreate = await canCreateCollectionPub({
+			userId: userId,
 			communityId: communityId,
 			collectionId: collectionId,
-			userId: userId,
+			pubId: pubId,
 		});
-		if (!permissions.create) {
+		if (!canCreate) {
 			throw new ForbiddenError();
 		}
 		const collectionPub = await createCollectionPub({
@@ -76,19 +82,16 @@ app.put(
 app.put(
 	'/api/collectionPubs',
 	wrap(async (req, res) => {
-		const { collectionPubId, communityId, collectionId, userId } = getRequestIds(req);
-		const permissions = await getPermissions({
+		const { collectionPubId, communityId, userId } = getRequestIds(req);
+		const updatableFields = await getUpdatableFieldsForCollectionPub({
 			communityId: communityId,
-			collectionId: collectionId,
+			collectionPubId: collectionPubId,
 			userId: userId,
 		});
-		if (!permissions.create) {
+		if (!updatableFields) {
 			throw new ForbiddenError();
 		}
-		const updated = await updateCollectionPub(
-			{ ...req.body, collectionPubId: collectionPubId },
-			permissions.update,
-		);
+		const updated = await updateCollectionPub(collectionPubId, req.body, updatableFields);
 		return res.status(200).json(updated);
 	}),
 );
@@ -96,16 +99,16 @@ app.put(
 app.delete(
 	'/api/collectionPubs',
 	wrap(async (req, res) => {
-		const { collectionPubId, communityId, collectionId, userId } = getRequestIds(req);
-		const permissions = await getPermissions({
+		const { collectionPubId, communityId, userId } = getRequestIds(req);
+		const canDestroy = await canDestroyCollectionPub({
 			communityId: communityId,
-			collectionId: collectionId,
+			collectionPubId: collectionPubId,
 			userId: userId,
 		});
-		if (!permissions.create) {
+		if (!canDestroy) {
 			throw new ForbiddenError();
 		}
-		await destroyCollectionPub({ collectionPubId: collectionPubId });
+		await destroyCollectionPub(collectionPubId);
 		return res.status(200).json(req.body.id);
 	}),
 );

--- a/server/collectionPub/model.js
+++ b/server/collectionPub/model.js
@@ -7,6 +7,7 @@ export default (sequelize, dataTypes) => {
 			collectionId: { type: dataTypes.UUID, allowNull: false },
 			contextHint: { type: dataTypes.TEXT },
 			rank: { type: dataTypes.TEXT, allowNull: false },
+			pubRank: { type: dataTypes.TEXT, allowNull: false },
 			isPrimary: { type: dataTypes.BOOLEAN, defaultValue: false, allowNull: false },
 		},
 		{

--- a/server/collectionPub/model.js
+++ b/server/collectionPub/model.js
@@ -12,14 +12,6 @@ export default (sequelize, dataTypes) => {
 		},
 		{
 			indexes: [
-				// Index to maintain invariant that every pub have at most one primary collection
-				{
-					fields: ['pubId'],
-					where: {
-						isPrimary: true,
-					},
-					unique: true,
-				},
 				// Index to enforce that there is one CollectionPub per (collection, pub) pair
 				{
 					fields: ['collectionId', 'pubId'],

--- a/server/collectionPub/permissions.js
+++ b/server/collectionPub/permissions.js
@@ -1,3 +1,4 @@
+import { CollectionPub } from 'server/models';
 import { getScope } from 'server/utils/queryHelpers';
 
 export const getPermissions = async ({ userId, communityId, collectionId }) => {
@@ -19,4 +20,46 @@ export const getPermissions = async ({ userId, communityId, collectionId }) => {
 		setPrimary: isAuthenticated,
 		destroy: isAuthenticated,
 	};
+};
+
+export const canCreateCollectionPub = async ({ userId, communityId, collectionId }) => {
+	const { activePermissions } = await getScope({
+		communityId: communityId,
+		collectionId: collectionId,
+		loginId: userId,
+	});
+	if (activePermissions.canManage) {
+		return true;
+	}
+	return false;
+};
+
+export const getUpdatableFieldsForCollectionPub = async ({
+	userId,
+	communityId,
+	collectionPubId,
+}) => {
+	const { collectionId } = await CollectionPub.findOne({ where: { id: collectionPubId } });
+	const { activePermissions } = await getScope({
+		communityId: communityId,
+		collectionId: collectionId,
+		loginId: userId,
+	});
+	if (activePermissions.canManage) {
+		return ['rank', 'pubRank', 'contextHint'];
+	}
+	return null;
+};
+
+export const canDestroyCollectionPub = async ({ userId, communityId, collectionPubId }) => {
+	const { collectionId } = await CollectionPub.findOne({ where: { id: collectionPubId } });
+	const { activePermissions } = await getScope({
+		communityId: communityId,
+		collectionId: collectionId,
+		loginId: userId,
+	});
+	if (activePermissions.canManage) {
+		return true;
+	}
+	return false;
 };

--- a/stubstub/modelize/builders.js
+++ b/stubstub/modelize/builders.js
@@ -2,9 +2,10 @@ import uuid from 'uuid';
 import SHA3 from 'crypto-js/sha3';
 import encHex from 'crypto-js/enc-hex';
 
-import { Branch, Community, Member, Pub, Release, User } from '../../server/models';
-import { createPub } from '../../server/pub/queries';
-import { createCollection } from '../../server/collection/queries';
+import { createCollectionPub } from 'server/collectionPub/queries';
+import { Branch, Community, Member, Pub, Release, User } from 'server/models';
+import { createPub } from 'server/pub/queries';
+import { createCollection } from 'server/collection/queries';
 
 const builders = {};
 
@@ -93,5 +94,7 @@ builders.Release = (args) => {
 	const { userId = uuid.v4(), branchId = uuid.v4(), ...restArgs } = args;
 	return Release.create({ userId: userId, branchId: branchId, ...restArgs });
 };
+
+builders.CollectionPub = createCollectionPub;
 
 export { builders };

--- a/stubstub/modelize/builders.js
+++ b/stubstub/modelize/builders.js
@@ -95,6 +95,7 @@ builders.Release = (args) => {
 	return Release.create({ userId: userId, branchId: branchId, ...restArgs });
 };
 
-builders.CollectionPub = createCollectionPub;
+builders.CollectionPub = ({ isPrimary, ...restArgs }) =>
+	createCollectionPub({ ...restArgs, isPrimary: isPrimary || false });
 
 export { builders };

--- a/tools/migrations/2020_10_27_addPubRanks.js
+++ b/tools/migrations/2020_10_27_addPubRanks.js
@@ -1,0 +1,11 @@
+export const up = async ({ sequelize, Sequelize }) => {
+	await sequelize.queryInterface.addColumn('CollectionPubs', 'pubRank', {
+		type: Sequelize.TEXT,
+		allowNull: false,
+		defaultValue: '',
+	});
+};
+
+export const down = async ({ sequelize }) => {
+	await sequelize.queryInterface.removeColumn('CollectionPubs', 'pubRank');
+};

--- a/tools/migrations/2020_10_27_backfillPubRanks.js
+++ b/tools/migrations/2020_10_27_backfillPubRanks.js
@@ -1,0 +1,33 @@
+import { generateRanks } from 'utils/rank';
+import { forEachInstance, forEach } from './util';
+
+export const up = async ({ models }) => {
+	const { Pub, CollectionPub } = models;
+	await forEachInstance(
+		Pub,
+		async (pub) => {
+			const collectionPubs = await CollectionPub.findAll({
+				where: { pubId: pub.id },
+			});
+			collectionPubs.sort((a, b) => {
+				if (a.isPrimary) {
+					return -1;
+				}
+				if (b.isPrimary) {
+					return 1;
+				}
+				return a.createdAt > b.createdAt ? 1 : -1;
+			});
+			const ranks = generateRanks(collectionPubs.length);
+			forEach(
+				collectionPubs,
+				async (collectionPub, index) => {
+					collectionPub.pubRank = ranks[index];
+					await collectionPub.save();
+				},
+				10,
+			);
+		},
+		10,
+	);
+};


### PR DESCRIPTION
This is the first bit of work to remove `isPrimary` from CollectionPubs and replace it with a ranking-based scheme to determine which Collection should be used in which contexts. Just as the model has a `rank` field that determines its order with respect to its Collection, it will now also have `pubRank` which determines its importance to the Pub.

All this PR does is add the field to the db schema, updates the `createCollectionPub` helper function, and provides a data migration to backfill `pubRanks`: currently-primary CollectionPubs appear earliest in a Pub's list, and the rest are sorted by creation date.

_Test plan:_
Run the CollectionPub unit tests:
```
npm run test-dev server/collectionPub
```