### PR TITLE
update: allow re-depositing of collections

### DIFF
--- a/client/containers/DashboardSettings/CollectionSettings/CollectionMetadataEditor.tsx
+++ b/client/containers/DashboardSettings/CollectionSettings/CollectionMetadataEditor.tsx
@@ -149,12 +149,7 @@ class CollectionMetadataEditor extends React.Component<Props, State> {
 				onConfirm={this.handleGetDoiClick}
 				confirmLabel="Assign DOI"
 				intent="primary"
-				text={
-					<span>
-						This is the first time this collection has been deposited to Crossref. Once
-						assigned, the DOI for this collection cannot be changed.
-					</span>
-				}
+				text="This is the first time this collection has been deposited to Crossref. Once assigned, the DOI for this collection cannot be changed."
 			>
 				{({ open }) => (
 					<Button

--- a/client/containers/DashboardSettings/CollectionSettings/CollectionMetadataEditor.tsx
+++ b/client/containers/DashboardSettings/CollectionSettings/CollectionMetadataEditor.tsx
@@ -172,9 +172,6 @@ class CollectionMetadataEditor extends React.Component<Props, State> {
 
 	renderFieldRightElement(field) {
 		const { name, defaultDerivedFrom, value } = field;
-		// if (field.name === 'doi') {
-		// 	return this.renderGetDoiButton();
-		// }
 		const derivedHintValue = defaultDerivedFrom && this.deriveInputValue(defaultDerivedFrom);
 		return (
 			derivedHintValue && (

--- a/client/containers/DashboardSettings/CollectionSettings/collectionMetadataEditor.scss
+++ b/client/containers/DashboardSettings/CollectionSettings/collectionMetadataEditor.scss
@@ -1,22 +1,25 @@
 .dashboard-content_collection-metadata-editor {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    .fields-empty-state {
-        flex-grow: 1;
-    }
-    .fields {
-        width: 100%;
-        padding-top: 8px;
-    }
-    .field {
-        width: 100%;
-        max-width: 500px;
-    }
-    &:last-child:after {
-        content: '';
-        height: 20px;
-        display: block;
-        flex-shrink: 0;
-    }
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	.fields-empty-state {
+		flex-grow: 1;
+	}
+	.fields {
+		width: 100%;
+		padding-top: 8px;
+	}
+	.field {
+		width: 100%;
+		max-width: 500px;
+	}
+	&:last-child:after {
+		content: '';
+		height: 20px;
+		display: block;
+		flex-shrink: 0;
+	}
+	.bp3-callout {
+		margin-top: 15px;
+	}
 }


### PR DESCRIPTION
Closes #988 

This PR removes the existing "Assign DOI" button from the collection settings DOI field and adds a new button to the bottom of the form. The new button behaves similarly to the old one by assigning a DOI when it is clicked for the first time, but also allows the collection to be deposited again.

<img width="555" alt="Screen Shot 2020-11-06 at 12 28 25 PM" src="https://user-images.githubusercontent.com/6402908/98396334-932fd480-202b-11eb-819e-adf07891a8cb.png">
