### PR TITLE
fix: float all children of left/right-aligned captions

### DIFF
--- a/client/components/Editor/styles/figure.scss
+++ b/client/components/Editor/styles/figure.scss
@@ -21,23 +21,23 @@ figure {
 		pointer-events: auto;
 	}
 
-	&[data-align='left'] > :first-child {
+	&[data-align='left'] > * {
 		float: left;
 		margin: 0.5em 1.5em 0.5em 0em;
 	}
 
-	&[data-align='right'] > :first-child {
+	&[data-align='right'] > * {
 		float: right;
 		margin: 0.5em 0em 0.5em 1.5em;
 	}
 
 	@for $i from 1 through 100 {
-		&[data-size='#{$i}'] > :first-child {
+		&[data-size='#{$i}'] > * {
 			width: percentage($i/100);
 		}
 	}
 
-	&[data-align='full'] > :first-child {
+	&[data-align='full'] > * {
 		width: 100%;
 	}
 

--- a/client/components/FormattingBar/controlComponents/controlsReference.scss
+++ b/client/components/FormattingBar/controlComponents/controlsReference.scss
@@ -5,7 +5,7 @@
 
 .controls-reference-settings-link {
 	&.dark {
-		color: #545454;
+		opacity: 0.8;
 
 		a {
 			color: #eee;


### PR DESCRIPTION
Fixes #1116

This PR applies floats and margins to all left/right aligned children of figures, so that the alignment applies to the `<figcaption>` as well as the media element.