### PR TITLE
fix: dont attempt to resolve collection via /:slug route pattern

### DIFF
--- a/server/routes/collection.js
+++ b/server/routes/collection.js
@@ -88,10 +88,15 @@ app.get(
 			return res.redirect(`/search?q=${collection.title}`);
 		}
 
-		// Some Crossref deposits have occured with this scheme so we must continue to support it.
-		const collectionByPartialId = await findCollectionByPartialId(collectionSlug);
-		if (collectionByPartialId) {
-			return res.redirect(`/${collectionByPartialId.slug}`);
+		// Some Crossref deposits have occured with this scheme so we must continue
+		// to support it. This only applies to URLs that match the /collection/:slug
+		// pattern.
+		if (/^\/collection/.test(req.path)) {
+			const collectionByPartialId = await findCollectionByPartialId(collectionSlug);
+
+			if (collectionByPartialId) {
+				return res.redirect(`/${collectionByPartialId.slug}`);
+			}
 		}
 
 		return next();


### PR DESCRIPTION
Quick fix to prevent the collection route handler from resolving a collection via partial ID when the pattern is `{community root}/:slug`