### PR TITLE
fix: Tables in exports and column resizing

### DIFF
--- a/client/components/Editor/plugins/table.ts
+++ b/client/components/Editor/plugins/table.ts
@@ -28,16 +28,17 @@ function wrapDomSerializer(domSerializer: DOMSerializer) {
 class PubTableView extends TableView {
 	constructor(node, ...rest) {
 		super(node, ...rest);
-		this.syncDom(node);
+		this.syncId(node);
+		this.syncCaption(node);
 	}
 
 	update(node, decorations) {
 		const shouldUpdate = super.update(node, decorations);
-		this.syncDom(node);
+		this.syncId(node);
 		return shouldUpdate;
 	}
 
-	syncDom(node) {
+	syncCaption(node) {
 		const { dom } = (this as any) as { dom: HTMLElement };
 		const label = buildLabel(node);
 		if (label) {
@@ -48,6 +49,10 @@ class PubTableView extends TableView {
 				table.append(caption);
 			}
 		}
+	}
+
+	syncId(node) {
+		const { dom } = (this as any) as { dom: HTMLElement };
 		dom.setAttribute('id', node.attrs.id);
 	}
 }

--- a/client/components/Editor/schemas/table.ts
+++ b/client/components/Editor/schemas/table.ts
@@ -70,7 +70,7 @@ table.toDOM = (node: ProsemirrorNode) => {
 	return pruneFalsyValues([
 		spec[0],
 		{ id: node.attrs.id },
-		withValue(buildLabel(node), (label) => ['caption', { spellcheck: 'false' }, label]),
+		withValue(buildLabel(node), (builtLabel) => ['caption', builtLabel]),
 		spec[1],
 	]) as DOMOutputSpec;
 };

--- a/client/components/Editor/utils/renderStatic.ts
+++ b/client/components/Editor/utils/renderStatic.ts
@@ -36,6 +36,7 @@ const attrsTransformations = {
 	rowspan: 'rowSpan',
 	colspan: 'colSpan',
 	class: 'className',
+	spellcheck: 'spellCheck',
 	style: (val) => {
 		return { style: typeof val === 'string' ? parseStyleToObject(val) : val };
 	},

--- a/client/components/FormattingBar/controlComponents/ControlsTable.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsTable.tsx
@@ -30,8 +30,8 @@ const buttonCommands = [
 	{ key: 'table-merge-cells', title: 'Merge cells', icon: 'merge-columns' },
 	{ key: 'table-split-cell', title: 'Split cells', icon: 'split-columns' },
 	{ key: 'toggle-header-cell', title: 'Toggle header cells', icon: 'header' },
-	{ key: 'table-delete', title: 'Remove table', icon: 'trash' },
 	{ key: 'table-toggle-label', title: 'Toggle label', icon: 'tag' },
+	{ key: 'table-delete', title: 'Remove table', icon: 'trash' },
 ];
 
 const ControlsTable = (props: Props) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4256,9 +4256,9 @@
       "integrity": "sha512-FpgvwDQTyEhFtVtQET48wb336msdqszPlbVRXrq3ZK53T/aTKttxDAshtg1J4QB9Auf7k3mQ0RkRVnypklbcQA=="
     },
     "@pubpub/prosemirror-reactive": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@pubpub/prosemirror-reactive/-/prosemirror-reactive-0.1.6.tgz",
-      "integrity": "sha512-rfrSBStDj5N1/L4fgkQDjBZaaRJDOzdU02iDBVFeCwDWKVeBYVgip2t4nweVPSIStczI0CXq5NroyEDGtx5w/Q==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@pubpub/prosemirror-reactive/-/prosemirror-reactive-0.1.7.tgz",
+      "integrity": "sha512-s0WoJGiL6Yc2fLcLxtnnP29BMsfojB3ziEO9LoByT38dJ6ps+BPQcV56iPXMlxbIb7tM0mUInloIJrE/B8caZg==",
       "requires": {
         "prosemirror-model": "^1.9.1",
         "prosemirror-state": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"@blueprintjs/icons": "^3.14.0",
 		"@blueprintjs/select": "^3.12.0",
 		"@pubpub/prosemirror-pandoc": "^0.6.1",
-		"@pubpub/prosemirror-reactive": "^0.1.6",
+		"@pubpub/prosemirror-reactive": "^0.1.7",
 		"@sentry/browser": "^5.5.0",
 		"@sentry/node": "^5.5.0",
 		"@storybook/addon-knobs": "^5.3.19",

--- a/workers/tasks/export/styles/printDocument.scss
+++ b/workers/tasks/export/styles/printDocument.scss
@@ -21,6 +21,10 @@ https://gitlab.pagedmedia.org/tools/pagedjs-cli/issues/11 */
 
 @import url('https://use.typekit.net/kmi0tdo.css');
 
+body {
+    font-family: $base-font;
+}
+
 /* Paged-specific overrides */
 .csl-bib-body,
 .csl-entry {
@@ -160,6 +164,10 @@ section.cover {
         table-layout: fixed;
         width: 100%;
         overflow: hidden;
+    }
+
+    table caption {
+        text-align: left;
     }
 
     table,


### PR DESCRIPTION
Resolves #1128 

This PR fixes two issues related to tables in Prosemirror:

- Tables are not appearing in exports
- Table resizing doesn't work

A lot of the core of what fixes these issues is accounted for in the version bump of `prosemirror-reactive`.

_Test plan:_
- Create tables in a new Pub. Verify that they are labeled correctly and that columns can be resized. Verify that the various table commands accessible from the inline context menu work as expected.
- Export the Pub to HTML and verify that the tables appear.