### PR TITLE
fix: Only show a given Pub once in a PubEdgeListing

### DIFF
--- a/client/components/PubEdge/PubEdge.tsx
+++ b/client/components/PubEdge/PubEdge.tsx
@@ -3,12 +3,8 @@ import classNames from 'classnames';
 
 import { Byline } from 'components';
 import { usePageContext } from 'utils/hooks';
-import { formatDate } from 'utils/dates';
-import { pubUrl, pubShortUrl } from 'utils/canonicalUrls';
-import { getPubPublishedDate } from 'utils/pub/pubDates';
-import { getAllPubContributors } from 'utils/contributors';
+import { getHostnameForUrl, getValuesFromPubEdge } from 'utils/pubEdge';
 
-import { getHostnameForUrl } from './util';
 import PubEdgeLayout from './PubEdgeLayout';
 import PubEdgeDescriptionButton from './PubEdgeDescriptionButton';
 
@@ -20,53 +16,6 @@ export type PubEdgeProps = {
 	pubEdge: any;
 	viewingFromTarget?: boolean;
 	showDescriptionByDefault?: boolean;
-};
-
-const getUrlForPub = (pubData, communityData) => {
-	if (communityData.id === pubData.communityId) {
-		return pubUrl(communityData, pubData);
-	}
-	if (pubData.community) {
-		return pubUrl(pubData.communityId, pubData);
-	}
-	return pubShortUrl(pubData);
-};
-
-const getValuesFromPubEdge = (pubEdge, communityData, viewingFromTarget) => {
-	const { externalPublication, targetPub, pub } = pubEdge;
-	const displayedPub = viewingFromTarget ? pub : targetPub;
-	if (displayedPub) {
-		const { title, description, avatar } = displayedPub;
-		const url = getUrlForPub(displayedPub, communityData);
-		const publishedDate = getPubPublishedDate(displayedPub);
-		return {
-			avatar: avatar,
-			contributors: getAllPubContributors(displayedPub, false, true),
-			description: description,
-			publishedAt: publishedDate && formatDate(publishedDate),
-			title: title,
-			url: url,
-		};
-	}
-	if (externalPublication) {
-		const {
-			title,
-			description,
-			contributors,
-			avatar,
-			url,
-			publicationDate,
-		} = externalPublication;
-		return {
-			avatar: avatar,
-			contributors: contributors || '',
-			description: description,
-			publishedAt: publicationDate && formatDate(publicationDate, { inUtcTime: true }),
-			title: title,
-			url: url,
-		};
-	}
-	return {};
 };
 
 const PubEdge = (props: PubEdgeProps) => {
@@ -132,7 +81,9 @@ const PubEdge = (props: PubEdgeProps) => {
 				tabIndex: '-1',
 			})}
 			titleElement={maybeLink(title)}
-			bylineElement={contributors.length > 0 && <Byline contributors={contributors} />}
+			bylineElement={
+				contributors && contributors.length > 0 && <Byline contributors={contributors} />
+			}
 			metadataElements={[
 				description && (
 					<PubEdgeDescriptionButton
@@ -142,7 +93,7 @@ const PubEdge = (props: PubEdgeProps) => {
 					/>
 				),
 				publishedAt && <>Published on {publishedAt}</>,
-				<span className="location">{getHostnameForUrl(url)}</span>,
+				url && <span className="location">{getHostnameForUrl(url)}</span>,
 			]}
 			detailsElement={
 				<details open={open} id={detailsElementId}>

--- a/client/components/PubEdge/PubEdgeEditor.tsx
+++ b/client/components/PubEdge/PubEdgeEditor.tsx
@@ -3,9 +3,9 @@ import { EditableText, TagInput } from '@blueprintjs/core';
 import { Button as RKButton } from 'reakit/Button';
 
 import { DatePicker } from 'components';
+import { getHostnameForUrl } from 'utils/pubEdge';
 
 import { externalPublicationType } from './constants';
-import { getHostnameForUrl } from './util';
 import PubEdgeLayout from './PubEdgeLayout';
 import PubEdgeDescriptionButton from './PubEdgeDescriptionButton';
 

--- a/client/components/PubEdge/util.ts
+++ b/client/components/PubEdge/util.ts
@@ -1,8 +1,0 @@
-export const getHostnameForUrl = (url) => {
-	try {
-		const parsedUrl = new URL(url);
-		return parsedUrl.hostname;
-	} catch (_) {
-		return url;
-	}
-};

--- a/client/components/PubEdgeListing/PubEdgeListingCard.tsx
+++ b/client/components/PubEdgeListing/PubEdgeListingCard.tsx
@@ -5,7 +5,7 @@ import React, { useState, useCallback } from 'react';
 import { PubEdge } from 'components';
 import { toTitleCase } from 'utils/strings';
 import { usePageContext } from 'utils/hooks';
-import { relationTypeDefinitions } from 'utils/pubEdge';
+import { relationTypeDefinitions, isViewingEdgeFromTarget } from 'utils/pubEdge';
 import { pubShortUrl } from 'utils/canonicalUrls';
 
 require('./pubEdgeListingCard.scss');
@@ -25,19 +25,6 @@ export type PubEdgeListingCardProps = {
 	viewingFromSibling?: boolean;
 };
 
-const getIsViewingFromTarget = (pubEdge, viewingFromSibling, isInboundEdge) => {
-	const { pubIsParent } = pubEdge;
-	if (viewingFromSibling) {
-		// If the `pub` in the edge relationship is the parent, then the `targetPub` is the child.
-		// We want this edge to display the child -- in other words, we want to view from the
-		// `targetPub` towards the `pub` only if the `pub` is the child.
-		return !pubIsParent;
-	}
-	// If this edge is inbound, that means another Pub (relative to our vantage point) created it,
-	// which is to say that we're viewing it from the target.
-	return isInboundEdge;
-};
-
 type Props = PubEdgeListingCardProps;
 
 const PubEdgeListingCard = (props: Props) => {
@@ -54,7 +41,7 @@ const PubEdgeListingCard = (props: Props) => {
 		viewingFromSibling = false,
 		pubData,
 	} = props;
-	const viewingFromTarget = getIsViewingFromTarget(pubEdge, viewingFromSibling, isInboundEdge);
+	const viewingFromTarget = isViewingEdgeFromTarget(pubEdge, viewingFromSibling, isInboundEdge);
 	const [hover, setHover] = useState(false);
 	const handleMouseEnter = useCallback(() => setHover(true), []);
 	const handleMouseLeave = useCallback(() => setHover(false), []);

--- a/utils/arrays.js
+++ b/utils/arrays.js
@@ -18,4 +18,18 @@ export const indexByProperty = (array, property) => {
 	return res;
 };
 
+export const unique = (array, fn) => {
+	const uniqueSymbol = Symbol('unique');
+	const res = [];
+	const seenValues = new Set();
+	array.forEach((el) => {
+		const value = fn(el, uniqueSymbol);
+		if (!seenValues.has(value) || value === uniqueSymbol) {
+			seenValues.add(value);
+			res.push(el);
+		}
+	});
+	return res;
+};
+
 export const pruneFalsyValues = (arr) => arr.filter(Boolean);

--- a/utils/pubEdge/helpers.ts
+++ b/utils/pubEdge/helpers.ts
@@ -1,0 +1,99 @@
+import { Community, Pub, PubEdge } from 'utils/types';
+import { formatDate } from 'utils/dates';
+import { pubUrl, pubShortUrl } from 'utils/canonicalUrls';
+import { getPubPublishedDate } from 'utils/pub/pubDates';
+import { getAllPubContributors } from 'utils/contributors';
+
+export const getHostnameForUrl = (url: string) => {
+	try {
+		const parsedUrl = new URL(url);
+		return parsedUrl.hostname;
+	} catch (_) {
+		return url;
+	}
+};
+
+const getUrlForPub = (pubData: Pub, communityData: Community) => {
+	if (communityData.id === pubData.communityId) {
+		return pubUrl(communityData, pubData);
+	}
+	if ((pubData as any).community) {
+		return pubUrl(pubData.communityId, pubData);
+	}
+	return pubShortUrl(pubData);
+};
+
+export const isViewingEdgeFromTarget = (
+	pubEdge: PubEdge,
+	viewingFromSibling: boolean,
+	isInboundEdge: boolean,
+) => {
+	const { pubIsParent } = pubEdge;
+	if (viewingFromSibling) {
+		// If the `pub` in the edge relationship is the parent, then the `targetPub` is the child.
+		// We want this edge to display the child -- in other words, we want to view from the
+		// `targetPub` towards the `pub` only if the `pub` is the child.
+		return !pubIsParent;
+	}
+	// If this edge is inbound, that means another Pub (relative to our vantage point) created it,
+	// which is to say that we're viewing it from the target.
+	return isInboundEdge;
+};
+
+export const getDisplayedPubForPubEdge = (
+	pubEdge: PubEdge,
+	context:
+		| { viewingFromTarget: boolean }
+		| { isInboundEdge: boolean; viewingFromSibling: boolean },
+) => {
+	const { pub, targetPub } = pubEdge;
+	const isViewingFromTarget =
+		'viewingFromTarget' in context
+			? context.viewingFromTarget
+			: isViewingEdgeFromTarget(pubEdge, context.viewingFromSibling, context.isInboundEdge);
+	return isViewingFromTarget ? pub : targetPub;
+};
+
+export const getValuesFromPubEdge = (
+	pubEdge: PubEdge,
+	communityData: Community,
+	viewingFromTarget: boolean,
+) => {
+	const { externalPublication } = pubEdge;
+	const displayedPub = getDisplayedPubForPubEdge(pubEdge, {
+		viewingFromTarget: viewingFromTarget,
+	});
+	if (displayedPub) {
+		const { title, description, avatar } = displayedPub;
+		const url = getUrlForPub(displayedPub, communityData);
+		const publishedDate = getPubPublishedDate(displayedPub);
+		return {
+			displayedPubId: displayedPub.id,
+			avatar: avatar,
+			contributors: getAllPubContributors(displayedPub, false, true),
+			description: description,
+			publishedAt: publishedDate && formatDate(publishedDate),
+			title: title,
+			url: url,
+		};
+	}
+	if (externalPublication) {
+		const {
+			title,
+			description,
+			contributors,
+			avatar,
+			url,
+			publicationDate,
+		} = externalPublication;
+		return {
+			avatar: avatar,
+			contributors: contributors || '',
+			description: description,
+			publishedAt: publicationDate && formatDate(publicationDate, { inUtcTime: true }),
+			title: title,
+			url: url,
+		};
+	}
+	return {};
+};

--- a/utils/pubEdge/index.js
+++ b/utils/pubEdge/index.js
@@ -1,1 +1,2 @@
 export { relationTypes, relationTypeDefinitions, RelationType } from './relations';
+export * from './helpers';


### PR DESCRIPTION
Folks are using Pub Connections to build some real complicated "I'm my Own Grandpa" kinds of non-tree graphs between their Pubs, with the result that Pubs can appear more than once in the `PubEdgeListing` of a Pub as a parent, child, or sibling by multiple different parents. No matter what, we really want to make sure that every Pub only appears once in this listing — so that's what this PR does.

_Test plan:_
I ran 

```
PUBPUB_LOCAL_COMMUNITY=hdsr PUBPUB_PRODUCTION=true npm start
```

and then visited [this Pub](http://localhost:9876/pub/cqncbp3l/release/3), verifying that there are no duplicates in its connections listing. I'll probably want to check about a dozen other Pubs, too.