### PR TITLE
feature: Full-resolution image support (including .gif and .webp)

### DIFF
--- a/client/components/Editor/styles/figure.scss
+++ b/client/components/Editor/styles/figure.scss
@@ -3,10 +3,6 @@ figure {
 	text-align: center;
 	margin: 0;
 
-	> * {
-		margin: 1em auto;
-	}
-
 	& > * {
 		pointer-events: none;
 		width: 100%;
@@ -46,7 +42,7 @@ figure {
 
 	figcaption {
 		opacity: 0.75;
-		padding: 2px 0px 5px;
+		margin: 1em auto;
 	}
 }
 

--- a/client/components/Editor/utils/index.ts
+++ b/client/components/Editor/utils/index.ts
@@ -3,6 +3,7 @@ export * from './discussionMaps';
 export * from './doc';
 export * from './firebase';
 export * from './firebaseDoc';
+export * from './media';
 export * from './misc';
 export * from './notes';
 export * from './references';

--- a/client/components/Editor/utils/media.ts
+++ b/client/components/Editor/utils/media.ts
@@ -1,0 +1,5 @@
+const resizableImageFormats = ['jpg', 'jpeg', 'png'];
+export const imageCanBeResized = (url: string) => {
+	const extension = (url.split('.').pop() as string).toLowerCase();
+	return resizableImageFormats.includes(extension);
+};

--- a/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
@@ -4,12 +4,13 @@ import { Node } from 'prosemirror-model';
 
 import { SimpleEditor } from 'components';
 
+import { usePubData } from 'client/containers/Pub/pubHooks';
+import { NodeLabelMap, ReferenceableNodeType } from 'client/components/Editor/types';
+import { imageCanBeResized } from 'client/components/Editor';
 import { ControlsButton, ControlsButtonGroup } from '../ControlsButton';
 import AlignmentControl from './AlignmentControl';
 import SliderInputControl from './SliderInputControl';
 import SourceControls from './SourceControls';
-import { usePubData } from 'client/containers/Pub/pubHooks';
-import { NodeLabelMap, ReferenceableNodeType } from 'client/components/Editor/types';
 import { ControlsReferenceSettingsLink } from '../ControlsReference';
 
 type Props = {
@@ -24,6 +25,7 @@ type Props = {
 				height: number;
 				caption: string;
 				hideLabel: boolean;
+				fullResolution: boolean;
 			};
 		};
 	};
@@ -44,17 +46,26 @@ const ControlsMedia = (props: Props) => {
 	const { isSmall, editorChangeObject, pendingAttrs, pubData } = props;
 	const { updateNode, selectedNode } = editorChangeObject;
 	const { hasPendingChanges, commitChanges, updateAttrs } = pendingAttrs;
-	const { size, align, height, caption, hideLabel } = selectedNode.attrs;
+	const { size, align, height, caption, url, fullResolution, hideLabel } = selectedNode.attrs;
 	const canEditHeight = getCanEditNodeHeight(selectedNode);
 	const itemName = getItemName(selectedNode);
+	const { nodeLabels } = usePubData();
+
+	const canHideLabel =
+		nodeLabels &&
+		(nodeLabels as NodeLabelMap)[selectedNode.type.name as ReferenceableNodeType]?.enabled;
+	const canSelectResizeOptions = imageCanBeResized(url);
+
 	const toggleLabel = useCallback(
 		(e: React.MouseEvent) => updateNode({ hideLabel: (e.target as HTMLInputElement).checked }),
 		[updateNode],
 	);
-	const { nodeLabels } = usePubData();
-	const canHideLabel =
-		nodeLabels &&
-		(nodeLabels as NodeLabelMap)[selectedNode.type.name as ReferenceableNodeType]?.enabled;
+
+	const toggleResize = useCallback(
+		(e: React.MouseEvent) =>
+			updateNode({ fullResolution: (e.target as HTMLInputElement).checked }),
+		[updateNode],
+	);
 
 	return (
 		<div className="controls-media-component">
@@ -93,12 +104,22 @@ const ControlsMedia = (props: Props) => {
 					isSmall={isSmall}
 				/>
 				<div className="controls-row">
+					{canSelectResizeOptions && (
+						<Checkbox
+							onClick={toggleResize}
+							alignIndicator="right"
+							label="Always use full resolution"
+							checked={fullResolution}
+						/>
+					)}
+				</div>
+				<div className="controls-row">
 					<Checkbox
 						disabled={!canHideLabel}
 						onClick={toggleLabel}
 						alignIndicator="right"
 						label="Hide label"
-						checked={selectedNode?.attrs?.hideLabel}
+						checked={hideLabel}
 					>
 						{!canHideLabel && (
 							<>

--- a/client/components/FormattingBar/controlComponents/controls.scss
+++ b/client/components/FormattingBar/controlComponents/controls.scss
@@ -74,6 +74,9 @@
 		height: 100%;
 		overflow: hidden;
 		& > *:not(:last-child) {
+			label.bp3-control {
+				margin-bottom: 0;
+			}
 			margin-bottom: 9px;
 		}
 		.title {

--- a/client/components/FormattingBar/media/MediaImage.tsx
+++ b/client/components/FormattingBar/media/MediaImage.tsx
@@ -48,7 +48,10 @@ class MediaImage extends Component<Props, State> {
 
 	render() {
 		return (
-			<Dropzone onDrop={this.onDrop} accept="image/png, image/jpeg, image/gif, image/svg+xml">
+			<Dropzone
+				onDrop={this.onDrop}
+				accept="image/png, image/jpeg, image/gif, image/webp, image/svg+xml"
+			>
 				{({ getRootProps, getInputProps, isDragActive }) => {
 					return (
 						<div
@@ -63,7 +66,9 @@ class MediaImage extends Component<Props, State> {
 									<Icon icon="circle-arrow-up" iconSize={50} />
 									<div className="drag-title">Drag & drop to upload an Image</div>
 									<div className="drag-details">Or click to browse files</div>
-									<div className="drag-details">.jpeg .png .svg or .gif</div>
+									<div className="drag-details">
+										.jpeg, .png, .svg, .webp, or .gif
+									</div>
 								</div>
 							)}
 							{this.state.isUploading && (

--- a/client/utils/upload.ts
+++ b/client/utils/upload.ts
@@ -64,6 +64,6 @@ export const s3Upload = (file: File, onProgress, onFinish, index?: number) => {
 	}
 	const getPolicy = new XMLHttpRequest();
 	getPolicy.addEventListener('load', beginUpload);
-	getPolicy.open('GET', `/api/uploadPolicy?contentType=${file.type}`);
+	getPolicy.open('GET', `/api/uploadPolicy?contentType=${encodeURIComponent(file.type)}`);
 	getPolicy.send();
 };


### PR DESCRIPTION
Resolves #1161 

This PR adds (restores?) support for gif and webp images by not passing them through the resizer. We also add a new control for other resizable image formats (jpg, png, did I miss any?) to allow them to skip the resizer as well, so that anyone who really wants a high-resolution image in their Pub can add one.

_New "full resolution" checkbox in `ControlsMedia`:_
![image](https://user-images.githubusercontent.com/2208769/99994277-c93cba80-2d86-11eb-9c40-fafea3253590.png)

_Test plan:_
- Add .gif and .webp files to a Pub and verify that they load correctly and the "full resolution" checkbox is hidden for them. 
- Add a .jpg and verify that it loads and that you can choose whether to resize it or not with the checkbox.
- Add a video and verify that the `ControlsMedia` works for it and the checkbox is hidden
- Check an existing image on an older Pub and verify that it loads.

[Here is a Pub](http://localhost:9876/pub/j9oul530/draft) with different image formats under test.