### PR TITLE
dev: Add a historyKey to every Release

### DIFF
--- a/server/release/__tests__/api.test.js
+++ b/server/release/__tests__/api.test.js
@@ -84,7 +84,7 @@ it('will create a Release for admins of a Pub', async () => {
 			}),
 		)
 		.expect(201);
-	expect(release.sourceBranchKey).toEqual(0);
+	expect(release.historyKey).toEqual(0);
 });
 
 it('will create a Release for admins of a Pub', async () => {
@@ -101,7 +101,7 @@ it('will create a Release for admins of a Pub', async () => {
 			}),
 		)
 		.expect(201);
-	expect(release.sourceBranchKey).toEqual(0);
+	expect(release.historyKey).toEqual(0);
 });
 
 it('will not create duplicate Releases for the same draft-key of a Pub', async () => {

--- a/server/release/model.js
+++ b/server/release/model.js
@@ -11,5 +11,6 @@ export default (sequelize, dataTypes) => {
 		/* Todo: We should be able to deprecate the following source ids */
 		sourceBranchId: { type: dataTypes.UUID },
 		sourceBranchKey: { type: dataTypes.INTEGER },
+		historyKey: { type: dataTypes.INTEGER, allowNull: false },
 	});
 };

--- a/server/release/queries.js
+++ b/server/release/queries.js
@@ -55,6 +55,7 @@ export const createRelease = async ({
 		noteText: noteText,
 		sourceBranchId: draftBranch.id,
 		sourceBranchKey: draftKey,
+		historyKey: draftKey,
 		branchId: publicBranch.id,
 		branchKey: mergeKey,
 		userId: userId,

--- a/stubstub/modelize/builders.js
+++ b/stubstub/modelize/builders.js
@@ -91,8 +91,13 @@ builders.Member = async ({ pubId, collectionId, communityId, ...restArgs }) => {
 builders.Release = (args) => {
 	// The Release model requires these, but it doesn't currently associate them, so it's safe
 	// to create random UUIDs for testing purposes.
-	const { userId = uuid.v4(), branchId = uuid.v4(), ...restArgs } = args;
-	return Release.create({ userId: userId, branchId: branchId, ...restArgs });
+	const { userId = uuid.v4(), branchId = uuid.v4(), historyKey = 0, ...restArgs } = args;
+	return Release.create({
+		userId: userId,
+		branchId: branchId,
+		historyKey: historyKey,
+		...restArgs,
+	});
 };
 
 builders.CollectionPub = createCollectionPub;

--- a/tools/migrations/2020_12_02_addReleaseHistoryKey.js
+++ b/tools/migrations/2020_12_02_addReleaseHistoryKey.js
@@ -1,0 +1,16 @@
+export const up = async ({ sequelize, Sequelize }) => {
+	await sequelize.queryInterface.addColumn('Releases', 'historyKey', {
+		type: Sequelize.INTEGER,
+		allowNull: false,
+		defaultValue: -1,
+	});
+	await sequelize.queryInterface.changeColumn('Releases', 'historyKey', {
+		type: Sequelize.INTEGER,
+		allowNull: false,
+		defaultValue: undefined,
+	});
+};
+
+export const down = async ({ sequelize }) => {
+	await sequelize.queryInterface.removeColumn('Releases', 'historyKey');
+};

--- a/tools/migrations/data/2020_12_02_addReleaseHistoryKeys.js
+++ b/tools/migrations/data/2020_12_02_addReleaseHistoryKeys.js
@@ -1,0 +1,187 @@
+/* eslint-disable no-console */
+import Slowdance from 'slowdance';
+
+import { Pub, Release } from 'server/models';
+import { getBranchRef } from 'server/utils/firebaseAdmin';
+import { forEach } from '../util';
+
+const assertMonotonic = (values, kind) => {
+	for (let i = 0; i < values.length - 1; i++) {
+		const one = values[i];
+		const two = values[i + 1];
+		const monotonic = one <= two;
+		if (!monotonic) {
+			throw new Error(`${kind} sequence ${values} is not monotonic`);
+		}
+	}
+};
+
+const getLatestChangeTimeInMerge = (merge) => {
+	const changes = Object.values(merge);
+	if (changes.length === 0) {
+		throw new Error('Empty merge');
+	}
+	return changes.reduce((latest, change) => {
+		if (typeof change.t !== 'number') {
+			throw new Error('Child of merge does not appear to be a change');
+		}
+		const { t } = change;
+		return Math.max(latest, t);
+	}, 0);
+};
+
+const getBestHistoryKeyForRelease = (release, keyTimePairs, historyKeyUpperBound) => {
+	assertMonotonic(
+		keyTimePairs.map((p) => p.latestChangeAt),
+		'latestChangeAt',
+	);
+	const releaseTime = new Date(release.createdAt).valueOf();
+	const latestPairBeforeRelease = keyTimePairs.reduce((best, next) => {
+		const { latestChangeAt, historyKey } = next;
+		const doesNotViolateUpperBound = historyKey <= historyKeyUpperBound;
+		const isRoughlyBeforeRelease =
+			latestChangeAt < releaseTime || Math.abs(latestChangeAt - releaseTime) <= 60 * 1000;
+		const isBetter = !best || next.latestChangeAt > best.latestChangeAt;
+		if (isRoughlyBeforeRelease && doesNotViolateUpperBound && isBetter) {
+			return next;
+		}
+		return best;
+	});
+	return latestPairBeforeRelease.historyKey;
+};
+
+const getHistoryKeysForReleases = (releases, keyTimePairs) => {
+	if (keyTimePairs.length === releases.length) {
+		const keys = keyTimePairs.map((p) => p.historyKey);
+		return { keys: keys, confidence: '✅' };
+	}
+	let confidence = '⚠️';
+	const keys = releases.map((release, index) => {
+		const { branchKey } = release;
+		if (typeof branchKey === 'number') {
+			if (branchKey >= keyTimePairs.length) {
+				confidence += '🚨';
+				return keyTimePairs[keyTimePairs.length - 1].historyKey;
+			}
+			return keyTimePairs[branchKey].historyKey;
+		}
+		confidence += '🔮';
+		const upperBoundFromSourceBranchKeys = Math.min(
+			Infinity,
+			...releases
+				.slice(index + 1)
+				.map((r) => r.sourceBranchKey)
+				.filter((k) => typeof k === 'number'),
+		);
+		return getBestHistoryKeyForRelease(release, keyTimePairs, upperBoundFromSourceBranchKeys);
+	});
+	return { keys: keys, confidence: confidence };
+};
+
+const addHistoryKeysToReleases = async (pubId, releaseBranchId, releases) => {
+	const firebaseRef = getBranchRef(pubId, releaseBranchId);
+
+	const mergesSnapshot = await firebaseRef.child('merges').once('value');
+	const merges = mergesSnapshot.val();
+
+	if (merges) {
+		const keyTimePairs = [];
+		let runningHistoryKey = -1;
+
+		Object.keys(merges)
+			.sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
+			.forEach((key) => {
+				const merge = merges[key];
+				const mergeLength = Object.keys(merge).length;
+				const latestChangeTimeInMerge = getLatestChangeTimeInMerge(merge);
+				runningHistoryKey += mergeLength;
+				keyTimePairs.push({
+					historyKey: runningHistoryKey,
+					latestChangeAt: latestChangeTimeInMerge,
+				});
+			});
+
+		assertMonotonic(
+			releases.map((release) => new Date(release.createdAt).valueOf()),
+			'release time',
+		);
+
+		assertMonotonic(
+			keyTimePairs.map((p) => p.historyKey),
+			'historyKey',
+		);
+
+		const { keys: releaseHistoryKeys, confidence } = getHistoryKeysForReleases(
+			releases,
+			keyTimePairs,
+		);
+
+		await Promise.all(
+			releases.map(async (release, index) => {
+				const historyKey = releaseHistoryKeys[index];
+				if (typeof historyKey !== 'number') {
+					throw new Error(`Release at index=${index} somehow missing key`);
+				}
+				await Release.update({ historyKey: historyKey }, { where: { id: release.id } });
+			}),
+		);
+
+		const latestReleaseTime = new Date(releases.concat().pop().createdAt).valueOf();
+		const latestKeyTimePair = keyTimePairs.concat().pop();
+		const latestReleaseHistoryKey = releaseHistoryKeys.concat().pop();
+		if (latestReleaseHistoryKey !== latestKeyTimePair.historyKey) {
+			throw new Error(
+				`Latest release (key=${latestReleaseHistoryKey}, time=${new Date(
+					latestReleaseTime,
+				)}) does not take latest history key (key=${
+					latestKeyTimePair.historyKey
+				}, time=${new Date(latestKeyTimePair.latestChangeAt)})`,
+			);
+		}
+
+		assertMonotonic(releaseHistoryKeys, 'key');
+		return confidence;
+	}
+	throw new Error('No merges');
+};
+
+const releaseHasValidHistoryKey = (release) => {
+	return typeof release.historyKey === 'number' && release.historyKey !== -1;
+};
+
+const handlePub = async (pub) => {
+	const releases = await Release.findAll({
+		where: { pubId: pub.id },
+		order: [['createdAt', 'ASC']],
+	});
+	if (releases.length > 0) {
+		if (new Set(releases.map((r) => r.branchId)).size > 1) {
+			throw new Error('Pub has releases from multiple branches');
+		}
+		if (releases.every(releaseHasValidHistoryKey)) {
+			return '🥚';
+		}
+		const releaseBranchId = releases[0].branchId;
+		return addHistoryKeysToReleases(pub.id, releaseBranchId, releases);
+	}
+	return '📝';
+};
+
+module.exports = async () => {
+	const slowdance = new Slowdance();
+	slowdance.start();
+
+	await forEach(
+		await Pub.findAll({ order: [['createdAt', 'DESC']] }),
+		async (pub) =>
+			slowdance
+				.wrapPromise(handlePub(pub), {
+					label: `[${pub.slug}] ${pub.title}`,
+					labelResult: (res) => res.toString(),
+					labelError: (err) => `(${err.message})`,
+				})
+				.catch(() => {}),
+
+		10,
+	);
+};

--- a/tools/migrations/util/index.js
+++ b/tools/migrations/util/index.js
@@ -1,9 +1,9 @@
 import Bluebird from 'bluebird';
 
-export const forEach = async (items, fn, concurrency) => {
+export const forEach = async (items, fn, concurrency = 1) => {
 	return Bluebird.map(items, fn, { concurrency: concurrency });
 };
 
-export const forEachInstance = async (Model, fn, concurrency) => {
+export const forEachInstance = async (Model, fn, concurrency = 1) => {
 	return forEach(await Model.findAll(), fn, concurrency);
 };


### PR DESCRIPTION
In order to eliminate Merges and treat Releases as simple pointers into a Pub draft, we need to be very sure which key of the draft a given Release points to. Our current understanding of that is surprisingly shaky — we have some Releases that don't correspond to a draft, some missing `branchKey` or `sourceBranchKey` fields that hint at the source of the Release, and some that appear to be duplicates of each other. In practice, when we load `/pub/:slug/release/:x` we just grab the `x-1`th merge without any regard for what Release it "actually" corresponds to, which gets us into trouble sometimes because database Release objects and Firebase merges aren't created atomically with each other during the release process, and sometimes we end up with one but not the other.

This PR contains:
- DB schema migrations to add `Release.historyKey`
- A backfill to assign a `historyKey` to every `Release`

_Test plan:_
I ran the database migration on dev:

```
npm run tools migrate -- --name 2020_12_02_addReleaseHistoryKey
```

Then I ran the backfill:

```
npm run tools migrate -- --name data/2020_12_02_addReleaseHistoryKeys
```

I observed that the only errors were `No merges`, which will occur when the dev and prod Firebase instances aren't in sync — I don't expect to see any of these in production except on Pubs that are already broken anyway. After running this, I expect that every Release with a `sourceBranchKey` (which should supposedly be the corresponding draft key) should now have an identical `historyKey`, so I ran:

```
SELECT * FROM "Releases" WHERE "Releases"."sourceBranchKey" IS NOT NULL AND "Releases"."historyKey" != -1 AND "Releases"."sourceBranchKey" != "Releases"."historyKey"
```

This yielded only 24 results (out of about 18,000 Releases) which tells me that the migration computed the correct `historyKey` for almost all Pubs. I'll write another script to clean these up by comparing entire documents in a separate PR.