### PR TITLE
dev: Migration to reconcile mismatched history keys

### DIFF
--- a/server/release/__tests__/api.test.js
+++ b/server/release/__tests__/api.test.js
@@ -84,7 +84,7 @@ it('will create a Release for admins of a Pub', async () => {
 			}),
 		)
 		.expect(201);
-	expect(release.sourceBranchKey).toEqual(0);
+	expect(release.historyKey).toEqual(0);
 });
 
 it('will create a Release for admins of a Pub', async () => {
@@ -101,7 +101,7 @@ it('will create a Release for admins of a Pub', async () => {
 			}),
 		)
 		.expect(201);
-	expect(release.sourceBranchKey).toEqual(0);
+	expect(release.historyKey).toEqual(0);
 });
 
 it('will not create duplicate Releases for the same draft-key of a Pub', async () => {

--- a/server/release/model.js
+++ b/server/release/model.js
@@ -11,5 +11,6 @@ export default (sequelize, dataTypes) => {
 		/* Todo: We should be able to deprecate the following source ids */
 		sourceBranchId: { type: dataTypes.UUID },
 		sourceBranchKey: { type: dataTypes.INTEGER },
+		historyKey: { type: dataTypes.INTEGER, allowNull: false },
 	});
 };

--- a/server/release/queries.js
+++ b/server/release/queries.js
@@ -55,6 +55,7 @@ export const createRelease = async ({
 		noteText: noteText,
 		sourceBranchId: draftBranch.id,
 		sourceBranchKey: draftKey,
+		historyKey: draftKey,
 		branchId: publicBranch.id,
 		branchKey: mergeKey,
 		userId: userId,

--- a/stubstub/modelize/builders.js
+++ b/stubstub/modelize/builders.js
@@ -91,8 +91,13 @@ builders.Member = async ({ pubId, collectionId, communityId, ...restArgs }) => {
 builders.Release = (args) => {
 	// The Release model requires these, but it doesn't currently associate them, so it's safe
 	// to create random UUIDs for testing purposes.
-	const { userId = uuid.v4(), branchId = uuid.v4(), ...restArgs } = args;
-	return Release.create({ userId: userId, branchId: branchId, ...restArgs });
+	const { userId = uuid.v4(), branchId = uuid.v4(), historyKey = 0, ...restArgs } = args;
+	return Release.create({
+		userId: userId,
+		branchId: branchId,
+		historyKey: historyKey,
+		...restArgs,
+	});
 };
 
 builders.CollectionPub = createCollectionPub;

--- a/tools/migrations/2020_12_02_addReleaseHistoryKey.js
+++ b/tools/migrations/2020_12_02_addReleaseHistoryKey.js
@@ -1,0 +1,16 @@
+export const up = async ({ sequelize, Sequelize }) => {
+	await sequelize.queryInterface.addColumn('Releases', 'historyKey', {
+		type: Sequelize.INTEGER,
+		allowNull: false,
+		defaultValue: -1,
+	});
+	await sequelize.queryInterface.changeColumn('Releases', 'historyKey', {
+		type: Sequelize.INTEGER,
+		allowNull: false,
+		defaultValue: undefined,
+	});
+};
+
+export const down = async ({ sequelize }) => {
+	await sequelize.queryInterface.removeColumn('Releases', 'historyKey');
+};

--- a/tools/migrations/data/2020_12_02_addReleaseHistoryKeys.js
+++ b/tools/migrations/data/2020_12_02_addReleaseHistoryKeys.js
@@ -1,0 +1,187 @@
+/* eslint-disable no-console */
+import Slowdance from 'slowdance';
+
+import { Pub, Release } from 'server/models';
+import { getBranchRef } from 'server/utils/firebaseAdmin';
+import { forEach } from '../util';
+
+const assertMonotonic = (values, kind) => {
+	for (let i = 0; i < values.length - 1; i++) {
+		const one = values[i];
+		const two = values[i + 1];
+		const monotonic = one <= two;
+		if (!monotonic) {
+			throw new Error(`${kind} sequence ${values} is not monotonic`);
+		}
+	}
+};
+
+const getLatestChangeTimeInMerge = (merge) => {
+	const changes = Object.values(merge);
+	if (changes.length === 0) {
+		throw new Error('Empty merge');
+	}
+	return changes.reduce((latest, change) => {
+		if (typeof change.t !== 'number') {
+			throw new Error('Child of merge does not appear to be a change');
+		}
+		const { t } = change;
+		return Math.max(latest, t);
+	}, 0);
+};
+
+const getBestHistoryKeyForRelease = (release, keyTimePairs, historyKeyUpperBound) => {
+	assertMonotonic(
+		keyTimePairs.map((p) => p.latestChangeAt),
+		'latestChangeAt',
+	);
+	const releaseTime = new Date(release.createdAt).valueOf();
+	const latestPairBeforeRelease = keyTimePairs.reduce((best, next) => {
+		const { latestChangeAt, historyKey } = next;
+		const doesNotViolateUpperBound = historyKey <= historyKeyUpperBound;
+		const isRoughlyBeforeRelease =
+			latestChangeAt < releaseTime || Math.abs(latestChangeAt - releaseTime) <= 60 * 1000;
+		const isBetter = !best || next.latestChangeAt > best.latestChangeAt;
+		if (isRoughlyBeforeRelease && doesNotViolateUpperBound && isBetter) {
+			return next;
+		}
+		return best;
+	});
+	return latestPairBeforeRelease.historyKey;
+};
+
+const getHistoryKeysForReleases = (releases, keyTimePairs) => {
+	if (keyTimePairs.length === releases.length) {
+		const keys = keyTimePairs.map((p) => p.historyKey);
+		return { keys: keys, confidence: '✅' };
+	}
+	let confidence = '⚠️';
+	const keys = releases.map((release, index) => {
+		const { branchKey } = release;
+		if (typeof branchKey === 'number') {
+			if (branchKey >= keyTimePairs.length) {
+				confidence += '🚨';
+				return keyTimePairs[keyTimePairs.length - 1].historyKey;
+			}
+			return keyTimePairs[branchKey].historyKey;
+		}
+		confidence += '🔮';
+		const upperBoundFromSourceBranchKeys = Math.min(
+			Infinity,
+			...releases
+				.slice(index + 1)
+				.map((r) => r.sourceBranchKey)
+				.filter((k) => typeof k === 'number'),
+		);
+		return getBestHistoryKeyForRelease(release, keyTimePairs, upperBoundFromSourceBranchKeys);
+	});
+	return { keys: keys, confidence: confidence };
+};
+
+const addHistoryKeysToReleases = async (pubId, releaseBranchId, releases) => {
+	const firebaseRef = getBranchRef(pubId, releaseBranchId);
+
+	const mergesSnapshot = await firebaseRef.child('merges').once('value');
+	const merges = mergesSnapshot.val();
+
+	if (merges) {
+		const keyTimePairs = [];
+		let runningHistoryKey = -1;
+
+		Object.keys(merges)
+			.sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
+			.forEach((key) => {
+				const merge = merges[key];
+				const mergeLength = Object.keys(merge).length;
+				const latestChangeTimeInMerge = getLatestChangeTimeInMerge(merge);
+				runningHistoryKey += mergeLength;
+				keyTimePairs.push({
+					historyKey: runningHistoryKey,
+					latestChangeAt: latestChangeTimeInMerge,
+				});
+			});
+
+		assertMonotonic(
+			releases.map((release) => new Date(release.createdAt).valueOf()),
+			'release time',
+		);
+
+		assertMonotonic(
+			keyTimePairs.map((p) => p.historyKey),
+			'historyKey',
+		);
+
+		const { keys: releaseHistoryKeys, confidence } = getHistoryKeysForReleases(
+			releases,
+			keyTimePairs,
+		);
+
+		await Promise.all(
+			releases.map(async (release, index) => {
+				const historyKey = releaseHistoryKeys[index];
+				if (typeof historyKey !== 'number') {
+					throw new Error(`Release at index=${index} somehow missing key`);
+				}
+				await Release.update({ historyKey: historyKey }, { where: { id: release.id } });
+			}),
+		);
+
+		const latestReleaseTime = new Date(releases.concat().pop().createdAt).valueOf();
+		const latestKeyTimePair = keyTimePairs.concat().pop();
+		const latestReleaseHistoryKey = releaseHistoryKeys.concat().pop();
+		if (latestReleaseHistoryKey !== latestKeyTimePair.historyKey) {
+			throw new Error(
+				`Latest release (key=${latestReleaseHistoryKey}, time=${new Date(
+					latestReleaseTime,
+				)}) does not take latest history key (key=${
+					latestKeyTimePair.historyKey
+				}, time=${new Date(latestKeyTimePair.latestChangeAt)})`,
+			);
+		}
+
+		assertMonotonic(releaseHistoryKeys, 'key');
+		return confidence;
+	}
+	throw new Error('No merges');
+};
+
+const releaseHasValidHistoryKey = (release) => {
+	return typeof release.historyKey === 'number' && release.historyKey !== -1;
+};
+
+const handlePub = async (pub) => {
+	const releases = await Release.findAll({
+		where: { pubId: pub.id },
+		order: [['createdAt', 'ASC']],
+	});
+	if (releases.length > 0) {
+		if (new Set(releases.map((r) => r.branchId)).size > 1) {
+			throw new Error('Pub has releases from multiple branches');
+		}
+		if (releases.every(releaseHasValidHistoryKey)) {
+			return '🥚';
+		}
+		const releaseBranchId = releases[0].branchId;
+		return addHistoryKeysToReleases(pub.id, releaseBranchId, releases);
+	}
+	return '📝';
+};
+
+module.exports = async () => {
+	const slowdance = new Slowdance();
+	slowdance.start();
+
+	await forEach(
+		await Pub.findAll({ order: [['createdAt', 'DESC']] }),
+		async (pub) =>
+			slowdance
+				.wrapPromise(handlePub(pub), {
+					label: `[${pub.slug}] ${pub.title}`,
+					labelResult: (res) => res.toString(),
+					labelError: (err) => `(${err.message})`,
+				})
+				.catch(() => {}),
+
+		10,
+	);
+};

--- a/tools/migrations/data/2020_12_03_reconcileMismatchedHistoryKeys.js
+++ b/tools/migrations/data/2020_12_03_reconcileMismatchedHistoryKeys.js
@@ -1,0 +1,88 @@
+/* eslint-disable no-console */
+import { Op } from 'sequelize';
+
+import { sequelize, Branch, Release } from 'server/models';
+import { getBranchDoc } from 'server/utils/firebaseAdmin';
+import { forEach } from '../util';
+
+const bucketByProperty = (array, property) => {
+	const res = {};
+	array.forEach((el) => {
+		const propValue = el[property];
+		if (!res[propValue]) {
+			res[propValue] = [];
+		}
+		res[propValue].push(el);
+	});
+	return res;
+};
+
+const handleReleasesForPub = async (pubId, releases) => {
+	const allReleasesForPub = await Release.findAll({
+		where: { pubId: pubId },
+		order: [['createdAt', 'ASC']],
+	});
+	const branches = await Branch.findAll({ where: { pubId: pubId } });
+	const draftBranch = branches.find((br) => br.title === 'draft');
+	const publicBranch = branches.find((br) => br.title === 'public');
+	console.log(`=== ${pubId} ===`);
+	await Promise.all(
+		releases.map(async (release) => {
+			const { sourceBranchKey, historyKey } = release;
+			if (
+				typeof sourceBranchKey === 'number' &&
+				typeof historyKey === 'number' &&
+				sourceBranchKey !== historyKey
+			) {
+				const relatedMergeIndex = allReleasesForPub.findIndex(
+					(otherRelease) => otherRelease.id === release.id,
+				);
+
+				const [
+					{ doc: releaseDoc },
+					{ doc: sourceBranchKeyDoc },
+					{ doc: historyKeyDoc },
+				] = await Promise.all([
+					getBranchDoc(pubId, publicBranch.id, relatedMergeIndex),
+					getBranchDoc(pubId, draftBranch.id, sourceBranchKey),
+					getBranchDoc(pubId, draftBranch.id, historyKey),
+				]);
+
+				const releaseDocString = JSON.stringify(releaseDoc);
+				const sourceBranchKeyMatches =
+					releaseDocString === JSON.stringify(sourceBranchKeyDoc);
+				const historyKeyMatches = releaseDocString === JSON.stringify(historyKeyDoc);
+				if (historyKeyMatches) {
+					console.log('History key is already correct');
+				} else if (sourceBranchKeyMatches) {
+					console.log('Setting historyKey = sourceBranchKey');
+					await Release.update(
+						{ historyKey: sourceBranchKey },
+						{ where: { id: release.id } },
+					);
+				} else {
+					console.log(
+						'Neither historyKey nor sourceBranchKey points to the correct document',
+					);
+				}
+			}
+		}),
+	);
+};
+
+module.exports = async () => {
+	const releasesWithMismatchedKeys = await Release.findAll({
+		where: {
+			sourceBranchKey: {
+				[Op.ne]: null,
+			},
+			historyKey: {
+				[Op.and]: [{ [Op.ne]: -1 }, { [Op.ne]: sequelize.col('sourceBranchKey') }],
+			},
+		},
+	});
+	const releasesByPubId = bucketByProperty(releasesWithMismatchedKeys, 'pubId');
+	await forEach(Object.entries(releasesByPubId), ([pubId, releases]) =>
+		handleReleasesForPub(pubId, releases),
+	);
+};

--- a/tools/migrations/util/index.js
+++ b/tools/migrations/util/index.js
@@ -1,9 +1,9 @@
 import Bluebird from 'bluebird';
 
-export const forEach = async (items, fn, concurrency) => {
+export const forEach = async (items, fn, concurrency = 1) => {
 	return Bluebird.map(items, fn, { concurrency: concurrency });
 };
 
-export const forEachInstance = async (Model, fn, concurrency) => {
+export const forEachInstance = async (Model, fn, concurrency = 1) => {
 	return forEach(await Model.findAll(), fn, concurrency);
 };


### PR DESCRIPTION
The migration in #1176 added `historyKey` properties to Releases, but left us with a handful that have `historyKey != sourceBranchKey`, where we expect these values to be the same. This further migration checks on these Releases to test which key is actually correct.

I ran:

```
npm run tools migrate -- --name data/2020_12_03_reconcileMismatchedHistoryKeys
```

It turns out that of the 24 Releases with mismatched keys, 23 of them have a `historyKey` that points to the correct document, and in one case neither `historyKey` or `sourceBranchKey` are correct (something to investigate by hand). In no case is the older `sourceBranchKey` correct where the new, canonical `historyKey` value is wrong, which is encouraging.