### PR TITLE
fix: Permit spaces in Pandoc-imported filenames

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"test": "npm run lint && jest --forceExit --silent",
 		"test-dev": "jest --forceExit",
 		"tools": "NODE_PATH=./client:./ node -r ts-node/register -r esm --max-old-space-size=12000 ./tools",
-		"workers-dev": "SEQUELIZE_MAX_CONNECTIONS=1 NODE_PATH=./dist/server/client:./dist/server WORKER=true nodemon dist/workers/workers/init --watch workers -e js",
+		"workers-dev": "SEQUELIZE_MAX_CONNECTIONS=1 NODE_PATH=./dist/server/client:./dist/server WORKER=true nodemon dist/server/workers/init --watch workers -e js",
 		"workers-prod": "SEQUELIZE_MAX_CONNECTIONS=1 NODE_PATH=./dist/server/client:./dist/server WORKER=true node dist/server/workers/init"
 	},
 	"dependencies": {

--- a/workers/tasks/import/images.ts
+++ b/workers/tasks/import/images.ts
@@ -1,6 +1,6 @@
 import tmp from 'tmp-promise';
 
-import { extensionFor, exec } from './util';
+import { extensionFor, spawn } from './util';
 
 export const convertFileTypeIfNecessary = async (tmpFilePath) => {
 	const extension = extensionFor(tmpFilePath);
@@ -9,14 +9,21 @@ export const convertFileTypeIfNecessary = async (tmpFilePath) => {
 		const { path: pngPath } = await tmp.file({ postfix: '.png' });
 		// pdftoppm tacks the extension onto the output file name. Whatever.
 		const pathWithoutExtension = pngPath.slice(0, -4);
-		await exec(
-			`pdftoppm ${tmpFilePath} ${pathWithoutExtension} -png -singlefile -rx 300 -ry 300`,
-		);
+		await spawn('pdftoppm', [
+			tmpFilePath,
+			pathWithoutExtension,
+			'-png',
+			'-singlefile',
+			'-rx',
+			'300',
+			'-ry',
+			'300',
+		]);
 		return pngPath;
 	}
 	if (extension === 'tiff' || extension === 'tif') {
 		const { path: pngPath } = await tmp.file({ postfix: '.png' });
-		await exec(`convert ${tmpFilePath} ${pngPath}`);
+		await spawn('convert', [tmpFilePath, pngPath]);
 		return pngPath;
 	}
 	return tmpFilePath;

--- a/workers/tasks/import/util.ts
+++ b/workers/tasks/import/util.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { exec as execWithCallback } from 'child_process';
+import { spawn as spawnChildProcess } from 'child_process';
 import {
 	callPandoc,
 	emitPandocJson,
@@ -81,15 +81,12 @@ export const extensionFor = (filePath) =>
 		.pop()
 		.toLowerCase();
 
-export const exec = (command) =>
-	new Promise((resolve, reject) =>
-		execWithCallback(command, (err, res) => {
-			if (err) {
-				return reject(err);
-			}
-			return resolve(res);
-		}),
-	);
+export const spawn = (command, args) =>
+	new Promise((resolve, reject) => {
+		const ps = spawnChildProcess(command, args);
+		ps.on('close', () => resolve());
+		ps.stderr.on('data', (err) => reject(err.toString()));
+	});
 
 export const getFullPathsInDir = (dir) => {
 	let paths = [];


### PR DESCRIPTION
Resolves #1184 (I hope)

This PR enables the importer to ingest referenced image files with spaces in their names.

_Test plan:_
I created a file like this:

```
<!-- test.html -->
<img src="hello there(1).pdf">
<img src="my image.tiff">
```

and verified that both of the related images were converted to PNG and added to the Pub.