### PR TITLE
fix: correctly scroll linked element on Pub load

### DIFF
--- a/client/containers/Pub/Pub.tsx
+++ b/client/containers/Pub/Pub.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { usePageContext } from 'utils/hooks';
 
@@ -13,8 +13,43 @@ type Props = {
 	pubData: any;
 };
 
+const isInViewport = (rect: DOMRect, offsets: { top?: number; left?: number } = {}) => {
+	const { top, left, bottom, right } = rect;
+	const { innerWidth, innerHeight } = window;
+	const { clientWidth, clientHeight } = document.documentElement;
+	const { top: offsetTop, left: offsetLeft } = Object.assign({ top: 0, left: 0 }, offsets);
+
+	return (
+		top >= offsetTop &&
+		left >= offsetLeft &&
+		bottom <= (innerHeight || clientHeight) &&
+		right <= (innerWidth || clientWidth)
+	);
+};
+
 const Pub = (props: Props) => {
 	const { loginData, locationData, communityData } = usePageContext();
+
+	useEffect(() => {
+		const hash = window.location.hash;
+
+		if (hash) {
+			const element = document.getElementById(hash.replace('#', ''));
+
+			if (!element) {
+				return;
+			}
+
+			setTimeout(() => {
+				const rect = element.getBoundingClientRect();
+
+				if (!isInViewport(rect, { top: 50 })) {
+					document.body.scrollTop += rect.top - 50;
+				}
+			}, 500);
+		}
+	}, []);
+
 	return (
 		<PubSuspendWhileTypingProvider>
 			<div id="pub-container">


### PR DESCRIPTION
This is a band-aid fix for #1170 and #1171. This code simply executes a function 500ms after a Pub loads before scrolling to the element who's id is `window.location.hash`, only if that element is not already in the viewport.