### PR TITLE
update: Small css simplifications

### DIFF
--- a/client/containers/Pricing/Pricing.tsx
+++ b/client/containers/Pricing/Pricing.tsx
@@ -12,7 +12,7 @@ const Pricing = () => {
 					<br />
 					to Support Nonprofit Infrastructure
 				</h1>
-				<p className="description" id="top">
+				<p className="description top">
 					PubPub's goal is to provide an affordable, high-quality, open-source,
 					institution-led, hosted non-profit publishing software. We offer plans with no
 					user or publishing limits for everyone from individual communities to larger
@@ -161,7 +161,7 @@ const Pricing = () => {
 						.
 					</p>
 
-					<p className="description" id="doi">
+					<p className="description">
 						* The free DOI limit applies to DOIs published via PubPub's Crossref
 						membership. Once the limit is reached, PubPub passes on the Crossref fee of
 						$1 per DOI registered to the Community. For Communities with their own

--- a/client/containers/Pricing/pricing.scss
+++ b/client/containers/Pricing/pricing.scss
@@ -5,28 +5,15 @@
 	background-image: url('/static/loginbg.png');
 	padding-bottom: 2em;
 	h1 {
-		margin: 1em 0em 0.5em;
+		margin: 1em 0em;
 		text-align: center;
 	}
-	// h2 {
-	// 	text-transform: uppercase;
-	// }
-	p {
-		margin: 0 auto;
-		font-size: 18px;
-	}
 	p.description {
-		padding: 0 2em;
-		&#top {
-			margin: 2em 3em;
+		margin: 1.5em auto;
+		font-size: 16px;
+		max-width: 900px;
+		&.top {
 			text-align: center;
-			font-size: 14px;
-		}
-	}
-	.pricing-footer p.description {
-		margin-bottom: 2em;
-		&#doi {
-			font-size: 11px;
 		}
 	}
 	p.subtitle {
@@ -64,7 +51,6 @@
 			}
 		}
 	}
-
 	.pricing-tiers {
 		display: flex;
 		.option {
@@ -73,7 +59,7 @@
 			text-align: center;
 			position: inline;
 			flex: 1;
-			margin: 4em 0.75em;
+			margin: 3em 0.75em;
 			background: #f7f7f9;
 			ul {
 				flex-grow: 1;


### PR DESCRIPTION
This PR has a couple small CSS updates to:

- Simplify the CSS code
- Make paragraph font sizes consistent
- Simplify margin spacing

I made the DOI asterisk text the same size as other paragraph text because it felt too small for accessibility reasons. I could see us making it a lighter color if we wanted to de-emphasize it still. 

![Screen Shot 2020-12-14 at 11 00 23 AM](https://user-images.githubusercontent.com/1000455/102103942-81f59700-3e25-11eb-975e-020672e4ad9b.png)
