### PR TITLE
update: Create Doc model for each Release

### DIFF
--- a/client/components/Editor/utils/branches.ts
+++ b/client/components/Editor/utils/branches.ts
@@ -66,5 +66,5 @@ export const mergeBranch = async (sourceFirebaseRef, destinationFirebaseRef, pro
 	const { doc } = await getFirebaseDoc(sourceFirebaseRef, prosemirrorSchema, sourceKey);
 	await storeCheckpoint(destinationFirebaseRef, doc, nextMergeKey);
 
-	return { mergeKey: nextMergeKey };
+	return { mergeKey: nextMergeKey, doc: doc };
 };

--- a/server/doc/queries.ts
+++ b/server/doc/queries.ts
@@ -1,0 +1,5 @@
+import { Doc } from 'server/models';
+
+export const createDoc = (content: {}) => {
+	return Doc.create({ content: content });
+};

--- a/server/release/__tests__/api.test.ts
+++ b/server/release/__tests__/api.test.ts
@@ -1,7 +1,7 @@
 /* global it, expect, beforeAll, afterAll, afterEach */
 import { setup, teardown, login, stubOut, modelize } from 'stubstub';
 
-import { Export, Release } from 'server/models';
+import { Doc, Export, Release } from 'server/models';
 import { getExportFormats } from 'utils/export/formats';
 
 const models = modelize`
@@ -36,8 +36,16 @@ afterEach(async () => {
 
 teardown(afterAll);
 
+const someDoc = {
+	type: 'doc',
+	content: [{ type: 'parargraph', content: [{ type: 'text', content: ['Hello there'] }] }],
+};
+
 stubOut('server/utils/firebaseAdmin', {
-	mergeFirebaseBranch: () => ({ mergeKey: 0 }),
+	mergeFirebaseBranch: () => ({
+		mergeKey: 0,
+		doc: someDoc,
+	}),
 	getLatestKey: () => 0,
 	getBranchDoc: () => {
 		return {
@@ -102,6 +110,8 @@ it('will create a Release for admins of a Pub', async () => {
 		)
 		.expect(201);
 	expect(release.historyKey).toEqual(0);
+	const doc = await Doc.findOne({ where: { id: release.docId } });
+	expect(doc.content).toEqual(someDoc);
 });
 
 it('will not create duplicate Releases for the same draft-key of a Pub', async () => {

--- a/server/release/model.ts
+++ b/server/release/model.ts
@@ -1,17 +1,31 @@
 export default (sequelize, dataTypes) => {
-	return sequelize.define('Release', {
-		id: sequelize.idType,
-		noteContent: { type: dataTypes.JSONB },
-		noteText: { type: dataTypes.TEXT },
-		branchKey: { type: dataTypes.INTEGER },
-		/* Set by Associations */
-		pubId: { type: dataTypes.UUID, allowNull: false },
-		branchId: { type: dataTypes.UUID, allowNull: false },
-		userId: { type: dataTypes.UUID, allowNull: false },
-		/* Todo: We should be able to deprecate the following source ids */
-		sourceBranchId: { type: dataTypes.UUID },
-		sourceBranchKey: { type: dataTypes.INTEGER },
-		historyKey: { type: dataTypes.INTEGER, allowNull: false },
-		historyKeyMissing: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
-	});
+	return sequelize.define(
+		'Release',
+		{
+			id: sequelize.idType,
+			noteContent: { type: dataTypes.JSONB },
+			noteText: { type: dataTypes.TEXT },
+			branchKey: { type: dataTypes.INTEGER },
+			/* Set by Associations */
+			pubId: { type: dataTypes.UUID, allowNull: false },
+			branchId: { type: dataTypes.UUID, allowNull: false },
+			userId: { type: dataTypes.UUID, allowNull: false },
+			docId: { type: dataTypes.UUID, allowNull: false },
+			sourceBranchId: { type: dataTypes.UUID },
+			sourceBranchKey: { type: dataTypes.INTEGER },
+			historyKey: { type: dataTypes.INTEGER, allowNull: false },
+			historyKeyMissing: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+		},
+		{
+			classMethods: {
+				associate: (models) => {
+					const { Doc, Release } = models;
+					Release.belongsTo(Doc, {
+						as: 'doc',
+						foreignKey: 'docId',
+					});
+				},
+			},
+		},
+	);
 };

--- a/server/release/queries.ts
+++ b/server/release/queries.ts
@@ -2,6 +2,7 @@ import { Release, Branch } from 'server/models';
 import { mergeFirebaseBranch, getLatestKey } from 'server/utils/firebaseAdmin';
 import { updateVisibilityForDiscussions } from 'server/discussion/queries';
 import { createBranchExports } from 'server/export/queries';
+import { createDoc } from 'server/doc/queries';
 
 export const createRelease = async ({
 	userId,
@@ -48,7 +49,8 @@ export const createRelease = async ({
 		throw new Error('Firebase branches were not merged.');
 	}
 
-	const { mergeKey } = mergeResult;
+	const { mergeKey, doc } = mergeResult;
+	const docModel = await createDoc(doc);
 
 	const newRelease = await Release.create({
 		noteContent: noteContent,
@@ -60,6 +62,7 @@ export const createRelease = async ({
 		branchKey: mergeKey,
 		userId: userId,
 		pubId: pubId,
+		docId: docModel.id,
 	});
 
 	if (createExports) {

--- a/stubstub/modelize/builders.js
+++ b/stubstub/modelize/builders.js
@@ -6,6 +6,7 @@ import { createCollectionPub } from 'server/collectionPub/queries';
 import { Branch, Community, Member, Pub, Release, User } from 'server/models';
 import { createPub } from 'server/pub/queries';
 import { createCollection } from 'server/collection/queries';
+import { createDoc } from 'server/doc/queries';
 
 const builders = {};
 
@@ -88,14 +89,28 @@ builders.Member = async ({ pubId, collectionId, communityId, ...restArgs }) => {
 	return Member.create({ ...getTargetArgs(), ...restArgs });
 };
 
-builders.Release = (args) => {
+builders.Release = async (args) => {
 	// The Release model requires these, but it doesn't currently associate them, so it's safe
 	// to create random UUIDs for testing purposes.
-	const { userId = uuid.v4(), branchId = uuid.v4(), historyKey = 0, ...restArgs } = args;
+	const {
+		userId = uuid.v4(),
+		branchId = uuid.v4(),
+		historyKey = 0,
+		docId = null,
+		...restArgs
+	} = args;
+
+	let resolvedDocId = docId;
+	if (!resolvedDocId) {
+		const fakeDoc = await createDoc({});
+		resolvedDocId = fakeDoc.id;
+	}
+
 	return Release.create({
 		userId: userId,
 		branchId: branchId,
 		historyKey: historyKey,
+		docId: resolvedDocId,
 		...restArgs,
 	});
 };

--- a/tools/migrations/2020_12_14_addReleaseDoc.js
+++ b/tools/migrations/2020_12_14_addReleaseDoc.js
@@ -1,0 +1,9 @@
+export const up = async ({ sequelize, Sequelize }) => {
+	await sequelize.queryInterface.addColumn('Releases', 'docId', {
+		type: Sequelize.UUID,
+	});
+};
+
+export const down = async ({ sequelize }) => {
+	await sequelize.queryInterface.removeColumn('Releases', 'docId');
+};

--- a/tools/migrations/2020_12_14_makeReleaseDocNonNull.js
+++ b/tools/migrations/2020_12_14_makeReleaseDocNonNull.js
@@ -1,0 +1,11 @@
+export const up = async ({ sequelize }) => {
+	await sequelize.queryInterface.changeColumn('Releases', 'docId', {
+		allowNull: false,
+	});
+};
+
+export const down = async ({ sequelize }) => {
+	await sequelize.queryInterface.changeColumn('Releases', 'docId', {
+		allowNull: true,
+	});
+};

--- a/tools/migrations/data/2020_12_14_backfillReleaseDocs.js
+++ b/tools/migrations/data/2020_12_14_backfillReleaseDocs.js
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+import Slowdance from 'slowdance';
+
+import { Pub, Branch, Release } from 'server/models';
+import { getBranchDoc } from 'server/utils/firebaseAdmin';
+import { createDoc } from 'server/doc/queries';
+import { forEach } from '../util';
+
+const handleReleasesForPub = async (pub) => {
+	const [publicBranch, releasesOrderedByDate] = await Promise.all([
+		Branch.findOne({
+			where: { pubId: pub.id, title: 'public' },
+		}),
+		Release.findAll({
+			where: { pubId: pub.id },
+			order: [['createdAt', 'ASC']],
+		}),
+	]);
+	await Promise.all(
+		releasesOrderedByDate.map(async (release, index) => {
+			if (!release.docId) {
+				const docContent = await getBranchDoc(pub.id, publicBranch.id, index);
+				const docModel = await createDoc(docContent);
+				await Release.update({ docId: docModel.id }, { where: { id: release.id } });
+			}
+		}),
+	);
+};
+
+module.exports = async () => {
+	const slowdance = new Slowdance();
+	slowdance.start();
+	await forEach(await Pub.findAll({ order: [['createdAt', 'DESC']] }), (pub) =>
+		slowdance
+			.wrapPromise(handleReleasesForPub(pub), {
+				label: `[${pub.slug}] ${pub.title}`,
+				labelError: (err) => err.message,
+			})
+			.catch(() => {}),
+	);
+};


### PR DESCRIPTION
This is the thing that's kind of at the heart of our plan to move Releases to Postgres — here, we store the Pub content in a Doc associated with every Release. We're not _reading_ from them, yet, though — that will be a much more complicated set of changes that we'll have to host in parallel with the existing Firebase code for a bit until it's clear that it works. For now we'll just get the codebase in the habit of storing Docs, and run a migration to backfill Docs for existing Releases.

_Test plan:_
Run `npm run test-dev server/releases`