### PR TITLE
fix: scroll to top of element and account for sticky pub header

### DIFF
--- a/client/components/FormattingBar/controlComponents/ControlsLink.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsLink.tsx
@@ -2,6 +2,9 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDebounce } from 'use-debounce';
 import { moveToEndOfSelection } from 'components/Editor';
 import { Button, AnchorButton, InputGroup } from '@blueprintjs/core';
+import { usePubContext, usePubData } from 'client/containers/Pub/pubHooks';
+import { pubUrl } from 'utils/canonicalUrls';
+import { usePageContext } from 'utils/hooks';
 
 type Props = {
 	editorChangeObject: {
@@ -17,9 +20,18 @@ const ControlsLink = (props: Props) => {
 		onClose,
 	} = props;
 
+	const { communityData } = usePageContext();
+	const pubData = usePubData();
 	const [href, setHref] = useState(activeLink.attrs.href);
 	const [debouncedHref] = useDebounce(href, 250);
 	const inputRef = useRef();
+
+	const setHashOrUrl = (value: string) => {
+		const basePubUrl = pubUrl(communityData, pubData);
+		const hashMatches = value.match(`^${basePubUrl}(.*)?#(.*)$`);
+
+		setHref(hashMatches ? `#${hashMatches[2]}` : value);
+	};
 
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	useEffect(() => activeLink.updateAttrs({ href: debouncedHref }), [debouncedHref]);
@@ -50,7 +62,7 @@ const ControlsLink = (props: Props) => {
 			<InputGroup
 				placeholder="Enter a URL"
 				value={href}
-				onChange={(evt) => setHref(evt.target.value)}
+				onChange={(evt) => setHashOrUrl(evt.target.value)}
 				onKeyPress={handleKeyPress}
 				// @ts-expect-error ts-migrate(2322) FIXME: Type 'MutableRefObject<undefined>' is not assignab... Remove this comment to see the full error message
 				inputRef={inputRef}

--- a/client/containers/Pub/Pub.tsx
+++ b/client/containers/Pub/Pub.tsx
@@ -72,7 +72,7 @@ const Pub = (props: Props) => {
 			document.addEventListener('click', onClick);
 			return () => document.removeEventListener('click', onClick);
 		}
-	}, [communityData, pubData]);
+	}, [pubData]);
 
 	return (
 		<PubSuspendWhileTypingProvider>

--- a/client/containers/Pub/Pub.tsx
+++ b/client/containers/Pub/Pub.tsx
@@ -27,28 +27,52 @@ const isInViewport = (rect: DOMRect, offsets: { top?: number; left?: number } = 
 	);
 };
 
+const scrollToElementTop = (selector: string, delay = 0) => {
+	const element = document.querySelector(selector);
+
+	if (!element) {
+		return;
+	}
+
+	setTimeout(() => {
+		const rect = element.getBoundingClientRect();
+
+		if (!isInViewport(rect, { top: 50 })) {
+			document.body.scrollTop += rect.top - 50;
+		}
+	}, delay);
+};
+
 const Pub = (props: Props) => {
+	const { pubData } = props;
 	const { loginData, locationData, communityData } = usePageContext();
 
 	useEffect(() => {
-		const hash = window.location.hash;
+		const { hash } = window.location;
 
 		if (hash) {
-			const element = document.getElementById(hash.replace('#', ''));
-
-			if (!element) {
-				return;
-			}
-
-			setTimeout(() => {
-				const rect = element.getBoundingClientRect();
-
-				if (!isInViewport(rect, { top: 50 })) {
-					document.body.scrollTop += rect.top - 50;
-				}
-			}, 500);
+			scrollToElementTop(hash, 500);
 		}
-	}, []);
+
+		const onClick = (event: MouseEvent) => {
+			const { target, metaKey } = event;
+
+			if (target instanceof HTMLAnchorElement && !metaKey) {
+				const href = target.getAttribute('href');
+
+				if (href && href.indexOf('#') === 0) {
+					event.preventDefault();
+					window.location.hash = href;
+					scrollToElementTop(href);
+				}
+			}
+		};
+
+		if (pubData.isReadOnly) {
+			document.addEventListener('click', onClick);
+			return () => document.removeEventListener('click', onClick);
+		}
+	}, [communityData, pubData]);
 
 	return (
 		<PubSuspendWhileTypingProvider>


### PR DESCRIPTION
Fixes #1171

Clicking on internal URLs (with hashes) within a Pub will scroll to the correct element, but the browser doesn't account for the sticky pub header, so the top of the element isn't visible. This PR overrides the default scroll behavior of hash links and scrolls to the element with a 50px offset so the entire element is visible. In addition, code was added to automatically convert internal links to hashes when pasted into the URL field in the anchor controls.

_Test Plan_
- In a Pub with enough content to scroll
- Copy a link towards the bottom of the Pub using the click-to-copy button
- Create a link at the top of the Pub and paste the URL in. The URL's host and path should automatically be removed, leaving only the hash.
- Publish the Pub.
- Click on the link in the release view. The window should scroll to the top of the element, and the entire element should be visible, and not overlapped by the sticky header component.