### PR TITLE
fix: Wrap long file names in download cards

### DIFF
--- a/client/components/Editor/styles/file.scss
+++ b/client/components/Editor/styles/file.scss
@@ -16,6 +16,7 @@
 			flex-grow: 1;
 			flex-shrink: 1;
 			margin: 0em 1em;
+			word-wrap: break-word;
 			a {
 				color: inherit;
 				&:hover {


### PR DESCRIPTION
Fixes an issue brought to our attention by @pkgw that caused long file names to overflow the download card and push the download button out of it. This still causes some awkwardness for file names with underscores or dashes, since that's not technically a CSS break character, but it's better than the name overflowing the card.

<img width="596" alt="Screen Shot 2020-12-16 at 09 26 39" src="https://user-images.githubusercontent.com/639110/102384079-26d8b700-3f81-11eb-987b-170419816bff.png">

<img width="498" alt="Screen Shot 2020-12-16 at 09 26 44" src="https://user-images.githubusercontent.com/639110/102384087-29d3a780-3f81-11eb-9d46-33b063bbfa12.png">

_Test plan_
1. Upload a file with a really long name (look here's one: 
[A File With A Bizzarely Long Name That Is Really Too Long Why Is It This Long.txt](https://github.com/pubpub/pubpub/files/5704392/A.File.With.A.Bizzarely.Long.Name.That.Is.Really.Too.Long.Why.Is.It.This.Long.txt)
). 
1. Make sure the name breaks rather than overflowing the card.