### PR TITLE
fix: sync Prosemirror table captions in update() method of NodeView

### DIFF
--- a/client/components/Editor/plugins/table.ts
+++ b/client/components/Editor/plugins/table.ts
@@ -28,13 +28,12 @@ function wrapDomSerializer(domSerializer: DOMSerializer) {
 class PubTableView extends TableView {
 	constructor(node, ...rest) {
 		super(node, ...rest);
-		this.syncId(node);
-		this.syncCaption(node);
+		this.sync(node);
 	}
 
 	update(node, decorations) {
 		const shouldUpdate = super.update(node, decorations);
-		this.syncId(node);
+		this.sync(node);
 		return shouldUpdate;
 	}
 
@@ -44,6 +43,10 @@ class PubTableView extends TableView {
 		if (label) {
 			const table = dom.querySelector('table');
 			if (table) {
+				const existingCaption = table.querySelector('caption');
+				if (existingCaption && existingCaption.parentNode === table) {
+					existingCaption.remove();
+				}
 				const caption = document.createElement('caption');
 				caption.innerHTML = label;
 				table.append(caption);
@@ -54,6 +57,11 @@ class PubTableView extends TableView {
 	syncId(node) {
 		const { dom } = (this as any) as { dom: HTMLElement };
 		dom.setAttribute('id', node.attrs.id);
+	}
+
+	sync(node) {
+		this.syncId(node);
+		this.syncCaption(node);
 	}
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6929,9 +6929,9 @@
 			"integrity": "sha512-FpgvwDQTyEhFtVtQET48wb336msdqszPlbVRXrq3ZK53T/aTKttxDAshtg1J4QB9Auf7k3mQ0RkRVnypklbcQA=="
 		},
 		"@pubpub/prosemirror-reactive": {
-			"version": "0.1.9",
-			"resolved": "https://registry.npmjs.org/@pubpub/prosemirror-reactive/-/prosemirror-reactive-0.1.9.tgz",
-			"integrity": "sha512-ZCzHKYj+yAT1R+EgJdtzp/sfQMG+fw4B+TikFt+w13ui9hNZdPS0H5X+XZFT8WauEQIRvl1dUFtIQ+kQdr2tmg==",
+			"version": "0.1.10",
+			"resolved": "https://registry.npmjs.org/@pubpub/prosemirror-reactive/-/prosemirror-reactive-0.1.10.tgz",
+			"integrity": "sha512-tg9US9CC6RPdrwluEZtlejhHY7Ob4MrhjIqu98lc7jRE8Xxk5YX5eqlndNzKLmD2XkMG3Bt1dYbdzfK3WlsZAA==",
 			"requires": {
 				"prosemirror-model": "^1.9.1",
 				"prosemirror-state": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"@blueprintjs/icons": "^3.14.0",
 		"@blueprintjs/select": "^3.12.0",
 		"@pubpub/prosemirror-pandoc": "^0.6.1",
-		"@pubpub/prosemirror-reactive": "^0.1.9",
+		"@pubpub/prosemirror-reactive": "^0.1.10",
 		"@sentry/browser": "^5.5.0",
 		"@sentry/node": "^5.5.0",
 		"algoliasearch": "^4.2.0",


### PR DESCRIPTION
Earlier this morning I made a change to `prosemirror-reactive` that cause reactive NodeView wrappers to return the value of `update()` provided from the NodeViews they wrap. This fixes behavior in highly stateful NodeViews like resizable tables, but breaks out table labeling code in our custom TableView subclass.

The fix has two parts:
1. In `prosemirror-reactive`, make sure wrapped NodeViews always receive a reactive copy to their update method. (See https://github.com/pubpub/prosemirror-reactive/commit/026d6135f5b2b3682cc47ba506679a80a308e56b)
2. In our Table view, call `syncCaption` from `update`. Don't forget to remove `caption` nodes left over from previous calls.

All I can say is...thank god for React.