### PR TITLE
dev: Some TS cleanup for Community Navigation code

### DIFF
--- a/client/containers/DashboardSettings/NavBuilder.tsx
+++ b/client/containers/DashboardSettings/NavBuilder.tsx
@@ -76,16 +76,14 @@ const NavBuilder = (props: Props) => {
 	};
 
 	const updateItem = (dropdownId, index, newItemValues: Partial<CommunityNavigationEntry>) => {
-		// TODO(ian): Remove this cast after completing migration
 		const newItemValuesObject = newItemValues as {};
 		const nextUserElements =
-			// TODO(ian): Remove these any casts after completing migration
 			dropdownId === 'main-list'
-				? userSetElements.map((item: any, currIndex) => {
+				? userSetElements.map((item, currIndex) => {
 						return currIndex === index ? { ...item, ...newItemValuesObject } : item;
 				  })
-				: userSetElements.map((item: any) => {
-						if (item.id === dropdownId) {
+				: userSetElements.map((item) => {
+						if (item.id === dropdownId && isCommunityNavigationMenu(item)) {
 							return {
 								...item,
 								children: item.children.map((subItem, subCurrIndex) => {
@@ -104,11 +102,10 @@ const NavBuilder = (props: Props) => {
 
 	const removeItem = (itemId, dropdownId) => {
 		const nextUserElements =
-			// TODO(ian): Remove these any casts after completing migration
 			dropdownId === 'main-list'
-				? userSetElements.filter((item: any) => item.id !== itemId && item !== itemId)
-				: userSetElements.map((item: any) => {
-						if (item.id === dropdownId) {
+				? userSetElements.filter((item) => item.id !== itemId && item !== itemId)
+				: userSetElements.map((item) => {
+						if (item.id === dropdownId && isCommunityNavigationMenu(item)) {
 							return {
 								...item,
 								children: item.children.filter((subItem) => {
@@ -134,10 +131,7 @@ const NavBuilder = (props: Props) => {
 					items={pages}
 					placeholder="Add Page"
 					usedItems={pages.filter((page) =>
-						// TODO(ian): Remove these any casts after completing migration
-						currentNav.some(
-							(current: any) => current === page.id || current.id === page.id,
-						),
+						currentNav.some((current) => current === page.id || current.id === page.id),
 					)}
 					onSelect={(page) => {
 						addItem({ type: 'page', id: page.id });
@@ -147,8 +141,7 @@ const NavBuilder = (props: Props) => {
 					items={collections}
 					placeholder="Add Collection"
 					usedItems={collections.filter((collection) =>
-						// TODO(ian): Remove these any casts after completing migration
-						currentNav.some((current: any) => current.id === collection.id),
+						currentNav.some((current) => current.id === collection.id),
 					)}
 					onSelect={(collection) => {
 						addItem({ type: 'collection', id: collection.id });

--- a/client/containers/DashboardSettings/NavBuilderRow.tsx
+++ b/client/containers/DashboardSettings/NavBuilderRow.tsx
@@ -45,14 +45,6 @@ const NavBuilderRow = (props: Props) => {
 	};
 
 	const renderTop = () => {
-		// TODO(ian): Remove this branch after migration
-		if (typeof item === 'string') {
-			const page = pages.find((pg) => pg.id === item);
-			if (page) {
-				return renderForPageOrCollection(page.title, 'page-layout');
-			}
-			return null;
-		}
 		if ('type' in item) {
 			if (item.type === 'collection') {
 				const collection = collections.find((c) => c.id === item.id);
@@ -96,7 +88,6 @@ const NavBuilderRow = (props: Props) => {
 						items={pages}
 						placeholder="Add Page"
 						usedItems={pages.filter((page) =>
-							// TODO(ian): Remove these any casts after completing migration
 							item.children.some(
 								(current: any) => current === page.id || current.id === page.id,
 							),
@@ -112,7 +103,6 @@ const NavBuilderRow = (props: Props) => {
 						items={collections}
 						placeholder="Add Collection"
 						usedItems={collections.filter((collection) =>
-							// TODO(ian): Remove these any casts after completing migration
 							item.children.some((current: any) => current.id === collection.id),
 						)}
 						onSelect={(collection) => {

--- a/client/utils/__tests__/navigation.test.ts
+++ b/client/utils/__tests__/navigation.test.ts
@@ -32,19 +32,6 @@ const collections = [
 ];
 
 describe('getNavItemsForCommunityNavigation', () => {
-	it('treats bare strings as Page IDs', () =>
-		expect(
-			getNavItemsForCommunityNavigation({
-				navigation: ['page-id-1', 'page-id-2', 'page-id-3'],
-				pages: pages,
-				collections: collections,
-			}),
-		).toEqual([
-			{ title: 'Page One', href: '/page1', id: 'page-id-1' },
-			{ title: 'Page Two', href: '/page2', isPrivate: true, id: 'page-id-2' },
-			{ title: 'Page Three', href: '/page3', id: 'page-id-3' },
-		]));
-
 	it('handles collections, pages, and links', () =>
 		expect(
 			getNavItemsForCommunityNavigation({
@@ -78,7 +65,7 @@ describe('getNavItemsForCommunityNavigation', () => {
 						title: 'Menu',
 						children: [
 							{ type: 'collection', id: 'collection-id-2' },
-							'page-id-1',
+							{ type: 'page', id: 'page-id-1' },
 							{ title: 'Ouch', href: 'ftp://ouch', id: '111' },
 						],
 					},

--- a/client/utils/navigation.ts
+++ b/client/utils/navigation.ts
@@ -27,7 +27,6 @@ type NavBuildContext = {
 
 type CommunityNavigationMenu = { id: string; title: string; children: CommunityNavigationChild[] };
 type CommunityNavigationChild =
-	| string // TODO(ian): We should be able to remove this after late-2020 nav refactor
 	| { id: string; type: 'page' | 'collection' }
 	| { id: string; title: string; href: string };
 
@@ -102,12 +101,7 @@ const getNavbarItemForCommunityNavigationChild = (
 	ctx: NavBuildContext,
 ): null | NavbarChild => {
 	const { pages, collections } = ctx;
-	if (typeof navEntry === 'string') {
-		const page = pages.find((p) => p.id === navEntry);
-		if (page) {
-			return getNavbarChildForPageOrCollection(page);
-		}
-	} else if ('type' in navEntry) {
+	if ('type' in navEntry) {
 		const { type, id } = navEntry;
 		const item =
 			type === 'collection'


### PR DESCRIPTION
I was clicking around this morning and found that to my horror I forgot to remove some shim code from the Page/Collection migration. So I'm doing it now. To make sure there really are no bare strings IDs left in the community nav JSON I tried this in the devshell:

```
cms = await Community.findAll();
const isProblematicNavEntry = entry => typeof entry === 'string' || entry.children && entry.children.some(isProblematicNavEntry);
const isProblematicNav = nav => nav.some(isProblematicNavEntry);
cms.filter(c => isProblematicNav(c.navigation)); // []

```
I'll still do some spot-checking on duqduq before deploying.