### PR TITLE
feature: Add support for image alt text and improve a11y of figcaptions

### DIFF
--- a/client/components/Editor/schemas/audio.ts
+++ b/client/components/Editor/schemas/audio.ts
@@ -41,6 +41,7 @@ export default {
 			},
 		],
 		toDOM: (node, { isReact } = { isReact: false }) => {
+			const figcaptionId = `${node.attrs.id}-figure-caption`;
 			return [
 				'figure',
 				{
@@ -56,11 +57,12 @@ export default {
 						preload: 'metadata',
 						src: node.attrs.url,
 						alt: node.attrs.caption,
+						'aria-describedby': figcaptionId,
 					},
 				],
 				[
 					'figcaption',
-					{},
+					{ id: figcaptionId },
 					pruneFalsyValues([
 						'div',
 						{},

--- a/client/components/Editor/schemas/iframe.ts
+++ b/client/components/Editor/schemas/iframe.ts
@@ -30,8 +30,8 @@ export default {
 				},
 			},
 		],
-		// @ts-expect-error ts-migrate(2525) FIXME: Initializer provides no value for this binding ele... Remove this comment to see the full error message
-		toDOM: (node, { isReact } = {}) => {
+		toDOM: (node, { isReact } = { isReact: false }) => {
+			const figcaptionId = `${node.attrs.id}-figure-caption`;
 			return [
 				'figure',
 				{
@@ -46,9 +46,14 @@ export default {
 						alt: node.attrs.caption,
 						src: node.attrs.url,
 						height: node.attrs.height,
+						'aria-describedby': figcaptionId,
 					},
 				],
-				['figcaption', {}, renderHtmlChildren(isReact, node.attrs.caption, 'div')],
+				[
+					'figcaption',
+					{ id: figcaptionId },
+					renderHtmlChildren(isReact, node.attrs.caption, 'div'),
+				],
 			] as DOMOutputSpec;
 		},
 		inline: false,

--- a/client/components/Editor/schemas/video.ts
+++ b/client/components/Editor/schemas/video.ts
@@ -42,6 +42,7 @@ export default {
 			},
 		],
 		toDOM: (node, { isReact } = { isReact: false }) => {
+			const figcaptionId = `${node.attrs.id}-figure-caption`;
 			return [
 				'figure',
 				{
@@ -57,11 +58,12 @@ export default {
 						preload: 'metadata',
 						src: node.attrs.url,
 						alt: node.attrs.caption,
+						'aria-describedby': figcaptionId,
 					},
 				],
 				[
 					'figcaption',
-					{},
+					{ id: figcaptionId },
 					pruneFalsyValues([
 						'div',
 						{},

--- a/client/components/FormattingBar/controlComponents/controls.scss
+++ b/client/components/FormattingBar/controlComponents/controls.scss
@@ -46,6 +46,34 @@
 		}
 	}
 
+	.bp3-tabs {
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+		.bp3-tab {
+			&[aria-selected='true'] {
+				color: white;
+				&:hover {
+					color: white;
+				}
+			}
+			&:not([aria-selected='true']) {
+				color: white;
+				opacity: 0.5;
+				&:hover {
+					color: white;
+				}
+			}
+		}
+		.bp3-tab-indicator {
+			background: white;
+		}
+		.bp3-tab-panel {
+			flex-grow: 1;
+			margin-top: 9px;
+		}
+	}
+
 	textarea {
 		background: rgba(255, 255, 255, 0.2);
 		border: none;
@@ -59,7 +87,7 @@
 		width: 100%;
 		overflow-y: hidden;
 		.editor-wrapper:focus-within {
-			box-shadow: inset 0px 0px 0px 1.5px white !important;
+			box-shadow: inset 0px 0px 0px 2px white !important;
 			border-top-color: transparent;
 		}
 		.editor,

--- a/client/components/FormattingBar/formattingBar.scss
+++ b/client/components/FormattingBar/formattingBar.scss
@@ -173,8 +173,8 @@
         flex-shrink: 0;
         padding-left: 5px
     }
-    *:focus:not(:disabled) {
+    *:focus:not(:disabled):not(.bp3-tab) {
         outline: none;
-        box-shadow: inset 0px 0px 0px 1.5px white !important;
+        box-shadow: inset 0px 0px 0px 2px white !important;
     }
 }

--- a/client/components/FormattingBar/usePendingAttrs.ts
+++ b/client/components/FormattingBar/usePendingAttrs.ts
@@ -6,7 +6,7 @@ const attrsHaveChanges = (oldAttrs, newAttrs, keys) => {
 
 export const usePendingAttrs = ({ selectedNode, updateNode }) => {
 	const [attrs, setAttrs] = useState(selectedNode && selectedNode.attrs);
-	const [pendingKeys, setPendingKeys] = useState([]);
+	const [pendingKeys, setPendingKeys] = useState<string[]>([]);
 
 	if (!selectedNode) {
 		return null;
@@ -17,7 +17,6 @@ export const usePendingAttrs = ({ selectedNode, updateNode }) => {
 	const commitChanges = () => {
 		const nextAttrs = {};
 		pendingKeys.forEach((key) => {
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'any' is not assignable to type 'never'.
 			nextAttrs[key] = attrs[key];
 		});
 		updateNode(nextAttrs);
@@ -25,17 +24,9 @@ export const usePendingAttrs = ({ selectedNode, updateNode }) => {
 	};
 
 	const updateAttrs = (nextAttrs) => {
-		Object.keys(nextAttrs).forEach((possiblyNewKey) => {
-			const nextKeys = [];
-			// @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
-			if (!pendingKeys.includes(possiblyNewKey)) {
-				// @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
-				nextKeys.push(possiblyNewKey);
-			}
-			if (nextKeys.length > 0) {
-				setPendingKeys([...pendingKeys, ...nextKeys]);
-			}
-		});
+		setPendingKeys((prevPendingKeys) => [
+			...new Set([...prevPendingKeys, ...Object.keys(nextAttrs)]),
+		]);
 		setAttrs((prevAttrs) => ({ ...prevAttrs, ...nextAttrs }));
 	};
 


### PR DESCRIPTION
Resolves #1208

Our current attempt at screenreader support for images and other captionable media has been to use a `figure`/`figcaption` pair, which should cause the `figcaption` contents to be read in a way similar to an image's alt text. As described in #1208, Gabe (and a Twitter user) found that this is not actually the case for many OS/reader/browser combinations. So this PR has two changes:

- We add an `aria-describedby` (or occasionally `aria-labelledby`) to `img`, `video`, `audio`, `iframe` tags that points at the `figcaption`, to improve the odds of the caption being associated with the media by the SR.
- For instances where SR users would benefit from more detail than is appropriate for a caption, we add an `altText` field to the image node schema, and a corresponding control to modify it in the editor:

![image](https://user-images.githubusercontent.com/2208769/103010535-7f223280-4506-11eb-9f65-8fe563baa9e8.png)

_Test plan:_
Check that:
- Adding alt text to images works and persists to the document
- Images without any alt text from existing documents don't crash or anything
- The alt text is applied to the image's `alt` tag.
- Images have an `aria-describedby` pointing to the caption if they also have an alt text, and an `aria-labelledby` pointing to the caption otherwise. If there is no caption or alt text provided by the Prosemirror image node, the corresponding DOM node should have no `aria-` attributes and `alt=""` (which will make the image invisible to the screenreader).
