### PR TITLE
dev: Split Editor.tsx into more files and add stronger typing

### DIFF
--- a/client/components/Editor/Editor.stories.tsx
+++ b/client/components/Editor/Editor.stories.tsx
@@ -67,13 +67,12 @@ const firebaseBranchRef = firebaseRootRef.child(branchKey);
 const newDiscussionId = String(Math.floor(Math.random() * 999999));
 
 const CursorOptionsDemoPub = () => {
-	const [editorView, setEditorView] = useState();
+	const [editorView, setEditorView] = useState<any>();
 
 	const cursorButtons = Object.keys(cursorCommands).map((key) => ({
 		children: key,
 		onClick: () => {
 			cursorCommands[key](editorView);
-			// @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
 			editorView.focus();
 		},
 	}));
@@ -87,9 +86,8 @@ const CursorOptionsDemoPub = () => {
 			</div>
 			<Editor
 				placeholder="Begin writing..."
-				initialContent={initialContent}
+				initialContent={initialContent as any}
 				isReadOnly={false}
-				// @ts-expect-error ts-migrate(2322) FIXME: Type '(editorChangeObject: any) => void' is not as... Remove this comment to see the full error message
 				onChange={(editorChangeObject) => setEditorView(editorChangeObject.view)}
 			/>
 		</div>
@@ -102,59 +100,13 @@ storiesOf('Editor', module)
 		<div style={editorWrapperStyle}>
 			<Editor
 				placeholder="Begin writing..."
-				initialContent={initialContent}
+				initialContent={initialContent as any}
 				// isReadOnly={true}
-				// @ts-expect-error ts-migrate(2322) FIXME: Type '(err: any) => void' is not assignable to typ... Remove this comment to see the full error message
-				onError={(err) => console.error(err)}
-				// @ts-expect-error ts-migrate(2322) FIXME: Type '(changeObject: any) => void' is not assignab... Remove this comment to see the full error message
 				onChange={(changeObject) => {
-					// console.log('====');
-					// console.log(JSON.stringify(changeObject.view.state.doc.toJSON(), null, 4));
-					// console.log(changeObject.menuItems);
-					// console.log(getCollabJSONs(changeObject.view));
-					if (changeObject.updateNode && changeObject.selectedNode.attrs.size === 50) {
+					if (changeObject.updateNode && changeObject.selectedNode?.attrs.size === 50) {
 						changeObject.updateNode({ size: 65 });
 					}
-
-					if (
-						changeObject.shortcutValues['@'] === 'dog' &&
-						changeObject.selection.empty
-					) {
-						changeObject.shortcutValues.selectShortCut();
-						changeObject.insertFunctions.image({
-							url:
-								'https://www.cesarsway.com/sites/newcesarsway/files/styles/large_article_preview/public/All-about-puppies--Cesar%E2%80%99s-tips%2C-tricks-and-advice.jpg?itok=bi9xUvwe',
-						});
-					}
-
-					// if ()
-					// if (changeObject.activeLink && changeObject.activeLink.attrs.href === '') {
-					// 	setTimeout(()=> {
-					// 		changeObject.activeLink.updateAttrs({ href: 'https://www.pubpub.org' });
-					// 	}, 2000);
-					// }
-					// if (changeObject.activeLink && changeObject.activeLink.attrs.href === 'https://www.pubpub.org') {
-					// 	setTimeout(()=> {
-					// 		changeObject.activeLink.removeLink();
-					// 	}, 2000);
-					// }
-					// if (thing === false) {
-					// 	thing = true;
-					// 	changeObject.insertFunctions.image({ url: 'https://www.cesarsway.com/sites/newcesarsway/files/styles/large_article_preview/public/All-about-puppies--Cesar%E2%80%99s-tips%2C-tricks-and-advice.jpg?itok=bi9xUvwe' });
-					// }
 				}}
-				highlights={[
-					{
-						exact: 'Introduction',
-						from: '25',
-						id: 'abcdefg',
-						permanent: false,
-						// prefix: 'Hello ',
-						// suffix: ' and',
-						to: '30',
-						version: undefined,
-					},
-				]}
 			/>
 		</div>
 	))
@@ -163,17 +115,6 @@ storiesOf('Editor', module)
 			const [changeObject, updatechangeObject] = useState({});
 			return (
 				<div style={editorWrapperStyle}>
-					{/* <button
-						type="button"
-						onClick={() => {
-							firebaseBranchRef
-								.child('discussions')
-								.child(Math.floor(Math.random() * 999999))
-								.set(getDiscussionData(changeObject.view));
-						}}
-					>
-						New
-					</button> */}
 					<button
 						type="button"
 						onClick={() => {
@@ -218,14 +159,11 @@ storiesOf('Editor', module)
 					<Editor
 						key={firebaseBranchRef ? 'ready' : 'unready'}
 						placeholder="Begin writing..."
-						// @ts-expect-error ts-migrate(2322) FIXME: Type '(evt: any) => void' is not assignable to typ... Remove this comment to see the full error message
 						onChange={(evt) => {
 							updatechangeObject(evt);
 						}}
-						// @ts-expect-error ts-migrate(2322) FIXME: Type '(err: any) => void' is not assignable to typ... Remove this comment to see the full error message
-						onError={(err) => console.error(err)}
 						collaborativeOptions={{
-							firebaseRef: firebaseBranchRef,
+							firebaseRef: firebaseBranchRef as any,
 							clientData: clientData,
 							initialDocKey: -1,
 							// onClientChange: () => {},
@@ -298,7 +236,6 @@ storiesOf('Editor', module)
 					<Editor
 						key={firebaseBranchRef ? 'ready' : 'unready'}
 						placeholder="Begin writing..."
-						// @ts-expect-error ts-migrate(2322) FIXME: Type '(evt: any) => void' is not assignable to typ... Remove this comment to see the full error message
 						onChange={(evt) => {
 							// updatechangeObject(evt);
 							if (times < 15) {
@@ -313,10 +250,8 @@ storiesOf('Editor', module)
 								}, 1000);
 							}
 						}}
-						// @ts-expect-error ts-migrate(2322) FIXME: Type '(err: any) => void' is not assignable to typ... Remove this comment to see the full error message
-						onError={(err) => console.error(err)}
 						collaborativeOptions={{
-							firebaseRef: firebaseBranchRef,
+							firebaseRef: firebaseBranchRef as any,
 							clientData: clientData,
 							initialDocKey: -1,
 							// onClientChange: () => {},
@@ -332,9 +267,8 @@ storiesOf('Editor', module)
 		<div style={editorWrapperStyle}>
 			<Editor
 				placeholder="Begin writing..."
-				initialContent={initialContent}
+				initialContent={initialContent as any}
 				isReadOnly={true}
-				// @ts-expect-error ts-migrate(2322) FIXME: Type '(changeObject: any) => void' is not assignab... Remove this comment to see the full error message
 				onChange={(changeObject) => {
 					console.log(changeObject.view);
 				}}

--- a/client/components/Editor/Editor.tsx
+++ b/client/components/Editor/Editor.tsx
@@ -1,201 +1,105 @@
-import React, { useEffect, useRef, useMemo, useState, useCallback } from 'react';
-import { EditorState } from 'prosemirror-state';
+import React, { useRef } from 'react';
+import classNames from 'classnames';
+import { MarkSpec, NodeSpec } from 'prosemirror-model';
 import { EditorView } from 'prosemirror-view';
-import { keydownHandler } from 'prosemirror-keymap';
-import { addTemporaryIdsToDoc } from '@pubpub/prosemirror-reactive';
 
-import SuggestionManager, {
-	SuggestionManagerStateSuggesting,
-} from 'client/utils/suggestions/suggestionManager';
-import ReferenceFinder from './ReferenceFinder';
+import { CitationManager } from 'client/utils/citations/citationManager';
 
-import { getPlugins } from './plugins';
-import { collabDocPluginKey } from './plugins/collaborative';
+import { Doc, NodeLabelMap, CollaborativeOptions, PluginLoader } from './types';
 import { getChangeObject } from './plugins/onChange';
-import { renderStatic, buildSchema, NodeReference } from './utils';
-import nodeViews from './views';
-import { NodeLabelMap } from './types';
+import { getEmptyDoc, NodeReference } from './utils';
+import { useSuggestions } from './hooks/useSuggestions';
+import { useInitialValues } from './hooks/useInitialValues';
+import { useEditorView } from './hooks/useEditorView';
+import ReferenceFinder from './ReferenceFinder';
 
 require('./styles/base.scss');
 
-export type EditorProps = {
-	nodeLabels: NodeLabelMap;
-	citationManager?: any;
-	customNodes?: any;
-	customMarks?: any;
-	customPlugins?: any;
-	collaborativeOptions?: any;
-	handleDoubleClick?: (...args: any[]) => any;
-	handleSingleClick?: (...args: any[]) => any;
-	initialContent?: any;
+type Props = {
+	citationManager?: CitationManager;
+	collaborativeOptions?: CollaborativeOptions;
+	customMarks?: Record<string, MarkSpec>;
+	customNodes?: Record<string, NodeSpec>;
+	customPlugins?: Record<string, null | PluginLoader>;
+	initialContent?: Doc;
 	isReadOnly?: boolean;
-	nodeOptions?: any;
-	onChange?: (...args: any[]) => any;
-	onError?: (...args: any[]) => any;
-	onKeyPress?: (...args: any[]) => any;
-	onScrollToSelection?: (...args: any[]) => any;
+	nodeLabels?: NodeLabelMap;
+	nodeOptions?: Record<string, any>;
+	onChange?: (editorChangeObject: ReturnType<typeof getChangeObject>) => unknown;
+	onError?: (err: Error) => unknown;
+	onKeyPress?: (view: EditorView, evt: KeyboardEvent) => boolean;
+	onScrollToSelection?: (view: EditorView) => boolean;
 	placeholder?: string;
 };
 
-const defaultProps = {
-	nodeLabels: {},
-	citationManager: null,
-	collaborativeOptions: {},
-	customMarks: {}, // defaults: 'em', 'strong', 'link', 'sub', 'sup', 'strike', 'code'
-	customNodes: {}, // defaults: 'blockquote', 'horizontal_rule', 'heading', 'ordered_list', 'bullet_list', 'list_item', 'code_block', 'text', 'hard_break', 'image'
-	customPlugins: {}, // defaults: inputRules, keymap, headerIds, placeholder
-	handleDoubleClick: undefined,
-	handleSingleClick: undefined,
-	initialContent: { type: 'doc', attrs: { meta: {} }, content: [{ type: 'paragraph' }] },
-	isReadOnly: false,
-	nodeOptions: {},
-	onChange: () => {},
-	onError: () => {},
-	onKeyPress: () => {},
-	onScrollToSelection: undefined,
-	placeholder: '',
-};
-
-const getInitialArguments = (props) => {
-	const {
-		nodeLabels,
-		citationManager,
-		customMarks,
-		customNodes,
-		initialContent,
-		isReadOnly,
-		nodeOptions,
-	} = props;
-	const schema = buildSchema(customNodes, customMarks, nodeOptions);
-	const hydratedDoc = schema.nodeFromJSON(initialContent);
-	const initialDoc = isReadOnly ? addTemporaryIdsToDoc(hydratedDoc) : hydratedDoc;
-	// @ts-expect-error ts-migrate(2345) FIXME: Argument of type '{ schema: Schema<"highlightQuote... Remove this comment to see the full error message
-	const staticContent = renderStatic({
-		schema: schema,
-		doc: props.initialContent,
-		nodeLabels: nodeLabels,
-		citationManager: citationManager,
-	});
-	return { schema: schema, initialDoc: initialDoc, staticContent: staticContent };
-};
-
-type Props = EditorProps & typeof defaultProps;
+const emptyDoc = getEmptyDoc();
 
 const Editor = (props: Props) => {
-	const editorRef = useRef<HTMLElement>();
-	const initialArguments = useRef(null);
-	const [suggesting, setSuggesting] = useState<SuggestionManagerStateSuggesting<
-		NodeReference
-	> | null>();
-	const suggestionManager = useMemo(() => new SuggestionManager<NodeReference>(), []);
-	const onSuggestionManagerTransition = useCallback(
-		() => setSuggesting(suggestionManager.isSuggesting() ? suggestionManager.state : null),
-		[],
-	);
+	const {
+		nodeLabels = {} as NodeLabelMap,
+		citationManager,
+		collaborativeOptions,
+		customMarks = {},
+		customNodes = {},
+		customPlugins = {},
+		initialContent = emptyDoc,
+		isReadOnly = false,
+		nodeOptions = {},
+		onChange,
+		onError,
+		onKeyPress,
+		onScrollToSelection,
+		placeholder = '',
+	} = props;
 
-	if (initialArguments.current === null) {
-		// @ts-expect-error ts-migrate(2322) FIXME: Type '{ schema: Schema<"highlightQuote" | "citatio... Remove this comment to see the full error message
-		initialArguments.current = getInitialArguments(props);
-	}
+	const mountRef = useRef<HTMLDivElement | null>(null);
+	const { suggesting, suggestionManager } = useSuggestions<NodeReference>();
 
-	useEffect(() => {
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'initialDoc' does not exist on type 'null... Remove this comment to see the full error message
-		const { initialDoc, schema } = initialArguments.current;
-		const state = EditorState.create({
-			doc: initialDoc,
-			schema: schema,
-			plugins: getPlugins(schema, {
-				citationManager: props.citationManager,
-				collaborativeOptions: props.collaborativeOptions,
-				customPlugins: props.customPlugins,
-				isReadOnly: props.isReadOnly,
-				onChange: props.onChange,
-				onError: props.onError,
-				placeholder: props.placeholder,
-				suggestionManager: suggestionManager,
-				nodeLabels: props.nodeLabels,
-			}),
-		});
+	const { initialDocNode, schema, staticContent } = useInitialValues({
+		nodeLabels: nodeLabels,
+		nodeOptions: nodeOptions,
+		citationManager: citationManager,
+		customNodes: customNodes,
+		customMarks: customMarks,
+		initialContent: initialContent,
+		isReadOnly: isReadOnly,
+	});
 
-		const view = new EditorView(
-			{ mount: editorRef.current! },
-			{
-				state: state,
-				nodeViews: nodeViews,
-				editable: (editorState) => {
-					const collaborativePluginState = collabDocPluginKey.getState(editorState) || {};
-					if (
-						props.collaborativeOptions.clientData &&
-						!collaborativePluginState.isLoaded
-					) {
-						return false;
-					}
-					return !props.isReadOnly;
-				},
-				handleKeyDown: keydownHandler({
-					/* Block Ctrl-S from launching the browser Save window */
-					'Mod-s': () => {
-						return true;
-					},
-				}),
-				handleKeyPress: props.onKeyPress,
-				handleClickOn: props.handleSingleClick,
-				handleDoubleClickOn: props.handleDoubleClick,
-				handleScrollToSelection: props.onScrollToSelection,
-			},
-		);
-
-		// Sometimes the view will call its dispatchTransaction from the constructor, but the
-		// function itself references the `view` variable bound above. So we need to set this
-		// prop immediately after it's constructed.
-		view.setProps({
-			dispatchTransaction: (transaction) => {
-				try {
-					const newState = view.state.apply(transaction);
-					const transactionHasSteps = transaction.steps.length;
-					view.updateState(newState);
-					if (props.collaborativeOptions.firebaseRef && transactionHasSteps) {
-						collabDocPluginKey.getState(newState).sendCollabChanges(newState);
-					}
-				} catch (err) {
-					console.error('Error applying transaction:', err);
-					props.onError(err);
-				}
-			},
-		});
-
-		props.onChange(getChangeObject(view, props));
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-
-		return suggestionManager.transitioned.subscribe(onSuggestionManagerTransition);
-	}, []);
-
-	/* Before createEditor is called from componentDidMount, we */
-	/* generate a static version of the doc for server-side rendering. */
-	/* This static version is overwritten when the editorView is */
-	/* mounted into the editor dom node. */
+	useEditorView({
+		customPlugins: customPlugins,
+		pluginsOptions: {
+			citationManager: citationManager,
+			collaborativeOptions: collaborativeOptions,
+			isReadOnly: isReadOnly,
+			nodeLabels: nodeLabels,
+			onChange: onChange,
+			onError: onError,
+			placeholder: placeholder,
+			suggestionManager: suggestionManager,
+		},
+		initialDocNode: initialDocNode,
+		schema: schema,
+		isReadOnly: isReadOnly,
+		onKeyPress: onKeyPress,
+		onScrollToSelection: onScrollToSelection,
+		onError: onError,
+		mountRef: mountRef,
+	});
 
 	return (
 		<>
 			<div
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'MutableRefObject<HTMLElement | undefined>' i... Remove this comment to see the full error message
-				ref={editorRef}
-				className={`editor ProseMirror ${props.isReadOnly ? 'read-only' : ''}`}
+				ref={mountRef}
+				className={classNames('editor', 'ProseMirror', isReadOnly && 'read-only')}
 			>
-				{/* @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'. */}
-				{initialArguments.current.staticContent}
+				{staticContent}
 			</div>
 			{suggesting && (
-				<div
-					style={{
-						position: 'absolute',
-						...suggestionManager.getPosition(),
-					}}
-				>
+				<div style={suggestionManager.getPosition()}>
 					<ReferenceFinder
-						nodeLabels={props.nodeLabels}
+						nodeLabels={nodeLabels}
 						references={suggesting.items}
-						activeReference={suggestionManager.getSelectedValue() || undefined}
+						activeReference={suggestionManager.getSelectedValue()}
 						onReferenceSelect={(reference) => suggestionManager.select(reference)}
 					/>
 				</div>
@@ -203,5 +107,5 @@ const Editor = (props: Props) => {
 		</>
 	);
 };
-Editor.defaultProps = defaultProps;
+
 export default Editor;

--- a/client/components/Editor/ReferenceFinder.tsx
+++ b/client/components/Editor/ReferenceFinder.tsx
@@ -9,7 +9,7 @@ require('./referenceFinder.scss');
 export type ReferenceFinderProps = {
 	nodeLabels: NodeLabelMap;
 	references: ReadonlyArray<NodeReference>;
-	activeReference?: NodeReference;
+	activeReference: NodeReference | null;
 	onReferenceSelect: (reference: NodeReference) => unknown;
 };
 

--- a/client/components/Editor/clientServerDiffStories.tsx
+++ b/client/components/Editor/clientServerDiffStories.tsx
@@ -46,7 +46,6 @@ const RenderTest = (props) => {
 						initialContent={props.doc}
 						/* We set readOnly for table so table plugins don't muck with diff */
 						isReadOnly={props.title === 'table'}
-						// @ts-expect-error ts-migrate(2322) FIXME: Type '(eco: any) => void' is not assignable to typ... Remove this comment to see the full error message
 						onChange={(eco) => {
 							setClientHtml(beautify.html(eco.view.dom.innerHTML, beautifyOptions));
 						}}

--- a/client/components/Editor/hooks/useEditorView.ts
+++ b/client/components/Editor/hooks/useEditorView.ts
@@ -1,0 +1,126 @@
+import React, { useEffect, useRef } from 'react';
+import { Node, Schema } from 'prosemirror-model';
+import { EditorState, Transaction } from 'prosemirror-state';
+import { EditorView } from 'prosemirror-view';
+import { keydownHandler } from 'prosemirror-keymap';
+
+import nodeViews from '../views';
+import { getPlugins } from '../plugins';
+import { collabDocPluginKey } from '../plugins/collaborative';
+import { PluginLoader, PluginsOptions } from '../types';
+import { immediatelyDispatchOnChange } from '../plugins/onChange';
+
+type EditorViewOptions = {
+	customPlugins: Record<string, null | PluginLoader>;
+	pluginsOptions: PluginsOptions;
+	initialDocNode: Node;
+	isReadOnly: boolean;
+	schema: Schema;
+	mountRef: React.MutableRefObject<HTMLDivElement | null>;
+	onKeyPress?: (view: EditorView, evt: KeyboardEvent) => boolean;
+	onScrollToSelection?: (view: EditorView) => boolean;
+	onError?: (err: Error) => unknown;
+};
+
+const blockSaveKeyHandler = keydownHandler({
+	'Mod-s': () => true,
+});
+
+const getIsEditable = ({ isReadOnly }: Pick<EditorViewOptions, 'isReadOnly'>) => (
+	state: EditorState,
+) => {
+	const collabState = collabDocPluginKey.getState(state);
+	if (collabState && !collabState.isLoaded) {
+		return false;
+	}
+	return !isReadOnly;
+};
+
+const getDispatchTransaction = (
+	view: EditorView,
+	{ onError }: Pick<EditorViewOptions, 'onError'>,
+) => (transaction: Transaction) => {
+	try {
+		const collabState = collabDocPluginKey.getState(view.state);
+		const newState = view.state.apply(transaction);
+		const transactionHasSteps = transaction.steps.length;
+		view.updateState(newState);
+		if (collabState && transactionHasSteps) {
+			collabState.sendCollabChanges(newState);
+		}
+	} catch (err) {
+		console.error('Error applying transaction:', err);
+		onError?.(err);
+	}
+};
+
+const createEditorView = (options: EditorViewOptions) => {
+	const {
+		initialDocNode,
+		schema,
+		customPlugins,
+		pluginsOptions,
+		onKeyPress,
+		onScrollToSelection,
+		mountRef,
+	} = options;
+
+	const state = EditorState.create({
+		doc: initialDocNode,
+		schema: schema,
+		plugins: getPlugins(schema, customPlugins, pluginsOptions),
+	});
+
+	const view: EditorView<typeof schema> = new EditorView(
+		{ mount: mountRef.current! },
+		{
+			state: state,
+			nodeViews: nodeViews,
+			editable: getIsEditable(options),
+			handleKeyDown: blockSaveKeyHandler,
+			handleKeyPress: onKeyPress,
+			handleScrollToSelection: onScrollToSelection,
+		},
+	);
+
+	// Sometimes the view will call its dispatchTransaction from the constructor, but the
+	// function itself references the `view` variable bound above. So we need to set this
+	// prop immediately after it's constructed.
+	view.setProps({
+		dispatchTransaction: getDispatchTransaction(view, options),
+	});
+
+	immediatelyDispatchOnChange(view);
+	return view;
+};
+
+export const useEditorView = (options: EditorViewOptions) => {
+	const { onError, onKeyPress, onScrollToSelection, isReadOnly } = options;
+	const viewRef = useRef<null | EditorView>(null);
+
+	useEffect(() => {
+		if (viewRef.current === null) {
+			viewRef.current = createEditorView(options);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	useEffect(() => {
+		viewRef.current?.setProps({
+			dispatchTransaction: getDispatchTransaction(viewRef.current, { onError: onError }),
+		});
+	}, [onError]);
+
+	useEffect(() => {
+		viewRef.current?.setProps({
+			handleKeyPress: onKeyPress,
+			handleScrollToSelection: onScrollToSelection,
+		});
+	}, [onKeyPress, onScrollToSelection]);
+
+	useEffect(() => {
+		viewRef.current?.setProps({
+			editable: getIsEditable({ isReadOnly: isReadOnly }),
+		});
+	}, [isReadOnly]);
+};

--- a/client/components/Editor/hooks/useInitialValues.ts
+++ b/client/components/Editor/hooks/useInitialValues.ts
@@ -1,0 +1,56 @@
+import { MarkSpec, Node, NodeSpec, Schema } from 'prosemirror-model';
+import { useRef } from 'react';
+import { addTemporaryIdsToDoc } from '@pubpub/prosemirror-reactive';
+
+import { CitationManager } from 'client/utils/citations/citationManager';
+
+import { Doc, NodeLabelMap } from '../types';
+import { buildSchema, renderStatic } from '../utils';
+
+type InitialValues = {
+	initialDocNode: Node;
+	staticContent: ReturnType<typeof renderStatic>;
+	schema: Schema;
+};
+
+type InitialValuesOptions = {
+	citationManager?: CitationManager;
+	customNodes: Record<string, NodeSpec>;
+	customMarks: Record<string, MarkSpec>;
+	nodeLabels: NodeLabelMap;
+	initialContent: Doc;
+	isReadOnly: boolean;
+	nodeOptions: Record<string, any>;
+};
+
+const getInitialOptions = (options: InitialValuesOptions) => {
+	const {
+		nodeLabels,
+		citationManager,
+		customMarks,
+		customNodes,
+		initialContent,
+		isReadOnly,
+		nodeOptions,
+	} = options;
+	const schema = buildSchema(customNodes, customMarks, nodeOptions);
+	const hydratedDoc = schema.nodeFromJSON(initialContent);
+	const initialDocNode = isReadOnly ? addTemporaryIdsToDoc(hydratedDoc) : hydratedDoc;
+	const staticContent = renderStatic({
+		schema: schema,
+		doc: initialContent,
+		nodeLabels: nodeLabels,
+		citationManager: citationManager,
+	});
+	return { schema: schema, initialDocNode: initialDocNode, staticContent: staticContent };
+};
+
+export const useInitialValues = (options: InitialValuesOptions) => {
+	const initialValuesRef = useRef<null | InitialValues>(null);
+
+	if (initialValuesRef.current === null) {
+		initialValuesRef.current = getInitialOptions(options);
+	}
+
+	return initialValuesRef.current!;
+};

--- a/client/components/Editor/hooks/useSuggestions.ts
+++ b/client/components/Editor/hooks/useSuggestions.ts
@@ -1,0 +1,22 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import SuggestionManager, {
+	SuggestionManagerStateSuggesting,
+} from 'client/utils/suggestions/suggestionManager';
+
+export const useSuggestions = <T>() => {
+	const suggestionManager = useMemo(() => new SuggestionManager<T>(), []);
+	const [suggesting, setSuggesting] = useState<null | SuggestionManagerStateSuggesting<T>>(null);
+
+	const onSuggestionManagerTransition = useCallback(
+		() => setSuggesting(suggestionManager.isSuggesting() ? suggestionManager.state : null),
+		[suggestionManager],
+	);
+
+	useEffect(() => suggestionManager.transitioned.subscribe(onSuggestionManagerTransition), [
+		suggestionManager,
+		onSuggestionManagerTransition,
+	]);
+
+	return { suggesting: suggesting, suggestionManager: suggestionManager };
+};

--- a/client/components/Editor/plugins/collaborative/document.ts
+++ b/client/components/Editor/plugins/collaborative/document.ts
@@ -146,9 +146,6 @@ export default (schema, props, collabDocPluginKey, localClientId) => {
 	};
 
 	const loadDocument = () => {
-		if (props.collaborativeOptions.delayLoadingDocument) {
-			return null;
-		}
 		return ref
 			.child('changes')
 			.orderByKey()

--- a/client/components/Editor/plugins/collaborative/index.ts
+++ b/client/components/Editor/plugins/collaborative/index.ts
@@ -10,7 +10,7 @@ import buildCursors from './cursors';
 export const collabDocPluginKey = new PluginKey('collaborative');
 
 export default (schema, props) => {
-	if (!props.collaborativeOptions.firebaseRef) {
+	if (!props.collaborativeOptions?.firebaseRef) {
 		return [];
 	}
 

--- a/client/components/Editor/plugins/placeholder.ts
+++ b/client/components/Editor/plugins/placeholder.ts
@@ -13,7 +13,7 @@ export default (schema, props) => {
 					state.doc.descendants((node, pos) => {
 						const collaborativePluginState = collabDocPluginKey.getState(state) || {};
 						const placeholderText =
-							props.collaborativeOptions.clientData &&
+							props.collaborativeOptions?.clientData &&
 							!collaborativePluginState.isLoaded
 								? 'Loading...'
 								: props.placeholder;

--- a/client/components/Editor/types.ts
+++ b/client/components/Editor/types.ts
@@ -1,3 +1,13 @@
+import { Reference } from '@firebase/database-types';
+import { Schema } from 'prosemirror-model';
+import { Plugin } from 'prosemirror-state';
+
+import { CitationManager } from 'client/utils/citations/citationManager';
+import SuggestionManager from 'client/utils/suggestions/suggestionManager';
+
+import { getChangeObject } from './plugins/onChange';
+import { NodeReference } from './utils';
+
 export enum ReferenceableNodeType {
 	Image = 'image',
 	Video = 'video',
@@ -13,8 +23,31 @@ export type NodeLabel = {
 	text: string;
 };
 
-// export type NodeLabelMap = {
-// 	[nodeType in ReferenceableNodeType]?: NodeLabel;
-// };
-
 export type NodeLabelMap = Record<ReferenceableNodeType, NodeLabel>;
+
+export type PluginLoader = (schema: Schema, options: PluginsOptions) => Plugin | Plugin[];
+
+export type EditorChangeObject = ReturnType<typeof getChangeObject>;
+
+export type CollaborativeOptions = {
+	clientData: {
+		id: string;
+	};
+	firebaseRef?: Reference;
+	initialDocKey: number;
+	onStatusChange?: (status: 'saving' | 'saved') => unknown;
+	onUpdateLatestKey?: (key: number) => unknown;
+};
+
+export type PluginsOptions = {
+	citationManager?: CitationManager;
+	collaborativeOptions?: CollaborativeOptions;
+	isReadOnly?: boolean;
+	nodeLabels: NodeLabelMap;
+	onChange?: (changeObject: EditorChangeObject) => unknown;
+	onError?: (error: Error) => unknown;
+	placeholder: string;
+	suggestionManager: SuggestionManager<NodeReference>;
+};
+
+export type Doc = { type: 'doc'; attrs: any; content: any[] };

--- a/client/components/Editor/utils/doc.ts
+++ b/client/components/Editor/utils/doc.ts
@@ -1,7 +1,7 @@
 import { DOMParser, Node } from 'prosemirror-model';
 
 export const getEmptyDoc = () => {
-	return { type: 'doc', attrs: { meta: {} }, content: [{ type: 'paragraph' }] };
+	return { type: 'doc' as const, attrs: { meta: {} }, content: [{ type: 'paragraph' }] };
 };
 
 export const docIsEmpty = (doc) => {

--- a/client/components/Editor/utils/renderStatic.ts
+++ b/client/components/Editor/utils/renderStatic.ts
@@ -155,7 +155,7 @@ export const getReactedDocFromJson = (doc, schema, citationManager, nodeLabels) 
 export const renderStatic = ({
 	schema,
 	doc,
-	reactedDoc,
+	reactedDoc = null,
 	citationManager,
 	nodeLabels = {},
 	context = {},

--- a/client/components/FormattingBar/FormattingBar.stories.tsx
+++ b/client/components/FormattingBar/FormattingBar.stories.tsx
@@ -52,11 +52,10 @@ class EditorUnit extends Component<Props, State> {
 				>
 					<Editor
 						placeholder="hello"
-						// @ts-expect-error ts-migrate(2322) FIXME: Type '(changeObject: any) => void' is not assignab... Remove this comment to see the full error message
 						onChange={(changeObject) => {
 							this.setState({ editorChangeObject: changeObject });
 						}}
-						initialContent={fullDoc}
+						initialContent={fullDoc as any}
 					/>
 				</div>
 			</div>

--- a/client/components/LayoutEditor/LayoutEditorText.tsx
+++ b/client/components/LayoutEditor/LayoutEditorText.tsx
@@ -95,8 +95,8 @@ class LayoutEditorText extends Component<Props, State> {
 								}}
 								placeholder="Enter text..."
 								initialContent={this.state.initialContent}
-								// @ts-expect-error ts-migrate(2322) FIXME: Type '(editorChangeObject: any) => void' is not as... Remove this comment to see the full error message
 								onChange={(editorChangeObject) => {
+									// @ts-expect-error
 									if (editorChangeObject.view.state.history$.prevTime) {
 										/* history$.prevTime will be 0 if the transaction */
 										/* does not generate an undo item in the history */

--- a/client/components/MinimalEditor/MinimalEditor.tsx
+++ b/client/components/MinimalEditor/MinimalEditor.tsx
@@ -26,6 +26,8 @@ const defaultProps = {
 
 type Props = OwnProps & typeof defaultProps;
 
+const handleScrollToSelection = () => true;
+
 const MinimalEditor = (props: Props) => {
 	const {
 		initialContent,
@@ -101,9 +103,7 @@ const MinimalEditor = (props: Props) => {
 				<Editor
 					initialContent={initialContent}
 					placeholder={placeholder}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type '() => boolean' is not assignable to type 'un... Remove this comment to see the full error message
-					onScrollToSelection={() => true}
-					// @ts-expect-error ts-migrate(2322) FIXME: Type '(editorChangeObject: any) => void' is not as... Remove this comment to see the full error message
+					onScrollToSelection={handleScrollToSelection}
 					onChange={(editorChangeObject) => {
 						setChangeObject(editorChangeObject);
 						onChange({
@@ -113,8 +113,8 @@ const MinimalEditor = (props: Props) => {
 						});
 					}}
 					customPlugins={{
-						headerIds: undefined,
-						highlights: undefined,
+						headerIds: null,
+						highlights: null,
 					}}
 				/>
 			</div>

--- a/client/components/ThreadInput/ThreadInput.tsx
+++ b/client/components/ThreadInput/ThreadInput.tsx
@@ -90,7 +90,6 @@ const ThreadInput = (props: Props) => {
 							<Editor
 								key={editorKey}
 								placeholder="Add a comment..."
-								// @ts-expect-error ts-migrate(2322) FIXME: Type '(editorChangeObject: any) => void' is not as... Remove this comment to see the full error message
 								onChange={(editorChangeObject) => {
 									setChangeObject(editorChangeObject);
 								}}

--- a/client/containers/DashboardOld/DashboardContent/Page/LayoutEditor/LayoutEditorText.tsx
+++ b/client/containers/DashboardOld/DashboardContent/Page/LayoutEditor/LayoutEditorText.tsx
@@ -95,8 +95,8 @@ class LayoutEditorText extends Component<Props, State> {
 								}}
 								placeholder="Enter text..."
 								initialContent={this.state.initialContent}
-								// @ts-expect-error ts-migrate(2322) FIXME: Type '(editorChangeObject: any) => void' is not as... Remove this comment to see the full error message
 								onChange={(editorChangeObject) => {
+									// @ts-expect-error
 									if (editorChangeObject.view.state.history$.prevTime) {
 										/* history$.prevTime will be 0 if the transaction */
 										/* does not generate an undo item in the history */

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionInput.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionInput.tsx
@@ -171,7 +171,6 @@ const DiscussionInput = (props: Props) => {
 						<Editor
 							key={editorKey}
 							placeholder={getPlaceholderText(isNewThread, isPubBottomInput)}
-							// @ts-expect-error ts-migrate(2322) FIXME: Type '(editorChangeObject: any) => void' is not as... Remove this comment to see the full error message
 							onChange={(editorChangeObject) => {
 								setChangeObject(editorChangeObject);
 							}}

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
@@ -131,7 +131,6 @@ const ThreadComment = (props: Props) => {
 							key={`${isEditing}-${threadCommentData.text}`}
 							isReadOnly={!isEditing}
 							initialContent={threadCommentData.content}
-							// @ts-expect-error ts-migrate(2322) FIXME: Type '(editorChangeObject: any) => void' is not as... Remove this comment to see the full error message
 							onChange={(editorChangeObject) => {
 								if (isEditing) {
 									setChangeObject(editorChangeObject);

--- a/client/utils/suggestions/suggestionManager.ts
+++ b/client/utils/suggestions/suggestionManager.ts
@@ -110,6 +110,7 @@ export default class SuggestionManager<T> {
 	getPosition() {
 		if (!this.isSuggesting()) {
 			return {
+				position: 'absolute' as const,
 				top: 0,
 				left: 0,
 			};
@@ -120,6 +121,7 @@ export default class SuggestionManager<T> {
 		const parent = document.body.getBoundingClientRect();
 
 		return {
+			position: 'absolute' as const,
 			top: bounds.bottom - parent.top,
 			left: bounds.left - parent.left,
 		};

--- a/workers/tasks/export/html.tsx
+++ b/workers/tasks/export/html.tsx
@@ -277,11 +277,9 @@ export const renderStaticHtml = async ({
 		!targetPandoc && addHrefsToNotes,
 		targetPaged && blankIframes,
 	]
-		.filter((x) => x)
-		// @ts-expect-error ts-migrate(2349) FIXME: This expression is not callable.
+		.filter((x): x is (nodes: any) => any => !!x)
 		.reduce((nodes, fn) => fn(nodes), pubDoc.content);
 
-	// @ts-expect-error ts-migrate(2345) FIXME: Argument of type '{ schema: Schema<"citation" | "f... Remove this comment to see the full error message
 	const docContent = renderStatic({
 		schema: editorSchema,
 		doc: { type: 'doc', content: renderableNodes },


### PR DESCRIPTION
I wanted to make some changes to the editor (in an upcoming PR) but I didn't feel comfortable doing so because the file has gotten a bit too big for its britches, so I decided to split it out into a few smaller files. There's no big rethink of how things work here and there should be _almost_ no behavioral changes — just smaller files and more types.

The one thing I _have_ changed here is that the a couple of the editor props — specifically `onError`, `onKeypress`, `onScrollToSelection`, and `isReadOnly` now follow the React model and update when the props update. We accomplish this by calling `editorView.setProps` within a set of `useEffect` hooks. One consequence of this is that the callbacks passed in here should be memoized using `useCallback`, which is good practice anyway. In the future, `<Editor>` props that can be updated without needing to reconstruct a new `EditorView` should behave this way, and we may eventually want a more scalable pattern for ensuring that this happens.

_Test plan:_
I'm chickening out of writing a specific test plan here for now and I'm going to come up with a list of things to playtest in the editor that we can use to test this release (and others that modify the editor in the future). For now, you should just be able to check out this branch and ensure that everything, including the collaborative features, seems to be working as expected.