### PR TITLE
update: Include forum and roadmap on landing page

### DIFF
--- a/client/components/Footer/Footer.tsx
+++ b/client/components/Footer/Footer.tsx
@@ -148,6 +148,9 @@ const Footer = (props: Props) => {
 								<li>
 									<a href="https://help.pubpub.org">Help</a>
 								</li>
+								<li>
+									<a href="https://github.com/pubpub/pubpub/discussions">Forum</a>
+								</li>
 							</ul>
 
 							<form onSubmit={handleEmailSubmit}>

--- a/client/containers/Landing/Landing.tsx
+++ b/client/containers/Landing/Landing.tsx
@@ -184,10 +184,13 @@ const Landing = () => {
 						</div>
 						<div>
 							<a className="git" href="https://github.com/pubpub/pubpub">
-								<Icon icon="git-repo" /> pubpub
+								<Icon icon="git-repo" /> code
 							</a>
-							<a className="git" href="https://github.com/pubpub/pubpub-editor">
-								<Icon icon="git-repo" /> pubpub-editor
+							<a className="git" href="https://github.com/orgs/pubpub/projects/9">
+								<Icon icon="map" /> roadmap
+							</a>
+							<a className="git" href="https://github.com/pubpub/pubpub/discussions">
+								<Icon icon="comment" /> forum
 							</a>
 						</div>
 					</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22673,7 +22673,8 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"gtoken": {
 			"version": "5.1.0",
@@ -31320,6 +31321,7 @@
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
 			"integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"growly": "^1.3.0",
 				"is-wsl": "^2.2.0",
@@ -31334,6 +31336,7 @@
 					"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
 					"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"is-docker": "^2.0.0"
 					}
@@ -31343,6 +31346,7 @@
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
@@ -31352,6 +31356,7 @@
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
 					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -31360,13 +31365,15 @@
 					"version": "8.3.2",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"which": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -31375,7 +31382,8 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -36286,7 +36294,8 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"shimmer": {
 			"version": "1.2.1",


### PR DESCRIPTION
Updates the landing page to include the roadmap and discussion forum in two places. The "open source" section, which has been modified to add other parts of our open source communities, not just repos:

<img width="838" alt="Screen Shot 2021-01-14 at 11 51 24" src="https://user-images.githubusercontent.com/639110/104622388-2eae7880-565f-11eb-824c-e39793b60bc1.png">

And the www footer, which now includes a link to the forum:

<img width="436" alt="Screen Shot 2021-01-14 at 11 51 38" src="https://user-images.githubusercontent.com/639110/104622404-366e1d00-565f-11eb-8534-fde1adf17451.png">

_Test plan_
Click all the links.