### PR TITLE
hotfix: Check for existence of date-parts in google scholar meta tags

### DIFF
--- a/utils/pub/metadata.js
+++ b/utils/pub/metadata.js
@@ -70,16 +70,22 @@ export const getGoogleScholarNotes = (notes) => {
 						break;
 					case 'author':
 						value.forEach((author) => {
-							noteArray.push(`citation_author=${author.given} ${author.family}`);
+							if (author.literal) {
+								console.log(author.literal, author.given);
+							}
+							const authorText = author.literal || `${author.given} ${author.family}`;
+							noteArray.push(`citation_author=${authorText}`);
 						});
 						break;
 					case 'container-title':
 						noteArray.push(`citation_${noteTypeString}_title=${value}`);
 						break;
 					case 'issued':
-						noteArray.push(
-							`citation_publication_date=${value['date-parts'][0].join('/')}`,
-						);
+						if (value['date-parts']) {
+							noteArray.push(
+								`citation_publication_date=${value['date-parts'][0].join('/')}`,
+							);
+						}
 						break;
 					case 'issue':
 					case 'volume':

--- a/utils/pub/metadata.js
+++ b/utils/pub/metadata.js
@@ -70,9 +70,6 @@ export const getGoogleScholarNotes = (notes) => {
 						break;
 					case 'author':
 						value.forEach((author) => {
-							if (author.literal) {
-								console.log(author.literal, author.given);
-							}
 							const authorText = author.literal || `${author.given} ${author.family}`;
 							noteArray.push(`citation_author=${authorText}`);
 						});


### PR DESCRIPTION
Hotfix fix for issue brought up in #2856 (freshdesk). We were not checking for existence of the date-part object before trying to access it by key, causing a 500. This simply checks for existence. The longterm fix is to use typescript.

This also adds a check for the existence of `author.literal`, and uses that if it exists rather than `author.first author.last,` as I noticed in my debugging that two citations in the doc used author.literal rather than first and last. I've verified in the citejs spec that it will always send one or the other, not both.

_To test_
1. Visit https://idmil.pubpub.org/pub/9w8wo2j1/draft on local (prod env) and verify it loads
2. Visit articles that use citations and verify that the google scholar tags show up correctly (easiest way to do this is to load zotero or mendeley, which will grab them).