### PR TITLE
fix: robots.txt was not resolving on www.pubpub.org 

### DIFF
--- a/server/routes/robots.ts
+++ b/server/routes/robots.ts
@@ -1,15 +1,21 @@
+import stripIndent from 'strip-indent';
+
 import app, { wrap } from 'server/server';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { communityUrl } from 'utils/canonicalUrls';
 
-const BASE_ROBOTS = `User-agent: *
-Disallow:`;
+const BASE_ROBOTS = stripIndent(`
+	User-agent: *
+	Disallow:
+`);
 
 const buildRobotsFile = (community) => {
 	if (community) {
-		return `${BASE_ROBOTS}
-Sitemap: ${communityUrl(community)}/sitemap-index.xml`;
+		return stripIndent(`
+			${BASE_ROBOTS}
+			Sitemap: ${communityUrl(community)}/sitemap-index.xml
+		`);
 	}
 	return BASE_ROBOTS;
 };
@@ -17,15 +23,13 @@ Sitemap: ${communityUrl(community)}/sitemap-index.xml`;
 app.get(
 	'/robots.txt',
 	wrap(async (req, res) => {
-		if (!hostIsValid(req, 'community')) {
-			// @ts-expect-error ts-migrate(2554) FIXME: Expected 1 arguments, but got 0.
-			return buildRobotsFile();
+		let communityData;
+		if (hostIsValid(req, 'community')) {
+			const initData = await getInitialData(req, true);
+			communityData = initData.communityData;
 		}
 
-		const { communityData } = await getInitialData(req, true);
-
 		res.header('Content-Type', 'text/plain');
-
 		return res.send(buildRobotsFile(communityData));
 	}),
 );

--- a/server/routes/robots.ts
+++ b/server/routes/robots.ts
@@ -5,19 +5,18 @@ import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { communityUrl } from 'utils/canonicalUrls';
 
-const BASE_ROBOTS = stripIndent(`
-	User-agent: *
-	Disallow:
-`);
-
 const buildRobotsFile = (community) => {
 	if (community) {
 		return stripIndent(`
-			${BASE_ROBOTS}
+			User-agent: *
+			Disallow:
 			Sitemap: ${communityUrl(community)}/sitemap-index.xml
-		`);
+		`).trim();
 	}
-	return BASE_ROBOTS;
+	return stripIndent(`
+		User-agent: *
+		Disallow:
+	`).trim();
 };
 
 app.get(

--- a/server/server.ts
+++ b/server/server.ts
@@ -112,7 +112,6 @@ app.use('/static', express.static(path.join(process.cwd(), 'static')));
 app.use('/service-worker.js', express.static(path.join(process.cwd(), 'static/service-worker.js')));
 app.use('/favicon.png', express.static(path.join(process.cwd(), 'static/favicon.png')));
 app.use('/favicon.ico', express.static(path.join(process.cwd(), 'static/favicon.png')));
-app.use('/robots.txt', express.static(path.join(process.cwd(), 'static/robots.txt')));
 
 /* -------------------- */
 /* Set Hostname for Dev */
@@ -121,7 +120,9 @@ app.use((req, res, next) => {
 	if (req.headers.communityhostname) {
 		req.headers.host = req.headers.communityhostname;
 	}
+	process.env.PUBPUB_LOCAL_COMMUNITY = 'demo';
 	if (process.env.PUBPUB_LOCAL_COMMUNITY || req.hostname.indexOf('localhost') > -1) {
+		
 		req.headers.localhost = req.headers.host;
 		if (process.env.PUBPUB_LOCAL_COMMUNITY) {
 			const subdomain = process.env.PUBPUB_LOCAL_COMMUNITY;

--- a/server/server.ts
+++ b/server/server.ts
@@ -120,9 +120,7 @@ app.use((req, res, next) => {
 	if (req.headers.communityhostname) {
 		req.headers.host = req.headers.communityhostname;
 	}
-	process.env.PUBPUB_LOCAL_COMMUNITY = 'demo';
 	if (process.env.PUBPUB_LOCAL_COMMUNITY || req.hostname.indexOf('localhost') > -1) {
-		
 		req.headers.localhost = req.headers.host;
 		if (process.env.PUBPUB_LOCAL_COMMUNITY) {
 			const subdomain = process.env.PUBPUB_LOCAL_COMMUNITY;


### PR DESCRIPTION
`robots.ts` was not properly returning a `res` for `www.pubpub.org`, which would cause the request to never resolve and simply hang. It resulted in requests to `/robots.txt` hanging indefinitely (this may be the cause for all those Heroku timeout errors).

This PR refactors the code a bit in addition to applying the fix. It also removes the deprecated static serving line for `robots.txt` that was in `server.js`.

_Test Plan:_
- Try to access `/robots.txt` from a community and verify that it returns with the sitemap URL detail.
- Try to access `/robots.txt` from the base `www` subdomain and verify that it returns without the sitemap URL detail.