### PR TITLE
new: Show pandoc warnings when importing LaTeX

### DIFF
--- a/client/containers/Pub/PubDocument/PubFileImport/FileImportDialog.tsx
+++ b/client/containers/Pub/PubDocument/PubFileImport/FileImportDialog.tsx
@@ -80,7 +80,7 @@ const FileImportDialog = ({
 
 	const isImportDisabled = !hasDocumentToImport || incompleteUploads.length > 0 || isImporting;
 	// @ts-expect-error ts-migrate(2339) FIXME: Property 'doc' does not exist on type '{}'.
-	const { doc, warnings = [], pandocInfos, error, proposedMetadata } = importResult;
+	const { doc, warnings = [], pandocErrorOutput, error, proposedMetadata } = importResult;
 	const hasProposedMetadata = proposedMetadata && Object.keys(proposedMetadata).length > 0;
 
 	useKeyPressEvent('/', (evt) => {
@@ -186,15 +186,7 @@ const FileImportDialog = ({
 			const missingCitations = warnings
 				.filter((w) => w.type === 'missingCitation')
 				.map((w) => w.id);
-			const pandocWarnings = pandocInfos.split('\n').map((info) => {
-				return (
-					<span>
-						{info}
-						<br />
-					</span>
-				);
-			});
-			if (missingImages.length > 0 || missingCitations.length > 0 || pandocInfos) {
+			if (missingImages.length > 0 || missingCitations.length > 0 || pandocErrorOutput) {
 				return (
 					<Callout
 						aria-live="assertive"
@@ -228,16 +220,18 @@ const FileImportDialog = ({
 									</details>
 								</li>
 							)}
-							{pandocInfos && (
+							{pandocErrorOutput && (
 								<li>
 									<i>
 										Conversion from LaTeX to HTML succeeded, with information (
-										<a href="https://help.pubpub.org/pub/2gfph6h8/release/2">
+										<a href="https://help.pubpub.org/pub/latex-compatibility">
 											more about PubPub and LaTeX
 										</a>
 										):
 									</i>
-									<details>{pandocWarnings}</details>
+									<details>
+										<pre>{pandocErrorOutput}</pre>
+									</details>
 								</li>
 							)}
 						</ul>

--- a/client/containers/Pub/PubDocument/PubFileImport/FileImportDialog.tsx
+++ b/client/containers/Pub/PubDocument/PubFileImport/FileImportDialog.tsx
@@ -80,7 +80,7 @@ const FileImportDialog = ({
 
 	const isImportDisabled = !hasDocumentToImport || incompleteUploads.length > 0 || isImporting;
 	// @ts-expect-error ts-migrate(2339) FIXME: Property 'doc' does not exist on type '{}'.
-	const { doc, warnings = [], error, proposedMetadata } = importResult;
+	const { doc, warnings = [], pandocInfos, error, proposedMetadata } = importResult;
 	const hasProposedMetadata = proposedMetadata && Object.keys(proposedMetadata).length > 0;
 
 	useKeyPressEvent('/', (evt) => {
@@ -186,8 +186,15 @@ const FileImportDialog = ({
 			const missingCitations = warnings
 				.filter((w) => w.type === 'missingCitation')
 				.map((w) => w.id);
-
-			if (missingImages.length > 0 || missingCitations.length > 0) {
+			const pandocWarnings = pandocInfos.split('\n').map((info) => {
+				return (
+					<span>
+						{info}
+						<br />
+					</span>
+				);
+			});
+			if (missingImages.length > 0 || missingCitations.length > 0 || pandocInfos) {
 				return (
 					<Callout
 						aria-live="assertive"
@@ -219,6 +226,18 @@ const FileImportDialog = ({
 										<summary>Missing citation IDs</summary>
 										{missingCitations.join(', ')}.
 									</details>
+								</li>
+							)}
+							{pandocInfos && (
+								<li>
+									<i>
+										Conversion from LaTeX to HTML succeeded, with information (
+										<a href="https://help.pubpub.org/pub/2gfph6h8/release/2">
+											more about PubPub and LaTeX
+										</a>
+										):
+									</i>
+									<details>{pandocWarnings}</details>
 								</li>
 							)}
 						</ul>

--- a/workers/tasks/import/import.ts
+++ b/workers/tasks/import/import.ts
@@ -29,7 +29,7 @@ const createPandocArgs = (pandocFormat, tmpDirPath, metadataPath) => {
 		shouldExtractMedia && [`--extract-media=${path.join(tmpDirPath, 'media')}`],
 		pandocFormat === 'latex' && ['--verbose'],
 	]
-		.filter((x) => x)
+		.filter((x): x is string[] => !!x)
 		.reduce((acc, next) => [...acc, ...next], []);
 };
 
@@ -90,7 +90,7 @@ const getPandocAst = ({
 		);
 	}
 	return {
-		pandocInfos: pandocError,
+		pandocErrorOutput: pandocError,
 		pandocAst: runTransforms(parsePandocJson(pandocRawAst), importerFlags),
 	};
 };
@@ -106,7 +106,7 @@ export const importFiles = async ({
 	const { preambles, document, bibliography, supplements, metadata } = categorizeSourceFiles(
 		sourceFiles,
 	);
-	const { pandocAst, pandocInfos } = getPandocAst({
+	const { pandocAst, pandocErrorOutput } = getPandocAst({
 		documentPath: document.tmpPath,
 		metadataPath: metadata && metadata.tmpPath,
 		preamblePaths: preambles.map((p) => p.tmpPath),
@@ -138,7 +138,7 @@ export const importFiles = async ({
 	return {
 		doc: prosemirrorDoc,
 		warnings: resourceTransformer.getWarnings(),
-		pandocInfos,
+		pandocErrorOutput,
 		proposedMetadata,
 		...(provideRawMetadata && { rawMetadata: getRawMetadata(pandocAst.meta) }),
 	};

--- a/workers/tasks/import/import.ts
+++ b/workers/tasks/import/import.ts
@@ -28,6 +28,7 @@ const createPandocArgs = (pandocFormat, tmpDirPath, metadataPath) => {
 			['-t', 'json'],
 			metadataPath && [`--metadata-file=${metadataPath}`],
 			shouldExtractMedia && [`--extract-media=${path.join(tmpDirPath, 'media')}`],
+			pandocFormat === 'latex' && ['--verbose'],
 		]
 			.filter((x) => x)
 			// @ts-expect-error ts-migrate(2488) FIXME: Type 'string | false | any[]' must have a '[Symbol... Remove this comment to see the full error message
@@ -91,7 +92,10 @@ const getPandocAst = ({
 			`Conversion from ${path.basename(documentPath)} failed. Pandoc says: ${pandocError}`,
 		);
 	}
-	return runTransforms(parsePandocJson(pandocRawAst), importerFlags);
+	return {
+		pandocInfos: pandocError,
+		pandocAst: runTransforms(parsePandocJson(pandocRawAst), importerFlags),
+	};
 };
 
 export const importFiles = async ({
@@ -105,7 +109,7 @@ export const importFiles = async ({
 	const { preambles, document, bibliography, supplements, metadata } = categorizeSourceFiles(
 		sourceFiles,
 	);
-	const pandocAst = getPandocAst({
+	const { pandocAst, pandocInfos } = getPandocAst({
 		documentPath: document.tmpPath,
 		metadataPath: metadata && metadata.tmpPath,
 		preamblePaths: preambles.map((p) => p.tmpPath),
@@ -137,6 +141,7 @@ export const importFiles = async ({
 	return {
 		doc: prosemirrorDoc,
 		warnings: resourceTransformer.getWarnings(),
+		pandocInfos,
 		proposedMetadata,
 		...(provideRawMetadata && { rawMetadata: getRawMetadata(pandocAst.meta) }),
 	};

--- a/workers/tasks/import/import.ts
+++ b/workers/tasks/import/import.ts
@@ -21,19 +21,16 @@ const dataRoot = process.env.NODE_ENV === 'production' ? '/app/.apt/usr/share/pa
 
 const createPandocArgs = (pandocFormat, tmpDirPath, metadataPath) => {
 	const shouldExtractMedia = ['odt', 'docx', 'epub'].includes(pandocFormat);
-	return (
-		[
-			dataRoot && [`--data-dir=${dataRoot}`],
-			['-f', pandocFormat],
-			['-t', 'json'],
-			metadataPath && [`--metadata-file=${metadataPath}`],
-			shouldExtractMedia && [`--extract-media=${path.join(tmpDirPath, 'media')}`],
-			pandocFormat === 'latex' && ['--verbose'],
-		]
-			.filter((x) => x)
-			// @ts-expect-error ts-migrate(2488) FIXME: Type 'string | false | any[]' must have a '[Symbol... Remove this comment to see the full error message
-			.reduce((acc, next) => [...acc, ...next], [])
-	);
+	return [
+		dataRoot && [`--data-dir=${dataRoot}`],
+		['-f', pandocFormat],
+		['-t', 'json'],
+		metadataPath && [`--metadata-file=${metadataPath}`],
+		shouldExtractMedia && [`--extract-media=${path.join(tmpDirPath, 'media')}`],
+		pandocFormat === 'latex' && ['--verbose'],
+	]
+		.filter((x) => x)
+		.reduce((acc, next) => [...acc, ...next], []);
 };
 
 const callPandoc = (tmpDirPath, files, args) => {


### PR DESCRIPTION
Improves PubPub's import UX to show Pandoc warnings when importing LaTeX documents. This is helpful because it shows the places where Pandoc has had to skip or modify LaTeX functions to successfully import the document, making it easier for production teams to understand why and how they'll need to fix errors introduced due to the unavoidable incompatibilities of the LateX schema, the pandoc schema, and PubPub's prosemirror schema.



I've tried to keep this incredibly simple, with the understanding that at some point we might want to parse these messages to show more info or give an indication of severity, but my sense is we actually won't quite know how to do that until we get more user feedback on the feature, and that this additional info, combined with a link to our new [help documentation](https://help.pubpub.org/pub/2gfph6h8/release/2), is already a huge improvement.

Having said that, I think there could be more thought put into how and where the data is passed to the client, parsed, and displayed, so please feel free to make suggestions there (and obviously on anything else, just calling that out in particular).

_Test Plan_
1. Import a complex latex doc on prod and make sure it imports without error.
2. Import the same complex latex doc on qubqub (not local, as your local pandoc version may vary) and make sure it imports but shows useful information.
3. Import a docx, an epub, and a txt file on prod and make sure they import.
4. Repeat on qubqub and make sure they import without showing information.