### PR TITLE
fix: Fix the 'Show anchored comments' toggle

### DIFF
--- a/client/components/Editor/plugins/discussions/decorations.ts
+++ b/client/components/Editor/plugins/discussions/decorations.ts
@@ -1,9 +1,12 @@
 import { Decoration, DecorationSet } from 'prosemirror-view';
 
 import { flattenOnce, isEmptySelection, getRangeFromSelection } from './util';
-import { DiscussionInfo, Discussions, DiscussionsUpdateResult } from './types';
-
-type DiscussionDecoration = Decoration<{ key: string; widgetForDiscussionId?: string }>;
+import {
+	DiscussionInfo,
+	Discussions,
+	DiscussionsUpdateResult,
+	DiscussionDecoration,
+} from './types';
 
 const createInlineDecoration = (
 	discussionId: string,

--- a/client/components/Editor/plugins/discussions/index.ts
+++ b/client/components/Editor/plugins/discussions/index.ts
@@ -1,3 +1,8 @@
-export { default, discussionsPluginKey, addDiscussionToView } from './plugin';
+export {
+	default,
+	discussionsPluginKey,
+	addDiscussionToView,
+	getAnchoredDiscussionIds,
+} from './plugin';
 export { mapDiscussionSelectionThroughSteps } from './util';
 export { DiscussionSelection } from './types';

--- a/client/components/Editor/plugins/discussions/plugin.ts
+++ b/client/components/Editor/plugins/discussions/plugin.ts
@@ -9,7 +9,7 @@ import { getDecorationsForDiscussions, getDecorationsForUpdateResult } from './d
 import { createDiscussionsState } from './discussionsState';
 import { createFastForwarder } from './fastForward';
 import { connectToFirebaseDiscussions } from './firebase';
-import { DiscussionsUpdateResult, DiscussionSelection } from './types';
+import { DiscussionsUpdateResult, DiscussionSelection, DiscussionDecoration } from './types';
 
 export const discussionsPluginKey = new PluginKey('discussions');
 
@@ -104,6 +104,22 @@ export const addDiscussionToView = (
 		return pluginState.addDiscussion(id, selection);
 	}
 	return null;
+};
+
+export const getAnchoredDiscussionIds = (view: EditorView) => {
+	const pluginState = discussionsPluginKey.getState(view.state) as null | PluginState;
+	if (pluginState) {
+		const { decorations } = pluginState;
+		const ids: string[] = [];
+		decorations.find().forEach((decoration) => {
+			const { widgetForDiscussionId } = decoration.spec as DiscussionDecoration['spec'];
+			if (widgetForDiscussionId) {
+				ids.push(widgetForDiscussionId);
+			}
+		});
+		return ids;
+	}
+	return [];
 };
 
 export default (_, options: PluginsOptions) => {

--- a/client/components/Editor/plugins/discussions/types.ts
+++ b/client/components/Editor/plugins/discussions/types.ts
@@ -1,5 +1,6 @@
 import { Node } from 'prosemirror-model';
 import { Mapping } from 'prosemirror-transform';
+import { Decoration } from 'prosemirror-view';
 
 export type Range = { from: number; to: number };
 
@@ -52,3 +53,8 @@ export type RemoteDiscussions = {
 	receiveDiscussions: (handler: DiscussionsHandler) => void;
 	disconnect: () => void;
 };
+
+export type DiscussionDecoration = Decoration<{
+	key: string;
+	widgetForDiscussionId?: string;
+}>;

--- a/client/containers/Pub/PubDocument/PubBottom/Discussions/DiscussionsSection.tsx
+++ b/client/containers/Pub/PubDocument/PubBottom/Discussions/DiscussionsSection.tsx
@@ -3,6 +3,8 @@ import { Popover, Position } from '@blueprintjs/core';
 
 import { usePageContext } from 'utils/hooks';
 import { PubPageData } from 'utils/types';
+import { getAnchoredDiscussionIds } from 'components/Editor/plugins/discussions';
+import { usePubContext } from 'client/containers/Pub/pubHooks';
 
 import SortList from './SortList';
 import FilterMenu from './FilterMenu';
@@ -21,6 +23,9 @@ const DiscussionsSection = (props: Props) => {
 	const { pubData, updateLocalData, sideContentRef, mainContentRef } = props;
 	const { discussions } = pubData;
 	const { communityData, scopeData } = usePageContext();
+	const {
+		collabData: { editorChangeObject },
+	} = usePubContext();
 	const { canView, canManage, canCreateDiscussions } = scopeData.activePermissions;
 	const [isBrowsingArchive, setIsBrowsingArchive] = useState(false);
 	const [isShowingAnchoredComments, setShowingAnchoredComments] = useState(true);
@@ -98,13 +103,16 @@ const DiscussionsSection = (props: Props) => {
 	};
 
 	const createDiscussionFilter = (searchTerm) => (threads) => {
+		const hiddenDiscussionIds = isShowingAnchoredComments
+			? null
+			: getAnchoredDiscussionIds(editorChangeObject.view);
 		const res = filterAndSortDiscussions(
 			threads,
 			isBrowsingArchive,
 			sortMode,
 			filteredLabels,
 			searchTerm,
-			isShowingAnchoredComments,
+			hiddenDiscussionIds,
 		);
 		return res;
 	};

--- a/client/containers/Pub/PubDocument/PubDiscussions/discussionUtils.ts
+++ b/client/containers/Pub/PubDocument/PubDiscussions/discussionUtils.ts
@@ -145,8 +145,8 @@ export const filterAndSortDiscussions = (
 	isClosedList,
 	sortMode,
 	filteredLabels,
-	searchTerm = null,
-	showAnchoredDiscussions = true,
+	searchTerm: string | null = null,
+	hiddenDiscussionIds: null | string[] = null,
 ) => {
 	return discussions
 		.filter((discussion) => (isClosedList ? discussion.isClosed : !discussion.isClosed))
@@ -158,7 +158,9 @@ export const filterAndSortDiscussions = (
 				discussionMatchesSearchTerm(threadComment, searchTerm),
 			);
 		})
-		.filter((discussion) => !discussion.anchor || showAnchoredDiscussions)
+		.filter(
+			(discussion) => !hiddenDiscussionIds || !hiddenDiscussionIds.includes(discussion.id),
+		)
 		.filter((discussion) => {
 			if (filteredLabels.length === 0) {
 				return true;


### PR DESCRIPTION
Resolves #1179

This PR fixes this thing:

<img width="333" alt="image" src="https://user-images.githubusercontent.com/2208769/108066813-e1db0a80-702d-11eb-8c1f-eb86ee2f7df1.png">

(Relatedly, I found a weird issue where collapsing the Pub-bottom discussions section hides all anchored discussions in the Pub — which makes sense based on how it's implemented, but we should fix it)

_Test plan:_
Visit a couple of Pubs on draft and Release with anchored Discussions and verify that this toggle works.