### PR TITLE
fix: Allow long sticky TOC to scroll

### DIFF
--- a/client/containers/Pub/PubHeader/PubHeaderSticky.tsx
+++ b/client/containers/Pub/PubHeader/PubHeaderSticky.tsx
@@ -22,10 +22,9 @@ const PubHeaderSticky = (props: Props) => {
 			<div className="sticky-buttons">
 				{pubHeadings.length > 0 && (
 					<React.Fragment>
-						{/* @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message */}
-						<PubToc headings={pubHeadings}>
+						<PubToc headings={pubHeadings} limitHeight>
 							{({ ref, ...disclosureProps }) => (
-								<Button minimal={true} {...disclosureProps} elementRef={ref}>
+								<Button minimal={true} {...disclosureProps} elementRef={ref as any}>
 									Contents
 								</Button>
 							)}

--- a/client/containers/Pub/PubHeader/PubToc.tsx
+++ b/client/containers/Pub/PubHeader/PubToc.tsx
@@ -1,41 +1,38 @@
 /* eslint-disable no-multi-assign */
 import React from 'react';
+import classNames from 'classnames';
 
 import { Menu, MenuItem } from 'components/Menu';
 import { usePageContext } from 'utils/hooks';
 
 require('./pubToc.scss');
 
-type OwnProps = {
-	children: ((...args: any[]) => any) | React.ReactNode;
+type MenuType = React.ComponentProps<typeof Menu>;
+
+type Props = {
+	children: MenuType['disclosure'];
 	headings: {
 		title?: string;
 		index?: any;
 		href?: string;
+		level?: number;
 	}[];
 	onSelect?: (...args: any[]) => any;
-	placement?: string;
+	placement?: MenuType['placement'];
+	limitHeight?: boolean;
 };
-
-const defaultProps = {
-	onSelect: null,
-	placement: 'bottom-end',
-};
-
-type Props = OwnProps & typeof defaultProps;
 
 const PubToc = (props: Props) => {
-	const { headings, children, onSelect, placement } = props;
+	const { headings, children, limitHeight, onSelect = null, placement = 'bottom-end' } = props;
 	const { scopeData } = usePageContext();
 	const { canEdit, canEditDraft } = scopeData.activePermissions;
 	return (
 		<Menu
 			aria-label="Table of contents"
-			className="pub-toc-component"
+			className={classNames('pub-toc-component', limitHeight && 'limit-height')}
 			disclosure={children}
 			placement={placement}
 		>
-			{/* @ts-expect-error ts-migrate(2339) FIXME: Property 'map' does not exist on type 'never'. */}
 			{headings.map((heading) => {
 				return (
 					<MenuItem
@@ -48,7 +45,6 @@ const PubToc = (props: Props) => {
 							/* unexpectedly on reload given the async loading of doc. Instead, */
 							/* manually scroll to the position and offset by fixed header height. */
 							if (onSelect) {
-								// @ts-expect-error ts-migrate(2349) FIXME: This expression is not callable.
 								onSelect();
 							}
 							if (canEdit || canEditDraft) {
@@ -68,5 +64,5 @@ const PubToc = (props: Props) => {
 		</Menu>
 	);
 };
-PubToc.defaultProps = defaultProps;
+
 export default PubToc;

--- a/client/containers/Pub/PubHeader/UtilityButtons.tsx
+++ b/client/containers/Pub/PubHeader/UtilityButtons.tsx
@@ -93,7 +93,6 @@ const UtilityButtons = (props: Props) => {
 				<SmallHeaderButton label="Download" labelPosition="left" icon="download2" />
 			</Download>
 			{pubHeadings.length > 0 && (
-				// @ts-expect-error ts-migrate(2745) FIXME: This JSX tag's 'children' prop expects type 'never... Remove this comment to see the full error message
 				<PubToc headings={pubHeadings}>
 					<SmallHeaderButton label="Contents" labelPosition="left" icon="toc" />
 				</PubToc>

--- a/client/containers/Pub/PubHeader/pubToc.scss
+++ b/client/containers/Pub/PubHeader/pubToc.scss
@@ -7,4 +7,7 @@
 			padding-left: 1.5em;
 		}
 	}
+	&.limit-height {
+		max-height: calc(100vh - 50px);
+	}
 }


### PR DESCRIPTION
Resolves #1241

Some very long Pubs like [this one](https://openscientist.pubpub.org/pub/play/) have tables of contents which overflow from the `PubHeaderSticky` which appears below the fold, making it impossible to select its lower elements. This PR fixes that.

_Before:_
<img width="1904" alt="Screen Shot 2021-02-16 at 8 28 16 AM" src="https://user-images.githubusercontent.com/2208769/108069321-3cc23100-7031-11eb-9d0f-5b887042c2af.png">

_After:_
<img width="1904" alt="Screen Shot 2021-02-16 at 8 28 24 AM" src="https://user-images.githubusercontent.com/2208769/108069330-40ee4e80-7031-11eb-84e3-16fb5d6dc93c.png">

_Test plan:_
Visit a Pub with a loooong TOC. I ran:

```
PUBPUB_PRODUCTION=true PUBPUB_LOCAL_COMMUNITY=openscientist
```

and then navigated to localhost:9876/pub/play. I observed that I was able to scroll the `PubHeaderSticky` TOC (the one in the Pub header itself remains unchanged)