### PR TITLE
Refactor getResizedUrl function and calls to use new resizer

### DIFF
--- a/client/components/Avatar/Avatar.tsx
+++ b/client/components/Avatar/Avatar.tsx
@@ -55,8 +55,8 @@ const Avatar = function(props) {
 		borderRadius: isBlock ? '2px' : '50%',
 	};
 
-	const imageSize = width <= 50 ? '50x50' : '250x250';
-	const resizedImageUrl = getResizedUrl(avatar, null, imageSize);
+	const imageSize = width <= 50 ? 50 : 250;
+	const resizedImageUrl = getResizedUrl(avatar, 'cover', imageSize, imageSize);
 
 	if (doesOverlap) {
 		// @ts-expect-error ts-migrate(2339) FIXME: Property 'marginRight' does not exist on type '{ w... Remove this comment to see the full error message

--- a/client/components/CommunityPreview/CommunityPreview.tsx
+++ b/client/components/CommunityPreview/CommunityPreview.tsx
@@ -27,8 +27,8 @@ const defaultProps = {
 };
 
 const CommunityPreview = function(props) {
-	const resizedHeroLogo = getResizedUrl(props.heroLogo, 'fit-in', '600x0');
-	const resizedHeroBackground = getResizedUrl(props.heroBackgroundImage, 'fit-in', '800x0');
+	const resizedHeroLogo = getResizedUrl(props.heroLogo, 'inside', 600);
+	const resizedHeroBackground = getResizedUrl(props.heroBackgroundImage, 'inside', 800);
 	const logoStyle = { color: props.accentTextColor };
 	const backgroundStyle = {
 		backgroundColor: props.accentColor,

--- a/client/components/Header/Header.tsx
+++ b/client/components/Header/Header.tsx
@@ -122,8 +122,9 @@ const Header = (props: Props) => {
 		if (communityData.heroBackgroundImage) {
 			const resizedBackgroundImage = getResizedUrl(
 				communityData.heroBackgroundImage,
-				'fit-in',
-				'1500x600',
+				'inside',
+				1500,
+				600,
 			);
 			// @ts-expect-error ts-migrate(2339) FIXME: Property 'backgroundImage' does not exist on type ... Remove this comment to see the full error message
 			backgroundStyle.backgroundImage = `url("${resizedBackgroundImage}")`;
@@ -149,9 +150,9 @@ const Header = (props: Props) => {
 	const canManage = scopeData.activePermissions.canManageCommunity;
 	const isBasePubPub = locationData.isBasePubPub;
 
-	const resizedHeaderLogo = getResizedUrl(communityData.headerLogo, 'fit-in', '0x50');
-	const resizedHeroLogo = getResizedUrl(communityData.heroLogo, 'fit-in', '0x200');
-	const resizedHeroImage = getResizedUrl(communityData.heroImage, 'fit-in', '600x0');
+	const resizedHeaderLogo = getResizedUrl(communityData.headerLogo, 'inside', 0, 50);
+	const resizedHeroLogo = getResizedUrl(communityData.heroLogo, 'inside', 0, 200);
+	const resizedHeroImage = getResizedUrl(communityData.heroImage, 'inside', 600);
 	const redirectString = `?redirect=${locationData.path}${
 		locationData.queryString.length > 1 ? locationData.queryString : ''
 	}`;

--- a/client/components/Layout/LayoutBanner.tsx
+++ b/client/components/Layout/LayoutBanner.tsx
@@ -92,7 +92,7 @@ class LayoutBanner extends Component<Props, State> {
 
 	render() {
 		const backgroundImageCss = this.props.content.backgroundImage
-			? `url("${getResizedUrl(this.props.content.backgroundImage, 'fit-in', '1500x600')}")`
+			? `url("${getResizedUrl(this.props.content.backgroundImage, 'inside', 1500, 600)}")`
 			: undefined;
 
 		const wrapperStyle = {

--- a/client/components/Layout/LayoutText.tsx
+++ b/client/components/Layout/LayoutText.tsx
@@ -28,7 +28,7 @@ const LayoutText = function(props) {
 							nodeOptions={{
 								image: {
 									onResizeUrl: (url) => {
-										return getResizedUrl(url, 'fit-in', '1200x0');
+										return getResizedUrl(url, 'inside', 1200);
 									},
 									linkToSrc: false,
 								},

--- a/client/components/LayoutEditor/LayoutEditorBanner.tsx
+++ b/client/components/LayoutEditor/LayoutEditorBanner.tsx
@@ -114,7 +114,7 @@ class LayoutEditorBanner extends Component<Props> {
 
 	render() {
 		const backgroundImageCss = this.props.content.backgroundImage
-			? `url("${getResizedUrl(this.props.content.backgroundImage, 'fit-in', '1500x600')}")`
+			? `url("${getResizedUrl(this.props.content.backgroundImage, 'inside', 1500, 600)}")`
 			: undefined;
 
 		const wrapperStyle = {

--- a/client/components/LayoutEditor/LayoutEditorText.tsx
+++ b/client/components/LayoutEditor/LayoutEditorText.tsx
@@ -88,7 +88,7 @@ class LayoutEditorText extends Component<Props, State> {
 								nodeOptions={{
 									image: {
 										onResizeUrl: (url) => {
-											return getResizedUrl(url, 'fit-in', '1200x0');
+											return getResizedUrl(url, 'inside', 1200);
 										},
 										linkToSrc: false,
 									},

--- a/client/components/PagePreview/PagePreview.tsx
+++ b/client/components/PagePreview/PagePreview.tsx
@@ -16,7 +16,7 @@ type Props = {
 const PagePreview = (props: Props) => {
 	const pageData = props.pageData;
 
-	const resizedBannerImage = getResizedUrl(pageData.avatar, 'fit-in', '600x0');
+	const resizedBannerImage = getResizedUrl(pageData.avatar, 'inside', 600);
 	const bannerStyle = pageData.avatar
 		? { backgroundImage: `url("${resizedBannerImage}")` }
 		: { background: generatePageBackground(pageData.title) };

--- a/client/components/PreviewImage/PreviewImage.tsx
+++ b/client/components/PreviewImage/PreviewImage.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 const PreviewImage = (props: Props) => {
 	const { className = '', fitIn = 800, src = null, title } = props;
-	const resizedImage = getResizedUrl(src, 'fit-in', `${fitIn}x0`);
+	const resizedImage = getResizedUrl(src, 'inside', fitIn);
 	const style = src
 		? { backgroundImage: `url("${resizedImage}")` }
 		: { background: generatePubBackground(title) };

--- a/client/components/PubEdge/PubEdge.stories.tsx
+++ b/client/components/PubEdge/PubEdge.stories.tsx
@@ -14,7 +14,7 @@ const pubEdge = {
 		url: 'https://hdsr.mitpress.mit.edu/pub/wot7mkc1/release/8',
 		contributors: ['Richard Jenkins', 'Bradley Whitford', 'Sigourney Weaver'],
 		publicationDate: Date.now(),
-		avatar: 'https://resize.pubpub.org/fit-in/800x0/9fk06ei5/41589421981678.jpg',
+		avatar: 'https://assets.pubpub.org/9fk06ei5/41589421981678.jpg',
 	},
 	relationType: RelationType.Review,
 	pubIsParent: true,

--- a/client/components/PubPreview/PubPreview.tsx
+++ b/client/components/PubPreview/PubPreview.tsx
@@ -59,7 +59,7 @@ const PubPreview = (props: Props) => {
 	const [canExpand, setCanExpand] = useState(false);
 	const contentRef = useRef<HTMLDivElement>(null);
 	const resizedHeaderLogo =
-		communityData && getResizedUrl(communityData.headerLogo, 'fit-in', '125x35');
+		communityData && getResizedUrl(communityData.headerLogo, 'inside', 125, 35);
 	const publishedDate = getPubPublishedDate(pubData);
 	const isPrivate = !isPubPublic(pubData, scopeData);
 	const showBannerImage = ['large', 'medium'].includes(size);

--- a/client/containers/DashboardOld/DashboardContent/Page/LayoutEditor/LayoutEditorText.tsx
+++ b/client/containers/DashboardOld/DashboardContent/Page/LayoutEditor/LayoutEditorText.tsx
@@ -88,7 +88,7 @@ class LayoutEditorText extends Component<Props, State> {
 								nodeOptions={{
 									image: {
 										onResizeUrl: (url) => {
-											return getResizedUrl(url, 'fit-in', '1200x0');
+											return getResizedUrl(url, 'inside', 1200);
 										},
 										linkToSrc: false,
 									},

--- a/client/containers/Search/Search.tsx
+++ b/client/containers/Search/Search.tsx
@@ -126,8 +126,8 @@ const Search = (props: Props) => {
 		let bannerStyle;
 		let keyId;
 		let isPublic;
-		const resizedBannerImage = getResizedUrl(item.avatar, 'fit-in', '800x0');
-		const resizedCommunityLogo = getResizedUrl(item.communityAvatar, 'fit-in', '125x35');
+		const resizedBannerImage = getResizedUrl(item.avatar, 'inside', 800);
+		const resizedCommunityLogo = getResizedUrl(item.communityAvatar, 'inside', 125, 35);
 
 		if (mode === 'pubs') {
 			link = `https://${item.communityDomain}/pub/${item.slug}`;

--- a/utils/images.ts
+++ b/utils/images.ts
@@ -1,8 +1,20 @@
 import { Maybe } from './types';
+import { btoaUniversal } from './strings';
 
-const validExtensions = ['jpg', 'jpeg', 'png', 'gif'];
+type validFits = 'cover' | 'contain' | 'fill' | 'inside' | 'outside';
 
-export const getResizedUrl = (url: Maybe<string>, type: string | null, dimensions: string) => {
+const validExtensions = ['jpg', 'jpeg', 'png'];
+
+export const getResizedUrl = (
+	url: Maybe<string>,
+	fit: validFits,
+	width?: number,
+	height?: number,
+) => {
+	/* Our resizer uses the AWS Serverless Image Handler CloudFormation */
+	/* (https://github.com/awslabs/serverless-image-handler). 			*/
+	/* That Handler uses sharp (https://sharp.pixelplumbing.com) as the */
+	/* underlying engine and thus relevant documentation source 		*/
 	if (!url || url.indexOf('https://assets.pubpub.org/') === -1) {
 		return url || '';
 	}
@@ -15,12 +27,23 @@ export const getResizedUrl = (url: Maybe<string>, type: string | null, dimension
 		return url;
 	}
 
-	const prefix = type ? `${type}/` : '';
-	const filepath = url.replace('https://assets.pubpub.org/', '');
-	return `https://resize.pubpub.org/${prefix}${dimensions}/${filepath}`;
+	const imageKey = url.replace('https://assets.pubpub.org/', '');
+	const imageRequest = {
+		bucket: 'assets.pubpub.org',
+		key: imageKey,
+		edits: {
+			resize: {
+				width,
+				height,
+				fit,
+			},
+		},
+	};
+
+	return `https://resize-v3.pubpub.org/${btoaUniversal(JSON.stringify(imageRequest))}`;
 };
 
 export const getDefaultResizedUrl = (url: string, align?: string) => {
 	const width = align === 'breakout' ? 1920 : 800;
-	return getResizedUrl(url, 'fit-in', `${width}x0`);
+	return getResizedUrl(url, 'inside', width);
 };

--- a/utils/images.ts
+++ b/utils/images.ts
@@ -1,13 +1,13 @@
 import { Maybe } from './types';
 import { btoaUniversal } from './strings';
 
-type validFits = 'cover' | 'contain' | 'fill' | 'inside' | 'outside';
+type validFit = 'cover' | 'contain' | 'fill' | 'inside' | 'outside';
 
 const validExtensions = ['jpg', 'jpeg', 'png'];
 
 export const getResizedUrl = (
 	url: Maybe<string>,
-	fit: validFits,
+	fit: validFit,
 	width?: number,
 	height?: number,
 ) => {

--- a/utils/strings.js
+++ b/utils/strings.js
@@ -35,3 +35,11 @@ export const joinOxford = (items, { joiner = strConcat, empty = '', ampersand = 
 		),
 	);
 };
+
+export const btoaUniversal = (input) => {
+	try {
+		return btoa(input);
+	} catch (err) {
+		return Buffer.from(input).toString('base64');
+	}
+};


### PR DESCRIPTION
This PR updates our Image Resizer stack to use version [5.2 of the Serverless Image Handler](https://github.com/awslabs/serverless-image-handler) and resolves #1257. 

The new Image Resizer lives as `resizer-v3.pubpub.org` and has a different API given that it's based on [Sharp](https://sharp.pixelplumbing.com/) rather than [Thumbor](http://thumbor.org). I find the documentation and formatting of Sharp much more modern and ergonomic - so that's a plus! The PR refactors the `getImageResizer` function to use the new API and also applies the slight modification to all invocations of `getImageResizer`. The main update is in `utils/images.ts` and most of the other changes are just function call refactors.

I'm hopeful that the more modern library also improves some of the compression issues we had previously been having. One positive sign in that direction is that the color performance seems to be much better in certain cases:

![Frame 1](https://user-images.githubusercontent.com/1000455/110987919-bbc43400-8367-11eb-974f-37097bee0db2.png)

Like our previous stack, Sharp does not support .gif resizing without a custom compilation that includes a few additional libraries. There seems to be decent documentation on doing that if we eventually want to add that functionality ([Sharp documentation](https://sharp.pixelplumbing.com/install#custom-libvips), [AWS documentation](https://github.com/awslabs/serverless-image-handler)).

You can play with the library's parameters and see a preview of the request body in [this demo](https://d3g904gs8h9bzj.cloudfront.net/index.html). You can use `assets.pubpub.org` as the bucket name and `g6k2yuu3/71567617067103.jpg` as the image key.

If we merge and everything seems to be working well after a couple days, I'll spin down the previous resizer's CloudFormation and remove its DNS records. It may feel a bit slower for the first couple days as the resizer cache will be built back up from scratch. 

Test plan:
Upload a .jpg (or .jpeg) or .png and verify that resizing behaves as expected and with sufficient quality.