### PR TITLE
feature: add custom linking to Community footer logo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 *.log
 .atomignore
 .info
+.nvmrc
 *.swp
 *.swo
 npm-debug.log

--- a/client/components/Footer/Footer.tsx
+++ b/client/components/Footer/Footer.tsx
@@ -218,7 +218,7 @@ const Footer = (props: Props) => {
 						</React.Fragment>
 					)}
 					{!isBasePubPub && communityData.footerImage && (
-						<a href="/">
+						<a href={communityData.footerLogoLink || '/'}>
 							<img
 								src={communityData.footerImage}
 								className="footer-image"

--- a/client/containers/DashboardSettings/CommunitySettings.tsx
+++ b/client/containers/DashboardSettings/CommunitySettings.tsx
@@ -96,6 +96,7 @@ const CommunitySettings = () => {
 	/* Footer */
 	const [footerLinks, setFooterLinks] = useState(communityData.footerLinks);
 	const [footerTitle, setFooterTitle] = useState(communityData.footerTitle);
+	const [footerLogoLink, setFooterLogoLink] = useState(communityData.footerLogoLink);
 	const [footerImage, setFooterImage] = useState(communityData.footerImage);
 	const [footerImageKey, setFooterImageKey] = useState(Math.random());
 	/* Social */
@@ -134,6 +135,7 @@ const CommunitySettings = () => {
 		heroAlign,
 		footerLinks,
 		footerTitle,
+		footerLogoLink,
 		footerImage,
 		website,
 		twitter,
@@ -755,7 +757,6 @@ const CommunitySettings = () => {
 					label="Footer Title"
 					type="text"
 					value={footerTitle || ''}
-					// helperText={`https://facebook.com/${facebook}`}
 					onChange={(evt) => {
 						setFooterTitle(evt.target.value);
 					}}
@@ -783,6 +784,15 @@ const CommunitySettings = () => {
 						setFooterImage(headerLogo);
 						setFooterImageKey(Math.random());
 					}}
+				/>
+				<InputField
+					label="Footer Logo Link"
+					type="text"
+					value={footerLogoLink || ''}
+					onChange={(evt) => {
+						setFooterLogoLink(evt.target.value);
+					}}
+					placeholder={communityUrl(communityData)}
 				/>
 
 				<InputField label="Footer Links">

--- a/server/community/model.ts
+++ b/server/community/model.ts
@@ -55,6 +55,7 @@ export default (sequelize, dataTypes) => {
 
 			navLinks: { type: dataTypes.JSONB },
 			footerLinks: { type: dataTypes.JSONB },
+			footerLogoLink: { type: dataTypes.TEXT },
 			footerTitle: { type: dataTypes.TEXT },
 			footerImage: { type: dataTypes.TEXT },
 

--- a/server/community/permissions.ts
+++ b/server/community/permissions.ts
@@ -50,6 +50,7 @@ export const getPermissions = async ({ userId, communityId }) => {
 		'navLinks',
 		'footerLinks',
 		'footerTitle',
+		'footerLogoLink',
 		'footerImage',
 	];
 

--- a/tools/migrations/2021_03_16_addCommunityFooterLogoLink.js
+++ b/tools/migrations/2021_03_16_addCommunityFooterLogoLink.js
@@ -1,0 +1,9 @@
+export const up = async ({ sequelize, Sequelize }) => {
+	await sequelize.queryInterface.addColumn('Communities', 'footerLogoLink', {
+		type: Sequelize.TEXT,
+	});
+};
+
+export const down = async ({ sequelize }) => {
+	await sequelize.queryInterface.removeColumn('Communities', 'footerLogoLink');
+};


### PR DESCRIPTION
Add option to link on footer logo in community settings.

To test: from community settings page, upload a logo image and add a 'Footer Logo Link' value. Save, then click footer logo in the preview.

![Screenshot from 2021-03-16 16-29-45](https://user-images.githubusercontent.com/14115194/111382319-d6065680-8674-11eb-89a7-0ae23dcf2954.png)
