### PR TITLE
bug: permit comments with image but no text

### DIFF
--- a/client/components/Editor/utils/view.ts
+++ b/client/components/Editor/utils/view.ts
@@ -20,6 +20,14 @@ export const getJSON = (editorView) => {
 export const getTextFromDoc = (doc: Node, separator = '\n') => {
 	return doc.textBetween(0, doc.nodeSize - 2, separator);
 };
+
+export const getImages = (editorView) => {
+	if (!editorView || !getJSON(editorView)) {
+		return [];
+	}
+	return getJSON(editorView).content.filter((con) => con.type === 'image');
+};
+
 export const getText = (editorView, separator = '\n') => {
 	if (!editorView) {
 		return null;

--- a/client/components/Editor/utils/view.ts
+++ b/client/components/Editor/utils/view.ts
@@ -21,11 +21,9 @@ export const getTextFromDoc = (doc: Node, separator = '\n') => {
 	return doc.textBetween(0, doc.nodeSize - 2, separator);
 };
 
-export const getImages = (editorView) => {
-	if (!editorView || !getJSON(editorView)) {
-		return [];
-	}
-	return getJSON(editorView).content.filter((con) => con.type === 'image');
+export const getTopLevelImages = (editorView) => {
+	const viewObject = getJSON(editorView);
+	return viewObject ? viewObject.content.filter((con) => con.type === 'image') : [];
 };
 
 export const getText = (editorView, separator = '\n') => {

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionInput.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionInput.tsx
@@ -3,7 +3,7 @@ import { AnchorButton, Button, Intent } from '@blueprintjs/core';
 
 import Editor, {
 	getText,
-	getImages,
+	getTopLevelImages,
 	getJSON,
 	removeLocalHighlight,
 	convertLocalHighlightToDiscussion,
@@ -179,7 +179,8 @@ const DiscussionInput = (props: Props) => {
 						text={isNewThread ? 'Post Discussion' : 'Post Reply'}
 						loading={isLoading}
 						disabled={
-							!getText(changeObject?.view) && !getImages(changeObject?.view).length
+							!getText(changeObject?.view) &&
+							!getTopLevelImages(changeObject?.view).length
 						}
 						onClick={isNewThread ? handlePostDiscussion : handlePostThreadComment}
 						small={true}

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionInput.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/DiscussionInput.tsx
@@ -3,6 +3,7 @@ import { AnchorButton, Button, Intent } from '@blueprintjs/core';
 
 import Editor, {
 	getText,
+	getImages,
 	getJSON,
 	removeLocalHighlight,
 	convertLocalHighlightToDiscussion,
@@ -177,7 +178,9 @@ const DiscussionInput = (props: Props) => {
 						intent={Intent.PRIMARY}
 						text={isNewThread ? 'Post Discussion' : 'Post Reply'}
 						loading={isLoading}
-						disabled={!getText(changeObject?.view)}
+						disabled={
+							!getText(changeObject?.view) && !getImages(changeObject?.view).length
+						}
 						onClick={isNewThread ? handlePostDiscussion : handlePostThreadComment}
 						small={true}
 					/>


### PR DESCRIPTION
Comments without text but with an image triggered the 'post button' to be disabled. No longer.

_Test Plan_
create and submit a comment to any pub with an image and no text