### PR TITLE
feature: Enable srcset for pub images

### DIFF
--- a/client/components/Editor/plugins/paste/upload.ts
+++ b/client/components/Editor/plugins/paste/upload.ts
@@ -1,5 +1,5 @@
 import { s3Upload } from 'client/utils/upload';
-import { getDefaultResizedUrl } from 'utils/images';
+import { getResizedUrl } from 'utils/images';
 
 import { MediaUploadHandler } from '../../types';
 
@@ -17,7 +17,7 @@ export const defaultMediaUploadHandler: MediaUploadHandler = (file: File) => {
 						const src = `https://assets.pubpub.org/${assetKey}`;
 						const img = new Image();
 						img.onload = () => onFinish(src);
-						img.src = getDefaultResizedUrl(src);
+						img.src = getResizedUrl(src, 'inside', 800);
 					},
 				);
 			},

--- a/client/components/Editor/schemas/image.ts
+++ b/client/components/Editor/schemas/image.ts
@@ -68,7 +68,6 @@ export default {
 			const widthBreakpoints = [675, 650, 350];
 			const maybeResizedSrc = isResizeable ? getResizedUrl(url, 'inside', width) : url;
 			const srcSet = isResizeable ? getSrcSet(url, 'inside', widthBreakpoints) : '';
-			// TODO: where to specify breakpoints in the code? Since each component has it's own breakpoint widths, it has to be at the component level. Can this be abstracted to match scss? What are all image locations? (pub, pub tiles, heros, ...?)
 			const sizes = `
 			(max-width: 400px) 350px,
 			(max-width: 750px) 650px,

--- a/client/components/Editor/schemas/image.ts
+++ b/client/components/Editor/schemas/image.ts
@@ -64,15 +64,8 @@ export default {
 
 			const width = align === 'breakout' ? 1920 : 800;
 			const isResizeable = isResizeableFormat(url) && !fullResolution;
-			const widthBreakpoints = [675, 650, 350];
 			const maybeResizedSrc = isResizeable ? getResizedUrl(url, 'inside', width) : url;
-			const srcSet = isResizeable ? getSrcSet(url, 'inside', widthBreakpoints) : '';
-			const sizes = `
-			(max-width: 400px) 350px,
-			(max-width: 750px) 650px,
-			675px,
-			`;
-
+			const srcSet = isResizeable ? getSrcSet(url, 'inside', width) : '';
 			const figcaptionId = `${id}-figure-caption`;
 
 			return [
@@ -89,7 +82,6 @@ export default {
 					'img',
 					{
 						srcSet,
-						sizes,
 						src: maybeResizedSrc,
 						alt: altText || '',
 						...getFigcaptionRefrenceAttrs(altText, caption, figcaptionId),

--- a/client/components/Editor/schemas/image.ts
+++ b/client/components/Editor/schemas/image.ts
@@ -63,7 +63,6 @@ export default {
 			const { url, align, id, altText, caption, fullResolution, size } = node.attrs;
 
 			const width = align === 'breakout' ? 1920 : 800;
-			// check here is for GIFs, which cannot be resized. Likewise, if the image ain't full res, don't resize. Keep these in place.
 			const isResizeable = isResizeableFormat(url) && !fullResolution;
 			const widthBreakpoints = [675, 650, 350];
 			const maybeResizedSrc = isResizeable ? getResizedUrl(url, 'inside', width) : url;

--- a/client/components/Editor/utils/media.ts
+++ b/client/components/Editor/utils/media.ts
@@ -1,5 +1,5 @@
 const resizableImageFormats = ['jpg', 'jpeg', 'png'];
-export const imageCanBeResized = (url: string) => {
+export const isResizeableFormat = (url: string) => {
 	const extension = (url.split('.').pop() as string).toLowerCase();
 	return resizableImageFormats.includes(extension);
 };

--- a/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
@@ -6,7 +6,7 @@ import { SimpleEditor } from 'components';
 
 import { usePubData } from 'client/containers/Pub/pubHooks';
 import { NodeLabelMap, ReferenceableNodeType } from 'client/components/Editor/types';
-import { imageCanBeResized } from 'client/components/Editor';
+import { isResizeableFormat } from 'client/components/Editor';
 
 import { ControlsButton, ControlsButtonGroup } from '../ControlsButton';
 import AlignmentControl from './AlignmentControl';
@@ -61,7 +61,7 @@ const ControlsMedia = (props: Props) => {
 	const canHideLabel =
 		nodeLabels &&
 		(nodeLabels as NodeLabelMap)[selectedNode.type.name as ReferenceableNodeType]?.enabled;
-	const canSelectResizeOptions = imageCanBeResized(url);
+	const canSelectResizeOptions = isResizeableFormat(url);
 
 	const toggleLabel = useCallback(
 		(e: React.MouseEvent) => updateNode({ hideLabel: (e.target as HTMLInputElement).checked }),

--- a/client/containers/Pub/PubDocument/PubBody.tsx
+++ b/client/containers/Pub/PubDocument/PubBody.tsx
@@ -8,7 +8,6 @@ import { saveAs } from 'file-saver';
 import { debounce } from 'debounce';
 
 import Editor, { getJSON } from 'components/Editor';
-import { getDefaultResizedUrl } from 'utils/images';
 import { usePageContext } from 'utils/hooks';
 
 import { usePubContext } from '../pubHooks';
@@ -147,9 +146,6 @@ const PubBody = (props: Props) => {
 					} as any
 				}
 				nodeOptions={{
-					image: {
-						onResizeUrl: getDefaultResizedUrl,
-					},
 					discussion: {
 						addRef: (embedId, mountRef, threadNumber) => {
 							embedDiscussions.current[embedId] = {

--- a/utils/images.ts
+++ b/utils/images.ts
@@ -43,7 +43,15 @@ export const getResizedUrl = (
 	return `https://resize-v3.pubpub.org/${btoaUniversal(JSON.stringify(imageRequest))}`;
 };
 
-export const getDefaultResizedUrl = (url: string, align?: string) => {
-	const width = align === 'breakout' ? 1920 : 800;
-	return getResizedUrl(url, 'inside', width);
+export const getSrcSet = (url: string, fit: validFit, widthBreakpoints: number[]) => {
+	return widthBreakpoints
+		.reduce((memo: number[], breakpoint) => {
+			return [...memo, breakpoint, breakpoint * 2, breakpoint * 3];
+		}, [])
+		.sort((a, b) => a - b)
+		.map((width) => {
+			const resizedUrl = getResizedUrl(url, fit, width);
+			return `${resizedUrl} ${width}w`;
+		})
+		.join(',');
 };

--- a/utils/images.ts
+++ b/utils/images.ts
@@ -43,15 +43,12 @@ export const getResizedUrl = (
 	return `https://resize-v3.pubpub.org/${btoaUniversal(JSON.stringify(imageRequest))}`;
 };
 
-export const getSrcSet = (url: string, fit: validFit, widthBreakpoints: number[]) => {
-	return widthBreakpoints
-		.reduce((memo: number[], breakpoint) => {
-			return [...memo, breakpoint, breakpoint * 2, breakpoint * 3];
-		}, [])
-		.sort((a, b) => a - b)
-		.map((width) => {
-			const resizedUrl = getResizedUrl(url, fit, width);
-			return `${resizedUrl} ${width}w`;
+export const getSrcSet = (url: string, fit: validFit, width: number) => {
+	const pixelDensities = [1, 2, 3];
+	return pixelDensities
+		.map((density) => {
+			const resizedUrl = getResizedUrl(url, fit, width * density);
+			return `${resizedUrl} ${density}x`;
 		})
 		.join(',');
 };


### PR DESCRIPTION
addresses #1274
Generate a srcset for resized images in pubs to accommodate devices of any pixel density.
Does not address banners and instances where resized images are applied as background-image via css.

_Test plan_
+ In inspector, enable devices of at least two different pixel densities (e.g., Chrome inspector's emulated 'laptop with HiDPI' and 'laptop with MDPI')
+ disable cache in inspector
+ with inspector open and lower DPI device activated, navigate to any pub with an image in pub body
+ note image size in bytes
+ switch emulated device to HiDPI device
+ reload page
+ note + compare image size, HiDPI size should be greater