### PR TITLE
fix: Use display:contents on li > p to fix text-algined lists

### DIFF
--- a/client/components/Editor/styles/main.scss
+++ b/client/components/Editor/styles/main.scss
@@ -33,6 +33,12 @@ h6 {
 	}
 }
 
+li {
+	> p {
+		display: contents;
+	}
+}
+
 .footnote {
 	vertical-align: super;
 	font-size: 0.85em;

--- a/client/containers/Pub/PubDocument/pubBody.scss
+++ b/client/containers/Pub/PubDocument/pubBody.scss
@@ -82,15 +82,11 @@ $pub-body-font-size: if-is-export(14px, 20px);
 		font-style: normal;
 		line-height: 1.7;
 		letter-spacing: -0.003em;
-		margin: 0em 0em 1em;
 		word-break: break-word;
 	}
 
-	li {
-		margin: 0em;
-		& > p {
-			margin: 0;
-		}
+	p {
+		margin: 0em 0em 1em;
 	}
 
 	ul {


### PR DESCRIPTION
We want center-aligned lists to look like this:

```
     - a
     - b
     - c
```

and not like this:

```
-      a
-      b
-      c
```

Our first few attempts:

1. Setting `display: inline-block` on `li > p`. This turned out not to work in Safari, and also created problems with bullet placement on tall `li` elements.
2. Setting `list-style-position: inside` on `ul, ol`. This caused multi-line `li` content to appear on a line beneath the bullet.

Ultimately, the problem is that our Prosemirror schema, all text content is contained within paragraphs, but `ul > li > p` adds an extra box within the list item that we could do without. So, our third attempt: use `display: contents` on `li > p` to remove the `p` from the box model entirely. Here is what this looks like:
<img width="716" alt="image" src="https://user-images.githubusercontent.com/2208769/113324690-6c797f80-92e5-11eb-9fc4-3419c0e9fb95.png">

Note that the final list item actually contains two paragraphs.

_Test plan:_
Inside Pubs and Page rich-text blocks, create ordered and unordered lists with every text alignment and check that they look okay. Pay attention to the behavior of text within an `li` element that spans multiple lines.