### PR TITLE
fix: change banner bg image strategy

### DIFF
--- a/client/components/CommunityPreview/CommunityPreview.tsx
+++ b/client/components/CommunityPreview/CommunityPreview.tsx
@@ -28,7 +28,7 @@ const defaultProps = {
 
 const CommunityPreview = function(props) {
 	const resizedHeroLogo = getResizedUrl(props.heroLogo, 'inside', 600);
-	const resizedHeroBackground = getResizedUrl(props.heroBackgroundImage, 'inside', 800);
+	const resizedHeroBackground = getResizedUrl(props.heroBackgroundImage, 'outside', 800);
 	const logoStyle = { color: props.accentTextColor };
 	const backgroundStyle = {
 		backgroundColor: props.accentColor,

--- a/client/components/Header/Header.tsx
+++ b/client/components/Header/Header.tsx
@@ -118,7 +118,7 @@ const Header = (props: Props) => {
 		if (communityData.heroBackgroundImage) {
 			const resizedBackgroundImage = getResizedUrl(
 				communityData.heroBackgroundImage,
-				'inside',
+				'outside',
 				1500,
 				600,
 			);

--- a/client/containers/DashboardSettings/CommunitySettings.tsx
+++ b/client/containers/DashboardSettings/CommunitySettings.tsx
@@ -510,7 +510,7 @@ const CommunitySettings = () => {
 											<span>
 												Used on the landing page.
 												<br />
-												Recommended: ~1200*800px
+												Recommended: ~1500*600px
 											</span>
 										}
 										// @ts-expect-error ts-migrate(2322) FIXME: Type '{ children: Element; content: Element; toolt... Remove this comment to see the full error message


### PR DESCRIPTION
Now that the updated resizer gives us some more image options, this PR proposes changing the strategy for resizing header background images from 'inside', which seeks to keep images to a dimension without going over in either width or height (keeping proportionality), to 'outside', which seeks to keep them to a dimension without going under in either width or height (keeping proportionality). By doing so, it drastically improves the quality of already uploaded background images without leading to drastic increases in pageload or major changes to how weirdly sized images are displayed. This doesn't replace doing image-sets (or not using css background images) eventually, but it does make it much more tolerable for now.

I noticed this issue when looking into a bg image for Allison. Right now, if you have a square-ish banner image, even if it is ginormous in size, the resizer will resize it proportionally with a max height of 600px. Because the image is square-ish, that means the width is also something like 600px. See, for example, TMBs current background, which resizes from the [uploaded image](https://assets.pubpub.org/xw01isxf/41609864185484.png) of 2400x1600 to the [resized image](https://resize-v3.pubpub.org/eyJidWNrZXQiOiJhc3NldHMucHVicHViLm9yZyIsImtleSI6Inh3MDFpc3hmLzQxNjA5ODY0MTg1NDg0LnBuZyIsImVkaXRzIjp7InJlc2l6ZSI6eyJ3aWR0aCI6MTUwMCwiaGVpZ2h0Ijo2MDAsImZpdCI6Imluc2lkZSIsIndpdGhvdXRFbmxhcmdlbWVudCI6dHJ1ZX19fQ==) of 900x600.

This causes the image to look noticeably pixelated on larger or more dense screens where the widths can be 2000+ pixels.

<img width="1901" alt="Screen Shot 2021-04-09 at 15 05 45" src="https://user-images.githubusercontent.com/639110/114231576-9fa4ba00-9948-11eb-9a08-3903d8a845e9.png">

Switching to the outside strategy doesn't change the positioning of the background image at all (because it's done in CSS), but loads a [resized image](https://resize-v3.pubpub.org/eyJidWNrZXQiOiJhc3NldHMucHVicHViLm9yZyIsImtleSI6Il90ZXN0aW5nLzcxNjE3OTk3MjgzMzU5LnBuZyIsImVkaXRzIjp7InJlc2l6ZSI6eyJ3aWR0aCI6MTUwMCwiaGVpZ2h0Ijo2MDAsImZpdCI6Im91dHNpZGUiLCJ3aXRob3V0RW5sYXJnZW1lbnQiOnRydWV9fX0=) of 1500x1000 that looks much better on wider screens.

<img width="1904" alt="Screen Shot 2021-04-09 at 15 05 38" src="https://user-images.githubusercontent.com/639110/114232675-3e7de600-994a-11eb-92e0-07e4337e2316.png">

To make sure this change wouldn't effect weird-sized images, I took a look at what happens currently, and with the new strategy, when you use very small, or very narrow, or very tall images. As you can see, there are few differences between our current strategy and the outside strategy (indeed, outside produces better results in some cases).

<img width="1882" alt="Screen Shot 2021-04-09 at 15 37 37" src="https://user-images.githubusercontent.com/639110/114233052-c4019600-994a-11eb-91d3-1a151180c5b7.png">

<img width="1898" alt="Screen Shot 2021-04-09 at 15 10 09" src="https://user-images.githubusercontent.com/639110/114233073-c8c64a00-994a-11eb-9c45-82725f078e66.png">

<img width="1894" alt="Screen Shot 2021-04-09 at 15 33 47" src="https://user-images.githubusercontent.com/639110/114232852-843aae80-994a-11eb-8d4d-c799e909587b.png">

<img width="1901" alt="Screen Shot 2021-04-09 at 15 11 34" src="https://user-images.githubusercontent.com/639110/114232965-a6343100-994a-11eb-84fa-58c4f982f779.png">

<img width="1895" alt="Screen Shot 2021-04-09 at 15 34 24" src="https://user-images.githubusercontent.com/639110/114233184-f90de880-994a-11eb-98bf-226f994b130d.png">

<img width="1901" alt="Screen Shot 2021-04-09 at 15 12 45" src="https://user-images.githubusercontent.com/639110/114233195-fd3a0600-994a-11eb-8be1-28504569b4c1.png">


_Test plan_
- Look at lots of different communities with outside strategy and make sure there are no drastic changes from the current inside strategy.