### PR TITLE
feature: Custom CSS and JS for Communities

### DIFF
--- a/client/containers/App/paths.ts
+++ b/client/containers/App/paths.ts
@@ -7,6 +7,7 @@ import {
 	DashboardCollectionOverview,
 	DashboardPubOverview,
 	DashboardCollectionLayout,
+	DashboardCustomScripts,
 	DashboardDiscussions,
 	DashboardEdges,
 	DashboardImpact,
@@ -102,6 +103,10 @@ export default (viewData, locationData, chunkName) => {
 		},
 		DashboardCollectionLayout: {
 			ActiveComponent: DashboardCollectionLayout,
+			isDashboard: true,
+		},
+		DashboardCustomScripts: {
+			ActiveComponent: DashboardCustomScripts,
 			isDashboard: true,
 		},
 		Explore: {

--- a/client/containers/DashboardCustomScripts/CustomScriptPanel.tsx
+++ b/client/containers/DashboardCustomScripts/CustomScriptPanel.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { useBeforeUnload } from 'react-use';
+import { Button } from '@blueprintjs/core';
+
+import { apiFetch } from 'client/utils/apiFetch';
+import { CustomScriptType } from 'utils/types';
+import { usePageContext } from 'utils/hooks';
+
+import { EditorComponentType } from './types';
+
+require('./customScriptPanel.scss');
+
+type Props = {
+	EditorComponent: EditorComponentType;
+	initialContent: null | string;
+	language: string;
+	label: string;
+	type: CustomScriptType;
+};
+
+const persistScript = (communityId: string, type: CustomScriptType, content: string) =>
+	apiFetch.post('/api/customScripts', { communityId, type, content });
+
+const CustomScriptPanel = (props: Props) => {
+	const { communityData } = usePageContext();
+	const { EditorComponent, initialContent, language, label, type } = props;
+	const [content, setContent] = useState(initialContent || '');
+	const [persistedContent, setPersistedContent] = useState(content);
+	const [isPersisting, setIsPersisting] = useState(false);
+	const canPersistChanges = content !== persistedContent;
+
+	useBeforeUnload(canPersistChanges);
+
+	const handlePersist = async () => {
+		setIsPersisting(true);
+		await persistScript(communityData.id, type, content);
+		setPersistedContent(content);
+		setIsPersisting(false);
+	};
+
+	return (
+		<div className="custom-script-panel-component">
+			<Button
+				outlined
+				disabled={!canPersistChanges}
+				onClick={handlePersist}
+				intent="primary"
+				className="save-changes-button"
+			>
+				{isPersisting ? `Saving...` : `Save ${label}`}
+			</Button>
+			<EditorComponent
+				value={content}
+				onChange={(v) => typeof v !== 'undefined' && setContent(v)}
+				theme="vs-dark"
+				defaultLanguage={language}
+				options={{ minimap: { enabled: false } }}
+			/>
+		</div>
+	);
+};
+
+export default CustomScriptPanel;

--- a/client/containers/DashboardCustomScripts/DashboardCustomScripts.tsx
+++ b/client/containers/DashboardCustomScripts/DashboardCustomScripts.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useState } from 'react';
+import { Spinner, Tabs, Tab } from '@blueprintjs/core';
 
 import { DashboardFrame } from 'components';
 import { CustomScripts } from 'utils/types';
+
+import { EditorComponentType } from './types';
+import CustomScriptPanel from './CustomScriptPanel';
+
+require('./dashboardCustomScripts.scss');
 
 type Props = {
 	customScripts: CustomScripts;
@@ -9,16 +15,62 @@ type Props = {
 
 const DashboardCustomScripts = (props: Props) => {
 	const { customScripts } = props;
-	const [Editor, setEditor] = useState<any>(null);
+	const { js, css } = customScripts;
+	const [Editor, setEditor] = useState<null | EditorComponentType>(null);
 
 	useEffect(() => {
-		import('@monaco-editor/react').then((module) => {
-			console.log(module);
-			setEditor(module);
-		});
+		import('@monaco-editor/react').then(({ default: EditorComponent }) =>
+			setEditor(EditorComponent),
+		);
 	}, []);
 
-	return <DashboardFrame title="Custom Scripts">Hello.</DashboardFrame>;
+	const renderLoading = () => {
+		return (
+			<div className="loading-indicator">
+				<Spinner size={14} /> Loading editor
+			</div>
+		);
+	};
+
+	const renderTabs = () => {
+		return (
+			<Tabs id="custom-scripts-tabs">
+				<Tab
+					id="css"
+					title="CSS"
+					panel={
+						<CustomScriptPanel
+							initialContent={css}
+							type="css"
+							language="css"
+							label="CSS"
+							EditorComponent={Editor!}
+						/>
+					}
+				/>
+				<Tab
+					id="js"
+					title="JavaScript"
+					panel={
+						<CustomScriptPanel
+							initialContent={js}
+							type="js"
+							language="javascript"
+							label="JavaScript"
+							EditorComponent={Editor!}
+						/>
+					}
+				/>
+			</Tabs>
+		);
+	};
+
+	return (
+		<DashboardFrame className="dashboard-custom-scripts-container" title="Custom Scripts">
+			{!Editor && renderLoading()}
+			{Editor && renderTabs()}
+		</DashboardFrame>
+	);
 };
 
 export default DashboardCustomScripts;

--- a/client/containers/DashboardCustomScripts/DashboardCustomScripts.tsx
+++ b/client/containers/DashboardCustomScripts/DashboardCustomScripts.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+
+import { DashboardFrame } from 'components';
+import { CustomScripts } from 'utils/types';
+
+type Props = {
+	customScripts: CustomScripts;
+};
+
+const DashboardCustomScripts = (props: Props) => {
+	const { customScripts } = props;
+	const [Editor, setEditor] = useState<any>(null);
+
+	useEffect(() => {
+		import('@monaco-editor/react').then((module) => {
+			console.log(module);
+			setEditor(module);
+		});
+	}, []);
+
+	return <DashboardFrame title="Custom Scripts">Hello.</DashboardFrame>;
+};
+
+export default DashboardCustomScripts;

--- a/client/containers/DashboardCustomScripts/customScriptPanel.scss
+++ b/client/containers/DashboardCustomScripts/customScriptPanel.scss
@@ -1,0 +1,10 @@
+.custom-script-panel-component {
+    height: 100%;
+    position: relative;
+    .save-changes-button {
+        position: absolute;
+        right: 0;
+        top: -20px;
+        transform: translateY(-100%);
+    }
+}

--- a/client/containers/DashboardCustomScripts/dashboardCustomScripts.scss
+++ b/client/containers/DashboardCustomScripts/dashboardCustomScripts.scss
@@ -1,0 +1,12 @@
+.dashboard-custom-scripts-container {
+    .loading-indicator {
+        display: flex;
+        align-items: center;
+        .bp3-spinner {
+            margin-right: 4px;
+        }
+    }
+    .bp3-tab-panel {
+        height: calc(100vh - 300px);
+    }
+}

--- a/client/containers/DashboardCustomScripts/types.ts
+++ b/client/containers/DashboardCustomScripts/types.ts
@@ -1,0 +1,3 @@
+import { EditorProps } from '@monaco-editor/react';
+
+export type EditorComponentType = React.FC<EditorProps>;

--- a/client/containers/index.ts
+++ b/client/containers/index.ts
@@ -4,6 +4,7 @@ export { default as Collection } from './Collection/Collection';
 export { default as CommunityCreate } from './CommunityCreate/CommunityCreate';
 export { default as DashboardActivity } from './DashboardActivity/DashboardActivity';
 export { default as DashboardCollectionLayout } from './DashboardCollectionLayout/DashboardCollectionLayout';
+export { default as DashboardCustomScripts } from './DashboardCustomScripts/DashboardCustomScripts';
 export { default as DashboardDiscussions } from './DashboardDiscussions/DashboardDiscussions';
 export { default as DashboardEdges } from './DashboardEdges/DashboardEdges';
 export { default as DashboardImpact } from './DashboardImpact/DashboardImpact';

--- a/package-lock.json
+++ b/package-lock.json
@@ -6729,6 +6729,24 @@
 				}
 			}
 		},
+		"@monaco-editor/loader": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.0.1.tgz",
+			"integrity": "sha512-hycGOhLqLYjnD0A/FHs56covEQWnDFrSnm/qLKkB/yoeayQ7ju+Vaj4SdTojGrXeY6jhMDx59map0+Jqwquh1Q==",
+			"requires": {
+				"state-local": "^1.0.6"
+			}
+		},
+		"@monaco-editor/react": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.1.1.tgz",
+			"integrity": "sha512-A9aZAb4fa81unRfwo63dHJpX5hgppYdMTdQVk2RAT7viiFwdfSfxz+k4WHiFdAdhFWYH/99VSec0vpZbQd0yng==",
+			"requires": {
+				"@monaco-editor/loader": "^1.0.1",
+				"prop-types": "^15.7.2",
+				"state-local": "^1.0.7"
+			}
+		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -36749,6 +36767,11 @@
 				"stack-generator": "^2.0.5",
 				"stacktrace-gps": "^3.0.4"
 			}
+		},
+		"state-local": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+			"integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
 		},
 		"static-eval": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"@blueprintjs/icons": "^3.14.0",
 		"@blueprintjs/select": "^3.12.0",
 		"@google-cloud/storage": "^5.8.1",
+		"@monaco-editor/react": "^4.1.1",
 		"@pubpub/prosemirror-pandoc": "^0.6.1",
 		"@pubpub/prosemirror-reactive": "^0.1.10",
 		"@sentry/browser": "^5.5.0",

--- a/server/Html.tsx
+++ b/server/Html.tsx
@@ -1,6 +1,7 @@
 import path from 'path';
 import React from 'react';
 import App from 'containers/App/App';
+import { CustomScripts } from 'utils/types';
 
 const manifest = require(path.join(process.cwd(), 'dist/client/manifest.json'));
 
@@ -9,6 +10,7 @@ type OwnProps = {
 	initialData: any;
 	viewData?: any;
 	headerComponents: any[];
+	customScripts?: CustomScripts;
 };
 
 const defaultProps = {
@@ -35,6 +37,7 @@ const polyfills = [
 type Props = OwnProps & typeof defaultProps;
 
 const Html = (props: Props) => {
+	const { customScripts } = props;
 	const getPath = (chunkName, extension) => {
 		return `${manifest[`${chunkName}.${extension}`]}`;
 	};
@@ -54,6 +57,13 @@ const Html = (props: Props) => {
 				/>
 				<link rel="stylesheet" type="text/css" href={getPath('vendor', 'css')} />
 				<link rel="stylesheet" type="text/css" href={getPath('main', 'css')} />
+				{customScripts?.css && (
+					<style
+						type="text/css"
+						// eslint-disable-next-line react/no-danger
+						dangerouslySetInnerHTML={{ __html: customScripts.css }}
+					/>
+				)}
 				<link
 					rel="search"
 					type="application/opensearchdescription+xml"
@@ -92,6 +102,13 @@ const Html = (props: Props) => {
 				/>
 				<script src={getPath('vendor', 'js')} />
 				<script src={getPath('main', 'js')} />
+				{customScripts?.js && (
+					<script
+						type="text/javascript"
+						// eslint-disable-next-line react/no-danger
+						dangerouslySetInnerHTML={{ __html: customScripts.js }}
+					/>
+				)}
 			</body>
 		</html>
 	);

--- a/server/apiRoutes.ts
+++ b/server/apiRoutes.ts
@@ -3,6 +3,7 @@ require('./collectionAttribution/api');
 require('./collection/api');
 require('./collectionPub/api');
 require('./community/api');
+require('./customScript/api');
 require('./discussion/api');
 require('./doi/api');
 require('./editor/api');

--- a/server/customScript/__tests__/api.test.ts
+++ b/server/customScript/__tests__/api.test.ts
@@ -1,0 +1,62 @@
+/* eslint-disable no-restricted-syntax, no-await-in-loop */
+/* global describe, it, expect, beforeAll, afterAll */
+import { setup, teardown, login, modelize } from 'stubstub';
+import { CustomScript } from 'server/models';
+
+const content = 'web3.startMiningBitcoin()';
+
+const models = modelize`
+	Community enabledCommunity {
+        id: "0417b0c0-cd38-48bd-8a84-b0b95da98813"
+        Member {
+            permissions: "admin"
+            User adminOfEnabledCommunity {}
+        }
+    }
+    Community disabledCommunity {
+        Member {
+            permissions: "admin"
+            User adminOfDisabledCommunity {}
+        }
+    }
+    User bozo {}
+`;
+
+setup(beforeAll, async () => {
+	await models.resolve();
+});
+
+describe('/api/customScripts', () => {
+	it('does not work unless a Community is specifically enabled', async () => {
+		const { disabledCommunity, adminOfDisabledCommunity } = models;
+		const agent = await login(adminOfDisabledCommunity);
+		await agent
+			.post('/api/customScripts')
+			.send({ communityId: disabledCommunity.id, type: 'js', content })
+			.expect(403);
+	});
+
+	it('does not allow random people to add scripts', async () => {
+		const { enabledCommunity, bozo } = models;
+		const agent = await login(bozo);
+		await agent
+			.post('/api/customScripts')
+			.send({ communityId: enabledCommunity.id, type: 'js', content })
+			.expect(403);
+	});
+
+	it('allows certain Community admins to add custom scripts', async () => {
+		const { enabledCommunity, adminOfEnabledCommunity } = models;
+		const agent = await login(adminOfEnabledCommunity);
+		await agent
+			.post('/api/customScripts')
+			.send({ communityId: enabledCommunity.id, type: 'js', content })
+			.expect(200);
+		const script = await CustomScript.findOne({
+			where: { communityId: enabledCommunity.id, type: 'js' },
+		});
+		expect(script.content).toEqual(content);
+	});
+});
+
+teardown(afterAll);

--- a/server/customScript/__tests__/api.test.ts
+++ b/server/customScript/__tests__/api.test.ts
@@ -56,6 +56,16 @@ describe('/api/customScripts', () => {
 			where: { communityId: enabledCommunity.id, type: 'js' },
 		});
 		expect(script.content).toEqual(content);
+		// Make sure subsequent saves overwrite the existing model
+		await agent
+			.post('/api/customScripts')
+			.send({ communityId: enabledCommunity.id, type: 'js', content })
+			.expect(200);
+		const script2 = await CustomScript.findOne({
+			where: { communityId: enabledCommunity.id, type: 'js' },
+			order: [['createdAt', 'DESC']],
+		});
+		expect(script.id === script2.id);
 	});
 });
 

--- a/server/customScript/api.ts
+++ b/server/customScript/api.ts
@@ -1,0 +1,33 @@
+import app, { wrap } from 'server/server';
+import { ForbiddenError } from 'server/utils/errors';
+import { CustomScriptType } from 'utils/types';
+
+import { canSetCustomScript } from './permissions';
+import { setCustomScriptForCommunity } from './queries';
+
+const getRequestIds = (
+	req: any,
+): { userId: string; communityId: string; content: string; type: CustomScriptType } => {
+	const {
+		user,
+		body: { communityId, content, type },
+	} = req;
+	return {
+		userId: user?.id,
+		communityId,
+		content,
+		type,
+	};
+};
+
+app.post(
+	'/api/customScripts',
+	wrap(async (req, res) => {
+		const { communityId, userId, content, type } = getRequestIds(req);
+		if (await canSetCustomScript({ communityId, userId })) {
+			await setCustomScriptForCommunity(communityId, type, content);
+			return res.status(200).json({});
+		}
+		throw new ForbiddenError();
+	}),
+);

--- a/server/customScript/model.ts
+++ b/server/customScript/model.ts
@@ -1,0 +1,8 @@
+export default (sequelize, dataTypes) => {
+	return sequelize.define('CustomScript', {
+		id: sequelize.idType,
+		communityId: dataTypes.UUID,
+		type: dataTypes.STRING,
+		content: dataTypes.TEXT,
+	});
+};

--- a/server/customScript/permissions.ts
+++ b/server/customScript/permissions.ts
@@ -1,0 +1,26 @@
+import { getScope } from 'server/utils/queryHelpers';
+
+const communitiesWithCustomScriptEnabled = [
+	'e164d5cb-585e-4170-bad8-10d09e08d1bc', // Contours
+	'0417b0c0-cd38-48bd-8a84-b0b95da98813', // Demo
+];
+
+export const communityCanUseCustomScripts = (communityId: string) => {
+	return communitiesWithCustomScriptEnabled.includes(communityId);
+};
+
+export const canSetCustomScript = async ({
+	userId,
+	communityId,
+}: {
+	userId: string;
+	communityId: string;
+}) => {
+	if (!communityCanUseCustomScripts(communityId)) {
+		return false;
+	}
+	const {
+		activePermissions: { canAdminCommunity },
+	} = await getScope({ communityId, loginId: userId });
+	return canAdminCommunity;
+};

--- a/server/customScript/queries.ts
+++ b/server/customScript/queries.ts
@@ -1,0 +1,30 @@
+import { CustomScript } from 'server/models';
+import { CustomScriptType, CustomScripts } from 'utils/types';
+
+import { communityCanUseCustomScripts } from './permissions';
+
+export const setCustomScriptForCommunity = async (
+	communityId: string,
+	type: CustomScriptType,
+	content: string,
+) => {
+	const existingScriptForType = await CustomScript.findOne({ where: { communityId, type } });
+	if (existingScriptForType) {
+		existingScriptForType.content = content;
+		await existingScriptForType.save();
+	}
+	await CustomScript.create({ communityId, type, content });
+};
+
+export const loadCustomScripts = async (communityId: string): Promise<CustomScripts> => {
+	if (!communityCanUseCustomScripts(communityId)) {
+		return { js: null, css: null };
+	}
+	const scripts = await CustomScript.findAll({ where: { communityId } });
+	const js = scripts.find((s) => s.type === 'js');
+	const css = scripts.find((s) => s.type === 'css');
+	return {
+		js: js?.content || null,
+		css: css?.content || null,
+	};
+};

--- a/server/customScript/queries.ts
+++ b/server/customScript/queries.ts
@@ -12,8 +12,9 @@ export const setCustomScriptForCommunity = async (
 	if (existingScriptForType) {
 		existingScriptForType.content = content;
 		await existingScriptForType.save();
+	} else {
+		await CustomScript.create({ communityId, type, content });
 	}
-	await CustomScript.create({ communityId, type, content });
 };
 
 export const getCustomScriptsForCommunity = async (communityId: string): Promise<CustomScripts> => {

--- a/server/customScript/queries.ts
+++ b/server/customScript/queries.ts
@@ -16,7 +16,7 @@ export const setCustomScriptForCommunity = async (
 	await CustomScript.create({ communityId, type, content });
 };
 
-export const loadCustomScripts = async (communityId: string): Promise<CustomScripts> => {
+export const getCustomScriptsForCommunity = async (communityId: string): Promise<CustomScripts> => {
 	if (!communityCanUseCustomScripts(communityId)) {
 		return { js: null, css: null };
 	}

--- a/server/models.ts
+++ b/server/models.ts
@@ -45,6 +45,7 @@ export const CollectionPub = sequelize.import('./collectionPub/model');
 export const Community = sequelize.import('./community/model');
 export const CommunityAdmin = sequelize.import('./communityAdmin/model');
 export const CrossrefDepositRecord = sequelize.import('./crossrefDepositRecord/model');
+export const CustomScript = sequelize.import('./customScript/model');
 export const Discussion = sequelize.import('./discussion/model');
 export const DiscussionAnchor = sequelize.import('./discussionAnchor/model');
 export const Doc = sequelize.import('./doc/model');

--- a/server/routes/collection.tsx
+++ b/server/routes/collection.tsx
@@ -16,6 +16,7 @@ import {
 } from 'server/models';
 import { handleErrors } from 'server/utils/errors';
 import { withValue } from 'utils/fp';
+import { getCustomScriptsForCommunity } from 'server/customScript/queries';
 
 const findCollectionByPartialId = (maybePartialId) => {
 	return Collection.findOne({
@@ -68,12 +69,15 @@ app.get(['/collection/:collectionSlug', '/:collectionSlug'], async (req, res, ne
 					collectionId: collection.id,
 				});
 
+				const customScripts = await getCustomScriptsForCommunity(communityData.id);
+
 				return renderToNodeStream(
 					res,
 					<Html
 						chunkName="Collection"
 						initialData={initialData}
 						viewData={{ layoutPubsByBlock, collection }}
+						customScripts={customScripts}
 						headerComponents={generateMetaComponents({
 							initialData,
 							title: `${collection.title} · ${communityData.title}`,

--- a/server/routes/dashboardCustomScripts.tsx
+++ b/server/routes/dashboardCustomScripts.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import Html from 'server/Html';
+import app from 'server/server';
+import { ForbiddenError, handleErrors } from 'server/utils/errors';
+import { getInitialData } from 'server/utils/initData';
+import { hostIsValid } from 'server/utils/routes';
+import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
+import { getCustomScriptsForCommunity } from 'server/customScript/queries';
+
+app.get('/dash/scripts', async (req, res, next) => {
+	try {
+		if (!hostIsValid(req, 'community')) {
+			next();
+		}
+		const initialData = await getInitialData(req, true);
+		const { scopeData, communityData } = initialData;
+
+		if (!scopeData.activePermissions.canAdminCommunity) {
+			throw new ForbiddenError();
+		}
+
+		const customScripts = await getCustomScriptsForCommunity(communityData.id);
+
+		return renderToNodeStream(
+			res,
+			<Html
+				chunkName="DashboardCustomScripts"
+				initialData={initialData}
+				viewData={{ customScripts }}
+				headerComponents={generateMetaComponents({
+					initialData,
+					title: `Custom Scripts · ${communityData.title}`,
+					unlisted: true,
+				})}
+			/>,
+		);
+	} catch (err) {
+		return handleErrors(req, res, next)(err);
+	}
+});

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -12,6 +12,7 @@ require('./dashboardImpact');
 require('./dashboardMembers');
 require('./dashboardCommunityOverview');
 require('./dashboardCollectionOverview');
+require('./dashboardCustomScripts');
 require('./dashboardPubOverview');
 require('./dashboardPage');
 require('./dashboardPages');

--- a/server/routes/page.tsx
+++ b/server/routes/page.tsx
@@ -7,6 +7,7 @@ import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
 import { getPage } from 'server/utils/queryHelpers';
+import { getCustomScriptsForCommunity } from 'server/customScript/queries';
 import { Page } from 'utils/types';
 
 app.get(['/', '/:slug'], async (req, res, next) => {
@@ -33,6 +34,7 @@ app.get(['/', '/:slug'], async (req, res, next) => {
 			return next();
 		}
 
+		const customScripts = await getCustomScriptsForCommunity(initialData.communityData.id);
 		const pageData = await getPage({ query: { id: pageId }, initialData });
 		const pageTitle = !pageData.slug
 			? initialData.communityData.title
@@ -44,6 +46,7 @@ app.get(['/', '/:slug'], async (req, res, next) => {
 				chunkName="Page"
 				initialData={initialData}
 				viewData={{ pageData }}
+				customScripts={customScripts}
 				headerComponents={generateMetaComponents({
 					initialData,
 					title: pageTitle,

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -465,3 +465,6 @@ export type PubGetOptions = {
 	getReviews?: boolean;
 	getEdgesOptions?: PubEdgeIncludesOptions;
 };
+
+export type CustomScriptType = 'css' | 'js';
+export type CustomScripts = { [type in CustomScriptType]: null | string };


### PR DESCRIPTION
Though we're planning to roll this out verrrry slowly, one Community needs this functionality starting next week so I went ahead and added it today. This is a bit of an MVP and we can always revisit some of these design decisions:

- Custom scripts are stored directly in the database and inlined with the request rather than stored as a separate asset in S3. I think we'll probably want to change this.
- We're using the `@monaco-editor/react` editor as a code editor here instead of CodeMirror or something else.
- Right now this is only suitable for use in Communities that we trust. For untrusted Communities we'll need to do some heavy-duty CSS sanitization, and I sort of doubt we'll ever want to turn on custom JS by default.

_Test plan:_
I wrote a few basic tests:
```
npm run test-dev server/customScript
```
To actually test-drive this, make sure you're in the `demo` Community where this is enabled, and then:

- Visit `/dash/scripts`
- Add and save some JS and CSS (I know, I want meta+S keybindings too)
- Refresh the page and make what you added is still there
- Then visit a Page and a Collection layout on the Community and make sure that the custom scripts are working!

_Screenshots:_

The editor:
<img width="1904" alt="Screen Shot 2021-04-14 at 3 23 04 PM" src="https://user-images.githubusercontent.com/2208769/114767581-ce020b00-9d35-11eb-95ce-9711aecbb129.png">

_The result:_
<img width="1904" alt="Screen Shot 2021-04-14 at 3 32 22 PM" src="https://user-images.githubusercontent.com/2208769/114768279-a2cbeb80-9d36-11eb-9576-84e1aabf618c.png">