### PR TITLE
fix: add licenseSlug and premiumLicenseFlag checks back

### DIFF
--- a/server/pub/permissions.ts
+++ b/server/pub/permissions.ts
@@ -1,5 +1,6 @@
 import { Community } from 'server/models';
 import { getScope } from 'server/utils/queryHelpers';
+import { licenses } from 'utils/licenses';
 
 import { getValidCollectionIdsFromCreatePubToken } from './tokens';
 
@@ -29,10 +30,7 @@ const isValidLicenseSlugForCommunity = (community, licenseSlug) => {
 	return (
 		!licenseSlug ||
 		community.premiumLicenseFlag ||
-		licenseSlug === 'cc-by' ||
-		licenseSlug === 'cc-0' ||
-		licenseSlug === 'cc-by-nd' ||
-		licenseSlug === 'cc-by-nc-nd'
+		!licenses.find((l) => l.slug === licenseSlug)?.requiresPremium
 	);
 };
 


### PR DESCRIPTION
Makes the changes @idreyn suggested to simplify license checks.

_Test Plan_
- Make sure any community can use any of the 5 cc-by licenses for a Pub by selecting them all and refreshing and making sure they stick.
- Make sure non-premium communities cannot select the copyright license.
- Make sure a "premium" community (e.g. https://covid-19.mitpress.mit.edu/) can use the Copyright license.