### PR TITLE
feature: Overview Quick actions

### DIFF
--- a/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
+++ b/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
@@ -10,8 +10,16 @@ import { indexByProperty } from 'utils/arrays';
 import { Collection, CollectionPub, Maybe, PubsQuery, DefinitelyHas } from 'utils/types';
 import { getSchemaForKind } from 'utils/collections/schemas';
 import { usePageContext } from 'utils/hooks';
+import { getDashUrl } from 'utils/dashboard';
 
-import { OverviewFrame, OverviewSearchGroup, OverviewSection, ScopeSummaryList } from '../helpers';
+import {
+	OverviewFrame,
+	OverviewSearchGroup,
+	OverviewSection,
+	QuickActions,
+	QuickAction,
+	ScopeSummaryList,
+} from '../helpers';
 import { PubOverviewRow, LoadMorePubsRow, SpecialRow } from '../overviewRows';
 import { PubWithCollections } from './types';
 import { useCollectionPubs, useCollectionState } from './collectionState';
@@ -27,6 +35,27 @@ type Props = {
 		pubs: PubWithCollections[];
 		includesAllPubs: boolean;
 	};
+};
+
+const getQuickActionsForCollection = (collection: Collection): QuickAction[] => {
+	const { slug: collectionSlug } = collection;
+	return [
+		{
+			label: 'Edit layout',
+			icon: 'page-layout',
+			href: getDashUrl({ collectionSlug, mode: 'layout' }),
+		},
+		{
+			label: 'Edit metadata',
+			icon: 'layers',
+			href: getDashUrl({ collectionSlug, mode: 'settings', section: 'metadata' }),
+		},
+		{
+			label: 'Edit attribution',
+			icon: 'edit',
+			href: getDashUrl({ collectionSlug, mode: 'settings', section: 'attribution' }),
+		},
+	];
 };
 
 const DashboardCollectionOverview = (props: Props) => {
@@ -184,6 +213,9 @@ const DashboardCollectionOverview = (props: Props) => {
 		};
 		return (
 			<>
+				<OverviewSection title="Quick Actions" spaced>
+					<QuickActions actions={getQuickActionsForCollection(collection)} />
+				</OverviewSection>
 				<OverviewSection title="About">
 					<ScopeSummaryList scopeKind="collection" scope={collectionWithScopeSummary} />
 				</OverviewSection>

--- a/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
+++ b/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
@@ -147,6 +147,7 @@ const DashboardCollectionOverview = (props: Props) => {
 		const pub = pubsById[collectionPub.pubId]!;
 		return (
 			<PubOverviewRow
+				inCollection
 				className={classNames(isDragging && 'collection-overview-row-is-dragging')}
 				pub={pub}
 				leftIconElement={canDragDrop && <DragHandle dragHandleProps={dragHandleProps} />}

--- a/client/containers/DashboardOverview/CommunityOverview/DashboardCommunityOverview.tsx
+++ b/client/containers/DashboardOverview/CommunityOverview/DashboardCommunityOverview.tsx
@@ -2,10 +2,17 @@ import React from 'react';
 
 import { DashboardFrame } from 'components';
 import { Collection, Pub } from 'utils/types';
-
 import { usePageContext } from 'utils/hooks';
+import { getDashUrl } from 'utils/dashboard';
+
 import CommunityItems from './CommunityItems';
-import { OverviewFrame, OverviewSection, ScopeSummaryList } from '../helpers';
+import {
+	OverviewFrame,
+	OverviewSection,
+	ScopeSummaryList,
+	QuickActions,
+	QuickAction,
+} from '../helpers';
 
 type Props = {
 	overviewData: {
@@ -14,6 +21,24 @@ type Props = {
 		includesAllPubs: boolean;
 	};
 };
+
+const quickActions: QuickAction[] = [
+	{
+		label: 'Edit home page',
+		icon: 'page-layout',
+		href: getDashUrl({ mode: 'pages', subMode: 'home' }),
+	},
+	{
+		label: 'Edit nav bar',
+		icon: 'cog',
+		href: getDashUrl({ mode: 'settings', section: 'navigation' }),
+	},
+	{
+		label: 'Edit members/roles',
+		icon: 'people',
+		href: getDashUrl({ mode: 'members' }),
+	},
+];
 
 const DashboardCommunityOverview = (props: Props) => {
 	const { overviewData } = props;
@@ -33,9 +58,14 @@ const DashboardCommunityOverview = (props: Props) => {
 					</OverviewSection>
 				}
 				secondary={
-					<OverviewSection title="About">
-						<ScopeSummaryList scope={communityData} scopeKind="community" />
-					</OverviewSection>
+					<>
+						<OverviewSection title="Quick Actions" spaced>
+							<QuickActions actions={quickActions} />
+						</OverviewSection>
+						<OverviewSection title="About">
+							<ScopeSummaryList scope={communityData} scopeKind="community" />
+						</OverviewSection>
+					</>
 				}
 			/>
 		</DashboardFrame>

--- a/client/containers/DashboardOverview/helpers/OverviewSection.tsx
+++ b/client/containers/DashboardOverview/helpers/OverviewSection.tsx
@@ -10,12 +10,13 @@ type Props = {
 	title: React.ReactNode;
 	icon?: IconName;
 	descendTitle?: boolean;
+	spaced?: boolean;
 };
 
 const OverviewSection = (props: Props) => {
-	const { children, icon, title, descendTitle } = props;
+	const { children, icon, title, descendTitle, spaced } = props;
 	return (
-		<div className="overview-section-component">
+		<div className={classNames('overview-section-component', spaced && 'spaced')}>
 			<div className={classNames('title', descendTitle && 'descending')}>
 				{icon && <Icon icon={icon} iconSize={18} />}
 				{title}

--- a/client/containers/DashboardOverview/helpers/QuickActions.tsx
+++ b/client/containers/DashboardOverview/helpers/QuickActions.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { Icon, IconName } from 'components';
+
+require('./quickActions.scss');
+
+export type QuickAction = {
+	icon: IconName;
+	label: React.ReactNode;
+	href: string;
+};
+
+type Props = {
+	actions: QuickAction[];
+};
+
+const QuickActions = (props: Props) => {
+	const { actions } = props;
+	return (
+		<div className="quick-actions-component">
+			{actions.map((action) => {
+				const { icon, label, href } = action;
+				return (
+					<a className="quick-action" href={href}>
+						<div className="icon-wrapper">
+							<Icon icon={icon} iconSize={14} />
+						</div>
+						<div className="label">{label}</div>
+					</a>
+				);
+			})}
+		</div>
+	);
+};
+
+export default QuickActions;

--- a/client/containers/DashboardOverview/helpers/index.ts
+++ b/client/containers/DashboardOverview/helpers/index.ts
@@ -2,4 +2,5 @@ export { default as KindToggle } from './KindToggle';
 export { default as OverviewFrame } from './OverviewFrame';
 export { default as OverviewSection } from './OverviewSection';
 export { default as OverviewSearchGroup } from './OverviewSearchGroup';
+export { default as QuickActions, QuickAction } from './QuickActions';
 export { default as ScopeSummaryList } from './ScopeSummaryList';

--- a/client/containers/DashboardOverview/helpers/overviewFrame.scss
+++ b/client/containers/DashboardOverview/helpers/overviewFrame.scss
@@ -1,8 +1,8 @@
 .overview-frame-component {
     display: grid;
     grid-template-areas: 'primary secondary';
-    grid-template-columns: 1fr 300px;
-    column-gap: 50px;
+    grid-template-columns: 1fr 250px;
+    column-gap: 75px;
 
     & > .primary {
         grid-area: primary;

--- a/client/containers/DashboardOverview/helpers/overviewSection.scss
+++ b/client/containers/DashboardOverview/helpers/overviewSection.scss
@@ -1,6 +1,8 @@
 @import '../overviewStyles.scss';
 
 .overview-section-component {
+    color: $darkest-grey;
+
     &.spaced {
         margin-bottom: 20px;
     }

--- a/client/containers/DashboardOverview/helpers/overviewSection.scss
+++ b/client/containers/DashboardOverview/helpers/overviewSection.scss
@@ -1,6 +1,10 @@
 @import '../overviewStyles.scss';
 
 .overview-section-component {
+    &.spaced {
+        margin-bottom: 20px;
+    }
+
     > .title {
         display: flex;
         align-items: center;

--- a/client/containers/DashboardOverview/helpers/quickActions.scss
+++ b/client/containers/DashboardOverview/helpers/quickActions.scss
@@ -1,0 +1,40 @@
+@import '../overviewStyles.scss';
+
+.quick-actions-component {
+    > .quick-action {
+        display: flex;
+        align-items: center;
+        text-decoration: none;
+
+        > .icon-wrapper {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 24px;
+            height: 24px;
+            border: 1px solid $light-grey;
+            border-radius: 2px;
+        }
+
+        > .label {
+            text-transform: uppercase;
+            letter-spacing: 0.1px;
+            font-size: 11px;
+            margin-left: 9px;
+        }
+
+        &:hover {
+            > .icon-wrapper {
+                box-shadow: 0 3px 1px -2px rgba(black, 0.1);
+            }
+
+            > .label {
+                text-decoration: underline;
+            }
+        }
+
+        &:not(:last-child) {
+            margin-bottom: 6px;
+        }
+    }
+}

--- a/client/containers/DashboardOverview/overviewRows/OverviewRowSkeleton.tsx
+++ b/client/containers/DashboardOverview/overviewRows/OverviewRowSkeleton.tsx
@@ -21,6 +21,7 @@ type Props = {
 	title: React.ReactNode;
 	byline?: React.ReactNode;
 	rightElement?: React.ReactNode;
+	darkenRightIcons?: boolean;
 	iconLabelPairs: IconLabelPair[];
 	withBorder?: boolean;
 	withHoverEffect?: boolean;
@@ -37,6 +38,7 @@ const OverviewRowSkeleton = React.forwardRef((props: Props, ref: any) => {
 		rightElement = null,
 		withBorder = true,
 		withHoverEffect = false,
+		darkenRightIcons = false,
 		onClick,
 		href,
 	} = props;
@@ -107,7 +109,9 @@ const OverviewRowSkeleton = React.forwardRef((props: Props, ref: any) => {
 					})}
 				</div>
 			</div>
-			<div className="right-element">{rightElement}</div>
+			<div className={classNames('right-element', darkenRightIcons && 'darker')}>
+				{rightElement}
+			</div>
 		</div>
 	);
 });

--- a/client/containers/DashboardOverview/overviewRows/PubOverviewRow.tsx
+++ b/client/containers/DashboardOverview/overviewRows/PubOverviewRow.tsx
@@ -18,10 +18,17 @@ type Props = {
 	rightElement?: React.ReactNode;
 	className?: string;
 	pub: Pub;
+	inCollection?: boolean;
 };
 
 const PubOverviewRow = (props: Props) => {
-	const { pub, className, leftIconElement = null, rightElement: providedRightElement } = props;
+	const {
+		pub,
+		className,
+		inCollection,
+		leftIconElement = null,
+		rightElement: providedRightElement,
+	} = props;
 	const { communityData } = usePageContext();
 	const rightElement = providedRightElement || (
 		<AnchorButton
@@ -43,6 +50,7 @@ const PubOverviewRow = (props: Props) => {
 			]}
 			leftIcon={leftIconElement || 'pubDoc'}
 			rightElement={rightElement}
+			darkenRightIcons={inCollection}
 		/>
 	);
 };

--- a/client/containers/DashboardOverview/overviewRows/collectionOverviewRow.scss
+++ b/client/containers/DashboardOverview/overviewRows/collectionOverviewRow.scss
@@ -1,6 +1,3 @@
 .collection-overview-row-component {
     cursor: pointer;
-    .public-private-indicator {
-        width: 135px;
-    }
 }

--- a/client/containers/DashboardOverview/overviewRows/overviewRowSkeleton.scss
+++ b/client/containers/DashboardOverview/overviewRows/overviewRowSkeleton.scss
@@ -38,6 +38,11 @@ $mobile-viewport-cutoff: 750px;
         .bp3-icon {
             color: $light-grey;
         }
+        &.darker {
+            .bp3-icon {
+                color: $medium-grey;
+            }
+        }
     }
 
     .center-container {
@@ -78,7 +83,6 @@ $mobile-viewport-cutoff: 750px;
                 display: flex;
                 align-items: center;
                 > :first-child {
-                    opacity: 0.6;
                     margin-right: 6px;
                 }
                 &:not(:last-child) {

--- a/client/containers/DashboardOverview/overviewStyles.scss
+++ b/client/containers/DashboardOverview/overviewStyles.scss
@@ -2,5 +2,6 @@ $gentle-shadow: 0 4px 2px -2px rgba(black, 0.1);
 $light-grey: #bdbdbd;
 $medium-grey: #999;
 $dark-grey: #747474;
+$darkest-grey: #333;
 $row-border-color: #ddd;
 $empty-state-margin-top: 75px;

--- a/client/containers/DashboardSettings/CollectionSettings/CollectionSettings.tsx
+++ b/client/containers/DashboardSettings/CollectionSettings/CollectionSettings.tsx
@@ -52,7 +52,7 @@ const CollectionSettings = () => {
 				/>
 			</SettingsSection>
 			{collection.kind !== 'tag' && (
-				<SettingsSection title="Metadata">
+				<SettingsSection title="Metadata" id="metadata">
 					<CollectionMetadataEditor
 						collection={collection}
 						communityData={communityData}
@@ -61,7 +61,7 @@ const CollectionSettings = () => {
 				</SettingsSection>
 			)}
 			{collection.kind !== 'tag' && (
-				<SettingsSection title="Attribution">
+				<SettingsSection title="Attribution" id="attribution">
 					<AttributionEditor
 						apiRoute="/api/collectionAttributions"
 						canEdit={true}

--- a/client/containers/DashboardSettings/CommunitySettings.tsx
+++ b/client/containers/DashboardSettings/CommunitySettings.tsx
@@ -412,7 +412,7 @@ const CommunitySettings = () => {
 					/>
 				</InputField>
 			</SettingsSection>
-			<SettingsSection title="Navigation">
+			<SettingsSection title="Navigation" id="navigation">
 				<InputField>
 					<Switch
 						large={true}


### PR DESCRIPTION
This PR adds Quick Actions to the dashboard overview pages, which are super neat, and will continue to gain utility as the number of non-obvious things to do with a scope expands.

_Test plan:_
Visit a Community and Collection overview and make sure the Quick Actions link where they ought to

_Screenshot:_
![Screen Shot 2021-04-29 at 14 24 11](https://user-images.githubusercontent.com/2208769/116454004-80a19580-a82d-11eb-9160-39954970f391.png)
