### PR TITLE
update: Load Connections dashboard tab without all Pubs

### DIFF
--- a/client/components/LayoutEditor/LayoutEditorPubs/PinnedPubs.tsx
+++ b/client/components/LayoutEditor/LayoutEditorPubs/PinnedPubs.tsx
@@ -77,12 +77,7 @@ const PinnedPubs = (props: Props) => {
 			selectedTitle="Pinned Pubs"
 			availableTitle="Available Pubs"
 			renderItem={(pub, onClick) => (
-				<PubMenuItem
-					title={pub.title}
-					contributors={pub.attributions}
-					onClick={onClick}
-					bylineProps={{ truncateAt: 4 }}
-				/>
+				<PubMenuItem title={pub.title} contributors={pub.attributions} onClick={onClick} />
 			)}
 			searchTerm={searchTerm}
 			onSearch={setSearchTerm}

--- a/client/components/PubMenuItem/PubMenuItem.tsx
+++ b/client/components/PubMenuItem/PubMenuItem.tsx
@@ -49,7 +49,12 @@ const PubMenuItem = React.forwardRef((props: Props, ref: any) => {
 				<div className={classNames('title', skeletonClass)}>{title}</div>
 				{contributors && (
 					<div className={classNames('subtitle', skeletonClass)}>
-						<Byline contributors={contributors} linkToUsers={false} {...bylineProps} />
+						<Byline
+							contributors={contributors}
+							linkToUsers={false}
+							truncateAt={4}
+							{...bylineProps}
+						/>
 					</div>
 				)}
 			</div>

--- a/client/containers/DashboardEdges/DashboardEdges.tsx
+++ b/client/containers/DashboardEdges/DashboardEdges.tsx
@@ -13,13 +13,6 @@ import { useDashboardEdges } from './useDashboardEdges';
 require('./dashboardEdges.scss');
 
 type Props = {
-	overviewData: {
-		pubs: {
-			id: string;
-			title: string;
-			avatar?: string;
-		}[];
-	};
 	pubData: Pub & { outboundEdges: OutboundEdge[]; inboundEdges: InboundEdge[] };
 };
 
@@ -34,7 +27,7 @@ const frameDetails = (
 );
 
 const DashboardEdges = (props: Props) => {
-	const { overviewData, pubData } = props;
+	const { pubData } = props;
 	const [showOutboundEmptyState, setShowOutboundEmptyState] = useState(true);
 	const {
 		scopeData: {
@@ -72,14 +65,12 @@ const DashboardEdges = (props: Props) => {
 			pubData.id,
 			...pubData.outboundEdges
 				.map((edge) => edge.targetPub && edge.targetPub.id)
-				.filter((x) => x),
+				.filter((x): x is string => !!x),
 		];
 		return (
 			<>
 				{canManageEdges && (
 					<NewEdgeEditor
-						availablePubs={overviewData.pubs}
-						// @ts-expect-error ts-migrate(2322) FIXME: Type '(string | undefined)[]' is not assignable to... Remove this comment to see the full error message
 						usedPubIds={usedPubsIds}
 						pubData={persistedPubData}
 						onCreateNewEdge={addCreatedOutboundEdge}

--- a/client/containers/DashboardEdges/NewEdgeEditor.tsx
+++ b/client/containers/DashboardEdges/NewEdgeEditor.tsx
@@ -7,23 +7,16 @@ import { MenuButton, MenuItem } from 'components/Menu';
 import { apiFetch } from 'client/utils/apiFetch';
 import { usePendingChanges } from 'utils/hooks';
 import { RelationType, relationTypeDefinitions } from 'utils/pubEdge';
+import { Pub, PubEdge } from 'utils/types';
 
 import NewEdgeInput from './NewEdgeInput';
 
 require('./newEdgeEditor.scss');
 
 type Props = {
-	availablePubs: {
-		id: string;
-		title: string;
-		avatar?: string;
-	}[];
-	onCreateNewEdge: (...args: any[]) => any;
-	onChangeCreatingState: (...args: any[]) => any;
-	pubData: {
-		title?: string;
-		id?: string;
-	};
+	onCreateNewEdge: (edge: PubEdge) => unknown;
+	onChangeCreatingState: (isCreating: boolean) => unknown;
+	pubData: Pub;
 	usedPubIds: string[];
 };
 
@@ -45,7 +38,7 @@ const stripMarkupFromString = (string) => {
 };
 
 const NewEdgeEditor = (props: Props) => {
-	const { availablePubs, onChangeCreatingState, onCreateNewEdge, pubData, usedPubIds } = props;
+	const { onChangeCreatingState, onCreateNewEdge, pubData, usedPubIds } = props;
 	const [newEdge, setNewEdge] = useState<any>(null);
 	const [isCreatingEdge, setIsCreatingEdge] = useState(false);
 	const [errorCreatingEdge, setErrorCreatingEdge] = useState(null);
@@ -56,7 +49,7 @@ const NewEdgeEditor = (props: Props) => {
 		relationTypeDefinitions[newEdge.relationType] &&
 		relationTypeDefinitions[newEdge.relationType].name;
 
-	useEffect(() => onChangeCreatingState(!!newEdge), [newEdge, onChangeCreatingState]);
+	useEffect(() => void onChangeCreatingState(!!newEdge), [newEdge, onChangeCreatingState]);
 
 	const handleSelectItem = (item) => {
 		const { targetPub, externalPublication, createNewFromUrl } = item;
@@ -194,13 +187,7 @@ const NewEdgeEditor = (props: Props) => {
 	};
 
 	const renderInputControl = () => {
-		return (
-			<NewEdgeInput
-				availablePubs={availablePubs}
-				usedPubIds={usedPubIds}
-				onSelectItem={handleSelectItem}
-			/>
-		);
+		return <NewEdgeInput usedPubIds={usedPubIds} onSelectItem={handleSelectItem} />;
 	};
 
 	return (

--- a/client/containers/DashboardEdges/NewEdgeInput.tsx
+++ b/client/containers/DashboardEdges/NewEdgeInput.tsx
@@ -86,21 +86,19 @@ const NewEdgeInput = (props: Props) => {
 		if ('indeterminate' in item && item.indeterminate) {
 			return indeterminateMenuItem;
 		}
-		if ('targetPub' in item) {
+		if ('targetPub' in item && item.targetPub) {
 			const { targetPub } = item;
-			if (targetPub) {
-				return (
-					<PubMenuItem
-						key={targetPub.id}
-						title={targetPub.title}
-						contributors={targetPub.attributions.filter((attr) => attr.isAuthor)}
-						image={targetPub.avatar}
-						active={modifiers.active}
-						onClick={handleClick}
-						showImage={true}
-					/>
-				);
-			}
+			return (
+				<PubMenuItem
+					key={targetPub.id}
+					title={targetPub.title}
+					contributors={targetPub.attributions.filter((attr) => attr.isAuthor)}
+					image={targetPub.avatar}
+					active={modifiers.active}
+					onClick={handleClick}
+					showImage={true}
+				/>
+			);
 		}
 		if (
 			'externalPublication' in item &&

--- a/client/containers/DashboardEdges/newEdgeInput.scss
+++ b/client/containers/DashboardEdges/newEdgeInput.scss
@@ -2,4 +2,10 @@
     .bp3-popover-target {
         width: 100%;
     }
+
+    .loading-menu-item {
+        height: 100%;
+        display: flex;
+        align-items: center;
+    }
 }

--- a/client/containers/DashboardOverview/CollectionOverview/PubSelect.tsx
+++ b/client/containers/DashboardOverview/CollectionOverview/PubSelect.tsx
@@ -40,7 +40,6 @@ const PubSelect = (props: Props) => {
 				title={pub.title}
 				contributors={pub.attributions}
 				active={active}
-				bylineProps={{ truncateAt: 4 }}
 			/>
 		);
 	};

--- a/client/utils/apiFetch.ts
+++ b/client/utils/apiFetch.ts
@@ -3,7 +3,7 @@ type ApiFetchFn = (path: string, opts?: RequestInit) => Promise<JSON>;
 
 type HttpMethodApiFetchWrapper = (
 	path: string,
-	body: JSON | string,
+	body?: JSON | string,
 	opts?: RequestInit,
 ) => Promise<JSON>;
 

--- a/server/routes/dashboardEdges.tsx
+++ b/server/routes/dashboardEdges.tsx
@@ -7,16 +7,7 @@ import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
-import { getOverview, sanitizeOverview, getPubForRequest } from 'server/utils/queryHelpers';
-
-const getOverviewForEdges = async (initialData) => {
-	const rawOverview = await getOverview({
-		...initialData.scopeData.elements,
-		activeTargetType: 'community',
-	});
-	const { pubs } = sanitizeOverview(initialData, rawOverview);
-	return { pubs };
-};
+import { getPubForRequest } from 'server/utils/queryHelpers';
 
 app.get(
 	'/dash/pub/:pubSlug/connections',
@@ -27,14 +18,11 @@ app.get(
 			}
 			const { pubSlug } = req.params;
 			const initialData = await getInitialData(req, true);
-			const [overviewData, pubData] = await Promise.all([
-				getOverviewForEdges(initialData),
-				getPubForRequest({
-					slug: pubSlug,
-					initialData,
-					getEdges: 'all',
-				}),
-			]);
+			const pubData = await getPubForRequest({
+				slug: pubSlug,
+				initialData,
+				getEdges: 'all',
+			});
 
 			if (!pubData) {
 				throw new ForbiddenError();
@@ -45,7 +33,7 @@ app.get(
 				<Html
 					chunkName="DashboardEdges"
 					initialData={initialData}
-					viewData={{ overviewData, pubData }}
+					viewData={{ pubData }}
 					headerComponents={generateMetaComponents({
 						initialData,
 						title: `Connections · ${pubData.title}`,


### PR DESCRIPTION
This PR addresses one of the last places where we load all Pubs into scope on the Dashboard: the Connections tab.

_Test plan:_
Visit the Connections tab for a Pub and make sure:
- You can search for a Pub from within the Community and add a Connection
- You can also add a Connection by pasting in an external URL or DOI

Resolves #1358 