### PR TITLE
fix: Match NoteManager state to initialStructuredCitations

### DIFF
--- a/client/containers/Pub/usePubNotes.ts
+++ b/client/containers/Pub/usePubNotes.ts
@@ -24,13 +24,16 @@ export const usePubNotes = () => {
 	const isNumberList = noteManager.citationInlineStyleKind === 'count';
 	const renderedFootnotes = footnotes.map((footnote, index) => ({
 		...footnote,
-		...notes[footnote.structuredValue],
+		renderedStructuredValue: notes[footnote.structuredValue],
 		number: index + 1,
 	}));
 	const renderedCitations = useMemo(
 		() =>
 			citations
-				.map((citation) => ({ ...citation, ...notes[citation.structuredValue] }))
+				.map((citation) => ({
+					...citation,
+					renderedStructuredValue: notes[citation.structuredValue],
+				}))
 				.map((citation, index) => ({
 					...citation,
 					...(isNumberList && { number: index + 1 }),

--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -2,10 +2,12 @@ import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import Cite from 'citation-js';
+import { Node } from 'prosemirror-model';
 
 import { getNotes } from 'components/Editor';
 import { citationStyles, CitationStyleKind, CitationInlineStyleKind } from 'utils/citations';
 import { StructuredValue, RenderedStructuredValue } from 'utils/notesCore';
+import { Pub } from 'types';
 
 /* Different styles available here: */
 /* https://github.com/citation-style-language/styles */
@@ -49,7 +51,7 @@ const extractAuthorFromApa = (apaStyleCitation: string) => {
 const getInlineCitation = (
 	citationJson: any[],
 	citationApa: string,
-	inlineStyle: string,
+	inlineStyle: CitationInlineStyleKind,
 	fallbackValue: string,
 ) => {
 	if (inlineStyle === 'authorYear') {
@@ -66,8 +68,8 @@ const getInlineCitation = (
 
 const getSingleStructuredCitation = async (
 	structuredInput: string,
-	citationStyle: string,
-	inlineStyle: string,
+	citationStyle: CitationStyleKind,
+	inlineStyle: CitationInlineStyleKind,
 ) => {
 	try {
 		const fallbackValue = generateFallbackHash(structuredInput);
@@ -120,13 +122,9 @@ export const getStructuredCitations = async (
 	return structuredCitationsMap;
 };
 
-export const getStructuredCitationsForPub = (pubData, pubDocument) => {
-	const { initialDoc, citationStyle, citationInlineStyle } = pubData;
-
-	const { footnotes, citations } = initialDoc
-		? getNotes(pubDocument)
-		: { footnotes: [] as any[], citations: [] };
-
+export const getStructuredCitationsForPub = (pubData: Pub, pubDocument: Node) => {
+	const { citationStyle = 'apa', citationInlineStyle = 'count' } = pubData;
+	const { footnotes, citations } = getNotes(pubDocument);
 	const structuredValuesInDoc = [
 		...new Set([...footnotes, ...citations].map((note) => note.structuredValue)),
 	];

--- a/types/pub.ts
+++ b/types/pub.ts
@@ -1,4 +1,5 @@
 import { NodeLabelMap } from 'components/Editor';
+import { CitationInlineStyleKind, CitationStyleKind } from 'utils/citations';
 
 import { PubAttribution } from './attribution';
 import { CollectionPub } from './collection';
@@ -75,8 +76,8 @@ export type Pub = {
 	downloads?: any[];
 	metadata?: {};
 	licenseSlug?: string;
-	citationStyle?: string;
-	citationInlineStyle?: string;
+	citationStyle?: CitationStyleKind;
+	citationInlineStyle?: CitationInlineStyleKind;
 	viewHash?: string;
 	editHash?: string;
 	communityId: string;

--- a/utils/notesCore.ts
+++ b/utils/notesCore.ts
@@ -8,12 +8,7 @@ export type RenderedStructuredValue = {
 	error?: boolean;
 };
 
-type Note = {
-	structuredValue: StructuredValue;
-	renderedStructuredValue: RenderedStructuredValue;
-};
-
-type Notes = Record<StructuredValue, Note>;
+type Notes = Record<StructuredValue, RenderedStructuredValue>;
 
 type RenderStructuredValuesFn = (
 	structuredValues: StructuredValue[],
@@ -39,7 +34,7 @@ export class NoteManagerCore {
 	) {
 		this.citationStyleKind = citationStyleKind;
 		this.citationInlineStyleKind = citationInlineStyleKind;
-		this.notes = notes;
+		this.notes = { ...notes };
 		this.callbacks = new Set();
 		this.renderStructuredValues = renderStructuredValues;
 	}
@@ -52,8 +47,7 @@ export class NoteManagerCore {
 	}
 
 	getRenderedValueSync(structuredValue: StructuredValue): null | RenderedStructuredValue {
-		const note = this.notes[structuredValue];
-		return note?.renderedStructuredValue || null;
+		return this.notes[structuredValue] || null;
 	}
 
 	getRenderedValue(structuredValue: StructuredValue): Promise<null | RenderedStructuredValue> {
@@ -66,10 +60,7 @@ export class NoteManagerCore {
 					this.citationInlineStyleKind,
 			  ).then((renderedStructuredValues) => {
 					const renderedStructuredValue = renderedStructuredValues[structuredValue];
-					this.notes[structuredValue] = {
-						structuredValue,
-						renderedStructuredValue,
-					};
+					this.notes[structuredValue] = renderedStructuredValue;
 					this.callbacks.forEach((callback) => callback(this.notes));
 					return renderedStructuredValue;
 			  });


### PR DESCRIPTION
Resolves #1393 

`NoteManager` currently holds notes in this shape:

```ts
Record<StructuredValue, {structuredValue: StructuredValue, renderedStructuredValue: RenderedStructuredValue}>
```

but the `initialStructuredCitations` it receives from the server has the shape:

```ts
Record<StructuredValue, RenderedStructuredValue>
```
This causes us to call `/api/citation-format` for each of the citations in a Pub when it's loaded. My chosen fix is to change `NoteManager` to use the type provided by `initialStructuredCitation`, since I don't think we're using `note.structuredValue` anywhere in `NoteManager`.

_Test plan:_
Add some citations to a Pub and verify that they render correctly. Then refresh the page and verify that the same citations appear in the document with their rendered values intact, but that `/api/citation-format` has not been called.