### PR TITLE
fix: Look up timestamp in Firebase from draft checkpoint instead of checkpointMap

### DIFF
--- a/client/components/Editor/utils/firebaseDoc.ts
+++ b/client/components/Editor/utils/firebaseDoc.ts
@@ -8,13 +8,7 @@ import { flattenKeyables } from './firebase';
 type Reference = firebase.database.Reference;
 type Query = firebase.database.Query;
 
-type Checkpoint = {
-	d: Record<any, any>;
-	t: number;
-	k: number;
-};
-
-type CheckpointMap = Record<string, Checkpoint>;
+type CheckpointMap = Record<string, number>;
 
 type ChooseKey = (keys: number[]) => number;
 type TraverseQuery = (query: Query) => Query;
@@ -41,7 +35,7 @@ const getMostRecentDocJson = async (
 			const checkpoint = checkpointSnapshot.val();
 			if (checkpoint) {
 				const { doc } = uncompressStateJSON(checkpoint);
-				return { doc, key: bestKey, timestamp: checkpointMap[bestKey]?.t };
+				return { doc, key: bestKey, timestamp: checkpoint.t };
 			}
 		}
 	}


### PR DESCRIPTION
Resolves #1408 (I think)

This definitely fixes a problem, and I believe it's the same problem reported above where Pubs won't load into their history at keys that are multiples of 100. This is happening because we create history checkpoints ever 100 changes, and I conflated the `checkpoints` and `checkpointMap` properties of a Firebase draft...the former has the entire checkpoint while the latter is just a timestamp — essentially I was trying to pull a `number` off of a `number`. Ultimately this sends an undefined timestamp to the client, which crashes when trying to render it as a human-readable date string.

What I don't understand is why this is causing the server to hang instead of just giving us a white screen of death in production — but let's definitely get this onto Heroku and see if it fixes the problem, or gives us more insight into why the production server is behaving this way.