### PR TITLE
update: Community ActivityItem backfill tool

### DIFF
--- a/client/utils/activity/renderers/pub.tsx
+++ b/client/utils/activity/renderers/pub.tsx
@@ -191,7 +191,11 @@ export const renderPubReviewCreated = itemRenderer<PubReviewCreatedActivityItem,
 		);
 	},
 	excerpt: ({ item }) => {
-		return item.payload.threadComment.text;
+		const { threadComment } = item.payload;
+		if (threadComment) {
+			return threadComment.text;
+		}
+		return null;
 	},
 });
 

--- a/client/utils/activity/titles/user.ts
+++ b/client/utils/activity/titles/user.ts
@@ -4,18 +4,20 @@ import { ActivityRenderContext, Title, TitleRenderer } from '../types';
 import { getUserFromContext } from './util';
 
 const getUserTitleFromUserIdAndContext = (
-	userId: string,
+	userId: null | string,
 	context: ActivityRenderContext,
 ): Title => {
-	if (userId === context.userId) {
-		return { title: 'you' };
-	}
-	const userFromContext = getUserFromContext(userId, context);
-	if (userFromContext) {
-		return {
-			title: userFromContext.fullName,
-			href: `/user/${userFromContext.slug}`,
-		};
+	if (userId) {
+		if (userId === context.userId) {
+			return { title: 'you' };
+		}
+		const userFromContext = getUserFromContext(userId, context);
+		if (userFromContext) {
+			return {
+				title: userFromContext.fullName,
+				href: `/user/${userFromContext.slug}`,
+			};
+		}
 	}
 	return {
 		title: 'unknown user',

--- a/server/activityItem/fetch.ts
+++ b/server/activityItem/fetch.ts
@@ -113,7 +113,9 @@ const getActivityItemAssociationIds = (
 	}
 	items.forEach((item) => {
 		community.push(item.communityId);
-		user.push(item.actorId);
+		if (item.actorId) {
+			user.push(item.actorId);
+		}
 		if (item.collectionId) {
 			collection.push(item.collectionId);
 		}

--- a/server/activityItem/model.ts
+++ b/server/activityItem/model.ts
@@ -10,7 +10,7 @@ export default (sequelize, dataTypes) => {
 			allowNull: false,
 		},
 		communityId: { type: dataTypes.UUID, allowNull: false },
-		actorId: { type: dataTypes.UUID, allowNull: false },
+		actorId: { type: dataTypes.UUID },
 		collectionId: { type: dataTypes.UUID },
 	});
 };

--- a/server/activityItem/queries.ts
+++ b/server/activityItem/queries.ts
@@ -1,22 +1,23 @@
 import * as types from 'types';
 import {
 	Collection,
-	Member,
+	CollectionPub,
 	Community,
-	PubEdge,
 	Discussion,
 	ExternalPublication,
-	ReviewNew,
+	Member,
 	Pub,
-	CollectionPub,
-	ThreadComment,
+	PubEdge,
+	Release,
+	ReviewNew,
 	Thread,
+	ThreadComment,
 } from 'server/models';
 
 import { getDiffsForPayload, getChangeFlagsForPayload, createActivityItem } from './utils';
 
 const resolvePartialMemberItem = async (member: types.Member) => {
-	if ('pubId' in member) {
+	if ('pubId' in member && member.pubId) {
 		const pub: types.Pub = await Pub.findOne({ where: { id: member.pubId } });
 		return {
 			tag: 'pub',
@@ -31,7 +32,7 @@ const resolvePartialMemberItem = async (member: types.Member) => {
 			},
 		} as const;
 	}
-	if ('collectionId' in member) {
+	if ('collectionId' in member && member.collectionId) {
 		const collection: types.Collection = await Collection.findOne({
 			where: { id: member.collectionId },
 		});
@@ -242,34 +243,61 @@ export const createCollectionUpdatedActivityItem = async (
 	});
 };
 
-export const createPubReviewCreatedActivityItem = async (
-	kind: 'pub-review-created' | 'pub-review-comment-added',
-	actorId: string,
-	communityId: string,
-	reviewId: string,
-	isReply: boolean,
-) => {
+export const createPubReviewCreatedActivityItem = async (reviewId: string) => {
 	const review: types.DefinitelyHas<types.Review, 'thread'> = await ReviewNew.findOne({
 		where: { id: reviewId },
-		includes: [
-			{ model: Thread, as: 'thread', includes: [{ model: ThreadComment, as: 'comments' }] },
+		include: [
+			{ model: Thread, as: 'thread', include: [{ model: ThreadComment, as: 'comments' }] },
 		],
 	});
 	const threadComment: types.ThreadComment = review.thread.comments[0];
 	const pub: types.Pub = await Pub.findOne({ where: { id: review.pubId } });
+
+	const payloadThreadComment = threadComment && {
+		id: threadComment.id,
+		text: threadComment.text,
+		userId: threadComment.userId,
+	};
+
 	return createActivityItem({
-		communityId,
-		actorId,
-		kind,
+		communityId: pub.communityId,
+		actorId: review.userId,
+		kind: 'pub-review-created',
 		pubId: pub.id,
 		payload: {
 			reviewId,
 			threadId: review.threadId,
-			isReply,
+			isReply: false,
+			pub: { title: pub.title },
+			...(payloadThreadComment && { threadComment: payloadThreadComment }),
+		},
+	});
+};
+
+export const createPubReviewCommentAddedActivityItem = async (
+	reviewId: string,
+	threadCommentId: string,
+) => {
+	const [review, threadComment]: [types.Review, types.ThreadComment] = await Promise.all([
+		ReviewNew.findOne({
+			where: { id: reviewId },
+		}),
+		ThreadComment.findOne({ where: { id: threadCommentId } }),
+	]);
+	const pub = await Pub.findOne({ where: { id: review.pubId } });
+	return createActivityItem({
+		communityId: pub.communityId,
+		actorId: threadComment.userId,
+		kind: 'pub-review-comment-added' as const,
+		pubId: pub.id,
+		payload: {
+			reviewId,
+			threadId: review.threadId,
+			isReply: true,
 			threadComment: {
 				id: threadComment.id,
 				text: threadComment.text,
-				userId: actorId,
+				userId: threadComment.userId,
 			},
 			pub: { title: pub.title },
 		},
@@ -374,18 +402,13 @@ export const createPubUpdatedActivityItem = async (
 	});
 };
 
-export const createPubReleasedActivityItem = async (
-	kind: 'pub-released',
-	actorId: string,
-	communityId: string,
-	releaseId: string,
-	pubId: string,
-) => {
-	const pub: types.Pub = await Pub.findOne({ where: { id: pubId } });
+export const createPubReleasedActivityItem = async (actorId: string, releaseId: string) => {
+	const release: types.Release = await Release.findOne({ where: { id: releaseId } });
+	const pub: types.Pub = await Pub.findOne({ where: { id: release.pubId } });
 	return createActivityItem({
-		kind,
+		kind: 'pub-released' as const,
 		actorId,
-		communityId,
+		communityId: pub.communityId,
 		pubId: pub.id,
 		payload: {
 			releaseId,
@@ -400,7 +423,6 @@ export const createPubEdgeActivityItem = async (
 	kind: 'pub-edge-created' | 'pub-edge-removed',
 	actorId: string,
 	pubEdgeId: string,
-	communityId: string,
 ) => {
 	const pubEdge: types.DefinitelyHas<types.PubEdge, 'pub'> &
 		types.DefinitelyHas<
@@ -408,8 +430,9 @@ export const createPubEdgeActivityItem = async (
 			'targetPub' | 'externalPublication'
 		> = await PubEdge.findOne({
 		where: { id: pubEdgeId },
-		includes: [
+		include: [
 			{ model: Pub, as: 'pub' },
+			{ model: Pub, as: 'targetPub' },
 			{ model: ExternalPublication, as: 'externalPublication' },
 		],
 	});
@@ -432,7 +455,7 @@ export const createPubEdgeActivityItem = async (
 	return createActivityItem({
 		kind,
 		actorId,
-		communityId,
+		communityId: pubEdge.pub.communityId,
 		pubId: pubEdge.pubId,
 		payload: {
 			pub: {
@@ -444,27 +467,25 @@ export const createPubEdgeActivityItem = async (
 	});
 };
 
-export const createPubDiscussionActivityItem = async (
-	kind: 'pub-discussion-comment-added',
-	actorId: string,
-	communityId: string,
-	isReply: boolean,
-	pubId: string,
+export const createPubDiscussionCommentAddedActivityItem = async (
 	discussionId: string,
 	threadCommentId: string,
+	isReply: boolean,
 ) => {
-	const pub: types.Pub = await Pub.findOne({ where: { id: pubId } });
-	const threadComment: types.ThreadComment = await ThreadComment.findOne({
-		where: { id: threadCommentId },
-	});
-	const discussion: types.DefinitelyHas<types.Discussion, 'thread'> = await Discussion.findOne({
-		where: { id: discussionId },
-	});
+	const [threadComment, discussion]: [types.ThreadComment, types.Discussion] = await Promise.all([
+		ThreadComment.findOne({
+			where: { id: threadCommentId },
+		}),
+		Discussion.findOne({
+			where: { id: discussionId },
+		}),
+	]);
+	const pub: types.Pub = await Pub.findOne({ where: { id: discussion.pubId } });
 	return createActivityItem({
-		kind,
-		pubId,
-		actorId,
-		communityId,
+		kind: 'pub-discussion-comment-added',
+		pubId: discussion.pubId,
+		actorId: threadComment.userId,
+		communityId: pub.communityId,
 		payload: {
 			pub: {
 				title: pub.title,
@@ -475,7 +496,7 @@ export const createPubDiscussionActivityItem = async (
 			threadComment: {
 				id: threadCommentId,
 				text: threadComment.text,
-				userId: actorId,
+				userId: threadComment.userId,
 			},
 		},
 	});

--- a/server/models.ts
+++ b/server/models.ts
@@ -7,10 +7,8 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
 	require(path.join(process.cwd(), 'config.js'));
 }
 
-// @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
-const useSSL = process.env.DATABASE_URL.indexOf('localhost') === -1;
-// @ts-expect-error ts-migrate(2351) FIXME: This expression is not constructable.
-export const sequelize = new Sequelize(process.env.DATABASE_URL, {
+const useSSL = process.env.DATABASE_URL!.indexOf('localhost') === -1;
+export const sequelize = new (Sequelize as any)(process.env.DATABASE_URL, {
 	logging: false,
 	dialectOptions: { ssl: useSSL ? { rejectUnauthorized: false } : false },
 	pool: {
@@ -104,8 +102,7 @@ export const includeUserModel = (() => {
 })();
 
 /* Create associations for models that have associate function */
-Object.values(sequelize.models).forEach((model) => {
-	// @ts-expect-error ts-migrate(2571) FIXME: Object is of type 'unknown'.
+Object.values(sequelize.models).forEach((model: any) => {
 	const classMethods = model.options.classMethods || {};
 	if (classMethods.associate) {
 		classMethods.associate(sequelize.models);

--- a/tools/activityItem/backfillCommunity.ts
+++ b/tools/activityItem/backfillCommunity.ts
@@ -1,0 +1,156 @@
+import * as types from 'types';
+import {
+	ActivityItem,
+	Collection,
+	CollectionPub,
+	Member,
+	Pub,
+	ReviewNew,
+	Discussion,
+	Release,
+	PubEdge,
+	PubAttribution,
+	ThreadComment,
+} from 'server/models';
+import {
+	createCollectionActivityItem,
+	createCollectionPubActivityItem,
+	createCommunityCreatedActivityItem,
+	createMemberCreatedActivityItem,
+	createPubActivityItem,
+	createPubEdgeActivityItem,
+	createPubReleasedActivityItem,
+	createPubReviewCreatedActivityItem,
+	createPubReviewCommentAddedActivityItem,
+	createPubDiscussionCommentAddedActivityItem,
+} from 'server/activityItem/queries';
+
+import { forEach } from '../migrations/util';
+
+type MembershipScope = { communityId: string } | { collectionId: string } | { pubId: string };
+
+type Context = {
+	community: types.Community;
+	defaultActorId: string;
+};
+
+const deleteExistingItemsForCommunity = async (ctx: Context) => {
+	const { community } = ctx;
+	await ActivityItem.destroy({ where: { communityId: community.id } });
+};
+
+const setItemTimestamp = async (item: any, timestamp: string) => {
+	item.timestamp = timestamp;
+	await item.save();
+};
+
+const backfillMembers = async (ctx: Context, scope: MembershipScope) => {
+	const members = await Member.findAll({ where: { ...scope } });
+	await forEach(members, async (member) => {
+		const item = await createMemberCreatedActivityItem(ctx.defaultActorId, member.id);
+		await setItemTimestamp(item, member.createdAt);
+	});
+};
+
+const backfillCommunity = async (ctx: Context) => {
+	const { defaultActorId, community } = ctx;
+	const item = await createCommunityCreatedActivityItem(defaultActorId, community.id);
+	await setItemTimestamp(item, community.createdAt);
+	await backfillMembers(ctx, { communityId: ctx.community.id });
+};
+
+const backfillCollectionPubs = async (ctx: Context, collection: types.Collection) => {
+	const collectionPubs = await CollectionPub.findAll({ where: { collectionId: collection.id } });
+	await forEach(collectionPubs, async (collectionPub) => {
+		const item = await createCollectionPubActivityItem(
+			'collection-pub-created',
+			ctx.defaultActorId,
+			collectionPub.id,
+		);
+		await setItemTimestamp(item, collectionPub.createdAt);
+	});
+};
+
+const backfillCollections = async (ctx: Context) => {
+	const collections = await Collection.findAll({ where: { communityId: ctx.community.id } });
+	await forEach(collections, async (collection) => {
+		const item = await createCollectionActivityItem(
+			'collection-created',
+			ctx.defaultActorId,
+			collection.id,
+		);
+		await setItemTimestamp(item, collection.createdAt);
+		await backfillCollectionPubs(ctx, collection);
+		await backfillMembers(ctx, { collectionId: collection.id });
+	});
+};
+
+const backfillReview = async (review: types.Review) => {
+	const threadComments = await ThreadComment.findAll({ where: { threadId: review.threadId } });
+	const createdItem = await createPubReviewCreatedActivityItem(review.id);
+	await setItemTimestamp(createdItem, review.createdAt);
+	await forEach(threadComments, async (threadComment) => {
+		const item = await createPubReviewCommentAddedActivityItem(review.id, threadComment.id);
+		await setItemTimestamp(item, threadComment.createdAt);
+	});
+};
+
+const backfillDiscussion = async (discussion: types.Discussion) => {
+	const threadComments = await ThreadComment.findAll({
+		where: { threadId: discussion.threadId },
+	});
+	await forEach(threadComments, async (threadComment, index) => {
+		const item = await createPubDiscussionCommentAddedActivityItem(
+			discussion.id,
+			threadComment.id,
+			index > 0,
+		);
+		await setItemTimestamp(item, threadComment.createdAt);
+	});
+};
+
+const backfillPub = async (ctx: Context, pub: types.Pub) => {
+	const [releases, reviews, discussions, pubEdges] = await Promise.all(
+		[Release, ReviewNew, Discussion, PubEdge, PubAttribution].map((Model) =>
+			Model.findAll({ where: { pubId: pub.id } }),
+		),
+	);
+	const createdItem = await createPubActivityItem('pub-created', ctx.defaultActorId, pub.id);
+	await setItemTimestamp(createdItem, pub.createdAt);
+	await backfillMembers(ctx, { pubId: pub.id });
+
+	await forEach(releases, async (release) => {
+		const item = await createPubReleasedActivityItem(ctx.defaultActorId, release.id);
+		await setItemTimestamp(item, release.createdAt);
+	});
+
+	await forEach(pubEdges, async (pubEdge) => {
+		const item = await createPubEdgeActivityItem(
+			'pub-edge-created',
+			ctx.defaultActorId,
+			pubEdge.id,
+		);
+		await setItemTimestamp(item, pubEdge.createdAt);
+	});
+
+	await forEach(reviews, (review) => backfillReview(review));
+	await forEach(discussions, (discussion) => backfillDiscussion(discussion));
+};
+
+const backfillPubs = async (ctx: Context) => {
+	const pubs = await Pub.findAll({ where: { communityId: ctx.community.id } });
+	await forEach(pubs, (pub) => backfillPub(ctx, pub), 10);
+};
+
+export const backfillItemsForCommunity = async (community: types.Community) => {
+	const ctx: Context = {
+		community,
+		// We won't always know who the actor is for the items the backfill creates, but we want
+		// to slip this `null` past the assertions that actorId will be given in the future.
+		defaultActorId: (null as unknown) as string,
+	};
+	await deleteExistingItemsForCommunity(ctx);
+	await backfillCommunity(ctx);
+	await backfillCollections(ctx);
+	await backfillPubs(ctx);
+};

--- a/tools/activityItem/singleCommunityCli.ts
+++ b/tools/activityItem/singleCommunityCli.ts
@@ -1,0 +1,21 @@
+import { Community } from 'server/models';
+import { promptOkay } from '../utils/prompt';
+
+import { backfillItemsForCommunity } from './backfillCommunity';
+
+const {
+	argv: { community: communitySubdomain },
+} = require('yargs');
+
+const main = async () => {
+	const community = await Community.findOne({ where: { subdomain: communitySubdomain } });
+	if (!community) {
+		throw new Error('Community does not exist');
+	}
+	await promptOkay(`Remove and rebuild ActivityItems for ${community.title}?`, {
+		throwIfNo: true,
+	});
+	await backfillItemsForCommunity(community);
+};
+
+main();

--- a/tools/index.js
+++ b/tools/index.js
@@ -13,6 +13,7 @@ require('utils/environment').setEnvironment(process.env.PUBPUB_PRODUCTION, proce
 
 const command = process.argv[2];
 const commandFiles = {
+	backfillCommunityActivity: './activityItem/singleCommunityCli',
 	backfillCheckpoints: './backfillCheckpoints',
 	backfillCrossrefDepositRecords: './backfillCrossrefDepositRecords',
 	backup: './backup/backup',

--- a/types/activity/base.ts
+++ b/types/activity/base.ts
@@ -1,7 +1,7 @@
 export type InsertableActivityItemBase = {
 	kind: string;
 	communityId: string;
-	actorId: string;
+	actorId: null | string;
 	collectionId?: string;
 	pubId?: string;
 };

--- a/types/activity/pub.ts
+++ b/types/activity/pub.ts
@@ -3,7 +3,7 @@ import { Diff } from '../util';
 
 import { InsertableActivityItemBase } from './base';
 import { DiscussionActivityItemBase } from './discussion';
-import { ThreadActivityItemBase } from './thread';
+import { MightHaveThreadCommentItemBase, ThreadActivityItemBase } from './thread';
 
 type PubActivityItemBase = InsertableActivityItemBase & {
 	pubId: string;
@@ -79,7 +79,7 @@ export type PubDiscussionCommentAddedActivityItem = PubDiscussionActivityItemBas
 type PubReviewActivityItemBase = PubActivityItemBase & { payload: { reviewId: string } };
 
 export type PubReviewCreatedActivityItem = PubReviewActivityItemBase &
-	ThreadActivityItemBase & {
+	MightHaveThreadCommentItemBase & {
 		kind: 'pub-review-created';
 	};
 

--- a/types/activity/thread.ts
+++ b/types/activity/thread.ts
@@ -1,3 +1,4 @@
+import { MightHave } from 'types/util';
 import { InsertableActivityItemBase } from './base';
 
 export type ThreadActivityItemBase = InsertableActivityItemBase & {
@@ -10,4 +11,8 @@ export type ThreadActivityItemBase = InsertableActivityItemBase & {
 			userId: string;
 		};
 	};
+};
+
+export type MightHaveThreadCommentItemBase = Omit<ThreadActivityItemBase, 'payload'> & {
+	payload: MightHave<ThreadActivityItemBase['payload'], 'threadComment'>;
 };

--- a/types/util.ts
+++ b/types/util.ts
@@ -2,6 +2,7 @@ export type Falsy = false | null | undefined | '' | 0;
 export type Maybe<X> = X extends Falsy ? never : X | Falsy;
 export type Some<X> = X extends Falsy ? never : X;
 export type DefinitelyHas<X extends {}, Keys> = X & { [k in keyof X & Keys]: Some<X[k]> };
+export type MightHave<X extends {}, Keys extends keyof X> = Pick<Partial<X>, Keys> & Omit<X, Keys>;
 
 type PatchFnUpdaterArg<T> = (current: T) => Partial<T>;
 type PatchFnPatchArg<T> = Partial<T>;


### PR DESCRIPTION
Resolves #1441

In this PR we add a tool that creates as many `ActivityItems` as can be inferred from the history of a Community. Also note:

- I made the `actorId` property of an `ActivityItem` nullable because it's not possible to infer an actor in many cases here
- There are some changes to some of the `ActivityItem` types and creation queries to best reflect their actual use (for instance, I discovered that not every created Review comes with a ThreadComment).

_Test plan:_

I ran
```
npm run tools backfillCommunityActivity -- --community kfg-notes
```
and observed that it completed, creating about 4,000 items in the database. I did the same thing with `hdsr` for good measure.