### PR TITLE
feature: Activity dashboard tab

### DIFF
--- a/client/containers/App/App.tsx
+++ b/client/containers/App/App.tsx
@@ -3,6 +3,7 @@ import { Provider as RKProvider } from 'reakit';
 import classNames from 'classnames';
 
 import { Header, Footer, LegalBanner, AccentStyle, NavBar, SkipLink } from 'components';
+import { Community } from 'types';
 import { PageContext } from 'utils/hooks';
 import { hydrateWrapper } from 'client/utils/hydrateWrapper';
 
@@ -18,6 +19,14 @@ type Props = {
 	chunkName: string;
 	initialData: any;
 	viewData: any;
+};
+
+const renderCssVariablesStyle = (community: Community) => {
+	return (
+		<style type="text/css">
+			{`:root { --community-accent-dark: ${community.accentColorDark} }`}
+		</style>
+	);
 };
 
 const App = (props: Props) => {
@@ -39,6 +48,7 @@ const App = (props: Props) => {
 	return (
 		<PageContext.Provider value={pageContextProps}>
 			<RKProvider>
+				{renderCssVariablesStyle(communityData)}
 				<div id="app" className={classNames({ dashboard: isDashboard })}>
 					<AccentStyle communityData={communityData} isNavHidden={!showNav} />
 					{locationData.isDuqDuq && (

--- a/client/containers/App/SideMenu/SideMenu.tsx
+++ b/client/containers/App/SideMenu/SideMenu.tsx
@@ -28,6 +28,12 @@ const SideMenu = () => {
 			href: getDashUrl({ collectionSlug, pubSlug }),
 		},
 		{
+			title: 'Activity',
+			icon: 'pulse' as const,
+			href: getDashUrl({ collectionSlug, pubSlug, mode: 'activity' }),
+			manageRequired: true,
+		},
+		{
 			title: 'Pages',
 			icon: 'page-layout' as const,
 			href: getDashUrl({

--- a/client/containers/DashboardActivity/ActivityFilters.tsx
+++ b/client/containers/DashboardActivity/ActivityFilters.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import classNames from 'classnames';
+import { Checkbox } from 'reakit/Checkbox';
+
+import { ActivityFilter, Scope } from 'types';
+import { Icon, IconName } from 'components';
+
+require('./activityFilters.scss');
+
+type Props = {
+	activeFilters: ActivityFilter[];
+	onUpdateActiveFilters: (nextFilters: ActivityFilter[]) => unknown;
+	scope: Scope;
+};
+
+type FilterLabel = {
+	label: string;
+	icon: IconName;
+};
+
+const filterLabels: Record<ActivityFilter, FilterLabel> = {
+	community: { label: 'Community', icon: 'office' },
+	collection: { label: 'Collections', icon: 'collection' },
+	pub: { label: 'Pubs', icon: 'pubDoc' },
+	member: { label: 'Members', icon: 'people' },
+	review: { label: 'Reviews', icon: 'social-media' },
+	discussion: { label: 'Discussions', icon: 'chat' },
+	pubEdge: { label: 'Connections', icon: 'layout-auto' },
+};
+
+const allFilters = Object.keys(filterLabels) as ActivityFilter[];
+const sortedFilters = (filters: ActivityFilter[]) =>
+	filters.concat().sort((a, b) => allFilters.indexOf(a) - allFilters.indexOf(b));
+
+const filtersByScopeKind = {
+	community: sortedFilters(['community', 'collection', 'pub', 'member', 'review', 'discussion']),
+	collection: sortedFilters(['pub', 'member', 'review', 'discussion']),
+	pub: sortedFilters(['member', 'review', 'discussion', 'pubEdge']),
+};
+
+const getFiltersForScope = (scope: Scope) => {
+	if ('pubId' in scope && scope.pubId) {
+		return filtersByScopeKind.pub;
+	}
+	if ('collectionId' in scope && scope.collectionId) {
+		return filtersByScopeKind.collection;
+	}
+	return filtersByScopeKind.community;
+};
+
+const toggleFilterInclusion = (currentFilters: ActivityFilter[], toggleFilter: ActivityFilter) => {
+	if (currentFilters.includes(toggleFilter)) {
+		return currentFilters.filter((filter) => filter !== toggleFilter);
+	}
+	return [...currentFilters, toggleFilter];
+};
+
+const ActivityFilters = (props: Props) => {
+	const { activeFilters, onUpdateActiveFilters, scope } = props;
+
+	return (
+		<div
+			className={classNames(
+				'activity-filters-component',
+				activeFilters.length > 0 && 'some-filters-active',
+			)}
+		>
+			<div className="label">Filter by</div>
+			{getFiltersForScope(scope).map((filter) => {
+				const { label, icon } = filterLabels[filter];
+				return (
+					<Checkbox
+						key={filter}
+						as="div"
+						className="activity-filter"
+						checked={activeFilters.includes(filter)}
+						onChange={() =>
+							onUpdateActiveFilters(toggleFilterInclusion(activeFilters, filter))
+						}
+					>
+						<Icon icon={icon} iconSize={12} />
+						{label}
+					</Checkbox>
+				);
+			})}
+		</div>
+	);
+};
+
+export default ActivityFilters;

--- a/client/containers/DashboardActivity/ActivityItemRow.tsx
+++ b/client/containers/DashboardActivity/ActivityItemRow.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { formatDate } from 'utils/dates';
+import { Icon } from 'client/components';
+import { RenderedActivityItem } from 'client/utils/activity/types';
+
+require('./activityItemRow.scss');
+
+type Props = {
+	item: RenderedActivityItem;
+};
+
+const ActivityItemRow = (props: Props) => {
+	const {
+		item: { message, excerpt, timestamp, icon },
+	} = props;
+	return (
+		<div className="activity-item-row-component">
+			<div className="timestamp">{formatDate(timestamp, { includeTime: true })}</div>
+			<div className="icon">
+				<Icon icon={icon} />
+			</div>
+			<div className="message">{message}</div>
+			{excerpt && <div className="excerpt">{excerpt}</div>}
+		</div>
+	);
+};
+
+export default ActivityItemRow;

--- a/client/containers/DashboardActivity/DashboardActivity.tsx
+++ b/client/containers/DashboardActivity/DashboardActivity.tsx
@@ -1,5 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Button, NonIdealState, Spinner } from '@blueprintjs/core';
+
+import { ActivityFilter } from 'types';
 import { usePageContext } from 'utils/hooks';
+import { DashboardFrame } from 'client/components';
+import { useInfiniteScroll } from 'client/utils/useInfiniteScroll';
+
+import { useActivityItems } from './useActivityItems';
+import ActivityItemRow from './ActivityItemRow';
+import ActivityFilters from './ActivityFilters';
 
 require('./dashboardActivity.scss');
 
@@ -9,17 +18,57 @@ type Props = {
 
 const DashboardActivity = (props: Props) => {
 	const { activityData } = props;
-	const { scopeData } = usePageContext();
+	const {
+		scopeData: { scope },
+		loginData: { id: userId },
+	} = usePageContext();
 
-	void activityData;
-	void scopeData;
+	const [filters, setFilters] = useState<ActivityFilter[]>([]);
+
+	const { items, loadMoreItems, isLoading, loadedAllItems } = useActivityItems({
+		initialActivityData: activityData,
+		scope,
+		userId,
+		filters,
+	});
+
+	useInfiniteScroll({
+		enabled: !isLoading && !loadedAllItems,
+		useDocumentElement: true,
+		onRequestMoreItems: loadMoreItems,
+		scrollTolerance: 200,
+	});
 
 	return (
-		<div className="dashboard-activity-container">
-			<div className="dashboard-content-header">
-				<div className="name">Activity</div>
+		<DashboardFrame className="dashboard-activity-container" title="Activity">
+			<ActivityFilters
+				activeFilters={filters}
+				onUpdateActiveFilters={setFilters}
+				scope={scope}
+			/>
+			<div className="activity-items">
+				{items.map((item) => (
+					<ActivityItemRow item={item} key={item.id} />
+				))}
 			</div>
-		</div>
+			{items.length === 0 && loadedAllItems && (
+				<NonIdealState
+					icon="clean"
+					className="empty-state"
+					title="No matching activity to show"
+					action={
+						<Button outlined onClick={() => setFilters([])}>
+							Clear filters
+						</Button>
+					}
+				/>
+			)}
+			{isLoading && (
+				<div className="loading-indicator">
+					<Spinner size={28} />
+				</div>
+			)}
+		</DashboardFrame>
 	);
 };
 export default DashboardActivity;

--- a/client/containers/DashboardActivity/activityFilters.scss
+++ b/client/containers/DashboardActivity/activityFilters.scss
@@ -1,0 +1,48 @@
+@import '../DashboardOverview/overviewStyles.scss';
+
+.activity-filters-component {
+    display: flex;
+
+    .label {
+        display: flex;
+        align-items: center;
+        margin-right: 8px;
+    }
+
+    &.some-filters-active {
+        .activity-filter {
+            color: #999;
+        }
+    }
+
+    .activity-filter {
+        color: #333;
+        cursor: pointer;
+        display: flex;
+        user-select: none;
+        align-items: center;
+        border-radius: 2px;
+        padding: 4px 8px;
+        border: 1px solid #aaa;
+        box-sizing: border-box;
+
+        .bp3-icon {
+            margin-right: 4px;
+            margin-top: 1px;
+        }
+
+        &:not(:last-child) {
+            margin-right: 8px;
+        }
+
+        &:hover {
+            box-shadow: $gentle-shadow;
+        }
+
+        &[aria-checked='true'] {
+            color: white;
+            background: var(--community-accent-dark);
+            border-color: var(--community-accent-dark);
+        }
+    }
+}

--- a/client/containers/DashboardActivity/activityItemRow.scss
+++ b/client/containers/DashboardActivity/activityItemRow.scss
@@ -1,0 +1,55 @@
+$border: 1px solid #ddd;
+
+.activity-item-row-component {
+    display: grid;
+    grid-template-areas:
+        'timestamp icon message'
+        '. . excerpt';
+    grid-template-columns: 160px 80px 1fr;
+    padding: 20px 0;
+    border-top: $border;
+
+    &:last-child {
+        border-bottom: $border;
+    }
+
+    > .timestamp {
+        font-weight: 300;
+        font-style: italic;
+        grid-area: timestamp;
+        text-align: right;
+    }
+
+    > .icon {
+        color: #999;
+        grid-area: icon;
+        display: flex;
+        justify-content: center;
+    }
+
+    > .message {
+        grid-area: message;
+
+        strong {
+            color: #999;
+        }
+
+        a {
+            text-decoration: none;
+            strong {
+                color: black;
+            }
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+    }
+
+    > .excerpt {
+        margin-top: 10px;
+        padding: 15px;
+        border-radius: 2px;
+        background: whitesmoke;
+        grid-area: excerpt;
+    }
+}

--- a/client/containers/DashboardActivity/dashboardActivity.scss
+++ b/client/containers/DashboardActivity/dashboardActivity.scss
@@ -1,3 +1,16 @@
 .dashboard-activity-container {
-	
+    .activity-items {
+        margin-top: 20px;
+    }
+
+    .empty-state {
+        margin-top: 40px;
+    }
+
+    .loading-indicator {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 20px 0;
+    }
 }

--- a/client/containers/DashboardActivity/useActivityItems.ts
+++ b/client/containers/DashboardActivity/useActivityItems.ts
@@ -1,0 +1,188 @@
+import { useMemo, useState } from 'react';
+
+import {
+	ActivityAssociations,
+	ActivityFilter,
+	ActivityItem,
+	ActivityItemsFetchResult,
+	IdIndex,
+	Maybe,
+} from 'types';
+import { ActivityRenderContext, RenderedActivityItem } from 'client/utils/activity/types';
+import { renderActivityItem } from 'client/utils/activity';
+import { apiFetch } from 'client/utils/apiFetch';
+import { createActivityAssociations } from '../../../utils/activity';
+
+type PartialActivityRenderContext = Omit<ActivityRenderContext, 'associations'>;
+
+type SerializedQuery = string;
+
+type Query = {
+	filters: ActivityFilter[];
+};
+
+type QueryState = {
+	itemIds: string[];
+	offset: number;
+	isLoading: boolean;
+	loadedAllItems: boolean;
+};
+
+type State = {
+	queries: Record<SerializedQuery, QueryState>;
+	associations: ActivityAssociations;
+	itemsById: IdIndex<RenderedActivityItem>;
+};
+
+type Options = PartialActivityRenderContext & {
+	filters: ActivityFilter[];
+	initialActivityData: ActivityItemsFetchResult;
+	batchSize?: number;
+};
+
+type ReturnValues = {
+	items: RenderedActivityItem[];
+	loadMoreItems: () => unknown;
+	loadedAllItems: boolean;
+	isLoading: boolean;
+};
+
+const initialState: State = {
+	queries: {},
+	associations: createActivityAssociations(),
+	itemsById: {},
+};
+
+const initialQueryState: QueryState = {
+	isLoading: false,
+	loadedAllItems: false,
+	offset: 0,
+	itemIds: [],
+};
+
+const serializeQuery = (query: Query) => {
+	const sortedFilters = query.filters.concat().sort();
+	return JSON.stringify({ filters: sortedFilters });
+};
+
+const updateQueryStateWithFetchResult = (
+	previousQueryState: Maybe<QueryState>,
+	result: ActivityItemsFetchResult,
+): QueryState => {
+	const { activityItems, fetchedAllItems } = result;
+	const { itemIds, offset } = previousQueryState || initialQueryState;
+	const newItemIds = activityItems.map((item) => item.id);
+	return {
+		loadedAllItems: fetchedAllItems,
+		isLoading: false,
+		itemIds: [...itemIds, ...newItemIds],
+		offset: offset + newItemIds.length,
+	};
+};
+
+const mergeAssociations = (
+	current: ActivityAssociations,
+	additional: ActivityAssociations,
+): ActivityAssociations => {
+	const associations = createActivityAssociations();
+	Object.keys(associations).forEach((key) => {
+		associations[key] = { ...current[key], ...additional[key] };
+	});
+	return associations;
+};
+
+const renderNewActivityItems = (
+	rendered: IdIndex<RenderedActivityItem>,
+	unrendered: ActivityItem[],
+	context: ActivityRenderContext,
+): IdIndex<RenderedActivityItem> => {
+	const next = { ...rendered };
+	unrendered.forEach((item) => {
+		if (!next[item.id]) {
+			next[item.id] = renderActivityItem(item, context);
+		}
+	});
+	return next;
+};
+
+const updateStateWithFetchResult = (
+	state: State,
+	query: Query,
+	result: ActivityItemsFetchResult,
+	context: PartialActivityRenderContext,
+): State => {
+	const serializedQuery = serializeQuery(query);
+	const associations = mergeAssociations(state.associations, result.associations);
+	return {
+		...state,
+		associations,
+		queries: {
+			...state.queries,
+			[serializedQuery]: updateQueryStateWithFetchResult(
+				state.queries[serializedQuery],
+				result,
+			),
+		},
+		itemsById: renderNewActivityItems(state.itemsById, result.activityItems, {
+			...context,
+			associations,
+		}),
+	};
+};
+
+const updateStateToIsLoading = (state: State, query: Query): State => {
+	const serializedQuery = serializeQuery(query);
+	return {
+		...state,
+		queries: {
+			...state.queries,
+			[serializedQuery]: {
+				...initialQueryState,
+				...state.queries[serializedQuery],
+				isLoading: true,
+			},
+		},
+	};
+};
+
+export const useActivityItems = (options: Options): ReturnValues => {
+	const { filters = [], initialActivityData, batchSize = 50, ...context } = options;
+	const [state, setState] = useState<State>(() => {
+		return updateStateWithFetchResult(initialState, { filters }, initialActivityData, context);
+	});
+
+	const query: Query = { filters };
+	const serializedQuery = serializeQuery({ filters });
+	const queryState = state.queries[serializedQuery] || initialQueryState;
+
+	const items = useMemo(() => {
+		const { itemIds } = queryState;
+		const { itemsById } = state;
+		return itemIds
+			.map((id) => itemsById[id])
+			.filter((item): item is RenderedActivityItem => !!item);
+	}, [queryState, state]);
+
+	const loadMoreItems = () => {
+		setState((currentState) => updateStateToIsLoading(currentState, query));
+		apiFetch
+			.post('/api/activityItems', {
+				offset: queryState.offset,
+				scope: context.scope,
+				filters: query.filters,
+				limit: batchSize,
+			})
+			.then((results) => {
+				setState((currentState) =>
+					updateStateWithFetchResult(currentState, query, results, context),
+				);
+			});
+	};
+
+	return {
+		items,
+		loadMoreItems,
+		isLoading: queryState.isLoading,
+		loadedAllItems: queryState.loadedAllItems,
+	};
+};

--- a/client/utils/activity/renderers/collection.tsx
+++ b/client/utils/activity/renderers/collection.tsx
@@ -123,7 +123,7 @@ export const renderCollectionPubCreated = itemRenderer<
 	CollectionPubCreatedActivityItem,
 	CollectionPubTitles
 >({
-	icon: 'pubDoc',
+	icon: ({ context }) => ('collectionId' in context.scope ? 'pubDoc' : 'collection'),
 	titleRenderers: {
 		collection: collectionTitle,
 		pub: pubTitle,
@@ -142,7 +142,7 @@ export const renderCollectionPubRemoved = itemRenderer<
 	CollectionPubRemovedActivityItem,
 	CollectionPubTitles
 >({
-	icon: 'pubDoc',
+	icon: ({ context }) => ('collectionId' in context.scope ? 'pubDoc' : 'collection'),
 	titleRenderers: {
 		collection: collectionTitle,
 		pub: pubTitle,

--- a/client/utils/activity/renderers/itemRenderer.tsx
+++ b/client/utils/activity/renderers/itemRenderer.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { ActivityItem, InsertableActivityItem } from 'types';
 import { isExternalUrl } from 'utils/urls';
 
-import { titleActor } from '../titles';
+import { actorTitle } from '../titles';
 import {
 	ActivityItemRenderOptions,
 	ActivityItemRenderer,
@@ -35,7 +35,7 @@ const renderTitles = <Item extends InsertableActivityItem, Titles extends string
 	context: ActivityRenderContext,
 ): Record<Titles | 'actor', React.ReactNode> => {
 	const renderedTitles = {
-		actor: renderTitleToReact(titleActor(item, context)),
+		actor: renderTitleToReact(actorTitle(item, context)),
 	};
 	Object.keys(titleRenderers).forEach((key) => {
 		const renderer = titleRenderers[key as Titles];

--- a/client/utils/activity/renderers/itemRenderer.tsx
+++ b/client/utils/activity/renderers/itemRenderer.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { ActivityItem, InsertableActivityItem } from 'types';
+import { isExternalUrl } from 'utils/urls';
 
-import { actorTitle } from '../titles';
+import { titleActor } from '../titles';
 import {
 	ActivityItemRenderOptions,
 	ActivityItemRenderer,
@@ -14,7 +15,7 @@ import {
 const renderTitleToReact = (title: Title) => {
 	const { title: titleString, href, prefix } = title;
 	const inner = href ? (
-		<a href={href} target="_blank" rel="noreferrer">
+		<a href={href} target={isExternalUrl(href) ? '_blank' : undefined} rel="noreferrer">
 			{titleString}
 		</a>
 	) : (
@@ -23,7 +24,7 @@ const renderTitleToReact = (title: Title) => {
 	return (
 		<>
 			{prefix ? `${prefix} ` : null}
-			<b>{inner}</b>
+			<strong>{inner}</strong>
 		</>
 	);
 };
@@ -34,7 +35,7 @@ const renderTitles = <Item extends InsertableActivityItem, Titles extends string
 	context: ActivityRenderContext,
 ): Record<Titles | 'actor', React.ReactNode> => {
 	const renderedTitles = {
-		actor: actorTitle(item, context),
+		actor: renderTitleToReact(titleActor(item, context)),
 	};
 	Object.keys(titleRenderers).forEach((key) => {
 		const renderer = titleRenderers[key as Titles];
@@ -51,10 +52,12 @@ export const itemRenderer = <Item extends InsertableActivityItem, Titles extends
 	return (item: Item, context: ActivityRenderContext) => {
 		const { communityId, collectionId, pubId } = item;
 		const titles = renderTitles(item, titleRenderers, context);
+		const { id, timestamp } = (item as unknown) as ActivityItem;
 		return {
-			icon,
+			id,
+			icon: typeof icon === 'function' ? icon({ context }) : icon,
 			context,
-			timestamp: new Date(((item as unknown) as ActivityItem).timestamp).valueOf(),
+			timestamp: new Date(timestamp),
 			message: message({ item, titles, context }),
 			excerpt: excerpt?.({ item, context }),
 			scope: {

--- a/client/utils/activity/renderers/member.tsx
+++ b/client/utils/activity/renderers/member.tsx
@@ -22,7 +22,7 @@ export const renderMemberCreated = itemRenderer<MemberCreatedActivityItem, Title
 		const { permissions } = item.payload;
 		return (
 			<>
-				{actor} added {member} as a member to {scope} with <i>{permissions}</i> permissions
+				{actor} added {member} as a member of {scope} with <i>{permissions}</i> permissions
 			</>
 		);
 	},

--- a/client/utils/activity/titles/user.ts
+++ b/client/utils/activity/titles/user.ts
@@ -25,10 +25,10 @@ const getUserTitleFromUserIdAndContext = (
 	};
 };
 
-export const titleActor: TitleRenderer<InsertableActivityItem> = (item, context) => {
+export const actorTitle: TitleRenderer<InsertableActivityItem> = (item, context) => {
 	return getUserTitleFromUserIdAndContext(item.actorId, context, 'someone');
 };
 
-export const titleMember: TitleRenderer<MemberActivityItem> = (item, context) => {
+export const memberTitle: TitleRenderer<MemberActivityItem> = (item, context) => {
 	return getUserTitleFromUserIdAndContext(item.payload.userId, context, 'unknown user');
 };

--- a/client/utils/activity/titles/user.ts
+++ b/client/utils/activity/titles/user.ts
@@ -6,6 +6,7 @@ import { getUserFromContext } from './util';
 const getUserTitleFromUserIdAndContext = (
 	userId: null | string,
 	context: ActivityRenderContext,
+	fallback: string,
 ): Title => {
 	if (userId) {
 		if (userId === context.userId) {
@@ -20,14 +21,14 @@ const getUserTitleFromUserIdAndContext = (
 		}
 	}
 	return {
-		title: 'unknown user',
+		title: fallback,
 	};
 };
 
-export const actorTitle: TitleRenderer<InsertableActivityItem> = (item, context) => {
-	return getUserTitleFromUserIdAndContext(item.actorId, context);
+export const titleActor: TitleRenderer<InsertableActivityItem> = (item, context) => {
+	return getUserTitleFromUserIdAndContext(item.actorId, context, 'someone');
 };
 
-export const memberTitle: TitleRenderer<MemberActivityItem> = (item, context) => {
-	return getUserTitleFromUserIdAndContext(item.payload.userId, context);
+export const titleMember: TitleRenderer<MemberActivityItem> = (item, context) => {
+	return getUserTitleFromUserIdAndContext(item.payload.userId, context, 'unknown user');
 };

--- a/client/utils/activity/types.ts
+++ b/client/utils/activity/types.ts
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { ActivityItemKind, ActivityItemsFetchResult, InsertableActivityItem, Scope } from 'types';
+import { ActivityAssociations, ActivityItemKind, InsertableActivityItem, Scope } from 'types';
 import { IconName } from 'components';
 
 // Information we'll pass around about the current render
-export type ActivityRenderContext = ActivityItemsFetchResult & {
+export type ActivityRenderContext = {
+	associations: ActivityAssociations;
 	scope: Scope;
 	userId: string;
 };
@@ -28,6 +29,8 @@ export type TitleRenderer<ItemType extends InsertableActivityItem> = (
 // A RenderedActivityItem is an almost fully-baked representation of how this item will be
 // displayed to users.
 export type RenderedActivityItem = {
+	// The ID of the underlying ActivityItem.
+	id: string;
 	// An icon to display with this item.
 	icon: IconName;
 	// The main thing we have to say about this item
@@ -37,7 +40,7 @@ export type RenderedActivityItem = {
 	// comment in a Thread.
 	excerpt: React.ReactNode;
 	// The time associated with this item.
-	timestamp: number;
+	timestamp: Date;
 	// The Scope associated with this item, which can be used for filtering.
 	scope: Scope;
 };

--- a/client/utils/activity/types.ts
+++ b/client/utils/activity/types.ts
@@ -52,7 +52,7 @@ export type ActivityItemRenderOptions<
 	Item extends InsertableActivityItem,
 	Titles extends string
 > = {
-	icon: IconName;
+	icon: IconName | ((options: { context: ActivityRenderContext }) => IconName);
 	titleRenderers: Record<Titles, TitleRenderer<Item>>;
 	message: (options: {
 		item: Item;

--- a/server/activityItem/api.ts
+++ b/server/activityItem/api.ts
@@ -1,0 +1,35 @@
+import app, { wrap } from 'server/server';
+import { ForbiddenError } from 'server/utils/errors';
+import { getScope } from 'server/utils/queryHelpers';
+import { ActivityFilter, Scope } from 'types';
+
+import { fetchActivityItems } from './fetch';
+
+const unwrapRequest = (req) => {
+	const { body, user } = req;
+	const { scope, offset, filters, limit } = body;
+	return {
+		filters: filters as ActivityFilter[],
+		scope: scope as Scope,
+		userId: user?.id ?? null,
+		offset: parseInt(offset, 10),
+		limit: parseInt(limit, 10),
+	};
+};
+
+app.post(
+	'/api/activityItems',
+	wrap(async (req, res) => {
+		const { scope, offset, limit, userId, filters } = unwrapRequest(req);
+		const {
+			activePermissions: { canView },
+		} = await getScope({ loginId: userId, ...scope });
+
+		if (!canView) {
+			throw new ForbiddenError();
+		}
+
+		const result = await fetchActivityItems({ limit, offset, scope, filters });
+		res.status(200).json(result);
+	}),
+);

--- a/server/apiRoutes.ts
+++ b/server/apiRoutes.ts
@@ -1,3 +1,4 @@
+require('./activityItem/api');
 require('./adminDashboard/api');
 require('./collectionAttribution/api');
 require('./collection/api');

--- a/server/models.ts
+++ b/server/models.ts
@@ -7,8 +7,10 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
 	require(path.join(process.cwd(), 'config.js'));
 }
 
-const useSSL = process.env.DATABASE_URL!.indexOf('localhost') === -1;
-export const sequelize = new (Sequelize as any)(process.env.DATABASE_URL, {
+// @ts-expect-error (interpreting this file as vanilla JavaScript from test runner)
+const useSSL = process.env.DATABASE_URL.indexOf('localhost') === -1;
+// @ts-expect-error (interpreting this file as vanilla JavaScript from test runner)
+export const sequelize = new Sequelize(process.env.DATABASE_URL, {
 	logging: false,
 	dialectOptions: { ssl: useSSL ? { rejectUnauthorized: false } : false },
 	pool: {
@@ -102,7 +104,8 @@ export const includeUserModel = (() => {
 })();
 
 /* Create associations for models that have associate function */
-Object.values(sequelize.models).forEach((model: any) => {
+Object.values(sequelize.models).forEach((model) => {
+	// @ts-expect-error (interpreting this file as vanilla JavaScript from test runner)
 	const classMethods = model.options.classMethods || {};
 	if (classMethods.associate) {
 		classMethods.associate(sequelize.models);

--- a/server/utils/queryHelpers/scopeGet.ts
+++ b/server/utils/queryHelpers/scopeGet.ts
@@ -1,4 +1,6 @@
 import { Op } from 'sequelize';
+
+import { Scope } from 'types';
 import {
 	Collection,
 	CollectionPub,
@@ -16,6 +18,16 @@ let getScopeElements;
 let getPublicPermissionsData;
 let getScopeMemberData;
 let getActivePermissions;
+
+const getScopeIdsObject = ({ pubId, collectionId, communityId }): Scope => {
+	if (pubId) {
+		return { pubId, communityId };
+	}
+	if (collectionId) {
+		return { collectionId, communityId };
+	}
+	return { communityId };
+};
 
 /* getScopeData can be called from either a route (e.g. to authenticate */
 /* whether a user has access to /pub/example), or it can be called from */
@@ -47,6 +59,7 @@ export default async (scopeInputs) => {
 		optionsData: publicPermissionsData,
 		memberData: scopeMemberData,
 		activePermissions,
+		scope: getScopeIdsObject(scopeElements.activeIds),
 	};
 };
 

--- a/types/activity/filters.ts
+++ b/types/activity/filters.ts
@@ -1,0 +1,8 @@
+export type ActivityFilter =
+	| 'community'
+	| 'collection'
+	| 'pub'
+	| 'member'
+	| 'review'
+	| 'discussion'
+	| 'pubEdge';

--- a/types/activity/index.ts
+++ b/types/activity/index.ts
@@ -36,8 +36,11 @@ export {
 export type ActivityItemsFetchResult = {
 	activityItems: ActivityItem[];
 	associations: ActivityAssociations;
+	fetchedAllItems: boolean;
 };
 
 export type ActivityItemsRenderContext = ActivityItemsFetchResult & {
 	scope: Scope;
 };
+
+export { ActivityFilter } from './filters';

--- a/types/request.ts
+++ b/types/request.ts
@@ -3,6 +3,7 @@ import { Collection } from './collection';
 import { Pub } from './pub';
 import { Member, MemberPermission } from './member';
 import { DefinitelyHas, Maybe } from './util';
+import { Scope } from './scope';
 
 export type LoginData = {
 	id: string | null;
@@ -52,6 +53,7 @@ export type ScopeData = {
 		activePub?: Pub;
 		inactiveCollections?: Collection[];
 	};
+	scope: Scope;
 	memberData: Member[];
 };
 

--- a/utils/activity.ts
+++ b/utils/activity.ts
@@ -1,0 +1,18 @@
+import { ActivityAssociations, ActivityAssociationType, activityAssociationTypes } from 'types';
+
+const createEmptyAssociationsObject = <T>(factory: () => T): Record<ActivityAssociationType, T> => {
+	const associations: Partial<Record<ActivityAssociationType, T>> = {};
+	activityAssociationTypes.forEach((type) => {
+		associations[type] = factory();
+	});
+	return associations as Record<ActivityAssociationType, T>;
+};
+
+export const createActivityAssociationArrays = () =>
+	createEmptyAssociationsObject(() => [] as string[]);
+
+export const createActivityAssociationSets = () =>
+	createEmptyAssociationsObject(() => new Set<string>());
+
+export const createActivityAssociations = () =>
+	createEmptyAssociationsObject(() => ({})) as ActivityAssociations;

--- a/utils/urls.js
+++ b/utils/urls.js
@@ -1,7 +1,0 @@
-export const parseUrl = (string) => {
-	try {
-		return new URL(string);
-	} catch (error) {
-		return null;
-	}
-};

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -1,0 +1,11 @@
+export const parseUrl = (url: string) => {
+	try {
+		return new URL(url);
+	} catch (error) {
+		return null;
+	}
+};
+
+export const isExternalUrl = (url: string) => {
+	return !url.startsWith('/');
+};


### PR DESCRIPTION
Resolves #1443
Resolves #1444

Hey hey at long last, here it is, the Activity tab of the dashboard. This PR gets us pretty far but we still need to do things like:

- Figure out the best way to display times (current format isn't ideal)
- Add mobile support

One fun thing here — I've finally cracked and started to use CSS variables (specifically `--community-accent-dark`) for community specific styles!

_Test plan:_

Visit the Activity dashboard tab for each of a Community (just `kfg-notes` for now), Collection, and Pub, and verify that:

- Activity items render
- Links work
- Lazy-loading on scroll works
- Filters work

Log in as a user who is not a scope member and verify that they cannot see this page.

_Screenshot:_

<img width="1904" alt="Screen Shot 2021-06-08 at 1 01 21 PM" src="https://user-images.githubusercontent.com/2208769/121227698-dd936100-c859-11eb-92e6-6669f45edb9e.png">
