### PR TITLE
update: Activity dashboard item time bucketing

### DIFF
--- a/client/containers/DashboardActivity/DashboardActivity.tsx
+++ b/client/containers/DashboardActivity/DashboardActivity.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Button, NonIdealState, Spinner } from '@blueprintjs/core';
 
 import { ActivityFilter } from 'types';
@@ -7,6 +7,7 @@ import { DashboardFrame } from 'client/components';
 import { useInfiniteScroll } from 'client/utils/useInfiniteScroll';
 
 import { useActivityItems } from './useActivityItems';
+import { getBoundaryGroupsForSortedActivityItems, BoundaryGroup } from './boundaries';
 import ActivityItemRow from './ActivityItemRow';
 import ActivityFilters from './ActivityFilters';
 
@@ -32,12 +33,28 @@ const DashboardActivity = (props: Props) => {
 		filters,
 	});
 
+	const boundaryGroups = useMemo(() => getBoundaryGroupsForSortedActivityItems(items), [items]);
+
 	useInfiniteScroll({
 		enabled: !isLoading && !loadedAllItems,
 		useDocumentElement: true,
 		onRequestMoreItems: loadMoreItems,
 		scrollTolerance: 200,
 	});
+
+	const renderBoundaryGroup = (group: BoundaryGroup) => {
+		const { label, key, items: groupItems } = group;
+		return (
+			<div className="boundary-group" key={key}>
+				<div className="heading">
+					<div className="label">{label}</div>
+				</div>
+				{groupItems.map((item) => (
+					<ActivityItemRow item={item} key={item.id} />
+				))}
+			</div>
+		);
+	};
 
 	return (
 		<DashboardFrame className="dashboard-activity-container" title="Activity">
@@ -46,11 +63,9 @@ const DashboardActivity = (props: Props) => {
 				onUpdateActiveFilters={setFilters}
 				scope={scope}
 			/>
-			<div className="activity-items">
-				{items.map((item) => (
-					<ActivityItemRow item={item} key={item.id} />
-				))}
-			</div>
+			{items.length > 0 && (
+				<div className="activity-items">{boundaryGroups.map(renderBoundaryGroup)}</div>
+			)}
 			{items.length === 0 && loadedAllItems && (
 				<NonIdealState
 					icon="clean"

--- a/client/containers/DashboardActivity/activityItemRow.scss
+++ b/client/containers/DashboardActivity/activityItemRow.scss
@@ -7,9 +7,8 @@ $border: 1px solid #ddd;
         '. . excerpt';
     grid-template-columns: 160px 80px 1fr;
     padding: 20px 0;
-    border-top: $border;
 
-    &:last-child {
+    &:not(:last-child) {
         border-bottom: $border;
     }
 
@@ -32,13 +31,14 @@ $border: 1px solid #ddd;
 
         strong {
             color: #999;
+            font-weight: 500;
+            a {
+                color: var(--community-accent-dark);
+            }
         }
 
         a {
             text-decoration: none;
-            strong {
-                color: black;
-            }
             &:hover {
                 text-decoration: underline;
             }

--- a/client/containers/DashboardActivity/boundaries.ts
+++ b/client/containers/DashboardActivity/boundaries.ts
@@ -1,0 +1,117 @@
+import dateFormat from 'dateformat';
+
+import { RenderedActivityItem } from 'client/utils/activity/types';
+
+type Boundary = {
+	definition: number;
+	label: string;
+};
+
+export type BoundaryGroup = {
+	label: string;
+	key: number;
+	items: RenderedActivityItem[];
+};
+
+const getMidnightLocalTimestamp = (dateSource: Date) => {
+	const date = new Date(dateSource);
+	date.setHours(23, 59, 59, 999);
+	return date.valueOf();
+};
+
+const getTodayBoundary = (today: Date): Boundary => {
+	return {
+		definition: getMidnightLocalTimestamp(today),
+		label: 'Today',
+	};
+};
+
+const getDaysAgoBoundary = (daysAgo: number, today: Date): Boundary => {
+	const yesterday = new Date(today);
+	yesterday.setDate(yesterday.getDate() - daysAgo);
+	const label = daysAgo === 1 ? 'Yesterday' : 'This week';
+	return {
+		definition: getMidnightLocalTimestamp(yesterday),
+		label,
+	};
+};
+
+const getWeeksAgoBoundary = (weeksAgo: number, today: Date): Boundary => {
+	const lastSunday = new Date(today);
+	lastSunday.setDate(lastSunday.getDate() - lastSunday.getDay());
+	const sundayWeeksAgo = new Date(lastSunday);
+	sundayWeeksAgo.setDate(sundayWeeksAgo.getDate() - 7 * (weeksAgo - 1));
+	const label = weeksAgo === 1 ? 'Last week' : `${weeksAgo} weeks ago`;
+	return {
+		definition: getMidnightLocalTimestamp(sundayWeeksAgo),
+		label,
+	};
+};
+
+const getMonthsAgoBoundary = (monthsAgo: number, today: Date): Boundary => {
+	const lastDayOfThisMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+	const lastDayOfMonthsAgo = new Date(lastDayOfThisMonth);
+	lastDayOfMonthsAgo.setMonth(lastDayOfMonthsAgo.getMonth() - monthsAgo);
+	const label = dateFormat(lastDayOfMonthsAgo, 'mmmm yyyy');
+	return {
+		definition: getMidnightLocalTimestamp(lastDayOfMonthsAgo),
+		label,
+	};
+};
+
+const createBoundaries = (today: Date, earliestDate: Date) => {
+	const earliestDateValue = earliestDate.valueOf();
+	const bounds = [
+		getTodayBoundary(today),
+		getDaysAgoBoundary(1, today),
+		getDaysAgoBoundary(2, today),
+		getWeeksAgoBoundary(1, today),
+	];
+	let monthsAgo = 1;
+	while (bounds[bounds.length - 1].definition >= earliestDateValue) {
+		bounds.push(getMonthsAgoBoundary(monthsAgo, today));
+		++monthsAgo;
+	}
+	bounds.push(getMonthsAgoBoundary(monthsAgo, today));
+	return bounds;
+};
+
+const itemFitsBetweenBoundaries = (
+	item: RenderedActivityItem,
+	later: Boundary,
+	earlier: Boundary,
+) => {
+	const itemTimestampValue = item.timestamp.valueOf();
+	return itemTimestampValue < later.definition && itemTimestampValue >= earlier.definition;
+};
+
+export const getBoundaryGroupsForSortedActivityItems = (
+	itemsSource: RenderedActivityItem[],
+): BoundaryGroup[] => {
+	if (itemsSource.length === 0) {
+		return [];
+	}
+
+	const today = new Date();
+	const items = [...itemsSource];
+	const boundaries = createBoundaries(today, items[items.length - 1].timestamp);
+	const boundaryGroups: BoundaryGroup[] = [];
+
+	for (let boundaryIndex = 0; boundaryIndex < boundaries.length - 2; boundaryIndex++) {
+		const laterBoundary = boundaries[boundaryIndex];
+		const earlierBoundary = boundaries[boundaryIndex + 1];
+		const itemsBetweenTheseBoundaries: RenderedActivityItem[] = [];
+		while (items[0] && itemFitsBetweenBoundaries(items[0], laterBoundary, earlierBoundary)) {
+			itemsBetweenTheseBoundaries.push(items.shift()!);
+		}
+		if (itemsBetweenTheseBoundaries.length > 0) {
+			boundaryGroups.push({
+				label: laterBoundary.label,
+				key: laterBoundary.definition,
+				items: itemsBetweenTheseBoundaries,
+			});
+		}
+	}
+
+	return boundaryGroups;
+};

--- a/client/containers/DashboardActivity/dashboardActivity.scss
+++ b/client/containers/DashboardActivity/dashboardActivity.scss
@@ -1,6 +1,26 @@
 .dashboard-activity-container {
     .activity-items {
-        margin-top: 20px;
+        margin-top: 40px;
+    }
+
+    .boundary-group {
+        .heading {
+            margin: 10px 0;
+            position: relative;
+            height: 1px;
+            background: var(--community-accent-dark);
+            color: var(--community-accent-dark);
+            .label {
+                font-size: 12px;
+                position: absolute;
+                background: white;
+                top: 50%;
+                transform: translateY(-50%);
+                border: 1px solid var(--community-accent-dark);
+                border-radius: 100px;
+                padding: 2px 10px;
+            }
+        }
     }
 
     .empty-state {


### PR DESCRIPTION
Couldn't resist a good idea here — I added some time bucketing for Activity items (e.g. `Today`, `Yesterday`, `Last Week`, etc) to help break them up visually.

_Test plan:_
Visit a few Activity dashboards with different filters enabled and make sure items are bucketed correctly.

_Screenshot:_
![image](https://user-images.githubusercontent.com/2208769/121401111-5a8c0c80-c926-11eb-8f81-de288e98cc32.png)
