### PR TITLE
feature: Alignment options for Pages & Collections blocks

### DIFF
--- a/client/components/Layout/LayoutPagesCollections.tsx
+++ b/client/components/Layout/LayoutPagesCollections.tsx
@@ -35,6 +35,7 @@ const resolveItemsFromContent = (
 		.filter((item): item is PageOrCollection => !!item);
 };
 
+
 const LayoutPagesCollections = (props: Props) => {
 	const { content, collections, pages } = props;
 	return (
@@ -49,7 +50,10 @@ const LayoutPagesCollections = (props: Props) => {
 				)}
 				<div className="row">
 					<div className="col-12">
-						<div className="pages-wrapper">
+						<div
+							className="pages-wrapper"
+							style={content.justify ? { justifyContent: content.justify } : {}}
+						>
 							{resolveItemsFromContent(content, collections, pages).map((item) => (
 								<PagePreview key={item.id} pageData={item} />
 							))}

--- a/client/components/Layout/LayoutPagesCollections.tsx
+++ b/client/components/Layout/LayoutPagesCollections.tsx
@@ -35,7 +35,6 @@ const resolveItemsFromContent = (
 		.filter((item): item is PageOrCollection => !!item);
 };
 
-
 const LayoutPagesCollections = (props: Props) => {
 	const { content, collections, pages } = props;
 	return (

--- a/client/components/Layout/layout.scss
+++ b/client/components/Layout/layout.scss
@@ -8,7 +8,8 @@
 		.container {
 			max-width: none !important;
 		}
-		.layout-pubs-block, .layout-pages-block {
+		.layout-pubs-block,
+		.layout-pages-block {
 			.container {
 				display: flex;
 				flex-wrap: wrap;
@@ -74,7 +75,7 @@
 			.pages-wrapper {
 				display: grid;
 				grid-gap: 2em;
-				grid-template-columns: repeat(auto-fill, 175px);
+				grid-template-columns: repeat(auto-fit, 175px);
 				justify-content: space-between;
 			}
 			.page-preview-component {

--- a/client/components/LayoutEditor/LayoutEditorPagesCollections.tsx
+++ b/client/components/LayoutEditor/LayoutEditorPagesCollections.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useMemo } from 'react';
 import { Button, FormGroup } from '@blueprintjs/core';
 
-import { InputField, Popover, OrderPicker, PubMenuItem } from 'components';
+import { InputField, Popover, OrderPicker, PubMenuItem, MenuSelect, MenuSelectItems } from 'components';
 import LayoutPagesCollections, {
 	Content,
 	BlockItem,
 	PageOrCollection,
 } from 'components/Layout/LayoutPagesCollections';
+import { CollectionsPagesJustifyType } from 'utils/layout/types';
 
 type Props = {
 	onChange: (index: number, block: Content) => any;
@@ -45,6 +46,13 @@ const getAllItems = (
 	].sort((a, b) => (a.title > b.title ? 1 : -1));
 };
 
+const justifiedContent: MenuSelectItems<CollectionsPagesJustifyType> = [
+	{ value: 'center', label: 'Center' },
+	{ value: 'space-between', label: 'Space Between' },
+	{ value: 'space-around', label: 'Space Around' },
+	{ value: 'left', label: 'Left' },
+];
+
 const LayoutEditorPagesCollections = (props: Props) => {
 	const { layoutIndex, onChange, content, collections, pages } = props;
 
@@ -76,6 +84,15 @@ const LayoutEditorPagesCollections = (props: Props) => {
 		[onChange, layoutIndex, content],
 	);
 
+	const setJustify = useCallback(
+		(justify: CollectionsPagesJustifyType) =>
+			onChange(layoutIndex, {
+				...content,
+				justify,
+			}),
+		[onChange, layoutIndex, content],
+	);
+
 	return (
 		<div className="layout-editor-pages-component">
 			<div className="block-header">
@@ -84,6 +101,16 @@ const LayoutEditorPagesCollections = (props: Props) => {
 					value={content.title}
 					onChange={(evt) => setTitle(evt.target.value)}
 				/>
+
+				<FormGroup label="Justify Content">
+					<MenuSelect
+						value={content.justify || 'space-between'}
+						items={justifiedContent}
+						onSelectValue={setJustify}
+						aria-label="Choose Justify Content"
+					/>
+				</FormGroup>
+
 				<FormGroup label="Collections & Pages">
 					<Popover
 						aria-label="Choose pinned Pubs for this block"

--- a/client/components/LayoutEditor/LayoutEditorPagesCollections.tsx
+++ b/client/components/LayoutEditor/LayoutEditorPagesCollections.tsx
@@ -1,7 +1,14 @@
 import React, { useCallback, useMemo } from 'react';
 import { Button, FormGroup } from '@blueprintjs/core';
 
-import { InputField, Popover, OrderPicker, PubMenuItem, MenuSelect, MenuSelectItems } from 'components';
+import {
+	InputField,
+	Popover,
+	OrderPicker,
+	PubMenuItem,
+	MenuSelect,
+	MenuSelectItems,
+} from 'components';
 import LayoutPagesCollections, {
 	Content,
 	BlockItem,

--- a/client/components/LayoutEditor/LayoutEditorPagesCollections.tsx
+++ b/client/components/LayoutEditor/LayoutEditorPagesCollections.tsx
@@ -102,37 +102,43 @@ const LayoutEditorPagesCollections = (props: Props) => {
 					onChange={(evt) => setTitle(evt.target.value)}
 				/>
 
-				<FormGroup label="Justify Content">
-					<MenuSelect
-						value={content.justify || 'space-between'}
-						items={justifiedContent}
-						onSelectValue={setJustify}
-						aria-label="Choose Justify Content"
-					/>
-				</FormGroup>
-
-				<FormGroup label="Collections & Pages">
-					<Popover
-						aria-label="Choose pinned Pubs for this block"
-						className="order-picker-popover"
-						placement="bottom-end"
-						content={
-							<OrderPicker
-								availableItems={availableItems}
-								selectedItems={selectedItems}
-								onSelectedItems={setSelectedItems}
-								renderItem={(item, handleClick) => (
-									<PubMenuItem title={item.title} onClick={handleClick} />
-								)}
+				<div className="dropdown-grouping">
+					<div className="dropdown">
+						<FormGroup label="Justify Content">
+							<MenuSelect
+								value={content.justify || 'space-between'}
+								items={justifiedContent}
+								onSelectValue={setJustify}
+								aria-label="Choose Justify Content"
 							/>
-						}
-					>
-						<Button rightIcon="caret-down" outlined>
-							Choose Items
-							{selectedItems.length ? ` (${selectedItems.length})` : ''}
-						</Button>
-					</Popover>
-				</FormGroup>
+						</FormGroup>
+					</div>
+
+					<div className="dropdown">
+						<FormGroup label="Collections & Pages">
+							<Popover
+								aria-label="Choose pinned Pubs for this block"
+								className="order-picker-popover"
+								placement="bottom-end"
+								content={
+									<OrderPicker
+										availableItems={availableItems}
+										selectedItems={selectedItems}
+										onSelectedItems={setSelectedItems}
+										renderItem={(item, handleClick) => (
+											<PubMenuItem title={item.title} onClick={handleClick} />
+										)}
+									/>
+								}
+							>
+								<Button rightIcon="caret-down" outlined>
+									Choose Items
+									{selectedItems.length ? ` (${selectedItems.length})` : ''}
+								</Button>
+							</Popover>
+						</FormGroup>
+					</div>
+				</div>
 			</div>
 			<LayoutPagesCollections content={content} pages={pages} collections={collections} />
 		</div>

--- a/client/components/LayoutEditor/LayoutEditorPagesCollections.tsx
+++ b/client/components/LayoutEditor/LayoutEditorPagesCollections.tsx
@@ -117,6 +117,7 @@ const LayoutEditorPagesCollections = (props: Props) => {
 								items={justifiedContent}
 								onSelectValue={setJustify}
 								aria-label="Choose Justify Content"
+								buttonProps={{ fill: true, alignText: 'left' }}
 							/>
 						</FormGroup>
 					</div>

--- a/client/components/LayoutEditor/LayoutEditorPubs/LayoutEditorPubs.tsx
+++ b/client/components/LayoutEditor/LayoutEditorPubs/LayoutEditorPubs.tsx
@@ -2,9 +2,14 @@ import React, { useCallback } from 'react';
 import classNames from 'classnames';
 import { Button } from '@blueprintjs/core';
 
-import { CollectionMultiSelect, InputField, Popover } from 'components';
+import {
+	CollectionMultiSelect,
+	InputField,
+	Popover,
+	MenuSelect,
+	MenuSelectItems,
+} from 'components';
 import { LayoutPubs } from 'components/Layout';
-import { MenuSelect, MenuSelectItems } from 'components/Menu';
 import { Community, Pub, Collection } from 'types';
 import { LayoutBlockPubs, PubPreviewType, PubSortOrder } from 'utils/layout/types';
 

--- a/client/components/LayoutEditor/layoutEditor.scss
+++ b/client/components/LayoutEditor/layoutEditor.scss
@@ -51,7 +51,7 @@
 		display: flex;
 		// align-items: flex-end;
 		.dropdown {
-			margin: 0 0 5px 20px;
+			margin: 0 0 0 20px;
 		}
 	}
 	.block-content {

--- a/client/components/LayoutEditor/layoutEditor.scss
+++ b/client/components/LayoutEditor/layoutEditor.scss
@@ -27,6 +27,7 @@
 		z-index: 1;
 		.input-field-component,
 		.image-upload-component,
+		.dropdown-grouping,
 		> .bp3-form-group {
 			margin: 0em 0.5em;
 		}
@@ -44,6 +45,13 @@
 			flex: 1 1 auto;
 			max-width: 100%;
 			padding-top: 12px;
+		}
+	}
+	.dropdown-grouping {
+		display: flex;
+		// align-items: flex-end;
+		.dropdown {
+			margin: 0 0 5px 20px;
 		}
 	}
 	.block-content {

--- a/client/components/index.ts
+++ b/client/components/index.ts
@@ -34,7 +34,14 @@ export { default as LicenseSelect } from './LicenseSelect/LicenseSelect';
 export { default as LinkedPageSelect } from './LinkedPageSelect/LinkedPageSelect';
 export { default as InheritedMembersBlock } from './Members/InheritedMembersBlock';
 export { default as MemberRow } from './Members/MemberRow';
-export { Menu, MenuButton, MenuConfigProvider, MenuItem } from './Menu';
+export {
+	Menu,
+	MenuButton,
+	MenuConfigProvider,
+	MenuItem,
+	MenuSelect,
+	MenuSelectItems,
+} from './Menu';
 export { default as MinimalEditor } from './MinimalEditor/MinimalEditor';
 export { default as NavBar } from './NavBar/NavBar';
 export { default as OrderPicker } from './OrderPicker/OrderPicker';

--- a/utils/layout/types.ts
+++ b/utils/layout/types.ts
@@ -83,6 +83,7 @@ export type LayoutBlockCollectionsPages = {
 	content: {
 		items: { type: 'collection' | 'page'; id: string }[];
 		title?: string;
+		justify?: 'space-around' | 'center';
 	};
 };
 

--- a/utils/layout/types.ts
+++ b/utils/layout/types.ts
@@ -12,6 +12,8 @@ export type PubSortOrder =
 	| 'publish-date-reversed'
 	| 'collection-rank';
 
+export type CollectionsPagesJustifyType = 'center' | 'space-between' | 'space-around' | 'left';
+
 export type LayoutPubsByBlock<PubType extends { id: string }> = {
 	pubsById: Record<string, PubType>;
 	pubIdsByBlockId: Record<string, string[]>;
@@ -83,7 +85,7 @@ export type LayoutBlockCollectionsPages = {
 	content: {
 		items: { type: 'collection' | 'page'; id: string }[];
 		title?: string;
-		justify?: 'space-around' | 'center';
+		justify?: CollectionsPagesJustifyType;
 	};
 };
 


### PR DESCRIPTION
Resolves #1459 

This feature allows users to change the alignment of pages and collections in the Collections & Pages Block editor. More selections can be made in regard to justification (see [here](https://css-tricks.com/almanac/properties/j/justify-content/)).

Test plan:

Visit the Pages dashboard of a Community and verify that:

Collections & Pages Block has a Justify Content section
justification can be be changed in the editor
justification setting persist after saving changes by going to the home page
a user that is not logged in also sees the changes

<img width="1193" alt="Screen Shot 2021-06-21 at 11 43 42 AM" src="https://user-images.githubusercontent.com/34730449/122790137-036f2b80-d286-11eb-9e9f-5a940ddcdf5a.png">

<img width="1792" alt="Screen Shot 2021-06-21 at 11 58 46 AM" src="https://user-images.githubusercontent.com/34730449/122792342-1551ce00-d288-11eb-80be-a078f16027a7.png">

