### PR TITLE
fix: Enforce that Pages have a non-null layout

### DIFF
--- a/client/containers/DashboardPage/DashboardPage.tsx
+++ b/client/containers/DashboardPage/DashboardPage.tsx
@@ -3,7 +3,6 @@ import { AnchorButton, Button } from '@blueprintjs/core';
 import { useUpdateEffect } from 'react-use';
 
 import { communityUrl } from 'utils/canonicalUrls';
-import { getDefaultLayout } from 'utils/pages';
 import { usePageContext, usePendingChanges } from 'utils/hooks';
 import { getDashUrl } from 'utils/dashboard';
 import { slugifyString } from 'utils/strings';
@@ -28,8 +27,6 @@ require('./dashboardPage.scss');
 type Props = {
 	pageData: Page & { layoutPubsByBlock: LayoutPubsByBlock<Pub> };
 };
-
-const defaultLayout = getDefaultLayout();
 
 const DashboardPage = (props: Props) => {
 	const { updateCommunity, locationData, communityData } = usePageContext();
@@ -212,7 +209,7 @@ const DashboardPage = (props: Props) => {
 			<SettingsSection title="Layout">
 				<LayoutEditor
 					onChange={(newLayout) => updatePageData({ layout: newLayout })}
-					initialLayout={layout || defaultLayout}
+					initialLayout={layout}
 					initialLayoutPubsByBlock={layoutPubsByBlock}
 					communityData={communityData}
 				/>

--- a/client/containers/Page/Page.tsx
+++ b/client/containers/Page/Page.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { Layout } from 'components';
 import { Pub } from 'types';
 import { LayoutBlock, LayoutPubsByBlock } from 'utils/layout';
-import { getDefaultLayout } from 'utils/pages';
 
 type Props = {
 	pageData: {
@@ -16,10 +15,9 @@ type Props = {
 
 const Page = (props: Props) => {
 	const { pageData } = props;
-	const blocks = pageData.layout || getDefaultLayout();
 	return (
 		<Layout
-			blocks={blocks}
+			blocks={pageData.layout}
 			isNarrow={pageData.isNarrow || pageData.isNarrowWidth}
 			layoutPubsByBlock={pageData.layoutPubsByBlock}
 		/>

--- a/server/page/model.ts
+++ b/server/page/model.ts
@@ -10,7 +10,7 @@ export default (sequelize, dataTypes) => {
 			isPublic: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
 			isNarrowWidth: { type: dataTypes.BOOLEAN },
 			viewHash: { type: dataTypes.TEXT },
-			layout: { type: dataTypes.JSONB },
+			layout: { type: dataTypes.JSONB, allowNull: false },
 
 			/* Set by Associations */
 			communityId: { type: dataTypes.UUID, allowNull: false },

--- a/server/page/queries.ts
+++ b/server/page/queries.ts
@@ -14,6 +14,7 @@ export const createPage = async (inputValues) => {
 		title: inputValues.title,
 		slug: await findAcceptableSlug(inputValues.slug, inputValues.communityId),
 		description: inputValues.description,
+		avatar: inputValues.avatar || null,
 		isPublic: false,
 		layout: generateDefaultPageLayout(),
 		viewHash: generateHash(8),

--- a/server/page/queries.ts
+++ b/server/page/queries.ts
@@ -4,6 +4,7 @@ import { findAcceptableSlug, slugIsAvailable } from 'server/utils/slugs';
 import { slugifyString } from 'utils/strings';
 import { PubPubError } from 'server/utils/errors';
 import { generateHash } from 'utils/hashes';
+import { generateDefaultPageLayout } from 'utils/pages';
 
 import { sanitizePageHtml } from './sanitizePageHtml';
 
@@ -14,6 +15,7 @@ export const createPage = async (inputValues) => {
 		slug: await findAcceptableSlug(inputValues.slug, inputValues.communityId),
 		description: inputValues.description,
 		isPublic: false,
+		layout: generateDefaultPageLayout(),
 		viewHash: generateHash(8),
 	})
 		.then((newPage) => {
@@ -30,7 +32,7 @@ export const createPage = async (inputValues) => {
 				oldNavigation[0],
 				{ type: 'page', id: newPage.id },
 				...oldNavigation.slice(1, oldNavigation.length),
-			];
+			].filter((x) => x);
 			const updateCommunity = Community.update(
 				{ navigation: newNavigationOutput },
 				{

--- a/server/routes/__tests__/collection.test.ts
+++ b/server/routes/__tests__/collection.test.ts
@@ -1,8 +1,6 @@
 /* global describe, it, expect, beforeAll, afterAll */
 import { setup, teardown, login, modelize } from 'stubstub';
 
-import { getDefaultLayout } from 'utils/pages';
-
 const models = modelize`
 	Community community {
 		Member {
@@ -13,13 +11,11 @@ const models = modelize`
 			kind: "issue"
 			title: "Issue One"
 			isPublic: true
-			layout: ${getDefaultLayout()}
 		}
 		Collection privateCollection {
 			kind: "issue"
 			title: "Issue One and a Half"
 			isPublic: false
-			layout: ${getDefaultLayout()}
 			Member {
 				permissions: "view"
 				User collectionViewer {}

--- a/stubstub/modelize/builders.js
+++ b/stubstub/modelize/builders.js
@@ -7,6 +7,7 @@ import { Community, Member, Release, User } from 'server/models';
 import { createPub } from 'server/pub/queries';
 import { createCollection } from 'server/collection/queries';
 import { createDoc } from 'server/doc/queries';
+import { createPage } from 'server/page/queries';
 
 const builders = {};
 
@@ -64,6 +65,8 @@ builders.Pub = async (args) => {
 
 builders.Collection = ({ title = 'Collection ' + uuid.v4(), kind = 'issue', ...restArgs }) =>
 	createCollection({ title, kind, ...restArgs });
+
+builders.Page = createPage;
 
 builders.Member = async ({ pubId, collectionId, communityId, ...restArgs }) => {
 	const getTargetArgs = () => {

--- a/tools/migrations/2021_06_29_makePageLayoutNonNullable.js
+++ b/tools/migrations/2021_06_29_makePageLayoutNonNullable.js
@@ -1,0 +1,13 @@
+export const up = async ({ sequelize, Sequelize }) => {
+	await sequelize.queryInterface.changeColumn('Pages', 'layout', {
+		type: Sequelize.JSONB,
+		allowNull: false,
+	});
+};
+
+export const down = async ({ sequelize, Sequelize }) => {
+	await sequelize.queryInterface.changeColumn('Pages', 'layout', {
+		type: Sequelize.JSONB,
+		allowNull: true,
+	});
+};

--- a/tools/migrations/data/2021_06_29_backfillPageLayouts.js
+++ b/tools/migrations/data/2021_06_29_backfillPageLayouts.js
@@ -1,0 +1,12 @@
+import { Page } from 'server/models';
+import { generateDefaultPageLayout } from 'utils/pages';
+
+export const up = async () => {
+	const defaultLayout = generateDefaultPageLayout();
+	const [numAffectedRows] = await Page.update(
+		{ layout: defaultLayout },
+		{ where: { layout: null } },
+	);
+	// eslint-disable-next-line no-console
+	console.log(`Updated ${numAffectedRows} Pages`);
+};

--- a/utils/pages.ts
+++ b/utils/pages.ts
@@ -1,4 +1,7 @@
-export const generatePageBackground = (pageTitle) => {
+import { generateHash } from './hashes';
+import { LayoutBlock } from './layout';
+
+export const generatePageBackground = (pageTitle: string) => {
 	const gradients = ['#b33939', '#cd6133', '#474787', '#227093', '#218c74'];
 
 	if (!pageTitle) {
@@ -7,24 +10,24 @@ export const generatePageBackground = (pageTitle) => {
 	return gradients[pageTitle.charCodeAt(pageTitle.length - 1) % 5];
 };
 
-export const getDefaultLayout = () => {
+export const generateDefaultPageLayout = (): LayoutBlock[] => {
 	return [
 		{
-			id: '0kyj32ay',
+			id: generateHash(8),
 			type: 'pubs',
 			content: {
 				title: '',
-				size: 'large',
+				pubPreviewType: 'large',
 				limit: 1,
 				pubIds: [],
 			},
 		},
 		{
-			id: 'gruw36cv',
+			id: generateHash(8),
 			type: 'pubs',
 			content: {
 				title: '',
-				size: 'medium',
+				pubPreviewType: 'medium',
 				limit: 0,
 				pubIds: [],
 			},


### PR DESCRIPTION
Resolves #1494 

We currently allow Pages to be created with `layout = null`. When we load such a Page, the client uses the value of `getDefaultLayout()` as a fallback layout, but the server doesn't send down Pubs for that layout, which results in an error. We solve this problem by enforcing that Pages do have a non-null `layout`, by backfilling existing null layouts to the default value, and using `getDefaultLayout()` — renamed to `generateDefaultPageLayout()` — to give Pages a layout when created.

This also fixes two minor bugs:
- The existing default layout blocks have an invalid `content.size` which has been replaced with `content.pubPreviewType`
- There is currently the possibility of adding a `null` value to `Community.navigation` during Page creation.

I ran the following to backfill null layouts (it's harmless but unnecessary to repeat these)
```
npm run tools migrate -- --name data/2021_06_29_backfillPageLayouts
```
and observed that a few hundred rows were affected. Then I ran:
```
npm run tools migrate -- --name 2021_06_29_makePageLayoutNonNullable
```
which successfully updated the database schema to prevent null Page layouts. These commands will need to be repeated at deploy time with `PUBPUB_PRODUCTION=true`.

_Test plan:_

I created a new Page and observed that it took on the default generated layout and was able to load at both `/dash/pages/:slug` and `/:slug`.