### PR TITLE
fix: more robust community check to avoid impersonation, phishing, and other hacks

### DIFF
--- a/server/community/__tests__/queries.test.ts
+++ b/server/community/__tests__/queries.test.ts
@@ -1,0 +1,95 @@
+/* global describe, it, expect, beforeAll, afterAll */
+import { modelize, setup, teardown } from 'stubstub';
+import { getCountOfPubsOrCollections } from 'server/community/queries';
+
+
+
+// 1. User is Member of Community => true
+// 2. User is Member of Collection in Community => true
+// 3. User is Member of Pub in Community => true
+// 4. User has PubAttribution in Pub Community => true
+// 5. User has CollectionAttribution in Collection in Community => true
+// 6. User has no affiliation with Community => false
+// 7. User is a Member of another Community => false
+
+const models = modelize`
+    Community theCommunity {
+        Member {
+            permissions: "view"
+            User communityMember {}
+        }
+
+        Collection {
+            Member {
+                permissions: "view"
+                User collectionUser {}
+            }
+
+            CollectionAttribution {
+                User collectionAttrUser {}
+            }
+        }
+
+        Pub {
+            Member {
+                permissions: "view"
+                User pubUser {}
+            }
+
+            PubAttribution {
+                User pubAttrUser {}
+            }
+        }
+    }
+
+    Community {
+        Member {
+            permissions: "admin"
+            User randoCommunityAdmin {} 
+        }
+        
+    }
+    User notACommunityMember {}
+`;
+
+setup(beforeAll, models.resolve);
+teardown(afterAll);
+
+// i dont get how to access stuff but he said it wasnt a tree so maybe just directlt cause userId is on pub maybe
+describe('getCountOfPubsOrCollections', () => {
+    it('returns true if user is member of the community', async () => {
+        const {theCommunity, communityMember} = models;
+
+        expect(await getCountOfPubsOrCollections(communityMember.id, theCommunity.id)).toEqual(true);
+    });
+
+    it('returns true if user is member of collection in the community', async () => {
+        const { theCommunity, collectionUser} = models;
+        expect(await getCountOfPubsOrCollections(collectionUser.id, theCommunity.id )).toEqual(true);
+    });
+
+    it('returns true if user is member of pub in the community', async () => {
+        const {theCommunity, pubUser} = models;
+        expect(await getCountOfPubsOrCollections(pubUser.id, theCommunity.id)).toEqual(true);
+    });
+
+    it('returns true if user has a CollectionAttribution in the community', async () => {
+        const { theCommunity, collectionAttrUser} = models;
+        expect(await getCountOfPubsOrCollections(collectionAttrUser.id, theCommunity.id )).toEqual(true);
+    });
+
+    it('returns true if user has a PubAttribution in the community', async () => {
+        const {theCommunity, pubAttrUser} = models;
+        expect(await getCountOfPubsOrCollections(pubAttrUser.id, theCommunity.id)).toEqual(true);
+    });
+
+    it('returns false if user is not in the community', async () => {
+        const {theCommunity, notACommunityMember} = models;
+        expect(await getCountOfPubsOrCollections(notACommunityMember.id, theCommunity.id)).toEqual(false);
+    });
+
+    it('returns false if user is an admin in another community but not in this community', async () => {
+        const {theCommunity, randoCommunityAdmin} = models;
+        expect(await getCountOfPubsOrCollections(randoCommunityAdmin.id, theCommunity.id)).toEqual(false);
+    });
+});

--- a/server/community/__tests__/queries.test.ts
+++ b/server/community/__tests__/queries.test.ts
@@ -1,14 +1,6 @@
 /* global describe, it, expect, beforeAll, afterAll */
 import { modelize, setup, teardown } from 'stubstub';
-import { getCountOfPubsOrCollections } from 'server/community/queries';
-
-// 1. User is Member of Community => true
-// 2. User is Member of Collection in Community => true
-// 3. User is Member of Pub in Community => true
-// 4. User has PubAttribution in Pub Community => true
-// 5. User has CollectionAttribution in Collection in Community => true
-// 6. User has no affiliation with Community => false
-// 7. User is a Member of another Community => false
+import { isUserAffiliatedWithCommunity } from 'server/community/queries';
 
 const models = modelize`
     Community theCommunity {
@@ -53,48 +45,47 @@ const models = modelize`
 setup(beforeAll, models.resolve);
 teardown(afterAll);
 
-// i dont get how to access stuff but he said it wasnt a tree so maybe just directlt cause userId is on pub maybe
-describe('getCountOfPubsOrCollections', () => {
+describe('isUserAffiliatedWithCommunity', () => {
 	it('returns true if user is member of the community', async () => {
 		const { theCommunity, communityMember } = models;
 
-		expect(await getCountOfPubsOrCollections(communityMember.id, theCommunity.id)).toEqual(
+		expect(await isUserAffiliatedWithCommunity(communityMember.id, theCommunity.id)).toEqual(
 			true,
 		);
 	});
 
 	it('returns true if user is member of collection in the community', async () => {
 		const { theCommunity, collectionUser } = models;
-		expect(await getCountOfPubsOrCollections(collectionUser.id, theCommunity.id)).toEqual(true);
+		expect(await isUserAffiliatedWithCommunity(collectionUser.id, theCommunity.id)).toEqual(true);
 	});
 
 	it('returns true if user is member of pub in the community', async () => {
 		const { theCommunity, pubUser } = models;
-		expect(await getCountOfPubsOrCollections(pubUser.id, theCommunity.id)).toEqual(true);
+		expect(await isUserAffiliatedWithCommunity(pubUser.id, theCommunity.id)).toEqual(true);
 	});
 
 	it('returns true if user has a CollectionAttribution in the community', async () => {
 		const { theCommunity, collectionAttrUser } = models;
-		expect(await getCountOfPubsOrCollections(collectionAttrUser.id, theCommunity.id)).toEqual(
+		expect(await isUserAffiliatedWithCommunity(collectionAttrUser.id, theCommunity.id)).toEqual(
 			true,
 		);
 	});
 
 	it('returns true if user has a PubAttribution in the community', async () => {
 		const { theCommunity, pubAttrUser } = models;
-		expect(await getCountOfPubsOrCollections(pubAttrUser.id, theCommunity.id)).toEqual(true);
+		expect(await isUserAffiliatedWithCommunity(pubAttrUser.id, theCommunity.id)).toEqual(true);
 	});
 
 	it('returns false if user is not in the community', async () => {
 		const { theCommunity, notACommunityMember } = models;
-		expect(await getCountOfPubsOrCollections(notACommunityMember.id, theCommunity.id)).toEqual(
+		expect(await isUserAffiliatedWithCommunity(notACommunityMember.id, theCommunity.id)).toEqual(
 			false,
 		);
 	});
 
 	it('returns false if user is an admin in another community but not in this community', async () => {
 		const { theCommunity, randoCommunityAdmin } = models;
-		expect(await getCountOfPubsOrCollections(randoCommunityAdmin.id, theCommunity.id)).toEqual(
+		expect(await isUserAffiliatedWithCommunity(randoCommunityAdmin.id, theCommunity.id)).toEqual(
 			false,
 		);
 	});

--- a/server/community/__tests__/queries.test.ts
+++ b/server/community/__tests__/queries.test.ts
@@ -55,47 +55,58 @@ teardown(afterAll);
 
 // i dont get how to access stuff but he said it wasnt a tree so maybe just directlt cause userId is on pub maybe
 describe('getCountOfPubsOrCollections', () => {
-	it('returns true if user is member of the community', async () => {
-		const { theCommunity, communityMember } = models;
+    it('returns true if user is member of the community', async () => {
+        const { theCommunity, communityMember } = models;
 
-		expect(await getCountOfPubsOrCollections(communityMember.id, theCommunity.id)).toEqual(
-			true,
-		);
-	});
+        expect(await getCountOfPubsOrCollections(communityMember.id, theCommunity.id)).toEqual(
+            true,
+        );
+    });
 
-	it('returns true if user is member of collection in the community', async () => {
-		const { theCommunity, collectionUser } = models;
-		expect(await getCountOfPubsOrCollections(collectionUser.id, theCommunity.id)).toEqual(true);
-	});
+    it('returns true if user is member of collection in the community', async () => {
+        const { theCommunity, collectionUser } = models;
+        expect(await getCountOfPubsOrCollections(collectionUser.id, theCommunity.id)).toEqual(true);
+    });
 
-	it('returns true if user is member of pub in the community', async () => {
-		const { theCommunity, pubUser } = models;
-		expect(await getCountOfPubsOrCollections(pubUser.id, theCommunity.id)).toEqual(true);
-	});
+    it('returns true if user is member of pub in the community', async () => {
+        const { theCommunity, pubUser } = models;
+        expect(await getCountOfPubsOrCollections(pubUser.id, theCommunity.id)).toEqual(true);
+    });
 
-	it('returns true if user has a CollectionAttribution in the community', async () => {
-		const { theCommunity, collectionAttrUser } = models;
-		expect(await getCountOfPubsOrCollections(collectionAttrUser.id, theCommunity.id)).toEqual(
-			true,
-		);
-	});
+    it('returns true if user has a CollectionAttribution in the community', async () => {
+        const { theCommunity, collectionAttrUser } = models;
+        expect(await getCountOfPubsOrCollections(collectionAttrUser.id, theCommunity.id)).toEqual(
+            true,
+        );
+    });
 
-	it('returns true if user has a PubAttribution in the community', async () => {
-		const { theCommunity, pubAttrUser } = models;
-		expect(await getCountOfPubsOrCollections(pubAttrUser.id, theCommunity.id)).toEqual(true);
-	});
+    it('returns true if user has a PubAttribution in the community', async () => {
+        const { theCommunity, pubAttrUser } = models;
+        expect(await getCountOfPubsOrCollections(pubAttrUser.id, theCommunity.id)).toEqual(true);
+    });
 
-	it('returns false if user is not in the community', async () => {
-		const { theCommunity, notACommunityMember } = models;
-		expect(await getCountOfPubsOrCollections(notACommunityMember.id, theCommunity.id)).toEqual(
-			false,
-		);
-	});
+    it('returns false if user is not in the community', async () => {
+        const { theCommunity, notACommunityMember } = models;
+        expect(await getCountOfPubsOrCollections(notACommunityMember.id, theCommunity.id)).toEqual(
+            false,
+        );
+    });
 
-	it('returns false if user is an admin in another community but not in this community', async () => {
-		const { theCommunity, randoCommunityAdmin } = models;
-		expect(await getCountOfPubsOrCollections(randoCommunityAdmin.id, theCommunity.id)).toEqual(
-			false,
-		);
-	});
+    it('returns false if user is an admin in another community but not in this community', async () => {
+        const { theCommunity, randoCommunityAdmin } = models;
+        expect(await getCountOfPubsOrCollections(randoCommunityAdmin.id, theCommunity.id)).toEqual(
+            false,
+        );
+    });
+
+
+
+
+
+
+
+
+
+
+
 });

--- a/server/community/__tests__/queries.test.ts
+++ b/server/community/__tests__/queries.test.ts
@@ -55,58 +55,47 @@ teardown(afterAll);
 
 // i dont get how to access stuff but he said it wasnt a tree so maybe just directlt cause userId is on pub maybe
 describe('getCountOfPubsOrCollections', () => {
-    it('returns true if user is member of the community', async () => {
-        const { theCommunity, communityMember } = models;
+	it('returns true if user is member of the community', async () => {
+		const { theCommunity, communityMember } = models;
 
-        expect(await getCountOfPubsOrCollections(communityMember.id, theCommunity.id)).toEqual(
-            true,
-        );
-    });
+		expect(await getCountOfPubsOrCollections(communityMember.id, theCommunity.id)).toEqual(
+			true,
+		);
+	});
 
-    it('returns true if user is member of collection in the community', async () => {
-        const { theCommunity, collectionUser } = models;
-        expect(await getCountOfPubsOrCollections(collectionUser.id, theCommunity.id)).toEqual(true);
-    });
+	it('returns true if user is member of collection in the community', async () => {
+		const { theCommunity, collectionUser } = models;
+		expect(await getCountOfPubsOrCollections(collectionUser.id, theCommunity.id)).toEqual(true);
+	});
 
-    it('returns true if user is member of pub in the community', async () => {
-        const { theCommunity, pubUser } = models;
-        expect(await getCountOfPubsOrCollections(pubUser.id, theCommunity.id)).toEqual(true);
-    });
+	it('returns true if user is member of pub in the community', async () => {
+		const { theCommunity, pubUser } = models;
+		expect(await getCountOfPubsOrCollections(pubUser.id, theCommunity.id)).toEqual(true);
+	});
 
-    it('returns true if user has a CollectionAttribution in the community', async () => {
-        const { theCommunity, collectionAttrUser } = models;
-        expect(await getCountOfPubsOrCollections(collectionAttrUser.id, theCommunity.id)).toEqual(
-            true,
-        );
-    });
+	it('returns true if user has a CollectionAttribution in the community', async () => {
+		const { theCommunity, collectionAttrUser } = models;
+		expect(await getCountOfPubsOrCollections(collectionAttrUser.id, theCommunity.id)).toEqual(
+			true,
+		);
+	});
 
-    it('returns true if user has a PubAttribution in the community', async () => {
-        const { theCommunity, pubAttrUser } = models;
-        expect(await getCountOfPubsOrCollections(pubAttrUser.id, theCommunity.id)).toEqual(true);
-    });
+	it('returns true if user has a PubAttribution in the community', async () => {
+		const { theCommunity, pubAttrUser } = models;
+		expect(await getCountOfPubsOrCollections(pubAttrUser.id, theCommunity.id)).toEqual(true);
+	});
 
-    it('returns false if user is not in the community', async () => {
-        const { theCommunity, notACommunityMember } = models;
-        expect(await getCountOfPubsOrCollections(notACommunityMember.id, theCommunity.id)).toEqual(
-            false,
-        );
-    });
+	it('returns false if user is not in the community', async () => {
+		const { theCommunity, notACommunityMember } = models;
+		expect(await getCountOfPubsOrCollections(notACommunityMember.id, theCommunity.id)).toEqual(
+			false,
+		);
+	});
 
-    it('returns false if user is an admin in another community but not in this community', async () => {
-        const { theCommunity, randoCommunityAdmin } = models;
-        expect(await getCountOfPubsOrCollections(randoCommunityAdmin.id, theCommunity.id)).toEqual(
-            false,
-        );
-    });
-
-
-
-
-
-
-
-
-
-
-
+	it('returns false if user is an admin in another community but not in this community', async () => {
+		const { theCommunity, randoCommunityAdmin } = models;
+		expect(await getCountOfPubsOrCollections(randoCommunityAdmin.id, theCommunity.id)).toEqual(
+			false,
+		);
+	});
 });

--- a/server/community/__tests__/queries.test.ts
+++ b/server/community/__tests__/queries.test.ts
@@ -2,8 +2,6 @@
 import { modelize, setup, teardown } from 'stubstub';
 import { getCountOfPubsOrCollections } from 'server/community/queries';
 
-
-
 // 1. User is Member of Community => true
 // 2. User is Member of Collection in Community => true
 // 3. User is Member of Pub in Community => true
@@ -57,39 +55,47 @@ teardown(afterAll);
 
 // i dont get how to access stuff but he said it wasnt a tree so maybe just directlt cause userId is on pub maybe
 describe('getCountOfPubsOrCollections', () => {
-    it('returns true if user is member of the community', async () => {
-        const {theCommunity, communityMember} = models;
+	it('returns true if user is member of the community', async () => {
+		const { theCommunity, communityMember } = models;
 
-        expect(await getCountOfPubsOrCollections(communityMember.id, theCommunity.id)).toEqual(true);
-    });
+		expect(await getCountOfPubsOrCollections(communityMember.id, theCommunity.id)).toEqual(
+			true,
+		);
+	});
 
-    it('returns true if user is member of collection in the community', async () => {
-        const { theCommunity, collectionUser} = models;
-        expect(await getCountOfPubsOrCollections(collectionUser.id, theCommunity.id )).toEqual(true);
-    });
+	it('returns true if user is member of collection in the community', async () => {
+		const { theCommunity, collectionUser } = models;
+		expect(await getCountOfPubsOrCollections(collectionUser.id, theCommunity.id)).toEqual(true);
+	});
 
-    it('returns true if user is member of pub in the community', async () => {
-        const {theCommunity, pubUser} = models;
-        expect(await getCountOfPubsOrCollections(pubUser.id, theCommunity.id)).toEqual(true);
-    });
+	it('returns true if user is member of pub in the community', async () => {
+		const { theCommunity, pubUser } = models;
+		expect(await getCountOfPubsOrCollections(pubUser.id, theCommunity.id)).toEqual(true);
+	});
 
-    it('returns true if user has a CollectionAttribution in the community', async () => {
-        const { theCommunity, collectionAttrUser} = models;
-        expect(await getCountOfPubsOrCollections(collectionAttrUser.id, theCommunity.id )).toEqual(true);
-    });
+	it('returns true if user has a CollectionAttribution in the community', async () => {
+		const { theCommunity, collectionAttrUser } = models;
+		expect(await getCountOfPubsOrCollections(collectionAttrUser.id, theCommunity.id)).toEqual(
+			true,
+		);
+	});
 
-    it('returns true if user has a PubAttribution in the community', async () => {
-        const {theCommunity, pubAttrUser} = models;
-        expect(await getCountOfPubsOrCollections(pubAttrUser.id, theCommunity.id)).toEqual(true);
-    });
+	it('returns true if user has a PubAttribution in the community', async () => {
+		const { theCommunity, pubAttrUser } = models;
+		expect(await getCountOfPubsOrCollections(pubAttrUser.id, theCommunity.id)).toEqual(true);
+	});
 
-    it('returns false if user is not in the community', async () => {
-        const {theCommunity, notACommunityMember} = models;
-        expect(await getCountOfPubsOrCollections(notACommunityMember.id, theCommunity.id)).toEqual(false);
-    });
+	it('returns false if user is not in the community', async () => {
+		const { theCommunity, notACommunityMember } = models;
+		expect(await getCountOfPubsOrCollections(notACommunityMember.id, theCommunity.id)).toEqual(
+			false,
+		);
+	});
 
-    it('returns false if user is an admin in another community but not in this community', async () => {
-        const {theCommunity, randoCommunityAdmin} = models;
-        expect(await getCountOfPubsOrCollections(randoCommunityAdmin.id, theCommunity.id)).toEqual(false);
-    });
+	it('returns false if user is an admin in another community but not in this community', async () => {
+		const { theCommunity, randoCommunityAdmin } = models;
+		expect(await getCountOfPubsOrCollections(randoCommunityAdmin.id, theCommunity.id)).toEqual(
+			false,
+		);
+	});
 });

--- a/server/community/__tests__/queries.test.ts
+++ b/server/community/__tests__/queries.test.ts
@@ -56,7 +56,9 @@ describe('isUserAffiliatedWithCommunity', () => {
 
 	it('returns true if user is member of collection in the community', async () => {
 		const { theCommunity, collectionUser } = models;
-		expect(await isUserAffiliatedWithCommunity(collectionUser.id, theCommunity.id)).toEqual(true);
+		expect(await isUserAffiliatedWithCommunity(collectionUser.id, theCommunity.id)).toEqual(
+			true,
+		);
 	});
 
 	it('returns true if user is member of pub in the community', async () => {
@@ -78,15 +80,15 @@ describe('isUserAffiliatedWithCommunity', () => {
 
 	it('returns false if user is not in the community', async () => {
 		const { theCommunity, notACommunityMember } = models;
-		expect(await isUserAffiliatedWithCommunity(notACommunityMember.id, theCommunity.id)).toEqual(
-			false,
-		);
+		expect(
+			await isUserAffiliatedWithCommunity(notACommunityMember.id, theCommunity.id),
+		).toEqual(false);
 	});
 
 	it('returns false if user is an admin in another community but not in this community', async () => {
 		const { theCommunity, randoCommunityAdmin } = models;
-		expect(await isUserAffiliatedWithCommunity(randoCommunityAdmin.id, theCommunity.id)).toEqual(
-			false,
-		);
+		expect(
+			await isUserAffiliatedWithCommunity(randoCommunityAdmin.id, theCommunity.id),
+		).toEqual(false);
 	});
 });

--- a/server/community/queries.ts
+++ b/server/community/queries.ts
@@ -125,25 +125,25 @@ export const updateCommunity = (inputValues, updatePermissions) => {
 	});
 };
 
-export const getCountOfPubsOrCollections = async (userData: string, communityData: string) => {
+export const getCountOfPubsOrCollections = async (userId: string, communityId: string) => {
 	const promises = [
 		Member.count({
 			where: {
-				communityId: communityData,
-				userId: userData,
+				communityId,
+				userId,
 			},
 		}),
 
 		Member.count({
 			where: {
-				userId: userData,
+				userId,
 			},
 			include: [
 				{
 					model: Pub,
 					as: 'pub',
 					where: {
-						communityId: communityData,
+						communityId,
 					},
 				},
 			],
@@ -151,14 +151,14 @@ export const getCountOfPubsOrCollections = async (userData: string, communityDat
 
 		Member.count({
 			where: {
-				userId: userData,
+				userId,
 			},
 			include: [
 				{
 					model: Collection,
 					as: 'collection',
 					where: {
-						communityId: communityData,
+						communityId,
 					},
 				},
 			],
@@ -166,14 +166,14 @@ export const getCountOfPubsOrCollections = async (userData: string, communityDat
 
 		PubAttribution.count({
 			where: {
-				userId: userData,
+				userId,
 			},
 			include: [
 				{
 					model: Pub,
 					as: 'pub',
 					where: {
-						communityId: communityData,
+						communityId,
 					},
 				},
 			],
@@ -181,14 +181,14 @@ export const getCountOfPubsOrCollections = async (userData: string, communityDat
 
 		CollectionAttribution.count({
 			where: {
-				userId: userData,
+				userId,
 			},
 			include: [
 				{
 					model: Collection,
 					as: 'collection',
 					where: {
-						communityId: communityData,
+						communityId,
 					},
 				},
 			],

--- a/server/community/queries.ts
+++ b/server/community/queries.ts
@@ -125,7 +125,7 @@ export const updateCommunity = (inputValues, updatePermissions) => {
 	});
 };
 
-export const getCountOfPubsOrCollections = async (userId: string, communityId: string) => {
+export const isUserAffiliatedWithCommunity = async (userId: string, communityId: string) => {
 	const promises = [
 		Member.count({
 			where: {
@@ -195,7 +195,7 @@ export const getCountOfPubsOrCollections = async (userId: string, communityId: s
 		}),
 	];
 	const counts = await Promise.all(promises);
-	// indicates if user is present
+
 	const isHere = counts.some((c) => c > 0);
 	return isHere;
 };

--- a/server/community/queries.ts
+++ b/server/community/queries.ts
@@ -1,6 +1,14 @@
 import uuidv4 from 'uuid/v4';
 
-import { Community, Page, Member, Collection, CollectionAttribution, PubAttribution, Pub } from 'server/models';
+import {
+	Community,
+	Page,
+	Member,
+	Collection,
+	CollectionAttribution,
+	PubAttribution,
+	Pub,
+} from 'server/models';
 import { slugifyString } from 'utils/strings';
 import { generateHash } from 'utils/hashes';
 import { isProd } from 'utils/environment';

--- a/server/community/queries.ts
+++ b/server/community/queries.ts
@@ -125,25 +125,25 @@ export const updateCommunity = (inputValues, updatePermissions) => {
 	});
 };
 
-export const getCountOfPubsOrCollections = async (userId: string, communityId: string) => {
+export const getCountOfPubsOrCollections = async (userData: string, communityData: string) => {
 	const promises = [
 		Member.count({
 			where: {
-				communityId: communityId,
-				userId: userId,
+				communityId: communityData,
+				userId: userData,
 			},
 		}),
 
 		Member.count({
 			where: {
-				userId: userId,
+				userId: userData,
 			},
 			include: [
 				{
 					model: Pub,
 					as: 'pub',
 					where: {
-						communityId: communityId,
+						communityId: communityData,
 					},
 				},
 			],
@@ -151,14 +151,14 @@ export const getCountOfPubsOrCollections = async (userId: string, communityId: s
 
 		Member.count({
 			where: {
-				userId: userId,
+				userId: userData,
 			},
 			include: [
 				{
 					model: Collection,
 					as: 'collection',
 					where: {
-						communityId: communityId,
+						communityId: communityData,
 					},
 				},
 			],
@@ -166,14 +166,14 @@ export const getCountOfPubsOrCollections = async (userId: string, communityId: s
 
 		PubAttribution.count({
 			where: {
-				userId: userId,
+				userId: userData,
 			},
 			include: [
 				{
 					model: Pub,
 					as: 'pub',
 					where: {
-						communityId: communityId,
+						communityId: communityData,
 					},
 				},
 			],
@@ -181,22 +181,20 @@ export const getCountOfPubsOrCollections = async (userId: string, communityId: s
 
 		CollectionAttribution.count({
 			where: {
-				userId: userId,
+				userId: userData,
 			},
 			include: [
 				{
 					model: Collection,
 					as: 'collection',
 					where: {
-						communityId: communityId,
+						communityId: communityData,
 					},
 				},
 			],
 		}),
 	];
-
 	const counts = await Promise.all(promises);
-
 	// indicates if user is present
 	const isHere = counts.some((c) => c > 0);
 	return isHere;

--- a/server/community/queries.ts
+++ b/server/community/queries.ts
@@ -1,6 +1,6 @@
 import uuidv4 from 'uuid/v4';
 
-import { Community, Page, Member } from 'server/models';
+import { Community, Page, Member, Collection, CollectionAttribution, PubAttribution, Pub } from 'server/models';
 import { slugifyString } from 'utils/strings';
 import { generateHash } from 'utils/hashes';
 import { isProd } from 'utils/environment';
@@ -115,4 +115,81 @@ export const updateCommunity = (inputValues, updatePermissions) => {
 		updateCommunityData(inputValues.communityId);
 		return filteredValues;
 	});
+};
+
+export const getCountOfPubsOrCollections = async (userId: string, communityId: string) => {
+	const promises = [
+		Member.count({
+			where: {
+				communityId: communityId,
+				userId: userId,
+			},
+		}),
+
+		Member.count({
+			where: {
+				userId: userId,
+			},
+			include: [
+				{
+					model: Pub,
+					as: 'pub',
+					where: {
+						communityId: communityId,
+					},
+				},
+			],
+		}),
+
+		Member.count({
+			where: {
+				userId: userId,
+			},
+			include: [
+				{
+					model: Collection,
+					as: 'collection',
+					where: {
+						communityId: communityId,
+					},
+				},
+			],
+		}),
+
+		PubAttribution.count({
+			where: {
+				userId: userId,
+			},
+			include: [
+				{
+					model: Pub,
+					as: 'pub',
+					where: {
+						communityId: communityId,
+					},
+				},
+			],
+		}),
+
+		CollectionAttribution.count({
+			where: {
+				userId: userId,
+			},
+			include: [
+				{
+					model: Collection,
+					as: 'collection',
+					where: {
+						communityId: communityId,
+					},
+				},
+			],
+		}),
+	];
+
+	const counts = await Promise.all(promises);
+
+	// indicates if user is present
+	const isHere = counts.some((c) => c > 0);
+	return isHere;
 };

--- a/server/routes/user.tsx
+++ b/server/routes/user.tsx
@@ -9,25 +9,25 @@ import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
 import { Collection, CollectionAttribution, Member, PubAttribution, Pub } from 'server/models';
 
 // check if member has any pubs or collections for user
-const getCountOfPubsOrCollections = async (userId, communityId) => {
+const getCountOfPubsOrCollections = async (userData, communityData) => {
 	const promises = [
 		Member.count({
 			where: {
-				communityId: communityId,
-				userId: userId,
+				communityId: communityData,
+				userId: userData,
 			},
 		}),
 
 		Member.count({
 			where: {
-				userId: userId,
+				userId: userData,
 			},
 			include: [
 				{
 					model: Pub,
 					as: 'pub',
 					where: {
-						communityId: communityId,
+						communityId: communityData,
 					},
 				},
 			],
@@ -35,14 +35,14 @@ const getCountOfPubsOrCollections = async (userId, communityId) => {
 
 		Member.count({
 			where: {
-				userId: userId,
+				userId: userData,
 			},
 			include: [
 				{
 					model: Collection,
 					as: 'collection',
 					where: {
-						communityId: communityId,
+						communityId: communityData,
 					},
 				},
 			],
@@ -50,14 +50,14 @@ const getCountOfPubsOrCollections = async (userId, communityId) => {
 
 		PubAttribution.count({
 			where: {
-				userId: userId,
+				userId: userData,
 			},
 			include: [
 				{
 					model: Pub,
 					as: 'pub',
 					where: {
-						communityId: communityId,
+						communityId: communityData,
 					},
 				},
 			],
@@ -65,14 +65,14 @@ const getCountOfPubsOrCollections = async (userId, communityId) => {
 
 		CollectionAttribution.count({
 			where: {
-				userId: userId,
+				userId: userData,
 			},
 			include: [
 				{
 					model: Collection,
 					as: 'collection',
 					where: {
-						communityId: communityId,
+						communityId: communityData,
 					},
 				},
 			],

--- a/server/routes/user.tsx
+++ b/server/routes/user.tsx
@@ -87,6 +87,9 @@ app.get(['/user/:slug', '/user/:slug/:mode'], async (req, res, next) => {
 		const userData = await getUser(req.params.slug, initialData);
 		const isNewishUser = Date.now() - userData.createdAt.valueOf() < 1000 * 86400 * 30;
 		const isThisUserAPartOfThisCOmmunity = await getCountOfPubsOrCollections(userData.id, initialData.communityData.id);
+		if (!isThisUserAPartOfThisCOmmunity){
+			return res.redirect(`https://www.pubpub.org/user/${userData.slug}`)
+		}
 		console.log(isThisUserAPartOfThisCOmmunity)
 		return renderToNodeStream(
 			res,

--- a/server/routes/user.tsx
+++ b/server/routes/user.tsx
@@ -6,85 +6,8 @@ import { getUser } from 'server/utils/queryHelpers';
 import { handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
-import { Collection, CollectionAttribution, Member, PubAttribution, Pub } from 'server/models';
-
+import { getCountOfPubsOrCollections } from 'server/community/queries';
 // check if member has any pubs or collections for user
-const getCountOfPubsOrCollections = async (userData, communityData) => {
-	const promises = [
-		Member.count({
-			where: {
-				communityId: communityData,
-				userId: userData,
-			},
-		}),
-
-		Member.count({
-			where: {
-				userId: userData,
-			},
-			include: [
-				{
-					model: Pub,
-					as: 'pub',
-					where: {
-						communityId: communityData,
-					},
-				},
-			],
-		}),
-
-		Member.count({
-			where: {
-				userId: userData,
-			},
-			include: [
-				{
-					model: Collection,
-					as: 'collection',
-					where: {
-						communityId: communityData,
-					},
-				},
-			],
-		}),
-
-		PubAttribution.count({
-			where: {
-				userId: userData,
-			},
-			include: [
-				{
-					model: Pub,
-					as: 'pub',
-					where: {
-						communityId: communityData,
-					},
-				},
-			],
-		}),
-
-		CollectionAttribution.count({
-			where: {
-				userId: userData,
-			},
-			include: [
-				{
-					model: Collection,
-					as: 'collection',
-					where: {
-						communityId: communityData,
-					},
-				},
-			],
-		}),
-	];
-
-	const counts = await Promise.all(promises);
-
-	// indicates if user is present
-	const isHere = counts.some((c) => c > 0);
-	return isHere;
-};
 
 app.get(['/user/:slug', '/user/:slug/:mode'], async (req, res, next) => {
 	try {

--- a/server/routes/user.tsx
+++ b/server/routes/user.tsx
@@ -21,7 +21,7 @@ app.get(['/user/:slug', '/user/:slug/:mode'], async (req, res, next) => {
 		if (!isThisUserAPartOfThisCOmmunity) {
 			return res.redirect(`https://www.pubpub.org/user/${userData.slug}`);
 		}
-		console.log(isThisUserAPartOfThisCOmmunity);
+
 		return renderToNodeStream(
 			res,
 			<Html

--- a/server/routes/user.tsx
+++ b/server/routes/user.tsx
@@ -6,7 +6,7 @@ import { getUser } from 'server/utils/queryHelpers';
 import { handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
-import { getCountOfPubsOrCollections } from 'server/community/queries';
+import { isUserAffiliatedWithCommunity } from 'server/community/queries';
 // check if member has any pubs or collections for user
 
 app.get(['/user/:slug', '/user/:slug/:mode'], async (req, res, next) => {
@@ -14,11 +14,11 @@ app.get(['/user/:slug', '/user/:slug/:mode'], async (req, res, next) => {
 		const initialData = await getInitialData(req);
 		const userData = await getUser(req.params.slug, initialData);
 		const isNewishUser = Date.now() - userData.createdAt.valueOf() < 1000 * 86400 * 30;
-		const isThisUserAPartOfThisCOmmunity = await getCountOfPubsOrCollections(
+		const isThisUserAPartOfThisCommunity = await isUserAffiliatedWithCommunity(
 			userData.id,
 			initialData.communityData.id,
 		);
-		if (!isThisUserAPartOfThisCOmmunity) {
+		if (!isThisUserAPartOfThisCommunity) {
 			return res.redirect(`https://www.pubpub.org/user/${userData.slug}`);
 		}
 

--- a/server/routes/user.tsx
+++ b/server/routes/user.tsx
@@ -6,12 +6,88 @@ import { getUser } from 'server/utils/queryHelpers';
 import { handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
+import { Collection, CollectionAttribution, Member, PubAttribution, Pub } from 'server/models';
+
+// check if member has any pubs or collections for user
+const getCountOfPubsOrCollections = async ( userId, communityId) => {
+
+	const promises = [
+	  Member.count({
+		  where: {
+			communityId: communityId,
+			userId: userId
+		  },
+		}),
+  
+	  Member.count({
+		  where: {
+			userId: userId,
+		  },
+		  include: [{
+			model: Pub,
+			as: 'pub',
+			where:{
+			  communityId: communityId
+			}
+		  }]
+		}),
+  
+	  Member.count({
+		  where: {
+			userId: userId,
+		  },
+		  include: [{
+			model: Collection,
+			as: 'collection',
+			where:{
+			  communityId: communityId
+			}
+		  }]
+		}),
+	  
+	   PubAttribution.count({
+		  where: {
+			userId: userId,
+		  },
+		  include: [{
+			model: Pub,
+			as: 'pub',
+			where:{
+			  communityId: communityId
+			}
+		  }]
+		}),
+  
+	  CollectionAttribution.count({
+		  where: {
+			userId: userId,
+		  },
+		  include: [{
+			model: Collection,
+			as: 'collection',
+			where:{
+			  communityId: communityId
+			}
+		  }]
+		}),
+	  
+	  
+	  ];
+	
+	const counts = await Promise.all(promises)
+	
+	// indicates if user is present
+	const isHere = counts.some(c => c > 0);
+	return isHere;
+  }
 
 app.get(['/user/:slug', '/user/:slug/:mode'], async (req, res, next) => {
 	try {
 		const initialData = await getInitialData(req);
 		const userData = await getUser(req.params.slug, initialData);
 		const isNewishUser = Date.now() - userData.createdAt.valueOf() < 1000 * 86400 * 30;
+		const isThisUserAPartOfThisCOmmunity = await getCountOfPubsOrCollections(userData.id, initialData.communityData.id);
+		console.log(isThisUserAPartOfThisCOmmunity)
 		return renderToNodeStream(
 			res,
 			<Html

--- a/server/routes/user.tsx
+++ b/server/routes/user.tsx
@@ -9,88 +9,96 @@ import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
 import { Collection, CollectionAttribution, Member, PubAttribution, Pub } from 'server/models';
 
 // check if member has any pubs or collections for user
-const getCountOfPubsOrCollections = async ( userId, communityId) => {
-
+const getCountOfPubsOrCollections = async (userId, communityId) => {
 	const promises = [
-	  Member.count({
-		  where: {
-			communityId: communityId,
-			userId: userId
-		  },
+		Member.count({
+			where: {
+				communityId: communityId,
+				userId: userId,
+			},
 		}),
-  
-	  Member.count({
-		  where: {
-			userId: userId,
-		  },
-		  include: [{
-			model: Pub,
-			as: 'pub',
-			where:{
-			  communityId: communityId
-			}
-		  }]
+
+		Member.count({
+			where: {
+				userId: userId,
+			},
+			include: [
+				{
+					model: Pub,
+					as: 'pub',
+					where: {
+						communityId: communityId,
+					},
+				},
+			],
 		}),
-  
-	  Member.count({
-		  where: {
-			userId: userId,
-		  },
-		  include: [{
-			model: Collection,
-			as: 'collection',
-			where:{
-			  communityId: communityId
-			}
-		  }]
+
+		Member.count({
+			where: {
+				userId: userId,
+			},
+			include: [
+				{
+					model: Collection,
+					as: 'collection',
+					where: {
+						communityId: communityId,
+					},
+				},
+			],
 		}),
-	  
-	   PubAttribution.count({
-		  where: {
-			userId: userId,
-		  },
-		  include: [{
-			model: Pub,
-			as: 'pub',
-			where:{
-			  communityId: communityId
-			}
-		  }]
+
+		PubAttribution.count({
+			where: {
+				userId: userId,
+			},
+			include: [
+				{
+					model: Pub,
+					as: 'pub',
+					where: {
+						communityId: communityId,
+					},
+				},
+			],
 		}),
-  
-	  CollectionAttribution.count({
-		  where: {
-			userId: userId,
-		  },
-		  include: [{
-			model: Collection,
-			as: 'collection',
-			where:{
-			  communityId: communityId
-			}
-		  }]
+
+		CollectionAttribution.count({
+			where: {
+				userId: userId,
+			},
+			include: [
+				{
+					model: Collection,
+					as: 'collection',
+					where: {
+						communityId: communityId,
+					},
+				},
+			],
 		}),
-	  
-	  
-	  ];
-	
-	const counts = await Promise.all(promises)
-	
+	];
+
+	const counts = await Promise.all(promises);
+
 	// indicates if user is present
-	const isHere = counts.some(c => c > 0);
+	const isHere = counts.some((c) => c > 0);
 	return isHere;
-  }
+};
 
 app.get(['/user/:slug', '/user/:slug/:mode'], async (req, res, next) => {
 	try {
 		const initialData = await getInitialData(req);
 		const userData = await getUser(req.params.slug, initialData);
 		const isNewishUser = Date.now() - userData.createdAt.valueOf() < 1000 * 86400 * 30;
-		const isThisUserAPartOfThisCOmmunity = await getCountOfPubsOrCollections(userData.id, initialData.communityData.id);
-		if (!isThisUserAPartOfThisCOmmunity){
-			return res.redirect(`https://www.pubpub.org/user/${userData.slug}`)
+		const isThisUserAPartOfThisCOmmunity = await getCountOfPubsOrCollections(
+			userData.id,
+			initialData.communityData.id,
+		);
+		if (!isThisUserAPartOfThisCOmmunity) {
+			return res.redirect(`https://www.pubpub.org/user/${userData.slug}`);
 		}
-		console.log(isThisUserAPartOfThisCOmmunity)
+		console.log(isThisUserAPartOfThisCOmmunity);
 		return renderToNodeStream(
 			res,
 			<Html


### PR DESCRIPTION
addresses issue #1429 

This fixes an issue where bad actors can impersonate members of communities they are not apart of. We now verify that a user has contributed to a community before their user page can be shown. If they are not, they will be redirected to the main pubpub page. 

Test:

1. Unit test for user redirect
2. Go to a pubpub community(https://www.pubpub.org/explore) you are not part of. At the end of the community homepage url type: /user/<firstname-lastname>. If you are not a member, this should redirect you back to the main pubpub site