### PR TITLE
Pub tools quick fix

### DIFF
--- a/tools/depositCollectionPubs.js
+++ b/tools/depositCollectionPubs.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import Bluebird from 'bluebird';
-import { Sequelize } from 'sequelize';
 import { Community, Collection, CollectionPub, Pub, Release } from 'server/models';
 import { setDoiData } from 'server/doi/queries';
 

--- a/tools/pubCrawl.js
+++ b/tools/pubCrawl.js
@@ -19,7 +19,7 @@ const crawl = async (pub) => {
 		if (response.status === 404) {
 			console.log(
 				`DOI did not resolve: ${pub.title} • https://${pub.community.domain ||
-					pub.community.subdomain}/pub/${pub.slug}`,
+					pub.community.subdomain + `.pubpub.org`}/pub/${pub.slug}`,
 			);
 		}
 		return Promise.resolve(response);


### PR DESCRIPTION
- Changes `depositCollectionPubs` to only deposit released pubs in a collection (I think trying to deposit unreleased pubs would fail at crossref processing time given no public URI). There's probably a better way to do this selection at query-time, but after battling Sequelize for 3 hours I gave up. Pointers welcome.
- Fixes the pubCrawl tool to spit out a real subdomain so you can click from the terminal when running it

_Test plan_
- Run `depositCollecitonPubs` against a collection with both released and unreleased Pubs (e.g. "aaaaaa" on demo). Make sure it only processes and deposits released pubs (the number spit out in the terminal should correspond to the number of released pubs).
- Run `pubCrawl` against a community _without_ a custom domain. Make sure the full subdomain (e.g. http://demo.pubpub.org...) shows up in any undeposited Pubs (depositing a Pub on a dev server community should create this scenario, so I think using demo should work).
