### PR TITLE
update: Add activity items for Pages

### DIFF
--- a/client/containers/DashboardActivity/ActivityFilters.tsx
+++ b/client/containers/DashboardActivity/ActivityFilters.tsx
@@ -22,6 +22,7 @@ const filterLabels: Record<ActivityFilter, FilterLabel> = {
 	community: { label: 'Community', icon: 'office' },
 	collection: { label: 'Collections', icon: 'collection' },
 	pub: { label: 'Pubs', icon: 'pubDoc' },
+	page: { label: 'Pages', icon: 'page-layout' },
 	member: { label: 'Members', icon: 'people' },
 	review: { label: 'Reviews', icon: 'social-media' },
 	discussion: { label: 'Discussions', icon: 'chat' },
@@ -33,7 +34,15 @@ const sortedFilters = (filters: ActivityFilter[]) =>
 	filters.concat().sort((a, b) => allFilters.indexOf(a) - allFilters.indexOf(b));
 
 const filtersByScopeKind = {
-	community: sortedFilters(['community', 'collection', 'pub', 'member', 'review', 'discussion']),
+	community: sortedFilters([
+		'community',
+		'collection',
+		'pub',
+		'page',
+		'member',
+		'review',
+		'discussion',
+	]),
 	collection: sortedFilters(['pub', 'member', 'review', 'discussion']),
 	pub: sortedFilters(['member', 'review', 'discussion', 'pubEdge']),
 };

--- a/client/containers/DashboardPage/PageDelete.tsx
+++ b/client/containers/DashboardPage/PageDelete.tsx
@@ -31,7 +31,7 @@ const PageDelete = (props: Props) => {
 			}),
 		)
 			.then(() => {
-				window.location.href = '/dashboard';
+				window.location.href = '/dash';
 			})
 			.catch((err) => {
 				console.error(err);

--- a/client/utils/activity/renderers/collection.tsx
+++ b/client/utils/activity/renderers/collection.tsx
@@ -45,6 +45,14 @@ export const renderCollectionUpdated = itemRenderer<CollectionUpdatedActivityIte
 				</>
 			);
 		}
+		if (payload.slug) {
+			return (
+				<>
+					{actor} changed the title of {collection} from {payload.slug.from} to{' '}
+					{payload.slug.to}
+				</>
+			);
+		}
 		if (payload.layout) {
 			return (
 				<>

--- a/client/utils/activity/renderers/index.ts
+++ b/client/utils/activity/renderers/index.ts
@@ -8,6 +8,7 @@ import {
 	renderCollectionRemoved,
 	renderCollectionUpdated,
 } from './collection';
+import { renderPageCreated, renderPageUpdated, renderPageRemoved } from './page';
 import {
 	renderPubCreated,
 	renderPubRemoved,
@@ -30,6 +31,9 @@ export const activityItemRenderers: ActivityItemRenderers = {
 	'collection-removed': renderCollectionRemoved,
 	'collection-pub-created': renderCollectionPubCreated,
 	'collection-pub-removed': renderCollectionPubRemoved,
+	'page-created': renderPageCreated,
+	'page-updated': renderPageUpdated,
+	'page-removed': renderPageRemoved,
 	'pub-created': renderPubCreated,
 	'pub-updated': renderPubUpdated,
 	'pub-removed': renderPubRemoved,

--- a/client/utils/activity/renderers/page.tsx
+++ b/client/utils/activity/renderers/page.tsx
@@ -8,7 +8,7 @@ import { itemRenderer } from './itemRenderer';
 type BaseTitles = 'page';
 
 export const renderPageCreated = itemRenderer<PageCreatedActivityItem, BaseTitles>({
-	icon: 'layout',
+	icon: 'page-layout',
 	titleRenderers: {
 		page: pageTitle,
 	},
@@ -23,7 +23,7 @@ export const renderPageCreated = itemRenderer<PageCreatedActivityItem, BaseTitle
 });
 
 export const renderPageUpdated = itemRenderer<PageUpdatedActivityItem, BaseTitles>({
-	icon: 'layout',
+	icon: 'page-layout',
 	titleRenderers: {
 		page: pageTitle,
 	},
@@ -98,7 +98,7 @@ export const renderPageUpdated = itemRenderer<PageUpdatedActivityItem, BaseTitle
 });
 
 export const renderPageRemoved = itemRenderer<PageRemovedActivityItem, BaseTitles>({
-	icon: 'layout',
+	icon: 'page-layout',
 	titleRenderers: {
 		page: pageTitle,
 	},

--- a/client/utils/activity/renderers/page.tsx
+++ b/client/utils/activity/renderers/page.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+
+import { PageCreatedActivityItem, PageUpdatedActivityItem, PageRemovedActivityItem } from 'types';
+
+import { pageTitle } from '../titles';
+import { itemRenderer } from './itemRenderer';
+
+type BaseTitles = 'page';
+
+export const renderPageCreated = itemRenderer<PageCreatedActivityItem, BaseTitles>({
+	icon: 'layout',
+	titleRenderers: {
+		page: pageTitle,
+	},
+	message: ({ titles }) => {
+		const { actor, page } = titles;
+		return (
+			<>
+				{actor} created {page}
+			</>
+		);
+	},
+});
+
+export const renderPageUpdated = itemRenderer<PageUpdatedActivityItem, BaseTitles>({
+	icon: 'layout',
+	titleRenderers: {
+		page: pageTitle,
+	},
+	message: ({ titles, item }) => {
+		const { payload } = item;
+		const { actor, page } = titles;
+		const changes: ((referent: React.ReactNode) => React.ReactNode)[] = [];
+
+		if (payload.title) {
+			const { title } = payload;
+			changes.push((referent: React.ReactNode) => (
+				<>
+					changed the title of {referent} from {title.from} to {title.to}
+				</>
+			));
+		}
+
+		if (payload.slug) {
+			const { slug } = payload;
+			changes.push((referent: React.ReactNode) => (
+				<>
+					changed the slug of {referent} from {slug.from} to {slug.to}
+				</>
+			));
+		}
+
+		if (payload.layout) {
+			changes.push((referent: React.ReactNode) => <>updated the layout of {referent}</>);
+		}
+
+		if (payload.isPublic) {
+			const isNowPublic = payload.isPublic.to;
+			changes.push((referent: React.ReactNode) => {
+				const resultingState = isNowPublic ? 'public' : 'private';
+				return (
+					<>
+						made {referent} {resultingState}
+					</>
+				);
+			});
+		}
+
+		if (changes.length > 1) {
+			return (
+				<>
+					{actor} made the following changes to {page}:
+					<ul>
+						{changes.map((change, index) => (
+							// eslint-disable-next-line react/no-array-index-key
+							<li key={index}>{change('the Page')}</li>
+						))}
+					</ul>
+				</>
+			);
+		}
+
+		if (changes.length === 1) {
+			const [change] = changes;
+			return (
+				<>
+					{actor} {change(page)}
+				</>
+			);
+		}
+
+		return (
+			<>
+				{actor} updated the settings for {page}
+			</>
+		);
+	},
+});
+
+export const renderPageRemoved = itemRenderer<PageRemovedActivityItem, BaseTitles>({
+	icon: 'layout',
+	titleRenderers: {
+		page: pageTitle,
+	},
+	message: ({ titles }) => {
+		const { actor, page } = titles;
+		return (
+			<>
+				{actor} removed {page}
+			</>
+		);
+	},
+});

--- a/client/utils/activity/titles/index.ts
+++ b/client/utils/activity/titles/index.ts
@@ -1,6 +1,7 @@
 export * from './collection';
 export * from './community';
 export * from './discussion';
+export * from './page';
 export * from './pub';
 export * from './pubEdge';
 export * from './release';

--- a/client/utils/activity/titles/page.ts
+++ b/client/utils/activity/titles/page.ts
@@ -6,7 +6,7 @@ import { TitleRenderer } from '../types';
 const prefix = 'the Page';
 
 export const pageTitle: TitleRenderer<PageActivityItem> = (item, context) => {
-	const pageFromContext = context.associations.page[item.payload.pageId];
+	const pageFromContext = context.associations.page[item.payload.page.id];
 	if (pageFromContext) {
 		return {
 			prefix,

--- a/client/utils/activity/titles/page.ts
+++ b/client/utils/activity/titles/page.ts
@@ -1,0 +1,24 @@
+import { PageActivityItem } from 'types';
+import { getDashUrl } from 'utils/dashboard';
+
+import { TitleRenderer } from '../types';
+
+const prefix = 'the Page';
+
+export const pageTitle: TitleRenderer<PageActivityItem> = (item, context) => {
+	const pageFromContext = context.associations.page[item.payload.pageId];
+	if (pageFromContext) {
+		return {
+			prefix,
+			title: pageFromContext.title,
+			href: getDashUrl({ mode: 'pages', subMode: pageFromContext.slug }),
+		};
+	}
+	if ('page' in item.payload) {
+		return {
+			prefix,
+			title: item.payload.page.title,
+		};
+	}
+	return { title: 'an unknown Page' };
+};

--- a/server/activityItem/fetch.ts
+++ b/server/activityItem/fetch.ts
@@ -63,6 +63,7 @@ const filterDefinitions: Record<ActivityFilter, SequelizeFilter | SequelizeFilte
 	collection: {
 		collectionId: { [Op.not]: null },
 	},
+	page: itemKindFilter(['page-created', 'page-updated', 'page-removed']),
 	pub: {
 		pubId: { [Op.not]: null },
 	},

--- a/server/activityItem/fetch.ts
+++ b/server/activityItem/fetch.ts
@@ -211,7 +211,7 @@ const getActivityItemAssociationIds = (
 			item.kind === 'page-updated' ||
 			item.kind === 'page-removed'
 		) {
-			page.add(item.payload.pageId);
+			page.add(item.payload.page.id);
 		}
 	});
 	return associationIds;

--- a/server/activityItem/fetch.ts
+++ b/server/activityItem/fetch.ts
@@ -17,6 +17,7 @@ import {
 	Community,
 	Discussion,
 	ExternalPublication,
+	Page,
 	Pub,
 	PubEdge,
 	Release,
@@ -143,6 +144,7 @@ const getActivityItemAssociationIds = (
 		community,
 		discussion,
 		externalPublication,
+		page,
 		pubEdge,
 		pub,
 		release,
@@ -204,6 +206,12 @@ const getActivityItemAssociationIds = (
 			item.kind === 'member-removed'
 		) {
 			user.add(item.payload.userId);
+		} else if (
+			item.kind === 'page-created' ||
+			item.kind === 'page-updated' ||
+			item.kind === 'page-removed'
+		) {
+			page.add(item.payload.pageId);
 		}
 	});
 	return associationIds;
@@ -242,6 +250,7 @@ const fetchAssociations = (
 		community,
 		discussion,
 		externalPublication,
+		page,
 		pubEdge,
 		pub,
 		release,
@@ -259,6 +268,7 @@ const fetchAssociations = (
 			ExternalPublication,
 			externalPublication,
 		),
+		page: fetchModels<types.Page>(Page, page),
 		pubEdge: fetchModels<types.PubEdge>(PubEdge, pubEdge),
 		pub: fetchModels<types.Pub>(Pub, pub),
 		release: fetchModels<types.Release>(Release, release),

--- a/server/activityItem/queries.ts
+++ b/server/activityItem/queries.ts
@@ -6,6 +6,7 @@ import {
 	Discussion,
 	ExternalPublication,
 	Member,
+	Page,
 	Pub,
 	PubEdge,
 	Release,
@@ -229,6 +230,7 @@ export const createCollectionUpdatedActivityItem = async (
 		'isPublic',
 		'isRestricted',
 		'title',
+		'slug',
 	]);
 	const flags = getChangeFlagsForPayload(collection, oldCollection, ['layout', 'metadata']);
 	return createActivityItem({
@@ -239,6 +241,48 @@ export const createCollectionUpdatedActivityItem = async (
 		payload: {
 			collection: {
 				title,
+			},
+			...flags,
+			...diffs,
+		},
+	});
+};
+
+export const createPageActivityItem = async (
+	kind: 'page-created' | 'page-removed',
+	actorId: null | string,
+	pageId: string,
+) => {
+	const page: types.Page = await Page.findOne({ where: { id: pageId } });
+	return createActivityItem({
+		kind,
+		actorId,
+		communityId: page.communityId,
+		payload: {
+			page: {
+				id: page.id,
+				title: page.title,
+			},
+		},
+	});
+};
+
+export const createPageUpdatedActivityItem = async (
+	actorId: null | string,
+	pageId: string,
+	oldPage: types.Page,
+) => {
+	const page: types.Page = await Page.findOne({ where: { id: pageId } });
+	const diffs = getDiffsForPayload(page, oldPage, ['isPublic', 'title', 'slug']);
+	const flags = getChangeFlagsForPayload(page, oldPage, ['layout']);
+	return createActivityItem({
+		kind: 'page-updated' as const,
+		actorId,
+		communityId: page.communityId,
+		payload: {
+			page: {
+				title: page.title,
+				id: page.id,
 			},
 			...flags,
 			...diffs,

--- a/server/activityItem/queries.ts
+++ b/server/activityItem/queries.ts
@@ -273,7 +273,7 @@ export const createPageUpdatedActivityItem = async (
 	oldPage: types.Page,
 ) => {
 	const page: types.Page = await Page.findOne({ where: { id: pageId } });
-	const diffs = getDiffsForPayload(page, oldPage, ['isPublic', 'title', 'slug']);
+	const diffs = getDiffsForPayload(page, oldPage, ['isPublic', 'title', 'slug', 'description']);
 	const flags = getChangeFlagsForPayload(page, oldPage, ['layout']);
 	return createActivityItem({
 		kind: 'page-updated' as const,

--- a/server/activityItem/utils.ts
+++ b/server/activityItem/utils.ts
@@ -4,6 +4,9 @@ import { ActivityItem } from 'server/models';
 
 export const createActivityItem = (ai: types.InsertableActivityItem) => ActivityItem.create(ai);
 
+const jsonValuesEqual = (first: any, second: any) =>
+	JSON.stringify(first) === JSON.stringify(second);
+
 export const getDiffsForPayload = <
 	Entry extends Record<string, any>,
 	EntryKey extends keyof Entry,
@@ -13,19 +16,18 @@ export const getDiffsForPayload = <
 	oldEntry: Entry,
 	keys: EntryKey[],
 ): Diffs => {
-	return keys.reduce(
-		(memo: Diffs, key: EntryKey) =>
-			oldEntry[key] === newEntry[key]
-				? memo
-				: {
-						...memo,
-						[key]: {
-							from: oldEntry[key],
-							to: newEntry[key],
-						},
-				  },
-		{} as Diffs,
-	);
+	return keys.reduce((memo: Diffs, key: EntryKey) => {
+		if (jsonValuesEqual(oldEntry[key], newEntry[key])) {
+			return memo;
+		}
+		return {
+			...memo,
+			[key]: {
+				from: oldEntry[key],
+				to: newEntry[key],
+			},
+		};
+	}, {} as Diffs);
 };
 
 export const getChangeFlagsForPayload = <
@@ -39,7 +41,7 @@ export const getChangeFlagsForPayload = <
 ): Flags => {
 	return keys.reduce(
 		(memo: Flags, key: EntryKey) =>
-			oldEntry[key] === newEntry[key] ? memo : { ...memo, [key]: true },
+			jsonValuesEqual(oldEntry[key], newEntry[key]) ? memo : { ...memo, [key]: true },
 		{} as Flags,
 	);
 };

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -2,6 +2,7 @@ import './collection/hooks';
 import './collectionPub/hooks';
 import './community/hooks';
 import './member/hooks';
+import './page/hooks';
 import './pub/hooks';
 import './pubEdge/hooks';
 import './review/hooks';

--- a/server/page/api.ts
+++ b/server/page/api.ts
@@ -21,8 +21,7 @@ app.post('/api/pages', (req, res) => {
 			if (!permissions.create) {
 				throw new Error('Not Authorized');
 			}
-			// @ts-expect-error ts-migrate(2554) FIXME: Expected 1 arguments, but got 2.
-			return createPage(req.body, req.user);
+			return createPage(req.body, req.user.id);
 		})
 		.then((newPage) => {
 			return res.status(201).json(newPage);
@@ -41,7 +40,7 @@ app.put(
 		if (!permissions.update) {
 			throw new ForbiddenError();
 		}
-		const updatedValues = await updatePage(req.body, permissions.update);
+		const updatedValues = await updatePage(req.body, permissions.update, req.user.id);
 		return res.status(201).json(updatedValues);
 	}),
 );
@@ -52,7 +51,7 @@ app.delete('/api/pages', (req, res) => {
 			if (!permissions.destroy) {
 				throw new Error('Not Authorized');
 			}
-			return destroyPage(req.body);
+			return destroyPage(req.body, req.user.id);
 		})
 		.then(() => {
 			return res.status(201).json(req.body.pageId);

--- a/server/page/hooks.ts
+++ b/server/page/hooks.ts
@@ -1,0 +1,10 @@
+import { createPageActivityItem, createPageUpdatedActivityItem } from 'server/activityItem/queries';
+import { Page } from 'server/models';
+import { createActivityHooks } from 'server/utils/activityHooks';
+
+createActivityHooks({
+	Model: Page,
+	onModelCreated: (actorId, pageId) => createPageActivityItem('page-created', actorId, pageId),
+	onModelUpdated: createPageUpdatedActivityItem,
+	onModelDestroyed: (actorId, pageId) => createPageActivityItem('page-removed', actorId, pageId),
+});

--- a/server/page/queries.ts
+++ b/server/page/queries.ts
@@ -91,18 +91,14 @@ export const updatePage = async (inputValues, updatePermissions, actorId = null)
 };
 
 export const destroyPage = (inputValues, actorId = null) => {
-	return Page.destroy(
-		{
-			where: {
-				id: inputValues.pageId,
-				communityId: inputValues.communityId,
-			},
+	return Page.destroy({
+		where: {
+			id: inputValues.pageId,
+			communityId: inputValues.communityId,
 		},
-		{
-			actorId,
-			individualHooks: true,
-		},
-	)
+		actorId,
+		individualHooks: true,
+	})
 		.then(() => {
 			return Community.findOne({
 				where: { id: inputValues.communityId },

--- a/tools/activityItem/backfillCommunity.ts
+++ b/tools/activityItem/backfillCommunity.ts
@@ -55,7 +55,7 @@ const backfillMembers = async (ctx: Context, scope: MembershipScope) => {
 };
 
 const backfillPages = async (ctx: Context) => {
-	const pages = await Page.findAll({ where: { id: ctx.community.id } });
+	const pages = await Page.findAll({ where: { communityId: ctx.community.id } });
 	await forEach(pages, async (page) => {
 		const item = await createPageActivityItem('page-created', ctx.defaultActorId, page.id);
 		await setItemTimestamp(item, page.createdAt);

--- a/tools/activityItem/backfillCommunity.ts
+++ b/tools/activityItem/backfillCommunity.ts
@@ -4,19 +4,21 @@ import {
 	Collection,
 	CollectionPub,
 	Member,
+	ThreadComment,
+	Page,
 	Pub,
 	ReviewNew,
 	Discussion,
 	Release,
 	PubEdge,
 	PubAttribution,
-	ThreadComment,
 } from 'server/models';
 import {
 	createCollectionActivityItem,
 	createCollectionPubActivityItem,
 	createCommunityCreatedActivityItem,
 	createMemberCreatedActivityItem,
+	createPageActivityItem,
 	createPubActivityItem,
 	createPubEdgeActivityItem,
 	createPubReleasedActivityItem,
@@ -52,11 +54,20 @@ const backfillMembers = async (ctx: Context, scope: MembershipScope) => {
 	});
 };
 
+const backfillPages = async (ctx: Context) => {
+	const pages = await Page.findAll({ where: { id: ctx.community.id } });
+	await forEach(pages, async (page) => {
+		const item = await createPageActivityItem('page-created', ctx.defaultActorId, page.id);
+		await setItemTimestamp(item, page.createdAt);
+	});
+};
+
 const backfillCommunity = async (ctx: Context) => {
 	const { defaultActorId, community } = ctx;
 	const item = await createCommunityCreatedActivityItem(defaultActorId, community.id);
 	await setItemTimestamp(item, community.createdAt);
 	await backfillMembers(ctx, { communityId: ctx.community.id });
+	await backfillPages(ctx);
 };
 
 const backfillCollectionPubs = async (ctx: Context, collection: types.Collection) => {

--- a/types/activity/associations.ts
+++ b/types/activity/associations.ts
@@ -5,6 +5,7 @@ import {
 	Community,
 	Discussion,
 	ExternalPublication,
+	Page,
 	PubEdge,
 	Pub,
 	Release,
@@ -20,6 +21,7 @@ export const activityAssociationTypes = [
 	'community',
 	'discussion',
 	'externalPublication',
+	'page',
 	'pubEdge',
 	'pub',
 	'review',
@@ -41,6 +43,7 @@ export type ActivityAssociationModels = {
 	community: Community;
 	discussion: Discussion;
 	externalPublication: ExternalPublication;
+	page: Page;
 	pubEdge: PubEdge;
 	pub: Pub;
 	release: Release;

--- a/types/activity/collection.ts
+++ b/types/activity/collection.ts
@@ -21,6 +21,7 @@ export type CollectionUpdatedActivityItem = CollectionActivityItemBase & {
 		isPublic?: Diff<boolean>;
 		isRestricted?: Diff<boolean>;
 		title?: Diff<string>;
+		slug?: Diff<string>;
 		doi?: Diff<null | string>;
 		layout?: true;
 		metadata?: true;

--- a/types/activity/filters.ts
+++ b/types/activity/filters.ts
@@ -1,8 +1,9 @@
 export type ActivityFilter =
-	| 'community'
 	| 'collection'
-	| 'pub'
-	| 'member'
-	| 'review'
+	| 'community'
 	| 'discussion'
-	| 'pubEdge';
+	| 'member'
+	| 'page'
+	| 'pub'
+	| 'pubEdge'
+	| 'review';

--- a/types/activity/index.ts
+++ b/types/activity/index.ts
@@ -2,18 +2,21 @@ import { Scope } from '../scope';
 
 import { CommunityActivityItem } from './community';
 import { CollectionActivityItem } from './collection';
+import { PageActivityItem } from './page';
 import { PubActivityItem } from './pub';
 import { MemberActivityItem } from './member';
 import { ActivityAssociations } from './associations';
 
 export * from './community';
 export * from './collection';
+export * from './page';
 export * from './pub';
 export * from './member';
 
 export type InsertableActivityItem =
 	| CommunityActivityItem
 	| CollectionActivityItem
+	| PageActivityItem
 	| PubActivityItem
 	| MemberActivityItem;
 

--- a/types/activity/page.ts
+++ b/types/activity/page.ts
@@ -1,0 +1,35 @@
+import { Diff } from '../util';
+
+import { InsertableActivityItemBase } from './base';
+
+type PageActivityItemBase = InsertableActivityItemBase & {
+	payload: {
+		pageId: string;
+		page: {
+			title: string;
+		};
+	};
+};
+
+export type PageCreatedActivityItem = PageActivityItemBase & {
+	kind: 'page-created';
+};
+
+export type PageUpdatedActivityItem = PageActivityItemBase & {
+	kind: 'page-updated';
+	payload: {
+		title?: Diff<string>;
+		slug?: Diff<string>;
+		isPublic?: Diff<boolean>;
+		layout?: true;
+	};
+};
+
+export type PageRemovedActivityItem = PageActivityItemBase & {
+	kind: 'page-removed';
+};
+
+export type PageActivityItem =
+	| PageCreatedActivityItem
+	| PageUpdatedActivityItem
+	| PageRemovedActivityItem;

--- a/types/activity/page.ts
+++ b/types/activity/page.ts
@@ -4,8 +4,8 @@ import { InsertableActivityItemBase } from './base';
 
 type PageActivityItemBase = InsertableActivityItemBase & {
 	payload: {
-		pageId: string;
 		page: {
+			id: string;
 			title: string;
 		};
 	};

--- a/types/activity/page.ts
+++ b/types/activity/page.ts
@@ -20,6 +20,7 @@ export type PageUpdatedActivityItem = PageActivityItemBase & {
 	payload: {
 		title?: Diff<string>;
 		slug?: Diff<string>;
+		description?: Diff<null | string>;
 		isPublic?: Diff<boolean>;
 		layout?: true;
 	};

--- a/types/page.ts
+++ b/types/page.ts
@@ -5,7 +5,7 @@ export type Page = {
 	title: string;
 	slug: string;
 	communityId: string;
-	description?: string;
+	description: null | string;
 	avatar?: string;
 	isPublic: boolean;
 	isNarrowWidth?: boolean;

--- a/types/page.ts
+++ b/types/page.ts
@@ -4,6 +4,7 @@ export type Page = {
 	id: string;
 	title: string;
 	slug: string;
+	communityId: string;
 	description?: string;
 	avatar?: string;
 	isPublic: boolean;


### PR DESCRIPTION
Resolves #1454 

During our first pass through Activity I left Pages alone because it was just one less thing to contend with. Now that we're almost ready to launch this feature I've gone back and added new activity items for Page creation, updating, and deletion as well as hooks to create these items and updates to the backfill to include them.

_Some Page items in Activity:_
<img width="707" alt="image" src="https://user-images.githubusercontent.com/2208769/127870216-6f52ae23-f8b2-4085-b43e-a5667e1f4ecb.png">


_Test plan:_
Unfortunately we have no unit tests for the Pages API, so you can test this by creating, changing, and deleting Pages and ensuring that these actions create corresponding activity items that appear in the Community-level Activity dashboard tab.