### PR TITLE
fix: Make sure long list of Pub contributors in PubDetails will scroll

### DIFF
--- a/client/containers/Pub/PubHeader/details/pubDetails.scss
+++ b/client/containers/Pub/PubHeader/details/pubDetails.scss
@@ -14,7 +14,7 @@
         font-family: $header-font;
         height: $top-bar-total-height;
         line-height: $top-bar-total-height;
-        margin-top: 2px;
+        margin: 0;
         width: calc(100% - 120px);
         overflow: hidden;
         white-space: nowrap;

--- a/client/containers/Pub/PubHeader/pubHeader.scss
+++ b/client/containers/Pub/PubHeader/pubHeader.scss
@@ -71,6 +71,11 @@ $mobile-bottom-buttons-spacing: 10px;
         }
     }
 
+    > .container,
+    > .container > .row {
+        height: 100%;
+    }
+
     .row > .pub-header-column {
         position: relative;
         margin-top: $header-margin-top;


### PR DESCRIPTION
Resolves #1526

Before:
![image](https://user-images.githubusercontent.com/2208769/128930122-30f9f980-73ae-4a7f-a80b-dc4b65df861e.png)

After:
![image](https://user-images.githubusercontent.com/2208769/128930077-67e57094-07a9-41ec-aa72-2d69df61b58f.png)

I'm curious how this happened, since I don't remember changing anything in this area for a long time, and I'm a little concerned this isn't the simplest fix. But it works.

_Test plan:_
Visit a Pub (like `/pub/k11o9bus/` on dev) that has more contributors than will fit above the fold of the "Show Details" view of the Pub header. Verify that they scroll instead of getting cut off.