### PR TITLE
fix: add line height to footnote

### DIFF
--- a/client/components/Editor/styles/main.scss
+++ b/client/components/Editor/styles/main.scss
@@ -36,6 +36,7 @@ h6 {
 .footnote {
 	vertical-align: super;
 	font-size: 0.85em;
+	line-height: 1;
 }
 
 span.citation {


### PR DESCRIPTION
Sets the line height for footnotes, so that they don't add height to interior lines of paragraphs. Fixes #1491.

Before:
<img width="711" alt="Screen Shot 2021-08-10 at 17 48 11" src="https://user-images.githubusercontent.com/639110/128939514-f595fa33-fdf7-4d04-802b-678b0cedc1b3.png">

After:
<img width="682" alt="Screen Shot 2021-08-10 at 17 48 18" src="https://user-images.githubusercontent.com/639110/128939528-db651f5f-d1e1-4a2c-80f9-2d03c940898a.png">


_Test Plan_
1. Visit any Pub with a footnote on an interior (e.g. not the first) line of a paragraph. Make sure that line is not bigger vertically than surrounding lines.
2. Export the Pub to a PDF and make sure the footnote also looks good in the PDF export.