### PR TITLE
fix: Let findAcceptableSlugs check all Community slugs for collisions

### DIFF
--- a/server/utils/slugs.ts
+++ b/server/utils/slugs.ts
@@ -19,15 +19,15 @@ export const slugIsAvailable = async ({ slug, communityId, activeElementId }) =>
 	return pages === 0 && collections === 0;
 };
 
-export const findAcceptableSlug = async (desiredSlug, communityId) => {
+export const findAcceptableSlug = async (desiredSlug: string, communityId: string) => {
 	const [pages, collections] = await Promise.all([
 		Page.findAll({
 			attributes: ['slug'],
-			where: { communityId, slug: desiredSlug },
+			where: { communityId },
 		}),
 		Collection.findAll({
 			attributes: ['slug'],
-			where: { communityId, slug: desiredSlug },
+			where: { communityId },
 		}),
 	]);
 	const allSlugs = [...pages, ...collections].map((item) => item.slug);

--- a/server/utils/slugs.ts
+++ b/server/utils/slugs.ts
@@ -30,7 +30,10 @@ export const findAcceptableSlug = async (desiredSlug: string, communityId: strin
 			where: { communityId },
 		}),
 	]);
-	const allSlugs = [...pages, ...collections].map((item) => item.slug);
+	const allSlugs = [
+		...[...pages, ...collections].map((item) => item.slug),
+		...definitelyForbiddenSlugs,
+	];
 	if (allSlugs.includes(desiredSlug)) {
 		let suffix = 2;
 		// eslint-disable-next-line no-constant-condition


### PR DESCRIPTION
We have a function called `findAcceptableSlug` that takes a `desiredSlug` for a new Community or Page and hyphenates it so that it doesn't collide with any other slugs in the Community. This PR fixes two problems with that function:

- It doesn't check the `definitelyForbiddenSlugs` with routes like `/dash` that belong to PubPub
- It intends to load every slug in the Community's Pages and Collections to check against `desiredSlug` but there's an extra `{ slug: desiredSlug }` clause on those queries that prevents most items from loading, which breaks the hyphenation.

_Test plan:_
- Create three Pages or Collections by the same name (I used `iantest`). These should automatically derive the following slugs: `iantest`, `iantest-2` and `iantest-3`.
- Create a Page or Collection called `dash` and verify that it is given the slug `dash-2`.