### PR TITLE
fix: Citation data rendering

### DIFF
--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -73,7 +73,6 @@ export const generateCitationHtml = async (pubData, communityData) => {
 	};
 	const pubCiteObject = await Cite.async({
 		...commonData,
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'containerDoi' does not exist on type '{ ... Remove this comment to see the full error message
 		DOI: pubData.doi || commonData.containerDoi,
 		ISSN: pubData.doi ? communityData.issn : null,
 		issued: pubIssuedDate && [getDatePartsObject(pubIssuedDate)],

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -77,6 +77,7 @@ export const generateCitationHtml = async (pubData, communityData) => {
 	};
 	const pubCiteObject = await Cite.async({
 		...commonData,
+		// @ts-expect-error ts-migrate(2339) FIXME: Property 'containerDoi' does not exist on type '{ ... Remove this comment to see the full error message
 		DOI: pubData.doi || commonData.containerDoi,
 		ISSN: pubData.doi ? communityData.issn : null,
 		issued: pubIssuedDate && [getDatePartsObject(pubIssuedDate)],

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -36,6 +36,20 @@ const getCollectionLevelData = (collection) => {
 	};
 };
 
+const getPublisherInfo = (collection, data) => {
+	if (collection?.kind === 'conference' || collection?.kind === 'book') {
+		return { publisher: data };
+	}
+	return {};
+};
+
+const getJournalInfo = (collection, data) => {
+	if (collection?.kind === 'issue') {
+		return { 'container-title': data };
+	}
+	return {};
+};
+
 export const generateCitationHtml = async (pubData, communityData) => {
 	// TODO: We need to set the updated times properly, which are likely stored in firebase.
 	const pubIssuedDate = getPubPublishedDate(pubData);
@@ -66,9 +80,9 @@ export const generateCitationHtml = async (pubData, communityData) => {
 		type: 'article-journal',
 		title: pubData.title,
 		...authorsEntry,
-		'container-title': communityData.citeAs || communityData.title,
+		...getJournalInfo(primaryCollection, communityData.citeAs || communityData.title),
 		...getCollectionLevelData(primaryCollection),
-		publisher: communityData.publishAs || '',
+		...getPublisherInfo(primaryCollection, communityData.publishAs),
 	};
 	const pubCiteObject = await Cite.async({
 		...commonData,

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -5,6 +5,7 @@ import getCollectionDoi from 'utils/collections/getCollectionDoi';
 import { getPubPublishedDate } from 'utils/pub/pubDates';
 import { pubUrl } from 'utils/canonicalUrls';
 import { getPrimaryCollection } from 'utils/collections/primary';
+import { renderCitationAs } from 'utils/citations';
 
 const getDatePartsObject = (date) => ({
 	'date-parts': [date.getFullYear(), date.getMonth() + 1, date.getDate()],
@@ -34,13 +35,6 @@ const getCollectionLevelData = (collection) => {
 		volume: metadata.volume,
 		issue: metadata.issue,
 	};
-};
-
-const getJournalInfo = (collection, data, commuityTitle) => {
-	if (collection?.kind === 'issue') {
-		return { 'container-title': data };
-	}
-	return { 'container-title': commuityTitle };
 };
 
 export const generateCitationHtml = async (pubData, communityData) => {
@@ -73,11 +67,7 @@ export const generateCitationHtml = async (pubData, communityData) => {
 		type: 'article-journal',
 		title: pubData.title,
 		...authorsEntry,
-		...getJournalInfo(
-			primaryCollection,
-			communityData.citeAs || communityData.title,
-			communityData.title,
-		),
+		...renderCitationAs[1](primaryCollection?.kind, communityData.citeAs, communityData.title),
 		...getCollectionLevelData(primaryCollection),
 		publisher: communityData.publishAs || '',
 	};

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -36,13 +36,6 @@ const getCollectionLevelData = (collection) => {
 	};
 };
 
-// const getPublisherInfo = (collection, data) => {
-// 	if (collection?.kind === 'conference' || collection?.kind === 'book') {
-// 		return { publisher: data };
-// 	}
-// 	return {};
-// };
-
 const getJournalInfo = (collection, data, commuityTitle) => {
 	if (collection?.kind === 'issue') {
 		return { 'container-title': data };

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -36,18 +36,18 @@ const getCollectionLevelData = (collection) => {
 	};
 };
 
-const getPublisherInfo = (collection, data) => {
-	if (collection?.kind === 'conference' || collection?.kind === 'book') {
-		return { publisher: data };
-	}
-	return {};
-};
+// const getPublisherInfo = (collection, data) => {
+// 	if (collection?.kind === 'conference' || collection?.kind === 'book') {
+// 		return { publisher: data };
+// 	}
+// 	return {};
+// };
 
-const getJournalInfo = (collection, data) => {
+const getJournalInfo = (collection, data, commuityTitle) => {
 	if (collection?.kind === 'issue') {
 		return { 'container-title': data };
 	}
-	return {};
+	return { 'container-title': commuityTitle };
 };
 
 export const generateCitationHtml = async (pubData, communityData) => {
@@ -80,9 +80,13 @@ export const generateCitationHtml = async (pubData, communityData) => {
 		type: 'article-journal',
 		title: pubData.title,
 		...authorsEntry,
-		...getJournalInfo(primaryCollection, communityData.citeAs || communityData.title),
+		...getJournalInfo(
+			primaryCollection,
+			communityData.citeAs || communityData.title,
+			communityData.title,
+		),
 		...getCollectionLevelData(primaryCollection),
-		...getPublisherInfo(primaryCollection, communityData.publishAs),
+		publisher: communityData.publishAs || '',
 	};
 	const pubCiteObject = await Cite.async({
 		...commonData,

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -5,7 +5,7 @@ import getCollectionDoi from 'utils/collections/getCollectionDoi';
 import { getPubPublishedDate } from 'utils/pub/pubDates';
 import { pubUrl } from 'utils/canonicalUrls';
 import { getPrimaryCollection } from 'utils/collections/primary';
-import { renderCitationAs } from 'utils/citations';
+import { renderJournalCitationForCitations } from 'utils/citations';
 
 const getDatePartsObject = (date) => ({
 	'date-parts': [date.getFullYear(), date.getMonth() + 1, date.getDate()],
@@ -67,7 +67,11 @@ export const generateCitationHtml = async (pubData, communityData) => {
 		type: 'article-journal',
 		title: pubData.title,
 		...authorsEntry,
-		...renderCitationAs[1](primaryCollection?.kind, communityData.citeAs, communityData.title),
+		...renderJournalCitationForCitations(
+			primaryCollection?.kind,
+			communityData.citeAs,
+			communityData.title,
+		),
 		...getCollectionLevelData(primaryCollection),
 		publisher: communityData.publishAs || '',
 	};

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -87,14 +87,10 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 		];
 	}
 
-	if (communityTitle && (!collection || collection.kind === 'issue')) {
+	if (communityTitle && !collection) {
 		outputComponents = [
 			...outputComponents,
-			<meta
-				key="sn2"
-				name="citation_journal_title"
-				content={communityCiteAs || communityTitle}
-			/>,
+			<meta key="sn2" name="citation_journal_title" content={communityTitle} />,
 		];
 	}
 
@@ -118,28 +114,29 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 		if (collection.kind === 'issue') {
 			outputComponents = [
 				...outputComponents,
-				<meta key="c1" name="citation_volume" content={collection.metadata?.volume} />,
-				<meta key="c2" name="citation_issue" content={collection.metadata?.issue} />,
+				<meta key="c1" name="citation_journal_title" content={communityCiteAs} />,
+				<meta key="c2" name="citation_volume" content={collection.metadata?.volume} />,
+				<meta key="c3" name="citation_issue" content={collection.metadata?.issue} />,
 				<meta
-					key="c3"
+					key="c4"
 					name="citation_issn"
 					content={collection.metadata?.electronic_issn}
 				/>,
-				<meta key="c4" name="citation_issn" content={collection.metadata?.print_issn} />,
+				<meta key="c5" name="citation_issn" content={collection.metadata?.print_issn} />,
 			];
 		}
 		if (collection.kind === 'book') {
 			outputComponents = [
 				...outputComponents,
-				<meta key="c5" name="citation_inbook_title" content={collection.title} />,
-				<meta key="c6" name="citation_book_title" content={collection.title} />,
-				<meta key="c7" name="citation_isbn" content={collection.metadata?.isbn} />,
+				<meta key="c6" name="citation_inbook_title" content={collection.title} />,
+				<meta key="c7" name="citation_book_title" content={collection.title} />,
+				<meta key="c8" name="citation_isbn" content={collection.metadata?.isbn} />,
 			];
 		}
 		if (collection.kind === 'conference') {
 			outputComponents = [
 				...outputComponents,
-				<meta key="c8" name="citation_conference_title" content={collection.title} />,
+				<meta key="c9" name="citation_conference_title" content={collection.title} />,
 			];
 		}
 	}

--- a/utils/citations.ts
+++ b/utils/citations.ts
@@ -1,3 +1,20 @@
+export const renderCitationAs: any[] = [
+	function renderJournalCitationData(kind, citation, communityTitle) {
+		if (kind === 'issue') {
+			return citation === '' || citation === undefined ? communityTitle : citation;
+		}
+		return communityTitle;
+	},
+	function renderJournalCitationData(kind, citation, communityTitle) {
+		if (kind === 'issue') {
+			return citation === '' || citation === undefined
+				? { 'container-title': communityTitle }
+				: { 'container-title': citation };
+		}
+		return { 'container-title': communityTitle };
+	},
+];
+
 export type CitationStyleKind =
 	| 'acm-siggraph'
 	| 'american-anthro'

--- a/utils/citations.ts
+++ b/utils/citations.ts
@@ -1,11 +1,11 @@
 export const renderCitationAs: any[] = [
-	function renderJournalCitationData(kind, citation, communityTitle) {
+	function renderJournalCitation(kind, citation, communityTitle) {
 		if (kind === 'issue') {
 			return citation === '' || citation === undefined ? communityTitle : citation;
 		}
 		return communityTitle;
 	},
-	function renderJournalCitationData(kind, citation, communityTitle) {
+	function renderJournalCitation(kind, citation, communityTitle) {
 		if (kind === 'issue') {
 			return citation === '' || citation === undefined
 				? { 'container-title': communityTitle }

--- a/utils/citations.ts
+++ b/utils/citations.ts
@@ -1,20 +1,3 @@
-export const renderCitationAs: any[] = [
-	function renderJournalCitation(kind, citation, communityTitle) {
-		if (kind === 'issue') {
-			return citation === '' || citation === undefined ? communityTitle : citation;
-		}
-		return communityTitle;
-	},
-	function renderJournalCitation(kind, citation, communityTitle) {
-		if (kind === 'issue') {
-			return citation === '' || citation === undefined
-				? { 'container-title': communityTitle }
-				: { 'container-title': citation };
-		}
-		return { 'container-title': communityTitle };
-	},
-];
-
 export type CitationStyleKind =
 	| 'acm-siggraph'
 	| 'american-anthro'
@@ -70,3 +53,14 @@ export const citationInlineStyles: CitationInlineStyle[] = [
 	{ key: 'author', title: 'Author', example: '(Goodall)' },
 	{ key: 'label', title: 'Label', example: '(bibtexKey)' },
 ];
+
+export const renderJournalCitation = (kind, citation, communityTitle) => {
+	if (kind === 'issue') {
+		return citation || communityTitle;
+	}
+	return communityTitle;
+};
+
+export const renderJournalCitationForCitations = (kind, citation, communityTitle) => {
+	return { 'container-title': renderJournalCitation(kind, citation, communityTitle) };
+};

--- a/utils/crossref/createDeposit.js
+++ b/utils/crossref/createDeposit.js
@@ -56,9 +56,6 @@ const renderBody = (context) => {
 		if (collection.kind === 'conference') {
 			return renderConference(context);
 		}
-		if (collection.kind === 'issue') {
-			return renderJournal(context);
-		}
 	}
 
 	return renderJournal(context);

--- a/utils/crossref/createDeposit.js
+++ b/utils/crossref/createDeposit.js
@@ -50,7 +50,6 @@ const renderBody = (context) => {
 	}
 
 	if (collection) {
-		console.log(collection.kind);
 		if (collection.kind === 'book') {
 			return renderBook(context);
 		}
@@ -58,7 +57,6 @@ const renderBody = (context) => {
 			return renderConference(context);
 		}
 		if (collection.kind === 'issue') {
-			context.flag = { issue: true };
 			return renderJournal(context);
 		}
 	}

--- a/utils/crossref/createDeposit.js
+++ b/utils/crossref/createDeposit.js
@@ -50,11 +50,16 @@ const renderBody = (context) => {
 	}
 
 	if (collection) {
+		console.log(collection.kind);
 		if (collection.kind === 'book') {
 			return renderBook(context);
 		}
 		if (collection.kind === 'conference') {
 			return renderConference(context);
+		}
+		if (collection.kind === 'issue') {
+			context.flag = { issue: true };
+			return renderJournal(context);
 		}
 	}
 

--- a/utils/crossref/render/journal.js
+++ b/utils/crossref/render/journal.js
@@ -11,7 +11,7 @@ import transformCollection from '../transform/collection';
 import transformPub from '../transform/pub';
 
 export default ({ globals, community, collection, pub }) => {
-	const communityProps = transformCommunity({ globals })(community);
+	const communityProps = transformCommunity({ globals })(community, collection);
 	const pubProps = pub && transformPub({ globals, community })(pub);
 	const collectionProps = collection && transformCollection({ globals, community })(collection);
 	return journal({

--- a/utils/crossref/schema/journal.js
+++ b/utils/crossref/schema/journal.js
@@ -1,8 +1,7 @@
 import doiData from './doiData';
 
-const getJournalInfo = (flag, citation, commuityTitle) => {
-	console.log(flag);
-	if (flag) {
+const getJournalInfo = (kind, citation, commuityTitle) => {
+	if (kind === 'issue') {
 		return citation !== '' ? citation : commuityTitle;
 	}
 	return commuityTitle;
@@ -18,12 +17,12 @@ export default ({
 	timestamp,
 	url,
 	contentVersion,
-	issue,
+	kind,
 }) => ({
 	journal: {
 		journal_metadata: {
 			'@language': language,
-			full_title: getJournalInfo(issue, citeAs, title),
+			full_title: getJournalInfo(kind, citeAs, title),
 			...(issn ? { '@media_type': 'electronic', '#text': issn } : {}),
 			...doiData(doi, timestamp, url, contentVersion),
 		},

--- a/utils/crossref/schema/journal.js
+++ b/utils/crossref/schema/journal.js
@@ -1,11 +1,5 @@
+import { renderCitationAs } from 'utils/citations';
 import doiData from './doiData';
-
-const getJournalInfo = (kind, citation, commuityTitle) => {
-	if (kind === 'issue') {
-		return citation !== '' ? citation : commuityTitle;
-	}
-	return commuityTitle;
-};
 
 export default ({
 	title,
@@ -22,7 +16,7 @@ export default ({
 	journal: {
 		journal_metadata: {
 			'@language': language,
-			full_title: getJournalInfo(kind, citeAs, title),
+			full_title: renderCitationAs[0](kind, citeAs, title),
 			...(issn ? { '@media_type': 'electronic', '#text': issn } : {}),
 			...doiData(doi, timestamp, url, contentVersion),
 		},

--- a/utils/crossref/schema/journal.js
+++ b/utils/crossref/schema/journal.js
@@ -1,4 +1,4 @@
-import { renderCitationAs } from 'utils/citations';
+import { renderJournalCitation } from 'utils/citations';
 import doiData from './doiData';
 
 export default ({
@@ -16,7 +16,7 @@ export default ({
 	journal: {
 		journal_metadata: {
 			'@language': language,
-			full_title: renderCitationAs[0](kind, citeAs, title),
+			full_title: renderJournalCitation(kind, citeAs, title),
 			...(issn ? { '@media_type': 'electronic', '#text': issn } : {}),
 			...doiData(doi, timestamp, url, contentVersion),
 		},

--- a/utils/crossref/schema/journal.js
+++ b/utils/crossref/schema/journal.js
@@ -1,5 +1,13 @@
 import doiData from './doiData';
 
+const getJournalInfo = (flag, citation, commuityTitle) => {
+	console.log(flag);
+	if (flag) {
+		return citation !== '' ? citation : commuityTitle;
+	}
+	return commuityTitle;
+};
+
 export default ({
 	title,
 	citeAs,
@@ -10,11 +18,12 @@ export default ({
 	timestamp,
 	url,
 	contentVersion,
+	issue,
 }) => ({
 	journal: {
 		journal_metadata: {
 			'@language': language,
-			full_title: citeAs || title,
+			full_title: getJournalInfo(issue, citeAs, title),
 			...(issn ? { '@media_type': 'electronic', '#text': issn } : {}),
 			...doiData(doi, timestamp, url, contentVersion),
 		},

--- a/utils/crossref/transform/community.js
+++ b/utils/crossref/transform/community.js
@@ -2,13 +2,15 @@ import { communityUrl } from 'utils/canonicalUrls';
 
 const getLanguageForCommunity = () => 'en';
 
-export default ({ globals }) => (community) => {
+export default ({ globals }) => (community, collection) => {
 	const { title, issn: denormalizedIssn, citeAs } = community;
+	const kind = collection?.kind || '';
 	const issn = denormalizedIssn && denormalizedIssn.replace('-', '');
 	return {
 		title,
 		issn,
 		citeAs,
+		kind,
 		timestamp: globals.timestamp,
 		language: getLanguageForCommunity(community),
 		doi: globals.dois.community,

--- a/workers/tasks/export/metadata.ts
+++ b/workers/tasks/export/metadata.ts
@@ -3,7 +3,7 @@ import dateFormat from 'dateformat';
 import ensureUserForAttribution from 'utils/ensureUserForAttribution';
 import { getPubPublishedDate, getPubUpdatedDate } from 'utils/pub/pubDates';
 import { getPrimaryCollection } from 'utils/collections/primary';
-import { renderCitationAs } from 'utils/citations';
+import { renderJournalCitation } from 'utils/citations';
 import {
 	Collection,
 	CollectionPub,
@@ -60,7 +60,7 @@ export const getPubMetadata = async (pubId) => {
 		licenseSlug: pubData.licenseSlug,
 		publishedDateString,
 		updatedDateString,
-		communityTitle: renderCitationAs[0](
+		communityTitle: renderJournalCitation(
 			primaryCollection?.kind,
 			pubData.community.citeAs,
 			pubData.community.title,

--- a/workers/tasks/export/metadata.ts
+++ b/workers/tasks/export/metadata.ts
@@ -3,6 +3,7 @@ import dateFormat from 'dateformat';
 import ensureUserForAttribution from 'utils/ensureUserForAttribution';
 import { getPubPublishedDate, getPubUpdatedDate } from 'utils/pub/pubDates';
 import { getPrimaryCollection } from 'utils/collections/primary';
+import { renderCitationAs } from 'utils/citations';
 import {
 	Collection,
 	CollectionPub,
@@ -20,13 +21,6 @@ const getPrimaryCollectionMetadata = (collectionPubs) => {
 		return { primaryCollectionMetadata: metadata, primaryCollectionTitle: title };
 	}
 	return null;
-};
-
-const getJournalInfo = (collection, data, commuityTitle) => {
-	if (collection?.kind === 'issue') {
-		return data;
-	}
-	return commuityTitle;
 };
 
 export const getPubMetadata = async (pubId) => {
@@ -66,9 +60,9 @@ export const getPubMetadata = async (pubId) => {
 		licenseSlug: pubData.licenseSlug,
 		publishedDateString,
 		updatedDateString,
-		communityTitle: getJournalInfo(
-			primaryCollection,
-			pubData.community.citeAs || pubData.community.title,
+		communityTitle: renderCitationAs[0](
+			primaryCollection?.kind,
+			pubData.community.citeAs,
 			pubData.community.title,
 		),
 		accentColor: pubData.community.accentColorDark,

--- a/workers/tasks/export/metadata.ts
+++ b/workers/tasks/export/metadata.ts
@@ -22,6 +22,13 @@ const getPrimaryCollectionMetadata = (collectionPubs) => {
 	return null;
 };
 
+const getJournalInfo = (collection, data, commuityTitle) => {
+	if (collection?.kind === 'issue') {
+		return data;
+	}
+	return commuityTitle;
+};
+
 export const getPubMetadata = async (pubId) => {
 	const pubData = await Pub.findOne({
 		where: { id: pubId },
@@ -59,10 +66,11 @@ export const getPubMetadata = async (pubId) => {
 		licenseSlug: pubData.licenseSlug,
 		publishedDateString,
 		updatedDateString,
-		communityTitle:
-			primaryCollection?.kind === 'issue'
-				? pubData.community.citeAs
-				: pubData.community.title,
+		communityTitle: getJournalInfo(
+			primaryCollection,
+			pubData.community.citeAs || pubData.community.title,
+			pubData.community.title,
+		),
 		accentColor: pubData.community.accentColorDark,
 		attributions: pubData.attributions
 			.concat()


### PR DESCRIPTION
this addresses issue #1537 

When rendering information for crossref, metadata, exports, and citations the journal name is being created for all collections. The set journal name should only apply to issues. I have written changes so that the expected behavior happens for issues journal title/citation-journal-title/container-title/title.  

Test plan(the only thing that changed):

With journal citation set and in a primary issue collection, create a crossref deposit for a pub. Be sure the journal metadata title is set to the journal citation name. Export the pub, be sure the header includes the journal name. Look at the citations in pub overview or details and be sure the Journal Name is listed. Use the inspector to make sure the the citation-journal-title is set to the journal name.

With Journal not set and in a primary issue collection, create a crossref deposit for a pub. Be sure the journal metadata title is set to the community name. Export the pub, be sure the header includes the community name. Look at the citations in pub overview or details and be sure the community name is listed. Use the inspector to make sure the the citation-journal-title is set to the community name.

This should be the same for any pub not in a book, issue, or, conference 

While in a book or conference, and with the publisher name set, create a crossref deposit for a pub. Be sure the book metadata title is set to the collection name. Export the pub, be sure the subheader includes the publisher name. Look at the citations in pub overview or details and be sure the publisher name is listed. Use the inspector to make sure the the citation-book-title is set to the collection name. 

When publisher name is not set these values should be the same, with 'PubPub' replacing publisher name