### PR TITLE
update: Upgrade to prosemirror-pandoc 0.7.0 and to latest Pandoc

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,5 +1,5 @@
 # Pandoc is central to the Pub import and export features
-https://github.com/jgm/pandoc/releases/download/2.9.2.1/pandoc-2.9.2.1-1-amd64.deb
+https://github.com/jgm/pandoc/releases/download/2.14.2/pandoc-2.14.2-1-amd64.deb
 
 # xsltproc is ued to extract bibliographies from XML (JATS) files on import
 xsltproc

--- a/client/containers/Pub/PubDocument/PubFileImport/MetadataEditor.tsx
+++ b/client/containers/Pub/PubDocument/PubFileImport/MetadataEditor.tsx
@@ -262,20 +262,13 @@ const MetadataEditor = (props: MetadataEditorProps) => {
 		return null;
 	};
 
-	const titleEntry = renderFreeformFieldEntry('title');
-	const descriptionEntry = renderFreeformFieldEntry('description');
-	const attributionsEntry = renderAttributions();
-
-	const entries = [titleEntry, descriptionEntry, attributionsEntry];
-
-	if (entries.some((x) => x)) {
-		return (
-			<div className="metadata-editor-component">
-				<h6>Metadata</h6>
-				{entries}
-			</div>
-		);
-	}
-	return null;
+	return (
+		<div className="metadata-editor-component">
+			<h6>Metadata</h6>
+			{renderFreeformFieldEntry('title')}
+			{renderFreeformFieldEntry('description')}
+			{renderAttributions()}
+		</div>
+	);
 };
 export default MetadataEditor;

--- a/client/containers/Pub/PubDocument/PubFileImport/MetadataEditor.tsx
+++ b/client/containers/Pub/PubDocument/PubFileImport/MetadataEditor.tsx
@@ -262,13 +262,20 @@ const MetadataEditor = (props: MetadataEditorProps) => {
 		return null;
 	};
 
-	return (
-		<div className="metadata-editor-component">
-			<h6>Metadata</h6>
-			{renderFreeformFieldEntry('title')}
-			{renderFreeformFieldEntry('description')}
-			{renderAttributions()}
-		</div>
-	);
+	const titleEntry = renderFreeformFieldEntry('title');
+	const descriptionEntry = renderFreeformFieldEntry('description');
+	const attributionsEntry = renderAttributions();
+
+	const entries = [titleEntry, descriptionEntry, attributionsEntry];
+
+	if (entries.some((x) => x)) {
+		return (
+			<div className="metadata-editor-component">
+				<h6>Metadata</h6>
+				{entries}
+			</div>
+		);
+	}
+	return null;
 };
 export default MetadataEditor;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6941,9 +6941,9 @@
 			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
 		},
 		"@pubpub/prosemirror-pandoc": {
-			"version": "0.7.0-beta.1",
-			"resolved": "https://registry.npmjs.org/@pubpub/prosemirror-pandoc/-/prosemirror-pandoc-0.7.0-beta.1.tgz",
-			"integrity": "sha512-75arH51J4RYRJahgYugCGqToLnxkHjj4kYQxk08YpeF7Cd5dDpOhLmHn5On7SRyyXAaGLuxZFJIhYeREYKn4NA=="
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@pubpub/prosemirror-pandoc/-/prosemirror-pandoc-0.7.0.tgz",
+			"integrity": "sha512-fGuG+H9s7I4GlZScEZvrJro39x9UoncghlUtWQR0O8Dc9k5XP+bVX6T9DnXaD5E9nA+0wvFonU26EY2x44rN9w=="
 		},
 		"@pubpub/prosemirror-reactive": {
 			"version": "0.1.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6941,9 +6941,9 @@
 			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
 		},
 		"@pubpub/prosemirror-pandoc": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@pubpub/prosemirror-pandoc/-/prosemirror-pandoc-0.6.1.tgz",
-			"integrity": "sha512-FpgvwDQTyEhFtVtQET48wb336msdqszPlbVRXrq3ZK53T/aTKttxDAshtg1J4QB9Auf7k3mQ0RkRVnypklbcQA=="
+			"version": "0.7.0-beta.1",
+			"resolved": "https://registry.npmjs.org/@pubpub/prosemirror-pandoc/-/prosemirror-pandoc-0.7.0-beta.1.tgz",
+			"integrity": "sha512-75arH51J4RYRJahgYugCGqToLnxkHjj4kYQxk08YpeF7Cd5dDpOhLmHn5On7SRyyXAaGLuxZFJIhYeREYKn4NA=="
 		},
 		"@pubpub/prosemirror-reactive": {
 			"version": "0.1.10",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@blueprintjs/select": "^3.12.0",
 		"@google-cloud/storage": "^5.8.1",
 		"@monaco-editor/react": "^4.1.1",
-		"@pubpub/prosemirror-pandoc": "^0.7.0-beta.1",
+		"@pubpub/prosemirror-pandoc": "^0.7.0",
 		"@pubpub/prosemirror-reactive": "^0.1.10",
 		"@sentry/browser": "^5.5.0",
 		"@sentry/node": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@blueprintjs/select": "^3.12.0",
 		"@google-cloud/storage": "^5.8.1",
 		"@monaco-editor/react": "^4.1.1",
-		"@pubpub/prosemirror-pandoc": "^0.6.1",
+		"@pubpub/prosemirror-pandoc": "^0.7.0-beta.1",
 		"@pubpub/prosemirror-reactive": "^0.1.10",
 		"@sentry/browser": "^5.5.0",
 		"@sentry/node": "^5.5.0",

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/first */
+/* eslint-disable import/first, import/order */
 import * as Sentry from '@sentry/node';
 import bodyParser from 'body-parser';
 import compression from 'compression';

--- a/workers/tasks/import/bibliography.ts
+++ b/workers/tasks/import/bibliography.ts
@@ -30,7 +30,7 @@ const extractCitationsUsingPandoc = (bibliographyTmpPath) => {
 	// @ts-expect-error ts-migrate(2339) FIXME: Property 'fromEntries' does not exist on type 'Obj... Remove this comment to see the full error message
 	return Object.fromEntries(
 		cslJson.map((entry) => {
-			const structuredValue = Cite.get.bibtex.text([entry]);
+			const structuredValue = new Cite(entry).format('bibtex');
 			return [entry.id, { structuredValue }];
 		}),
 	);

--- a/workers/tasks/import/bibliography.ts
+++ b/workers/tasks/import/bibliography.ts
@@ -24,7 +24,7 @@ export const extractRefBlocks = (pandocAst) => {
 };
 
 const extractUsingPandocCiteproc = (bibliographyTmpPath) => {
-	const proc = spawnSync('pandoc-citeproc', ['-j', bibliographyTmpPath]);
+	const proc = spawnSync('pandoc', [bibliographyTmpPath, '-t', 'csljson']);
 	const output = proc.stdout.toString();
 	const cslJson = JSON.parse(output);
 	// @ts-expect-error ts-migrate(2339) FIXME: Property 'fromEntries' does not exist on type 'Obj... Remove this comment to see the full error message

--- a/workers/tasks/import/bibliography.ts
+++ b/workers/tasks/import/bibliography.ts
@@ -23,7 +23,7 @@ export const extractRefBlocks = (pandocAst) => {
 	return { pandocAst, refBlocks: null };
 };
 
-const extractUsingPandocCiteproc = (bibliographyTmpPath) => {
+const extractCitationsUsingPandoc = (bibliographyTmpPath) => {
 	const proc = spawnSync('pandoc', [bibliographyTmpPath, '-t', 'csljson']);
 	const output = proc.stdout.toString();
 	const cslJson = JSON.parse(output);
@@ -44,11 +44,11 @@ const getBibPathFromXslTransform = async (documentTmpPath) => {
 
 export const extractBibliographyItems = async ({ bibliography, document, extractBibFromJats }) => {
 	if (bibliography) {
-		return extractUsingPandocCiteproc(bibliography.tmpPath);
+		return extractCitationsUsingPandoc(bibliography.tmpPath);
 	}
 	if (document && extensionFor(document.tmpPath) === 'xml' && extractBibFromJats) {
 		const generatedBibPath = await getBibPathFromXslTransform(document.tmpPath);
-		return extractUsingPandocCiteproc(generatedBibPath);
+		return extractCitationsUsingPandoc(generatedBibPath);
 	}
 	return {};
 };

--- a/workers/tasks/import/import.ts
+++ b/workers/tasks/import/import.ts
@@ -15,7 +15,7 @@ import { getProposedMetadata, getRawMetadata } from './metadata';
 import { getTmpDirectoryPath } from './tmpDirectory';
 import { createResourceTransformer } from './resources';
 
-setPandocApiVersion([1, 20]);
+setPandocApiVersion([1, 22]);
 
 const dataRoot = process.env.NODE_ENV === 'production' ? '/app/.apt/usr/share/pandoc/data ' : '';
 

--- a/workers/tasks/import/import.ts
+++ b/workers/tasks/import/import.ts
@@ -130,6 +130,7 @@ export const importFiles = async ({
 	const prosemirrorDoc = fromPandoc(pandocAst, pandocRules, {
 		resource: resourceTransformer.getResource,
 		useSmartQuotes: !keepStraightQuotes,
+		prosemirrorDocWidth: 675,
 	}).asNode();
 	const [proposedMetadata] = await Promise.all([
 		getProposedMetadata(pandocAst.meta),

--- a/workers/tasks/import/metadata.ts
+++ b/workers/tasks/import/metadata.ts
@@ -32,7 +32,7 @@ const getAttributions = async (author) => {
 		);
 		return attributions;
 	}
-	return [];
+	return null;
 };
 
 const stripFalseyValues = (object) =>

--- a/workers/tasks/import/rules.ts
+++ b/workers/tasks/import/rules.ts
@@ -1,4 +1,4 @@
-import { buildRuleset, commonTransformers, transformUtil } from '@pubpub/prosemirror-pandoc';
+import { buildRuleset, transformers, transformUtil } from '@pubpub/prosemirror-pandoc';
 import { defaultNodes, defaultMarks } from 'components/Editor/schemas';
 
 import * as katex from 'katex';
@@ -20,8 +20,8 @@ const {
 	nullTransformer,
 	pandocPassThroughTransformer,
 	pandocQuotedTransformer,
-	tableTransformer,
-} = commonTransformers;
+	pandocTableTransformer,
+} = transformers;
 
 const { textFromStrSpace, textToStrSpace, createAttr, intersperse, flatten } = transformUtil;
 
@@ -209,7 +209,7 @@ rules.fromPandoc('RawInline', (node, { transform }) => {
 });
 
 // Tables
-rules.transform('Table', 'table', tableTransformer);
+rules.fromPandoc('Table', pandocTableTransformer);
 
 // Equations
 rules.fromPandoc('Math', (node) => {

--- a/workers/tasks/import/rules.ts
+++ b/workers/tasks/import/rules.ts
@@ -171,6 +171,7 @@ rules.fromPandoc('SoftBreak', nullTransformer);
 
 // Stuff we don't have equivalents for
 rules.fromPandoc('Span', pandocPassThroughTransformer);
+rules.fromPandoc('Underline', pandocPassThroughTransformer);
 
 // Pandoc insists that text in quotes is actually its own node type
 rules.fromPandoc('Quoted', pandocQuotedTransformer);

--- a/workers/tasks/import/rules.ts
+++ b/workers/tasks/import/rules.ts
@@ -264,7 +264,7 @@ rules.fromProsemirror('image', (node) => {
 // ~~~ Rules for citations and footnotes ~~~ //
 
 rules.transform('Cite', 'citation', {
-	fromPandoc: (node, { count, resource }) => {
+	fromPandoc: (node, { resource }) => {
 		const { citations } = node;
 		return citations.map((citation) => {
 			const { structuredValue, unstructuredValue } = resource(
@@ -277,7 +277,6 @@ rules.transform('Cite', 'citation', {
 					value: structuredValue || unstructuredValue,
 					structuredValue,
 					unstructuredValue,
-					count: 1 + count('Cite'),
 					customLabel: pandocInlineToPlain(node.content) || '',
 				},
 			};
@@ -307,14 +306,13 @@ rules.transform('Cite', 'citation', {
 });
 
 rules.transform('Note', 'footnote', {
-	fromPandoc: (node, { count }) => {
+	fromPandoc: (node) => {
 		const { content } = node;
 		const value = pandocBlocksToHtmlString(content);
 		return {
 			type: 'footnote',
 			attrs: {
 				value,
-				count: 1 + count('Note'),
 			},
 		};
 	},


### PR DESCRIPTION
Also a few related things:

- Updated the importer rules to accommodate these changes
- Migrated off `pandoc-citeproc` to equivalent new command in Pandoc for citation processing
- Snuck in a fix to hide the `MetadataEditor` when it has nothing interesting to say