### PR TITLE
enhancement: Custom css for communities

### DIFF
--- a/client/containers/DashboardCustomScripts/DashboardCustomScripts.tsx
+++ b/client/containers/DashboardCustomScripts/DashboardCustomScripts.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Spinner, Tabs, Tab } from '@blueprintjs/core';
+import { Callout, Spinner, Tabs, Tab } from '@blueprintjs/core';
 
 import { communityCanUseCustomScripts } from 'utils/customScripts';
 import { DashboardFrame } from 'components';
@@ -20,7 +20,6 @@ const DashboardCustomScripts = (props: Props) => {
 	const { js, css } = customScripts;
 	const { id } = communityId;
 	const [Editor, setEditor] = useState<null | EditorComponentType>(null);
-
 	useEffect(() => {
 		import('@monaco-editor/react').then(({ default: EditorComponent }) =>
 			setEditor(EditorComponent),
@@ -72,6 +71,15 @@ const DashboardCustomScripts = (props: Props) => {
 
 	return (
 		<DashboardFrame className="dashboard-custom-scripts-container" title="Custom Scripts">
+			<div className="callout-text">
+				<Callout className="error-callout" intent="warning" title="Warning: Experimental">
+					We do not guarantee that future product updates will preserve existing page
+					structures of class names. Adding custom CSS can cause your community to be
+					unusable. We do not provide support for issues caused by CSS customization. Use
+					at your own risk.
+				</Callout>
+			</div>
+
 			{!Editor && renderLoading()}
 			{Editor && renderTabs()}
 		</DashboardFrame>

--- a/client/containers/DashboardCustomScripts/DashboardCustomScripts.tsx
+++ b/client/containers/DashboardCustomScripts/DashboardCustomScripts.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { Spinner, Tabs, Tab } from '@blueprintjs/core';
 
+import { communityCanUseCustomScripts } from 'utils/customScripts';
 import { DashboardFrame } from 'components';
-import { CustomScripts } from 'types';
+import { CustomScripts, Community } from 'types';
 
 import { EditorComponentType } from './types';
 import CustomScriptPanel from './CustomScriptPanel';
@@ -11,11 +12,13 @@ require('./dashboardCustomScripts.scss');
 
 type Props = {
 	customScripts: CustomScripts;
+	communityId: Community;
 };
 
 const DashboardCustomScripts = (props: Props) => {
-	const { customScripts } = props;
+	const { customScripts, communityId } = props;
 	const { js, css } = customScripts;
+	const { id } = communityId;
 	const [Editor, setEditor] = useState<null | EditorComponentType>(null);
 
 	useEffect(() => {
@@ -48,19 +51,21 @@ const DashboardCustomScripts = (props: Props) => {
 						/>
 					}
 				/>
-				<Tab
-					id="js"
-					title="JavaScript"
-					panel={
-						<CustomScriptPanel
-							initialContent={js}
-							type="js"
-							language="javascript"
-							label="JavaScript"
-							EditorComponent={Editor!}
-						/>
-					}
-				/>
+				{communityCanUseCustomScripts(id) && (
+					<Tab
+						id="js"
+						title="JavaScript"
+						panel={
+							<CustomScriptPanel
+								initialContent={js}
+								type="js"
+								language="javascript"
+								label="JavaScript"
+								EditorComponent={Editor!}
+							/>
+						}
+					/>
+				)}
 			</Tabs>
 		);
 	};

--- a/client/containers/DashboardCustomScripts/DashboardCustomScripts.tsx
+++ b/client/containers/DashboardCustomScripts/DashboardCustomScripts.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Callout, Spinner, Tabs, Tab } from '@blueprintjs/core';
 
+import { usePageContext } from 'utils/hooks';
 import { communityCanUseCustomScripts } from 'utils/customScripts';
 import { DashboardFrame } from 'components';
-import { CustomScripts, Community } from 'types';
+import { CustomScripts } from 'types';
 
 import { EditorComponentType } from './types';
 import CustomScriptPanel from './CustomScriptPanel';
@@ -12,13 +13,14 @@ require('./dashboardCustomScripts.scss');
 
 type Props = {
 	customScripts: CustomScripts;
-	communityId: Community;
 };
 
 const DashboardCustomScripts = (props: Props) => {
-	const { customScripts, communityId } = props;
+	const { customScripts } = props;
 	const { js, css } = customScripts;
-	const { id } = communityId;
+	const {
+		communityData: { id: communityId },
+	} = usePageContext();
 	const [Editor, setEditor] = useState<null | EditorComponentType>(null);
 	useEffect(() => {
 		import('@monaco-editor/react').then(({ default: EditorComponent }) =>
@@ -50,7 +52,7 @@ const DashboardCustomScripts = (props: Props) => {
 						/>
 					}
 				/>
-				{communityCanUseCustomScripts(id) && (
+				{communityCanUseCustomScripts(communityId) && (
 					<Tab
 						id="js"
 						title="JavaScript"
@@ -73,10 +75,13 @@ const DashboardCustomScripts = (props: Props) => {
 		<DashboardFrame className="dashboard-custom-scripts-container" title="Custom Scripts">
 			<div className="callout-text">
 				<Callout className="error-callout" intent="warning" title="Warning: Experimental">
-					We do not guarantee that future product updates will preserve existing page
-					structures of class names. Adding custom CSS can cause your community to be
-					unusable. We do not provide support for issues caused by CSS customization. Use
-					at your own risk.
+					Custom CSS lets you change the look and feel of your Community, but it also lets
+					you introduce bugs that make it hard or impossible to use. The PubPub team may
+					also make changes to our own source code that could break your CSS without
+					warning. We don't provide support for problems caused by Custom CSS. Use caution
+					(but have fun!) <br />
+					Note that Custom CSS is not loaded on your Dashboard — including this page — so
+					you can always return here to undo your changes if they are causing problems.
 				</Callout>
 			</div>
 

--- a/client/containers/DashboardCustomScripts/dashboardCustomScripts.scss
+++ b/client/containers/DashboardCustomScripts/dashboardCustomScripts.scss
@@ -10,7 +10,7 @@
         height: calc(100vh - 300px);
     }
     .callout-text {
-        max-width: 500px;
         line-height: 15px;
+        padding-bottom: 30px;
     }
 }

--- a/client/containers/DashboardCustomScripts/dashboardCustomScripts.scss
+++ b/client/containers/DashboardCustomScripts/dashboardCustomScripts.scss
@@ -9,4 +9,8 @@
     .bp3-tab-panel {
         height: calc(100vh - 300px);
     }
+    .callout-text {
+        max-width: 500px;
+        line-height: 15px;
+    }
 }

--- a/client/containers/DashboardSettings/CommunitySettings.tsx
+++ b/client/containers/DashboardSettings/CommunitySettings.tsx
@@ -347,11 +347,13 @@ const CommunitySettings = () => {
 					<div style={{ paddingLeft: '5px' }}>
 						<Tooltip
 							content={
-								<span>
-									Used as default preview image for social sharing cards.
-									<br />
-									Recommended: 500*500px
-								</span>
+								<div style={{ maxWidth: '400px' }}>
+									Warning: Experimental, use at your own risk. We do not guarantee
+									that future product updates will preserve existing page
+									structures of class names. Adding custom CSS can cause your
+									community to be unusable. We do not provide support for issues
+									caused by CSS customization.
+								</div>
 							}
 						>
 							<Icon icon="warning-sign" color="orange" />

--- a/client/containers/DashboardSettings/CommunitySettings.tsx
+++ b/client/containers/DashboardSettings/CommunitySettings.tsx
@@ -342,6 +342,22 @@ const CommunitySettings = () => {
 						/>
 					</InputField>
 				</div>
+				<div className="row-wrapper">
+					<a href="/dash/scripts">Customize CSS</a>
+					<div style={{ paddingLeft: '5px' }}>
+						<Tooltip
+							content={
+								<span>
+									Used as default preview image for social sharing cards.
+									<br />
+									Recommended: 500*500px
+								</span>
+							}
+						>
+							<Icon icon="warning-sign" color="orange" />
+						</Tooltip>
+					</div>
+				</div>
 			</SettingsSection>
 			<SettingsSection title="Header">
 				<ImageUpload

--- a/client/containers/DashboardSettings/CommunitySettings.tsx
+++ b/client/containers/DashboardSettings/CommunitySettings.tsx
@@ -23,6 +23,8 @@ import { apiFetch } from 'client/utils/apiFetch';
 
 import NavBuilder from './NavBuilder';
 
+require('./communitySettings.scss');
+
 const CommunitySettings = () => {
 	const { scopeData, communityData } = usePageContext();
 
@@ -343,22 +345,23 @@ const CommunitySettings = () => {
 					</InputField>
 				</div>
 				<div className="row-wrapper">
-					<a href="/dash/scripts">Customize CSS</a>
-					<div style={{ paddingLeft: '5px' }}>
-						<Tooltip
-							content={
-								<div style={{ maxWidth: '400px' }}>
-									Warning: Experimental, use at your own risk. We do not guarantee
-									that future product updates will preserve existing page
-									structures of class names. Adding custom CSS can cause your
-									community to be unusable. We do not provide support for issues
-									caused by CSS customization.
-								</div>
-							}
-						>
-							<Icon icon="warning-sign" color="orange" />
-						</Tooltip>
-					</div>
+					<a href={getDashUrl({ mode: 'scripts' })}>Customize CSS</a>
+					<Tooltip
+						targetClassName="custom-css-tooltip-target"
+						popoverClassName="dashboard-settings-container_custom-css-popover"
+						content={
+							<>
+								Warning: Experimental feature. Custom CSS lets you change the look
+								and feel of your Community, but it also lets you introduce bugs that
+								make it hard or impossible to use. The PubPub team may also make
+								changes to our own source code that could break your CSS without
+								warning. We don't provide support for problems caused by Custom CSS.
+								Use caution (but have fun!)
+							</>
+						}
+					>
+						<Icon icon="warning-sign" color="orange" />
+					</Tooltip>
 				</div>
 			</SettingsSection>
 			<SettingsSection title="Header">

--- a/client/containers/DashboardSettings/communitySettings.scss
+++ b/client/containers/DashboardSettings/communitySettings.scss
@@ -1,0 +1,3 @@
+.dashboard-settings-container_custom-css-popover {
+    max-width: 400px;
+}

--- a/client/containers/DashboardSettings/dashboardSettings.scss
+++ b/client/containers/DashboardSettings/dashboardSettings.scss
@@ -26,5 +26,8 @@
 	}
 	.settings-section-component .bp3-label .bp3-popover-wrapper {
 		display: inline-block;
-	  }
+	}
+	.custom-css-tooltip-target {
+		margin-left: 5px;
+	}
 }

--- a/server/customScript/api.ts
+++ b/server/customScript/api.ts
@@ -24,11 +24,7 @@ app.post(
 	'/api/customScripts',
 	wrap(async (req, res) => {
 		const { communityId, userId, content, type } = getRequestIds(req);
-		if (type === 'css') {
-			await setCustomScriptForCommunity(communityId, type, content);
-			return res.status(200).json({});
-		}
-		if (await canSetCustomScript({ communityId, userId })) {
+		if (await canSetCustomScript({ communityId, userId, type })) {
 			await setCustomScriptForCommunity(communityId, type, content);
 			return res.status(200).json({});
 		}

--- a/server/customScript/api.ts
+++ b/server/customScript/api.ts
@@ -24,6 +24,10 @@ app.post(
 	'/api/customScripts',
 	wrap(async (req, res) => {
 		const { communityId, userId, content, type } = getRequestIds(req);
+		if (type === 'css') {
+			await setCustomScriptForCommunity(communityId, type, content);
+			return res.status(200).json({});
+		}
 		if (await canSetCustomScript({ communityId, userId })) {
 			await setCustomScriptForCommunity(communityId, type, content);
 			return res.status(200).json({});

--- a/server/customScript/permissions.ts
+++ b/server/customScript/permissions.ts
@@ -4,11 +4,13 @@ import { communityCanUseCustomScripts } from 'utils/customScripts';
 export const canSetCustomScript = async ({
 	userId,
 	communityId,
+	type,
 }: {
 	userId: string;
 	communityId: string;
+	type: string;
 }) => {
-	if (!communityCanUseCustomScripts(communityId)) {
+	if (type === 'js' && !communityCanUseCustomScripts(communityId)) {
 		return false;
 	}
 	const {

--- a/server/customScript/permissions.ts
+++ b/server/customScript/permissions.ts
@@ -1,16 +1,5 @@
 import { getScope } from 'server/utils/queryHelpers';
-
-const communitiesWithCustomScriptEnabled = [
-	'6ffd8432-b3c1-4094-8ee1-a9de2e72cc27', // Commonplace
-	'eb361ef0-d557-4cac-a949-8bd196e096e7', // Staging-place
-	'e164d5cb-585e-4170-bad8-10d09e08d1bc', // Contours
-	'0417b0c0-cd38-48bd-8a84-b0b95da98813', // Demo
-	'36a3e2c8-74ed-417f-b616-4b57b85b9338', // digitalpubsummit
-];
-
-export const communityCanUseCustomScripts = (communityId: string) => {
-	return communitiesWithCustomScriptEnabled.includes(communityId);
-};
+import { communityCanUseCustomScripts } from 'utils/customScripts';
 
 export const canSetCustomScript = async ({
 	userId,

--- a/server/customScript/queries.ts
+++ b/server/customScript/queries.ts
@@ -1,7 +1,7 @@
 import { CustomScript } from 'server/models';
 import { CustomScriptType, CustomScripts } from 'types';
 
-import { communityCanUseCustomScripts } from './permissions';
+import { communityCanUseCustomScripts } from 'utils/customScripts';
 
 export const setCustomScriptForCommunity = async (
 	communityId: string,

--- a/server/customScript/queries.ts
+++ b/server/customScript/queries.ts
@@ -18,12 +18,12 @@ export const setCustomScriptForCommunity = async (
 };
 
 export const getCustomScriptsForCommunity = async (communityId: string): Promise<CustomScripts> => {
-	if (!communityCanUseCustomScripts(communityId)) {
-		return { js: null, css: null };
-	}
 	const scripts = await CustomScript.findAll({ where: { communityId } });
-	const js = scripts.find((s) => s.type === 'js');
 	const css = scripts.find((s) => s.type === 'css');
+	if (!communityCanUseCustomScripts(communityId)) {
+		return { js: null, css: css?.content || null };
+	}
+	const js = scripts.find((s) => s.type === 'js');
 	return {
 		js: js?.content || null,
 		css: css?.content || null,

--- a/server/routes/dashboardCustomScripts.tsx
+++ b/server/routes/dashboardCustomScripts.tsx
@@ -21,13 +21,12 @@ app.get('/dash/scripts', async (req, res, next) => {
 		}
 
 		const customScripts = await getCustomScriptsForCommunity(communityData.id);
-		const communityId = { id: communityData.id };
 		return renderToNodeStream(
 			res,
 			<Html
 				chunkName="DashboardCustomScripts"
 				initialData={initialData}
-				viewData={{ customScripts, communityId }}
+				viewData={{ customScripts }}
 				headerComponents={generateMetaComponents({
 					initialData,
 					title: `Custom Scripts · ${communityData.title}`,

--- a/server/routes/dashboardCustomScripts.tsx
+++ b/server/routes/dashboardCustomScripts.tsx
@@ -21,13 +21,13 @@ app.get('/dash/scripts', async (req, res, next) => {
 		}
 
 		const customScripts = await getCustomScriptsForCommunity(communityData.id);
-
+		const communityId = { id: communityData.id };
 		return renderToNodeStream(
 			res,
 			<Html
 				chunkName="DashboardCustomScripts"
 				initialData={initialData}
-				viewData={{ customScripts }}
+				viewData={{ customScripts, communityId }}
 				headerComponents={generateMetaComponents({
 					initialData,
 					title: `Custom Scripts · ${communityData.title}`,

--- a/utils/customScripts.ts
+++ b/utils/customScripts.ts
@@ -1,0 +1,11 @@
+const communitiesWithCustomScriptEnabled = [
+	'6ffd8432-b3c1-4094-8ee1-a9de2e72cc27', // Commonplace
+	'eb361ef0-d557-4cac-a949-8bd196e096e7', // Staging-place
+	'e164d5cb-585e-4170-bad8-10d09e08d1bc', // Contours
+	'0417b0c0-cd38-48bd-8a84-b0b95da98813', // Demo
+	'36a3e2c8-74ed-417f-b616-4b57b85b9338', // digitalpubsummit
+];
+
+export const communityCanUseCustomScripts = (communityId: string) => {
+	return communitiesWithCustomScriptEnabled.includes(communityId);
+};


### PR DESCRIPTION
addresses issue #1546 

Adds custom css for all communities. Community admins can now access a custom scripts editor via the settings dashboard. 

![image](https://user-images.githubusercontent.com/34730449/132543379-2f260d1d-8791-4fa7-a391-679824c885c7.png)


![image](https://user-images.githubusercontent.com/34730449/132544894-610b430b-9ad4-4bb5-b160-4cd1c8de42f4.png)

Test plan
go to community settings as an admin
scroll to custom css link, hover over ⚠️ symbol and read the tooltip disclaimer 
click on custom css link
most community admins should only see the css tab. if you are hardcoded to have js access you will see both

run test suite locally for custom scripts