### PR TITLE
bug: CJK fonts render for export

### DIFF
--- a/client/styles/variables.scss
+++ b/client/styles/variables.scss
@@ -11,6 +11,6 @@ $header-font: multi-display, -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'R
 	'Open Sans', 'Helvetica Neue', sans-serif;
 
 // We make this distinction because Adobe Acrobat hates skolar
-$export-body-font: Georgia, Cambria, 'Times New Roman', Times, serif;
+$export-body-font: Georgia, Cambria, 'Times New Roman', Times, source-han-serif-sc, serif;
 $screen-body-font: skolar-latin, Georgia, Cambria, 'Times New Roman', Times, serif;
 $body-font: if-is-export($export-body-font, $screen-body-font);

--- a/client/styles/variables.scss
+++ b/client/styles/variables.scss
@@ -5,12 +5,18 @@
 	@return $default;
 }
 
-$base-font: -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Open Sans',
-	'Helvetica Neue', sans-serif;
-$header-font: multi-display, -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
-	'Open Sans', 'Helvetica Neue', sans-serif;
+$cjk-body-font: source-han-serif-tc, source-han-serif-korean, source-han-serif-japanese,
+	source-han-serif-sc;
+
+$cjk-header-font: source-han-sans-cjk-tc, source-han-sans-cjk-ko, source-han-sans-cjk-ja,
+	source-han-sans-cjk-sc;
+
+$base-font: -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+	'Cantarell', 'Open Sans', 'Helvetica Neue', sans-serif;
+$header-font: multi-display, -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen',
+	'Ubuntu', 'Cantarell', 'Open Sans', 'Helvetica Neue', sans-serif, $cjk-header-font;
 
 // We make this distinction because Adobe Acrobat hates skolar
-$export-body-font: Georgia, Cambria, 'Times New Roman', Times, source-han-serif-sc, serif;
+$export-body-font: Georgia, Cambria, 'Times New Roman', Times, $cjk-body-font, serif;
 $screen-body-font: skolar-latin, Georgia, Cambria, 'Times New Roman', Times, serif;
 $body-font: if-is-export($export-body-font, $screen-body-font);

--- a/workers/tasks/export/html.tsx
+++ b/workers/tasks/export/html.tsx
@@ -14,7 +14,9 @@ const nonExportableNodeTypes = ['discussion'];
 const katexCdnPrefix = 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/';
 const bullet = ' • ';
 
-const createCJKFontScript = `
+// This script is provided by the "cjk-fonts" Web Fonts project that we manage from here:
+// https://fonts.adobe.com/my_fonts#web_projects-section
+const loadCjkFontsScript = `
 (function(d) {
   var config = {
 	kitId: 'seb8nix',
@@ -310,7 +312,7 @@ export const renderStaticHtml = async ({
 					<style type="text/css" dangerouslySetInnerHTML={{ __html: staticCss }} />
 				)}
 				{/* eslint-disable-next-line react/no-danger */}
-				<script dangerouslySetInnerHTML={{ __html: createCJKFontScript }} />
+				<script dangerouslySetInnerHTML={{ __html: loadCjkFontsScript }} />
 			</head>
 			<body>
 				{targetPandoc && (

--- a/workers/tasks/export/html.tsx
+++ b/workers/tasks/export/html.tsx
@@ -17,7 +17,7 @@ const bullet = ' • ';
 const createCJKFontScript = `
 (function(d) {
   var config = {
-	kitId: 'wgk2zjg',
+	kitId: 'seb8nix',
 	scriptTimeout: 3000,
 	async: true
   },

--- a/workers/tasks/export/html.tsx
+++ b/workers/tasks/export/html.tsx
@@ -14,6 +14,17 @@ const nonExportableNodeTypes = ['discussion'];
 const katexCdnPrefix = 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/';
 const bullet = ' • ';
 
+const createCJKFontScript = `
+(function(d) {
+  var config = {
+	kitId: 'wgk2zjg',
+	scriptTimeout: 3000,
+	async: true
+  },
+  h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\bwf-loading\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='https://use.typekit.net/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f||a&&a!="complete"&&a!="loaded")return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
+})(document);
+`;
+
 const createCss = () => {
 	const entrypoint = path.join(__dirname, 'styles', 'printDocument.scss');
 	const cssPath = path.join(__dirname, 'styles', 'printDocument.css');
@@ -298,6 +309,8 @@ export const renderStaticHtml = async ({
 					// eslint-disable-next-line react/no-danger
 					<style type="text/css" dangerouslySetInnerHTML={{ __html: staticCss }} />
 				)}
+				{/* eslint-disable-next-line react/no-danger */}
+				<script dangerouslySetInnerHTML={{ __html: createCJKFontScript }} />
 			</head>
 			<body>
 				{targetPandoc && (


### PR DESCRIPTION
addresses issue #1509

CJK fonts cannot be loaded via bundle on Heroku because they are huge. Having dynamic subsetting allows fonts to be loaded during export as opposed to resting on the Heroku bundle. 

before
![image](https://user-images.githubusercontent.com/34730449/135295088-753175a6-d76f-4403-9de1-3c49fbf5050e.png)

after
![image](https://user-images.githubusercontent.com/34730449/135295478-8ade9a9b-e161-4c04-bb42-e1e5e39c617e.png)

Test:
Add Korean, Japanese, and Chinese characters in header of pub doc
Add Korean, Japanese, and Chinese characters in body of pub doc

verify that all characters a re rendered

heres a pub with all three
https://demo.duqduq.org/pub/t0tkgi74/draft