### PR TITLE
dev: bump katex to 0.13.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29454,17 +29454,17 @@
 			"integrity": "sha512-40aUybvhH9t2h71ncA1/1SbtTNCVZHgsTsTgqPUxGWDmUDrXyDf2wMNQKEbdBjbf4AI+fQhbECNTV6lWxQKUzg=="
 		},
 		"katex": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/katex/-/katex-0.11.1.tgz",
-			"integrity": "sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==",
+			"version": "0.13.18",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.13.18.tgz",
+			"integrity": "sha512-a3dC4NSVSDU3O1WZbTnOiA8rVNJ2lSiomOl0kmckCIGObccIHXof7gAseIY0o1gjEspe+34ZeSEX2D1ChFKIvA==",
 			"requires": {
-				"commander": "^2.19.0"
+				"commander": "^6.0.0"
 			},
 			"dependencies": {
 				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+					"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
 				}
 			}
 		},
@@ -32229,6 +32229,21 @@
 					"requires": {
 						"mdn-data": "~1.1.0",
 						"source-map": "^0.5.3"
+					}
+				},
+				"katex": {
+					"version": "0.11.1",
+					"resolved": "https://registry.npmjs.org/katex/-/katex-0.11.1.tgz",
+					"integrity": "sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==",
+					"requires": {
+						"commander": "^2.19.0"
+					},
+					"dependencies": {
+						"commander": {
+							"version": "2.20.3",
+							"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+							"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+						}
 					}
 				},
 				"mdn-data": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"json-stable-stringify": "^1.0.1",
 		"jsonpath": "^1.1.0",
 		"jsonwebtoken": "^8.5.1",
-		"katex": "^0.11.1",
+		"katex": "^0.13.18",
 		"keyboardjs": "^2.5.1",
 		"knex": "^0.21.17",
 		"linkifyjs": "^3.0.0-beta.3",

--- a/workers/tasks/export/html.tsx
+++ b/workers/tasks/export/html.tsx
@@ -11,7 +11,7 @@ import SimpleNotesList from './SimpleNotesList';
 import { digestCitation } from './util';
 
 const nonExportableNodeTypes = ['discussion'];
-const katexCdnPrefix = 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/';
+const katexCdnPrefix = 'https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.13.18/';
 const bullet = ' • ';
 
 const createCss = () => {


### PR DESCRIPTION
Bumps KaTeX to 0.13.18, resolving #1551 and making our LaTeX support much better.

I did basic QA on a number of HDSR articles with lots of LaTeX, particularly: http://localhost:9876/pub/fxz7kr65/release/6 and https://localhost:9876/pub/y9vc2u36/release/7.

Luckily, it doesn't look like this will break our implementation of KaTeX in any way. In the future, we may want to take advantage of some new features like the improved error messages in particular, and we will want to make the fix described in #1577 to take full advantage of the new features. But that's beyond the scope of this PR.

There were a few breaking changes in KaTeX's support of LaTeX, however, and I searched the Docs table in the db for Pubs that may have these issues. Once we release, we'll want to fix these pubs

### Macro token expansion
Very hard to search for, but I didn't find anyone using `\newcommand` or `\def`, so I think our exposure to this kind of token expansion will be very limited, if at all.

### `\newline` and `\cr` --> \\
The following pubs use `\cr` and will need to be manually converted to `\\`:

- cerje44v
- arrih5vx
- arrih5vx

### `\cfrac`, `\color`, `\textcolor`, `\colorbox`, `\fcolorbox`
There was one use of \color, but it didn't use it as an argument, so there were no mods to make. I tested them on localhost with the bumped KaTeX to be sure.

_Test Plan_
1. Create a new Pub and add some LaTex, making sure it still works as expected.
2. Browse some LaTeX-heavy Pubs (HDSR, mostly) and make sure no errors appear (red).
3. Export a fresh Pub with tex as PDF and HTML and make sure it appears correctly

_Post release_
Modify those three pubs and re-release