### PR TITLE
fix: Correctly position the reference suggestion (@-menu) popover

### DIFF
--- a/client/utils/suggestions/suggestionManager.ts
+++ b/client/utils/suggestions/suggestionManager.ts
@@ -118,7 +118,7 @@ export default class SuggestionManager<T> {
 
 		const { params } = this.state;
 		const bounds = params.view.coordsAtPos(params.range.from + 1);
-		const parent = document.body.getBoundingClientRect();
+		const parent = (params.view.dom as HTMLElement).offsetParent!.getBoundingClientRect();
 
 		return {
 			position: 'absolute' as const,


### PR DESCRIPTION
Resolves #1578

This bad boy fixes the positioning of the menu that gives suggestable items which appears when you type "@". I think I broke this a while ago by adding `position: relative` to `.pub-body-component`.

![image](https://user-images.githubusercontent.com/2208769/135915535-bc2ee23e-86b5-4145-a145-841ba90c41be.png)

_Test plan:_
Visit [this Pub](http://localhost:9876/pub/igh7ltk4/draft) and make sure the menu appears when you type "@"


