### PR TITLE
fix: use TeX display mode for block_equation

### DIFF
--- a/client/components/FormattingBar/controlComponents/ControlsEquation.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsEquation.tsx
@@ -52,7 +52,7 @@ const ControlsEquation = (props: Props) => {
 			hasMountedRef.current = true;
 			return;
 		}
-		renderLatexString(debouncedValue, false, (nextHtml) => {
+		renderLatexString(debouncedValue, isBlock, (nextHtml) => {
 			updateAttrs({ html: nextHtml });
 		});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -66,8 +66,10 @@ const ControlsEquation = (props: Props) => {
 	const handleChangeNodeType = () => {
 		const targetNodeType = isBlock ? 'equation' : 'block_equation';
 		const schemaDefinition = getSchemaDefinitionForNodeType(editorChangeObject, targetNodeType);
-		commitChanges();
-		changeNode(schemaDefinition, { value, html }, null);
+		renderLatexString(debouncedValue, !isBlock, (nextHtml) => {
+			commitChanges();
+			changeNode(schemaDefinition, { value, html: nextHtml }, null);
+		});
 	};
 
 	return (


### PR DESCRIPTION
Resolves #1577 by causing `block_equation` elements to render in TeX "display mode", which roughly maps to the concept of "block level math". As the description notes we have our KaTeX wrapper code mostly glued up to do this, except that _someone_ left the `isBlock` argument hard-coded to `false` when rebuilding the formatting bar...some time ago.

This fixes that, and also changes the behavior of the "Change to (block/inline)" button in the equation editor — now it will fetch the new HTML for an equation based on the incoming block/inline status before updating the node and closing.

_Test plan:_
Create an equation element and add the following TeX:

```
\begin{equation*}
f(x)=(x+a)(x+b)
\end{equation*}
```

It should render properly. Now click "Change to inline" and the element should have a red error message indicating that this is invalid TeX outside of display mode. Now click "Change to block" again and the original layout should be recovered.