### PR TITLE
fix: Use black text when editing black-blocks themed Pub title

### DIFF
--- a/client/containers/Pub/PubHeader/themes.scss
+++ b/client/containers/Pub/PubHeader/themes.scss
@@ -141,6 +141,9 @@ $off-black: #333;
             padding: 2px 10px;
         }
     }
+    .bp3-editable-text-input {
+        color: black;
+    }
     .pub-header-themed-box {
         border-radius: 0;
     }


### PR DESCRIPTION
Resolves #1554

This adds an exception to the `color: white` on the `black-blocks` header theme for the text input part of an `EditableText` — since the background of the text input is still light, we want the text to remain dark as shown:

<img width="889" alt="image" src="https://user-images.githubusercontent.com/2208769/135924461-24d830e8-19f3-4cf9-90bc-ffc00d6ba026.png">

_Test plan:_
Create a Pub and use the "Edit Theme" button in the header to turn on the "Black Blocks" theme. Click the Pub title to edit it and verify that the text is black on a light background while editing.
