### PR TITLE
fix: Don't block forever on Cite.async

### DIFF
--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -8,6 +8,7 @@ import { getNotes } from 'components/Editor';
 import { citationStyles, CitationStyleKind, CitationInlineStyleKind } from 'utils/citations';
 import { StructuredValue, RenderedStructuredValue } from 'utils/notesCore';
 import { Pub } from 'types';
+import { expiringPromise } from 'utils/promises';
 
 /* Different styles available here: */
 /* https://github.com/citation-style-language/styles */
@@ -66,6 +67,13 @@ const getInlineCitation = (
 	return null;
 };
 
+const getSingleCitationAsync = expiringPromise(
+	async (structuredValue: string) => {
+		return Cite.async(structuredValue);
+	},
+	{ timeout: 2000, throws: () => new Error('Citation data failed to load') },
+);
+
 const getSingleStructuredCitation = async (
 	structuredInput: string,
 	citationStyle: CitationStyleKind,
@@ -73,7 +81,7 @@ const getSingleStructuredCitation = async (
 ) => {
 	try {
 		const fallbackValue = generateFallbackHash(structuredInput);
-		const citationData = await Cite.async(structuredInput);
+		const citationData = await getSingleCitationAsync(structuredInput);
 		if (citationData) {
 			const citationJson = citationData.format('data', { format: 'object' });
 			const citationHtml = citationData.format('bibliography', {

--- a/utils/promises.ts
+++ b/utils/promises.ts
@@ -1,17 +1,14 @@
-type FnOf<Arguments extends any[], ReturnType> = (...args: Arguments) => ReturnType;
-
 type ExpiringPromiseOptions<ReturnType> = { timeout: number } & (
 	| { fallback: ReturnType }
 	| { throws: () => Error }
 );
 
 export const expiringPromise = <Arguments extends any[], ReturnType>(
-	fn: FnOf<Arguments, Promise<ReturnType>>,
+	fn: (...args: Arguments) => Promise<ReturnType>,
 	options: ExpiringPromiseOptions<ReturnType>,
 ) => {
-	const { timeout } = options;
-	return (...args: Arguments): Promise<ReturnType> =>
-		new Promise((resolve, reject) => {
+	return (...args: Arguments): Promise<ReturnType> => {
+		return new Promise((resolve, reject) => {
 			fn(...args)
 				.then(resolve)
 				.catch(reject);
@@ -21,6 +18,7 @@ export const expiringPromise = <Arguments extends any[], ReturnType>(
 				} else if ('throws' in options) {
 					reject(options.throws());
 				}
-			}, timeout);
+			}, options.timeout);
 		});
+	};
 };

--- a/utils/promises.ts
+++ b/utils/promises.ts
@@ -1,0 +1,26 @@
+type FnOf<Arguments extends any[], ReturnType> = (...args: Arguments) => ReturnType;
+
+type ExpiringPromiseOptions<ReturnType> = { timeout: number } & (
+	| { fallback: ReturnType }
+	| { throws: () => Error }
+);
+
+export const expiringPromise = <Arguments extends any[], ReturnType>(
+	fn: FnOf<Arguments, Promise<ReturnType>>,
+	options: ExpiringPromiseOptions<ReturnType>,
+) => {
+	const { timeout } = options;
+	return (...args: Arguments): Promise<ReturnType> =>
+		new Promise((resolve, reject) => {
+			fn(...args)
+				.then(resolve)
+				.catch(reject);
+			setTimeout(() => {
+				if ('fallback' in options) {
+					resolve(options.fallback);
+				} else if ('throws' in options) {
+					reject(options.throws());
+				}
+			}, timeout);
+		});
+};


### PR DESCRIPTION
There is currently [an issue with Crossref](https://twitter.com/CrossrefSupport/status/1445788491275587584) that prevents Citation.js from loading structured citation data — in turn, this is causing some Pubs to not load. We should consider caching this data — a quicker fix is to let these citations error out if they do not load quickly enough.

_Test plan:_
Create a new Pub and add a citation with a DOI as its structured data. Refresh the page and see that it loads.