### PR TITLE
fix: Crossref timestamp rejection

### DIFF
--- a/server/doi/queries.ts
+++ b/server/doi/queries.ts
@@ -154,7 +154,7 @@ export const setDoiData = async (
 	const ids = { collectionId, pubId };
 	// Crossref requires us to first delete any existing relationships (by
 	// submitting a deposit without them), and then submit a deposit with the
-	// updated relationships.
+	// updated relationships. The second deposit must have a newer timestamp.
 	await submitDoiData(detachedDeposit, timestamp, communityId);
 	await submitDoiData(deposit, secondDepositTimestamp, communityId);
 	// Store the DOIs and Crossref deposit record.


### PR DESCRIPTION
Long story, but there was a small issue with crossref rejecting the second deposit because of a duplicate timestamp. I've fixed this by incrementing the timestamp for the second one, which seems to work fine and not even require creating a new Date object, which is a bit slow. That's the main thing I need checked here, because I'm not sure how kosher that is, but I included a test plan jic.

_Test plan_
1. Deposit a released pub to Crossref
2. Add a released connection and re-deposit the pub
3. Login to test.crossref.org, open the submissions -> admin tab, search for deposits within the last day, and make sure that two error-free deposits appear in the queue. The first should be the deposit without connections, the second with connections.