### PR TITLE
collection impact dashboard

### DIFF
--- a/client/containers/App/SideMenu/SideMenu.tsx
+++ b/client/containers/App/SideMenu/SideMenu.tsx
@@ -81,7 +81,7 @@ const SideMenu = () => {
 				pubSlug,
 				mode: 'impact',
 			}),
-			validScopes: ['pub', 'community'],
+			validScopes: ['pub', 'community', 'collection'],
 		},
 		{
 			title: 'Members',

--- a/client/containers/DashboardImpact/DashboardImpact.tsx
+++ b/client/containers/DashboardImpact/DashboardImpact.tsx
@@ -1,13 +1,6 @@
 import React from 'react';
 import { usePageContext } from 'utils/hooks';
-import {
-	Callout,
-	Button,
-	Intent,
-	Tooltip,
-	Position,
-	PopoverInteractionKind,
-} from '@blueprintjs/core';
+import { Button, Intent, Tooltip, Position, PopoverInteractionKind } from '@blueprintjs/core';
 import IframeResizer from 'iframe-resizer-react';
 
 import { DashboardFrame } from 'components';
@@ -80,9 +73,6 @@ const DashboardImpact = (props: Props) => {
 						</Tooltip>
 					)}
 				</h3>
-				{canView && isCollection && (
-					<Callout>Collection-level impact data coming soon.</Callout>
-				)}
 				{canView ? (
 					<IframeResizer
 						className="metabase main"

--- a/server/utils/metabase.ts
+++ b/server/utils/metabase.ts
@@ -6,6 +6,9 @@ export const generateMetabaseToken = (scopeType, scopeId, dashboardType) => {
 			base: 2,
 			benchmark: 8,
 		},
+		collection: {
+			base: 7,
+		},
 		pub: {
 			base: 3,
 			benchmark: 9,


### PR DESCRIPTION
Adds the Impact tab and associated collection dashboard to PubPub, which addresses #1565 and resolves https://github.com/pubpub/pubpub/issues/1008.

_Test Plan_
1. Visit a Collection dash as an admin and make sure the impact tab is visible and the dashboard loads.
2. Visit a Collection dash as a view-only member and make sure the dashboard does not load.
3. Visit a Collection dash without being logged in and make sure Impact tab is not visible and dashboard does not load.