### PR TITLE
fix: Style tweaks to PubEdge card

### DIFF
--- a/client/components/PubEdge/PubEdge.tsx
+++ b/client/components/PubEdge/PubEdge.tsx
@@ -34,6 +34,13 @@ const PubEdge = (props: PubEdgeProps) => {
 	);
 
 	const detailsElementId = `edge-details-${pubEdge.id}`;
+	const detailsElement = description && (
+		<details open={open} id={detailsElementId}>
+			<summary>Description</summary>
+			<hr />
+			<p>{description}</p>
+		</details>
+	);
 
 	const handleToggleDescriptionClick = useCallback(
 		(e: React.MouseEvent | React.KeyboardEvent) => {
@@ -99,13 +106,7 @@ const PubEdge = (props: PubEdgeProps) => {
 				publishedAt && <>Published on {publishedAt}</>,
 				url && <span className="location">{getHostnameForUrl(url)}</span>,
 			]}
-			detailsElement={
-				<details open={open} id={detailsElementId}>
-					<summary>Description</summary>
-					<hr />
-					<p>{description}</p>
-				</details>
-			}
+			detailsElement={detailsElement}
 		/>,
 		{ className: classNames('pub-edge-component', actsLikeLink && 'acts-like-link') },
 	);

--- a/client/components/PubEdge/pubEdge.scss
+++ b/client/components/PubEdge/pubEdge.scss
@@ -22,7 +22,6 @@
 	.top {
 		display: flex;
 		flex-direction: row;
-		min-height: 90px;
 
 		.top-left {
 			flex: 0 0 120px;


### PR DESCRIPTION
Removes horizontal divider in the absence of details to render, and cuts out the `min-height`.

_Before:_
![image](https://user-images.githubusercontent.com/2208769/137019769-8f41f6ab-6b59-441e-aa22-9e2086af1b86.png)

_After:_
![image](https://user-images.githubusercontent.com/2208769/137019703-366d6b30-ea2a-466d-b091-910514b74bf9.png)


