### PR TITLE
fix: Font issues in PDF exports

### DIFF
--- a/client/styles/variables.scss
+++ b/client/styles/variables.scss
@@ -17,7 +17,7 @@ $header-font: multi-display, -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'R
 	'Ubuntu', 'Cantarell', 'Open Sans', 'Helvetica Neue', sans-serif, $cjk-header-font;
 
 // We make this distinction because Adobe Acrobat hates skolar
-$export-body-font: Georgia, Cambria, 'Times New Roman', 'Nimbus Roman No9', Times, $cjk-body-font,
+$export-body-font: Georgia, Cambria, 'Times New Roman', Times, 'Nimbus Roman No9', $cjk-body-font,
 	serif;
 $screen-body-font: skolar-latin, Georgia, Cambria, 'Times New Roman', Times, serif;
 $body-font: if-is-export($export-body-font, $screen-body-font);

--- a/client/styles/variables.scss
+++ b/client/styles/variables.scss
@@ -17,6 +17,7 @@ $header-font: multi-display, -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'R
 	'Ubuntu', 'Cantarell', 'Open Sans', 'Helvetica Neue', sans-serif, $cjk-header-font;
 
 // We make this distinction because Adobe Acrobat hates skolar
-$export-body-font: Georgia, Cambria, 'Times New Roman', Times, $cjk-body-font, serif;
+$export-body-font: Georgia, Cambria, 'Times New Roman', 'Nimbus Roman No9', Times, $cjk-body-font,
+	serif;
 $screen-body-font: skolar-latin, Georgia, Cambria, 'Times New Roman', Times, serif;
 $body-font: if-is-export($export-body-font, $screen-body-font);

--- a/client/styles/variables.scss
+++ b/client/styles/variables.scss
@@ -17,6 +17,6 @@ $header-font: multi-display, -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'R
 	'Ubuntu', 'Cantarell', 'Open Sans', 'Helvetica Neue', sans-serif, $cjk-header-font;
 
 // We make this distinction because Adobe Acrobat hates skolar
-$export-body-font: Georgia, Cambria, 'Times New Roman', Times, 'DejaVu', $cjk-body-font, serif;
+$export-body-font: Georgia, Cambria, 'Times New Roman', Times, 'DejaVu Serif', $cjk-body-font, serif;
 $screen-body-font: skolar-latin, Georgia, Cambria, 'Times New Roman', Times, serif;
 $body-font: if-is-export($export-body-font, $screen-body-font);

--- a/client/styles/variables.scss
+++ b/client/styles/variables.scss
@@ -17,7 +17,6 @@ $header-font: multi-display, -apple-system, 'BlinkMacSystemFont', 'Segoe UI', 'R
 	'Ubuntu', 'Cantarell', 'Open Sans', 'Helvetica Neue', sans-serif, $cjk-header-font;
 
 // We make this distinction because Adobe Acrobat hates skolar
-$export-body-font: Georgia, Cambria, 'Times New Roman', Times, 'Nimbus Roman No9', $cjk-body-font,
-	serif;
+$export-body-font: Georgia, Cambria, 'Times New Roman', Times, 'DejaVu', $cjk-body-font, serif;
 $screen-body-font: skolar-latin, Georgia, Cambria, 'Times New Roman', Times, serif;
 $body-font: if-is-export($export-body-font, $screen-body-font);


### PR DESCRIPTION
Resolves #1640. See that issue for context.

This adds the font 'DejaVu Serif' to the stack for exports, because it's the only truetype serif that exists on our Heroku Ubuntu machine. It's ... not too far from Georgia, and generates non-janky PDFs that can be copy/pasted and annotated! Huzzah.

Long term, we should execute on our plan to move the export pipeline to another machine where we don't have the same slug constraints and can provide required fonts locally.

Weirdness it's doing now:
<img width="49" alt="Screen Shot 2021-10-27 at 17 18 57" src="https://user-images.githubusercontent.com/639110/139106697-50e2bf2a-edec-465c-8b66-01e8ceb729b8.png">

Georgia (local):
<img width="49" alt="Screen Shot 2021-10-27 at 17 18 57" src="https://user-images.githubusercontent.com/639110/139106652-959cbc2e-1b00-4df2-ad3f-fe0f71662e87.png">

DejaVu Serif:
<img width="49" alt="Screen Shot 2021-10-27 at 17 18 57" src="https://user-images.githubusercontent.com/639110/139149487-0a262446-bee5-402d-b5f1-25ec856dbab1.png">

_Test plan_
1. Export a complex PDF and make sure it looks decent!

E.g.:
[394acb67-40e4-4b0d-be19-5c937815bba1 (2).pdf](https://github.com/pubpub/pubpub/files/7429700/394acb67-40e4-4b0d-be19-5c937815bba1.2.pdf)
 