### PR TITLE
Submissions model, query, api, and tests

### DIFF
--- a/server/apiRoutes.ts
+++ b/server/apiRoutes.ts
@@ -27,6 +27,7 @@ require('./rss/api');
 require('./search/api');
 require('./signup/api');
 require('./subscribe/api');
+require('./submission/api');
 require('./threadComment/api');
 require('./uploadPolicy/api');
 require('./user/api');

--- a/server/models.ts
+++ b/server/models.ts
@@ -69,6 +69,7 @@ export const Release = sequelize.import('./release/model');
 export const Review = sequelize.import('./review/model');
 export const ReviewEvent = sequelize.import('./reviewEvent/model');
 export const ScopeSummary = sequelize.import('./scopeSummary/model');
+export const Submission = sequelize.import('./submission/model');
 export const Signup = sequelize.import('./signup/model');
 export const ReviewNew = sequelize.import('./review/modelNew');
 export const Thread = sequelize.import('./thread/model');

--- a/server/pub/model.ts
+++ b/server/pub/model.ts
@@ -75,6 +75,7 @@ export default (sequelize, dataTypes) => {
 						Release,
 						ReviewNew,
 						ScopeSummary,
+						Submission,
 					} = models;
 					Pub.hasMany(PubAttribution, {
 						onDelete: 'CASCADE',
@@ -137,6 +138,11 @@ export default (sequelize, dataTypes) => {
 					Pub.belongsTo(ScopeSummary, {
 						as: 'scopeSummary',
 						foreignKey: 'scopeSummaryId',
+					});
+					Pub.hasOne(Submission, {
+						onDelete: 'CASCADE',
+						as: 'submission',
+						foreignKey: 'pubId',
 					});
 				},
 			},

--- a/server/pub/model.ts
+++ b/server/pub/model.ts
@@ -75,7 +75,6 @@ export default (sequelize, dataTypes) => {
 						Release,
 						ReviewNew,
 						ScopeSummary,
-						Submission,
 					} = models;
 					Pub.hasMany(PubAttribution, {
 						onDelete: 'CASCADE',
@@ -138,11 +137,6 @@ export default (sequelize, dataTypes) => {
 					Pub.belongsTo(ScopeSummary, {
 						as: 'scopeSummary',
 						foreignKey: 'scopeSummaryId',
-					});
-					Pub.hasOne(Submission, {
-						onDelete: 'CASCADE',
-						as: 'submission',
-						foreignKey: 'pubId',
 					});
 				},
 			},

--- a/server/submission/__tests__/api.test.ts
+++ b/server/submission/__tests__/api.test.ts
@@ -1,6 +1,5 @@
 /* global it, expect, beforeAll, afterAll */
 import { setup, teardown, login, modelize } from 'stubstub';
-import { createSubmission } from '../queries';
 import { Submission } from '../../models';
 
 const models = modelize`
@@ -55,11 +54,10 @@ it('creates a new submission', async () => {
 		.send({
 			communityId: community.id,
 			pubId: spub.id,
-			status: 'submitted',
 		})
 		.expect(201);
 	expect(pubId).toEqual(spub.id);
-	expect(status).toEqual('submitted');
+	expect(status).toEqual('incomplete');
 });
 
 it('forbids pub admins to update pub status beyond completed', async () => {
@@ -68,7 +66,7 @@ it('forbids pub admins to update pub status beyond completed', async () => {
 	await agent
 		.put('/api/submissions')
 		.send({
-			submissionId: submission.id,
+			id: submission.id,
 			status: 'accepted',
 		})
 		.expect(403);
@@ -82,7 +80,7 @@ it('forbids admins of another community to update pub status', async () => {
 		.send({
 			communityId: community.id,
 			collectionId: collection.id,
-			submissionId: submission.id,
+			id: submission.id,
 			status: 'completed',
 		})
 		.expect(403);
@@ -95,7 +93,7 @@ it('forbids collection editors to update pub status', async () => {
 		.put('/api/submissions')
 		.send({
 			communityId: community.id,
-			submissionId: submission.id,
+			id: submission.id,
 			status: 'completed',
 		})
 		.expect(403);
@@ -107,7 +105,7 @@ it('forbids admins to update from incomplete status', async () => {
 	await agent
 		.put('/api/submissions')
 		.send({
-			submissionId: submission.id,
+			id: submission.id,
 			status: 'accepted',
 		})
 		.expect(403);
@@ -119,7 +117,7 @@ it('allows pub editors to set submitted status', async () => {
 	await agent
 		.put('/api/submissions')
 		.send({
-			submissionId: submission.id,
+			id: submission.id,
 			pubId: spub.id,
 			status: 'submitted',
 		})
@@ -134,7 +132,7 @@ it('forbids admins to update status out of one of [submitted, accepted, declined
 	await agent
 		.put('/api/submissions')
 		.send({
-			submissionId: submission.id,
+			id: submission.id,
 			status: 'incomplete',
 		})
 		.expect(403);
@@ -147,7 +145,7 @@ it('allows collection managers to update pub status', async () => {
 		.put('/api/submissions')
 		.send({
 			collectionId: collection.id,
-			submissionId: submission.id,
+			id: submission.id,
 			status: 'accepted',
 		})
 		.expect(201);
@@ -160,7 +158,7 @@ it('forbids normal user to delete a submission', async () => {
 	const agent = await login(guest);
 	await agent
 		.delete('/api/submissions')
-		.send({ submissionId: submission.id, communityId: community.id })
+		.send({ id: submission.id, communityId: community.id })
 		.expect(403);
 	const submissionNow = await Submission.findOne({ where: { id: submission.id } });
 	expect(submissionNow.id).toEqual(submission.id);
@@ -171,7 +169,7 @@ it('allows admin to delete a submission', async () => {
 	const agent = await login(admin);
 	await agent
 		.delete('/api/submissions')
-		.send({ submissionId: submission.id, communityId: community.id })
+		.send({ id: submission.id, communityId: community.id })
 		.expect(200);
 	const submissionNow = await Submission.findOne({ where: { id: submission.id } });
 	expect(submissionNow).toEqual(null);

--- a/server/submission/__tests__/api.test.ts
+++ b/server/submission/__tests__/api.test.ts
@@ -1,0 +1,175 @@
+/* global it, expect, beforeAll, afterAll */
+import { setup, teardown, login, modelize } from 'stubstub';
+import { createSubmission } from '../queries';
+import { Submission } from '../../models';
+
+const models = modelize`
+	Community community {
+		Member {
+			permissions: "admin"
+			User admin {}
+		}
+		Collection collection {
+			Member {
+				permissions: "edit"
+				User collectionEditor {}
+			}
+			Member {
+				permissions: "manager"
+				User collectionManager {}
+			}
+			CollectionPub {
+				Pub spubbable {}
+				Pub spub {
+					Member {
+						permissions: "admin"
+						User pubAdmin {}
+					}
+					Submission submission {
+						status: "incomplete"
+					}
+				}
+			}
+		}
+	}
+	Community {
+		Member {
+			permissions: "admin"
+			User anotherAdmin {}
+		}
+	}
+	User guest {}
+`;
+
+setup(beforeAll, async () => {
+	await models.resolve();
+});
+
+it('creates a new submission', async () => {
+	const { admin, spub } = models;
+	const agent = await login(admin);
+	const {
+		body: { pubId, status },
+	} = await agent
+		.post('/api/submissions')
+		.send({
+			pubId: spub.id,
+			status: 'submitted',
+		})
+		.expect(201);
+	expect(pubId).toEqual(spub.id);
+	expect(status).toEqual('submitted');
+});
+
+it('changes a submission status', async () => {
+	const { admin, spub, submission } = models;
+	const agent = await login(admin);
+	const {
+		body: { status, id, pubId },
+	} = await agent
+		.put('/api/submissions')
+		.send({
+			id: submission.id,
+			status: 'incomplete',
+		})
+		.expect(201);
+	expect(pubId).toEqual(spub.id);
+	expect(id).toEqual(submission.id);
+	expect(status).toEqual('incomplete');
+});
+
+it('does not allow admins of another community to modify a submission', async () => {
+	const { submission, anotherAdmin } = models;
+	const agent = await login(anotherAdmin);
+	await agent
+		.put('/api/submissions')
+		.send({
+			id: submission.id,
+			status: 'completed',
+		})
+		.expect(403);
+});
+
+it('does not allow normal users to modify a submission', async () => {
+	const { submission, guest } = models;
+	const agent = await login(guest);
+	await agent
+		.put('/api/submissions')
+		.send({
+			id: submission.id,
+			status: 'completed',
+		})
+		.expect(403);
+});
+
+it('does not allow pub admins to update pub status', async () => {
+	const { pubAdmin, submission } = models;
+	const agent = await login(pubAdmin);
+	await agent
+		.put('/api/submissions')
+		.send({
+			id: submission.id,
+			status: 'completed',
+		})
+		.expect(403);
+});
+
+it('does allow collection managers to update pub status', async () => {
+	const { collectionManager, submission } = models;
+	const agent = await login(collectionManager);
+	await agent
+		.put('/api/submissions')
+		.send({
+			id: submission.id,
+			status: 'completed',
+		})
+		.expect(403);
+});
+
+it('does not allow changing status to something besides incomplete, submitted, accepted, declined', async () => {
+	const { admin, spubbable } = models;
+	const submission = await createSubmission({
+		pubId: spubbable.id,
+		status: 'submitted',
+	});
+	const agent = await login(admin);
+	await agent
+		.put('/api/submissions')
+		.send({
+			id: submission.id,
+			status: 'disallowed status',
+		})
+		.expect(400);
+});
+
+it('deletes an existing submission with appropriate permissions', async () => {
+	const { admin, community, spub } = models;
+	const submission = await createSubmission({
+		pubId: spub.id,
+		status: 'incomplete',
+	});
+	const agent = await login(admin);
+	await agent
+		.delete('/api/submissions')
+		.send({ id: submission.id, communityId: community.id })
+		.expect(200);
+	const submissionNow = await Submission.findOne({ where: { id: submission.id } });
+	expect(submissionNow).toEqual(null);
+});
+
+it('does not allow normal users to delete a submission', async () => {
+	const { guest, spub } = models;
+	const submission = await createSubmission({
+		pubId: spub.id,
+		title: 'incomplete',
+	});
+	const agent = await login(guest);
+	await agent
+		.delete('/api/submissions')
+		.send({ id: submission.id })
+		.expect(403);
+	const submissionNow = await Submission.findOne({ where: { id: submission.id } });
+	expect(submissionNow.id).toEqual(submission.id);
+});
+
+teardown(afterAll);

--- a/server/submission/__tests__/api.test.ts
+++ b/server/submission/__tests__/api.test.ts
@@ -164,10 +164,7 @@ it('does not allow normal users to delete a submission', async () => {
 		title: 'incomplete',
 	});
 	const agent = await login(guest);
-	await agent
-		.delete('/api/submissions')
-		.send({ id: submission.id })
-		.expect(403);
+	await agent.delete('/api/submissions').send({ id: submission.id }).expect(403);
 	const submissionNow = await Submission.findOne({ where: { id: submission.id } });
 	expect(submissionNow.id).toEqual(submission.id);
 });

--- a/server/submission/api.ts
+++ b/server/submission/api.ts
@@ -7,10 +7,10 @@ import { createSubmission, updateSubmission, destroySubmission } from './queries
 const getRequestIds = (req) => {
 	const user = req.user || {};
 	return {
+		id: req.body.id || null,
 		userId: user.id,
 		communityId: req.body.communityId,
 		collectionId: req.body.collectionId,
-		submissionId: req.body.submissionId || null,
 	};
 };
 
@@ -49,6 +49,6 @@ app.delete(
 			throw new ForbiddenError();
 		}
 		await destroySubmission(req.body);
-		return res.status(200).json(req.body.submissionId);
+		return res.status(200).json(req.body.id);
 	}),
 );

--- a/server/submission/api.ts
+++ b/server/submission/api.ts
@@ -1,0 +1,54 @@
+import app, { wrap } from 'server/server';
+import { ForbiddenError } from 'server/utils/errors';
+
+import { getPermissions } from './permissions';
+import { createSubmission, updateSubmission, destroySubmission } from './queries';
+
+const getRequestIds = (req) => {
+	const user = req.user || {};
+	return {
+		userId: user.id,
+		communityId: req.body.communityId,
+		collectionId: req.body.collectionId,
+		submissionId: req.body.submissionId || null,
+	};
+};
+
+app.post(
+	'/api/submissions',
+	wrap(async (req, res) => {
+		const ids = getRequestIds(req);
+		const permissions = await getPermissions(ids);
+		if (!permissions.create) {
+			throw new ForbiddenError();
+		}
+		const newSubmission = await createSubmission(req.body, req.user.id);
+		return res.status(201).json(newSubmission);
+	}),
+);
+
+app.put(
+	'/api/submissions',
+	wrap(async (req, res) => {
+		const ids = getRequestIds(req);
+		const permissions = await getPermissions(ids);
+		if (!permissions.update) {
+			throw new ForbiddenError();
+		}
+		const updatedValues = await updateSubmission(req.body, permissions.update, req.user.id);
+		return res.status(201).json(updatedValues);
+	}),
+);
+
+app.delete(
+	'/api/submissions',
+	wrap(async (req, res) => {
+		const ids = getRequestIds(req);
+		const permissions = await getPermissions(ids);
+		if (!permissions.update) {
+			throw new ForbiddenError();
+		}
+		await destroySubmission(req.body, req.user.id);
+		return res.status(201).json(req.body.submissionId);
+	}),
+);

--- a/server/submission/api.ts
+++ b/server/submission/api.ts
@@ -32,7 +32,7 @@ app.put(
 	wrap(async (req, res) => {
 		const ids = getRequestIds(req);
 		const { status } = req.body;
-		if (!canUpdate({ ...ids, status })) {
+		if (!(await canUpdate({ ...ids, status }))) {
 			throw new ForbiddenError();
 		}
 		const updatedValues = await updateSubmission(req.body);
@@ -45,10 +45,10 @@ app.delete(
 	wrap(async (req, res) => {
 		const ids = getRequestIds(req);
 		const permissions = await getPermissions(ids);
-		if (!permissions.update) {
+		if (!permissions.destroy) {
 			throw new ForbiddenError();
 		}
 		await destroySubmission(req.body);
-		return res.status(201).json(req.body.submissionId);
+		return res.status(200).json(req.body.submissionId);
 	}),
 );

--- a/server/submission/model.ts
+++ b/server/submission/model.ts
@@ -4,7 +4,7 @@ export default (sequelize, dataTypes) => {
 		{
 			id: sequelize.idType,
 			status: {
-				type: dataTypes.ENUM('incomplete', 'submitted', 'accepted', 'declined'),
+				type: dataTypes.TEXT,
 				allowNull: false,
 			},
 			/* Set by Associations */

--- a/server/submission/model.ts
+++ b/server/submission/model.ts
@@ -1,0 +1,26 @@
+export default (sequelize, dataTypes) => {
+	return sequelize.define(
+		'Submission',
+		{
+			id: sequelize.idType,
+			status: {
+				type: dataTypes.ENUM('incomplete', 'submitted', 'accepted', 'declined'),
+				allowNull: false,
+			},
+			/* Set by Associations */
+			pubId: { type: dataTypes.UUID, allowNull: false },
+		},
+		{
+			classMethods: {
+				associate: (models) => {
+					const { Submission, Pub } = models;
+					Submission.belongsTo(Pub, {
+						onDelete: 'CASCADE',
+						as: 'submission',
+						foreignKey: 'pubId',
+					});
+				},
+			},
+		},
+	);
+};

--- a/server/submission/permissions.ts
+++ b/server/submission/permissions.ts
@@ -1,12 +1,11 @@
 import { Submission } from 'server/models';
 import { getScope } from 'server/utils/queryHelpers';
 
-export const getPermissions = async ({ userId, communityId, submissionId, collectionId }) => {
+export const getPermissions = async ({ userId, submissionId, collectionId }) => {
 	if (!userId) {
 		return {};
 	}
 	const scopeData = await getScope({
-		communityId,
 		collectionId,
 		loginId: userId,
 	});

--- a/server/submission/permissions.ts
+++ b/server/submission/permissions.ts
@@ -1,0 +1,25 @@
+import { Submission } from 'server/models';
+import { getScope } from 'server/utils/queryHelpers';
+
+export const getPermissions = async ({ userId, communityId, submissionId, collectionId }) => {
+	if (!userId) {
+		return {};
+	}
+	const scopeData = await getScope({
+		communityId,
+		collectionId,
+		loginId: userId,
+	});
+	const isAuthenticated = scopeData.activePermissions.canManage;
+	const submissionData = await Submission.findOne({ where: { id: submissionId } });
+
+	if (!submissionData) {
+		return { create: isAuthenticated };
+	}
+	const editProps = ['status'];
+	return {
+		create: isAuthenticated,
+		update: isAuthenticated && editProps,
+		destroy: isAuthenticated,
+	};
+};

--- a/server/submission/permissions.ts
+++ b/server/submission/permissions.ts
@@ -1,5 +1,6 @@
 import { Submission } from 'server/models';
 import { getScope } from 'server/utils/queryHelpers';
+import { initialStatuses, managerStatuses, submitterStatuses } from 'types';
 
 export const getPermissions = async ({ userId, submissionId, collectionId }) => {
 	if (!userId) {
@@ -17,8 +18,24 @@ export const getPermissions = async ({ userId, submissionId, collectionId }) => 
 	}
 	const editProps = ['status'];
 	return {
+		setSubmittedStatus: true,
+		manageStatus: true,
 		create: isAuthenticated,
 		update: isAuthenticated && editProps,
 		destroy: isAuthenticated,
 	};
+};
+
+export const canUpdate = async ({ userId, collectionId, status, submissionId }) => {
+	const { status: oldStatus, pubId } = await Submission.findOne({ where: { id: submissionId } });
+	const {
+		activePermissions: { canManage: canManagePub },
+	} = await getScope({ pubId, loginId: userId });
+	const {
+		activePermissions: { canManage: canManageCollection },
+	} = await getScope({ collectionId, loginId: userId });
+	return (
+		(canManagePub && status in submitterStatuses && oldStatus in initialStatuses) ||
+		(canManageCollection && status in managerStatuses)
+	);
 };

--- a/server/submission/permissions.ts
+++ b/server/submission/permissions.ts
@@ -2,7 +2,7 @@ import { Submission } from 'server/models';
 import { getScope } from 'server/utils/queryHelpers';
 import { initialStatuses, managerStatuses, submitterStatuses } from 'types';
 
-export const getPermissions = async ({ userId, submissionId, collectionId, communityId }) => {
+export const getPermissions = async ({ userId, id, collectionId, communityId }) => {
 	if (!userId) {
 		return {};
 	}
@@ -12,7 +12,7 @@ export const getPermissions = async ({ userId, submissionId, collectionId, commu
 		loginId: userId,
 	});
 	const isAuthenticated = scopeData.activePermissions.canManage;
-	const submissionData = await Submission.findOne({ where: { id: submissionId } });
+	const submissionData = await Submission.findOne({ where: { id } });
 
 	if (!submissionData) {
 		return { create: isAuthenticated };
@@ -26,8 +26,8 @@ export const getPermissions = async ({ userId, submissionId, collectionId, commu
 	};
 };
 
-export const canUpdate = async ({ userId, collectionId, status, submissionId }) => {
-	const { status: oldStatus, pubId } = await Submission.findOne({ where: { id: submissionId } });
+export const canUpdate = async ({ userId, collectionId, status, id }) => {
+	const { status: oldStatus, pubId } = await Submission.findOne({ where: { id } });
 	const {
 		activePermissions: { canManage },
 	} = await getScope({ pubId, loginId: userId, collectionId });

--- a/server/submission/permissions.ts
+++ b/server/submission/permissions.ts
@@ -17,21 +17,23 @@ export const getPermissions = async ({ userId, submissionId, collectionId, commu
 	if (!submissionData) {
 		return { create: isAuthenticated };
 	}
-	const editProps = ['status'];
 	return {
 		setSubmittedStatus: true,
 		manageStatus: true,
 		create: isAuthenticated,
-		update: isAuthenticated && editProps,
+		update: isAuthenticated,
 		destroy: isAuthenticated,
 	};
 };
 
 export const canUpdate = async ({ userId, collectionId, status, submissionId }) => {
 	const { status: oldStatus, pubId } = await Submission.findOne({ where: { id: submissionId } });
-	const { activePermissions } = await getScope({ pubId, loginId: userId, collectionId });
-	const { canManage } = activePermissions;
-	const canSubmitPub = canManage && status in submitterStatuses && oldStatus in initialStatuses;
-	const canManagePub = canManage && status in managerStatuses;
+	const {
+		activePermissions: { canManage },
+	} = await getScope({ pubId, loginId: userId, collectionId });
+	const canSubmitPub =
+		canManage && submitterStatuses.includes(status) && initialStatuses.includes(oldStatus);
+	const canManagePub =
+		canManage && managerStatuses.includes(status) && !initialStatuses.includes(oldStatus);
 	return canSubmitPub || canManagePub;
 };

--- a/server/submission/queries.ts
+++ b/server/submission/queries.ts
@@ -1,9 +1,11 @@
 import { Submission } from 'server/models';
-import { managerStatuses, submitterStatuses } from 'types';
+import { Submission as SubmissionType, managerStatuses, submitterStatuses } from 'types';
 
 const updateToStatuses = [...managerStatuses, ...submitterStatuses] as const;
 
 type UpdateToStatus = typeof updateToStatuses;
+
+type PatchType = Partial<SubmissionType> & { status: UpdateToStatus };
 
 export const createSubmission = async ({ pubId }) =>
 	Submission.create({
@@ -11,23 +13,15 @@ export const createSubmission = async ({ pubId }) =>
 		status: 'incomplete',
 	});
 
-export const updateSubmission = async ({
-	status,
-	submissionId,
-}: {
-	status: UpdateToStatus;
-	submissionId: string;
-}) =>
+export const updateSubmission = async (patch: PatchType) =>
 	Submission.update(
-		{ status },
+		{ status: patch.status },
 		{
-			where: { id: submissionId },
+			where: { id: patch.id },
 		},
 	);
 
-export const destroySubmission = async ({ submissionId }: { submissionId: string }) =>
+export const destroySubmission = async ({ id }: { id: string }) =>
 	Submission.destroy({
-		where: {
-			id: submissionId,
-		},
+		where: { id },
 	});

--- a/server/submission/queries.ts
+++ b/server/submission/queries.ts
@@ -1,20 +1,22 @@
 import { Submission } from 'server/models';
 
-export const createSubmission = async (inputValues) =>
+export const createSubmission = async ({ pubId, status }) =>
 	Submission.create({
-		pubId: inputValues.pubId,
-		status: inputValues.status,
+		pubId,
+		status,
 	});
 
-export const updateSubmission = async (inputValues) =>
-	Submission.update(inputValues, {
-		where: { id: inputValues.submissionId },
-	});
+export const updateSubmission = async ({ status, submissionId }) =>
+	Submission.update(
+		{ status },
+		{
+			where: { id: submissionId },
+		},
+	);
 
-export const destroySubmission = (inputValues) =>
+export const destroySubmission = async ({ submissionId }) =>
 	Submission.destroy({
 		where: {
-			id: inputValues.submissionId,
-			pubId: inputValues.pubId,
+			id: submissionId,
 		},
 	});

--- a/server/submission/queries.ts
+++ b/server/submission/queries.ts
@@ -1,0 +1,34 @@
+import { Submission } from 'server/models';
+
+export const createSubmission = async (inputValues, actorId = null) =>
+	Submission.create(
+		{
+			pubId: inputValues.pubId,
+			status: inputValues.status,
+		},
+		{ actorId },
+	);
+
+export const updateSubmission = async (inputValues, updatePermissions, actorId = null) => {
+	const filteredValues: Record<string, any> = {};
+	Object.keys(inputValues).forEach((key) => {
+		if (updatePermissions.includes(key)) {
+			filteredValues[key] = inputValues[key];
+		}
+	});
+	return Submission.update(filteredValues, {
+		where: { id: inputValues.submissionId },
+		actorId,
+		individualHooks: true,
+	}).then(() => filteredValues);
+};
+
+export const destroySubmission = (inputValues, actorId = null) =>
+	Submission.destroy({
+		where: {
+			id: inputValues.submissionId,
+			pubId: inputValues.pubId,
+		},
+		actorId,
+		individualHooks: true,
+	});

--- a/server/submission/queries.ts
+++ b/server/submission/queries.ts
@@ -1,34 +1,20 @@
 import { Submission } from 'server/models';
 
-export const createSubmission = async (inputValues, actorId = null) =>
-	Submission.create(
-		{
-			pubId: inputValues.pubId,
-			status: inputValues.status,
-		},
-		{ actorId },
-	);
-
-export const updateSubmission = async (inputValues, updatePermissions, actorId = null) => {
-	const filteredValues: Record<string, any> = {};
-	Object.keys(inputValues).forEach((key) => {
-		if (updatePermissions.includes(key)) {
-			filteredValues[key] = inputValues[key];
-		}
+export const createSubmission = async (inputValues) =>
+	Submission.create({
+		pubId: inputValues.pubId,
+		status: inputValues.status,
 	});
-	return Submission.update(filteredValues, {
-		where: { id: inputValues.submissionId },
-		actorId,
-		individualHooks: true,
-	}).then(() => filteredValues);
-};
 
-export const destroySubmission = (inputValues, actorId = null) =>
+export const updateSubmission = async (inputValues) =>
+	Submission.update(inputValues, {
+		where: { id: inputValues.submissionId },
+	});
+
+export const destroySubmission = (inputValues) =>
 	Submission.destroy({
 		where: {
 			id: inputValues.submissionId,
 			pubId: inputValues.pubId,
 		},
-		actorId,
-		individualHooks: true,
 	});

--- a/server/submission/queries.ts
+++ b/server/submission/queries.ts
@@ -1,12 +1,23 @@
 import { Submission } from 'server/models';
+import { managerStatuses, submitterStatuses } from 'types';
 
-export const createSubmission = async ({ pubId, status }) =>
+const updateToStatuses = [...managerStatuses, ...submitterStatuses] as const;
+
+type UpdateToStatus = typeof updateToStatuses;
+
+export const createSubmission = async ({ pubId }) =>
 	Submission.create({
 		pubId,
-		status,
+		status: 'incomplete',
 	});
 
-export const updateSubmission = async ({ status, submissionId }) =>
+export const updateSubmission = async ({
+	status,
+	submissionId,
+}: {
+	status: UpdateToStatus;
+	submissionId: string;
+}) =>
 	Submission.update(
 		{ status },
 		{
@@ -14,7 +25,7 @@ export const updateSubmission = async ({ status, submissionId }) =>
 		},
 	);
 
-export const destroySubmission = async ({ submissionId }) =>
+export const destroySubmission = async ({ submissionId }: { submissionId: string }) =>
 	Submission.destroy({
 		where: {
 			id: submissionId,

--- a/types/index.ts
+++ b/types/index.ts
@@ -15,6 +15,7 @@ export * from './request';
 export * from './review';
 export * from './scope';
 export * from './sequelize';
+export * from './submission';
 export * from './slug';
 export * from './thread';
 export * from './userSubscription';

--- a/types/submission.ts
+++ b/types/submission.ts
@@ -1,0 +1,6 @@
+export type SubmissionStatus = 'incomplete' | 'submitted' | 'accepted' | 'declined';
+
+export type Submission = {
+	id: string;
+	status: SubmissionStatus;
+};

--- a/types/submission.ts
+++ b/types/submission.ts
@@ -1,6 +1,14 @@
-export type SubmissionStatus = 'incomplete' | 'submitted' | 'accepted' | 'declined';
+export const managerStatuses = ['submitted', 'accepted', 'declined'] as const;
+export const submitterStatuses = ['submitted'] as const;
+export const initialStatuses = ['incomplete'] as const;
+
+export const submissionStatuses = [
+	...initialStatuses,
+	...managerStatuses,
+	...submitterStatuses,
+] as const;
 
 export type Submission = {
 	id: string;
-	status: SubmissionStatus;
+	status: typeof submissionStatuses;
 };

--- a/utils/pub/pubDates.ts
+++ b/utils/pub/pubDates.ts
@@ -83,6 +83,5 @@ export const getPubCopyrightYear = (
 		}
 	}
 	const pubPublishedDate = getPubPublishedDate(pub);
-	// dateFormat defaults to today's date if its first argument is null
-	return dateFormat(pubPublishedDate, 'yyyy');
+	return pubPublishedDate ? dateFormat(pubPublishedDate, 'yyyy') : dateFormat('yyyy');
 };


### PR DESCRIPTION
implements #1612 

Testing via API tests.
Largely boilerplate.

Question this raises: are we only ever interacting with `Submissions` directly when we are changing their statuses? For creation/deletion, that would only occur when the `Spub` is created/deleted, yes? So operations on `Submissions` then are typically side-effect like?