### PR TITLE
fix: Restore anchored discussion text on Pub bottom

### DIFF
--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/Discussion.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/Discussion.tsx
@@ -6,6 +6,7 @@ import { Icon } from 'components';
 import { apiFetch } from 'client/utils/apiFetch';
 import { usePageContext } from 'utils/hooks';
 
+import { PubPageData, PubPageDiscussion } from 'types';
 import { discussionMatchesSearchTerm } from '../discussionUtils';
 import DiscussionInput from './DiscussionInput';
 import LabelList from './LabelList';
@@ -14,23 +15,17 @@ import ThreadComment from './ThreadComment';
 
 require('./discussion.scss');
 
-type ThreadCommentType = {
-	createdAt: string;
-	id: string;
-	author: {
-		lastName: string;
-	};
-};
+type PubPageThreadComment = PubPageDiscussion['thread']['comments'][number];
 
 type Props = {
-	pubData: any;
-	discussionData: any;
-	updateLocalData: (...args: any[]) => any;
+	pubData: PubPageData;
+	discussionData: PubPageDiscussion;
+	updateLocalData: (kind: string, patch: any) => unknown;
 	canPreview?: boolean;
 	searchTerm?: string;
 };
 
-const sortThreadComments = (threadComments: ThreadCommentType[], sortType: SortType) => {
+const sortThreadComments = (threadComments: PubPageThreadComment[], sortType: SortType) => {
 	if (sortType === 'alphabetical') {
 		return threadComments
 			.concat()

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/Discussion.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/Discussion.tsx
@@ -126,16 +126,19 @@ const Discussion = (props: Props) => {
 	};
 
 	const renderAnchorText = () => {
-		const { anchor } = discussionData;
-		if (anchor) {
-			const { prefix, suffix, exact } = anchor;
-			return (
-				<div className="anchor-text">
-					{prefix}
-					<span className="exact">{exact}</span>
-					{suffix}
-				</div>
-			);
+		const { anchors } = discussionData;
+		if (anchors) {
+			const [firstAnchor] = anchors.sort((a, b) => a.historyKey - b.historyKey);
+			if (firstAnchor) {
+				const { originalTextPrefix, originalText, originalTextSuffix } = firstAnchor;
+				return (
+					<div className="anchor-text">
+						{originalTextPrefix}
+						<span className="exact">{originalText}</span>
+						{originalTextSuffix}
+					</div>
+				);
+			}
 		}
 		return null;
 	};

--- a/types/pub.ts
+++ b/types/pub.ts
@@ -10,6 +10,7 @@ import { Member } from './member';
 import { Review } from './review';
 import { InboundEdge, OutboundEdge } from './pubEdge';
 import { ScopeSummary } from './scope';
+import { ThreadComment, Thread } from './thread';
 import { DefinitelyHas, Maybe } from './util';
 
 export type Draft = {
@@ -72,7 +73,7 @@ export type Pub = {
 	lastPublishedAt?: string;
 	customPublishedAt?: string;
 	doi: null | string;
-	labels?: string;
+	labels?: string[];
 	downloads?: any[];
 	metadata?: {};
 	licenseSlug?: string;
@@ -113,9 +114,18 @@ export type PubDocInfo = {
 	};
 };
 
-export type PubPageData = DefinitelyHas<Pub, 'attributions' | 'collectionPubs'> &
+export type PubPageDiscussion = DefinitelyHas<Discussion, 'anchors'> & {
+	thread: Thread & {
+		comments: DefinitelyHas<ThreadComment, 'author'>[];
+	};
+};
+
+export type PubPageData = DefinitelyHas<
+	Omit<Pub, 'discussions'>,
+	'attributions' | 'collectionPubs'
+> &
 	PubDocInfo & {
-		discussions: DefinitelyHas<Discussion, 'anchors' | 'thread'>[];
+		discussions: PubPageDiscussion[];
 		viewHash: Maybe<string>;
 		editHash: Maybe<string>;
 		isReadOnly: boolean;

--- a/types/thread.ts
+++ b/types/thread.ts
@@ -1,18 +1,22 @@
+import { User } from './attribution';
 import { Discussion } from './discussion';
 import { Review } from './review';
 
 export type ThreadComment = {
 	id: string;
+	createdAt: string;
+	updatedAt: string;
 	text: string;
 	content: {};
 	userId: string;
 	threadId: string;
+	author?: User;
 };
 
 export type Thread = {
 	id: string;
-	updatedAt: string;
 	createdAt: string;
+	updatedAt: string;
 	locked?: boolean;
 	comments: ThreadComment[];
 };


### PR DESCRIPTION
Resolves #1655 

When displaying anchored Pub discussions at the bottom of a Pub, we used to show a helpful box with the anchor text to provide context for the discussion. That probably disappeared during our discussion refactor last year, but now it's back!

![image](https://user-images.githubusercontent.com/2208769/141150430-2a25bcaf-ea15-4a32-ae0d-c6ae59a2f716.png)

_Test plan:_
- Visit the draft of a Pub and make an anchored comment
- Check the discussions section at the bottom of the Pub and make sure the highlighted text appears alongside it.