### PR TITLE
fix: Always show correct 'calendar date' for Collection metadata

### DIFF
--- a/client/components/Layout/LayoutCollectionHeader.tsx
+++ b/client/components/Layout/LayoutCollectionHeader.tsx
@@ -41,7 +41,7 @@ const MetadataDetails = (props: Props) => {
 				const data = metadata[name];
 				const isField = hiddenMetadataFields.includes(name);
 				const formattedData = formattedMetadata(name, data);
-				return <>{data && !isField && <div> {formattedData}</div>}</>;
+				return <>{data && !isField && <div>{formattedData}</div>}</>;
 			})}
 		</>
 	);

--- a/client/components/Layout/LayoutCollectionHeader.tsx
+++ b/client/components/Layout/LayoutCollectionHeader.tsx
@@ -39,9 +39,12 @@ const MetadataDetails = (props: Props) => {
 			{fields.map((field) => {
 				const name = field.name;
 				const data = metadata[name];
-				const isField = hiddenMetadataFields.includes(name);
-				const formattedData = formattedMetadata(name, data);
-				return <>{data && !isField && <div>{formattedData}</div>}</>;
+				const isShown = !hiddenMetadataFields.includes(name);
+				const formattedData = isShown && data && formattedMetadata(name, data);
+				if (formattedData) {
+					return <div>{formattedData}</div>;
+				}
+				return null;
 			})}
 		</>
 	);

--- a/utils/collections/getMetadata.ts
+++ b/utils/collections/getMetadata.ts
@@ -1,32 +1,40 @@
 import { Collection } from 'types';
 import { getSchemaForKind } from 'utils/collections/schemas';
-import { formatDate, getLocalDateMatchingUtcCalendarDate } from 'utils/dates';
+import { formatDate, getLocalDateMatchingUtcCalendarDate, isValidDate } from 'utils/dates';
 
 export const getOrderedCollectionMetadataFields = (collection: Collection) => {
 	return getSchemaForKind(collection.kind)!.metadata;
 };
 
-const formatCalendarDate = (date: any) => {
-	return formatDate(getLocalDateMatchingUtcCalendarDate(date));
+const formatCalendarDate = (value: any, prefix: string) => {
+	const date = new Date(value);
+	if (isValidDate(date)) {
+		const localDate = getLocalDateMatchingUtcCalendarDate(date);
+		if (isValidDate(localDate)) {
+			const localDateString = formatDate(localDate);
+			return `${prefix}${localDateString}`;
+		}
+	}
+	return null;
 };
 
-export const formattedMetadata = (field: any, data: any) => {
-	if (field === 'printIssn') return `ISSN: ${data}`;
-	if (field === 'electronicIssn') return `e-ISSN: ${data}`;
-	if (field === 'volume') return `Volume ${data}`;
-	if (field === 'issue') return `Issue ${data}`;
-	if (field === 'printPublicationDate') return `Printed ${formatCalendarDate(data)}`;
+export const formattedMetadata = (field: string, value: string) => {
+	if (field === 'printIssn') return `ISSN: ${value}`;
+	if (field === 'electronicIssn') return `e-ISSN: ${value}`;
+	if (field === 'volume') return `Volume ${value}`;
+	if (field === 'issue') return `Issue ${value}`;
+	if (field === 'printPublicationDate') return formatCalendarDate(value, 'Printed ');
 
-	if (field === 'publicationDate') return `Published ${formatCalendarDate(data)}`;
+	if (field === 'publicationDate') return formatCalendarDate(value, 'Published ');
 
-	if (field === 'isbn') return `ISBN: ${data}`;
-	if (field === 'copyrightYear') return `Copyright © ${data}`;
-	if (field === 'edition') return `${data} ed.`;
+	if (field === 'isbn') return `ISBN: ${value}`;
+	if (field === 'copyrightYear') return `Copyright © ${value}`;
+	if (field === 'edition') return `${value} ed.`;
 
-	if (field === 'theme') return `${data}`;
-	if (field === 'acronym') return ` ${data}`;
-	if (field === 'location') return `${data}`;
-	if (field === 'date') return `${formatCalendarDate(data)}`;
+	if (field === 'theme') return `${value}`;
+	if (field === 'acronym') return ` ${value}`;
+	if (field === 'location') return `${value}`;
+	if (field === 'date') return formatCalendarDate(value, '');
 
-	return data;
+	return value;
 };

--- a/utils/collections/getMetadata.ts
+++ b/utils/collections/getMetadata.ts
@@ -1,9 +1,13 @@
 import { Collection } from 'types';
 import { getSchemaForKind } from 'utils/collections/schemas';
-import { formatDate } from 'utils/dates';
+import { formatDate, getLocalDateMatchingUtcCalendarDate } from 'utils/dates';
 
 export const getOrderedCollectionMetadataFields = (collection: Collection) => {
 	return getSchemaForKind(collection.kind)!.metadata;
+};
+
+const formatCalendarDate = (date: any) => {
+	return formatDate(getLocalDateMatchingUtcCalendarDate(date));
 };
 
 export const formattedMetadata = (field: any, data: any) => {
@@ -11,9 +15,9 @@ export const formattedMetadata = (field: any, data: any) => {
 	if (field === 'electronicIssn') return `e-ISSN: ${data}`;
 	if (field === 'volume') return `Volume ${data}`;
 	if (field === 'issue') return `Issue ${data}`;
-	if (field === 'printPublicationDate') return `Printed ${formatDate(data)}`;
+	if (field === 'printPublicationDate') return `Printed ${formatCalendarDate(data)}`;
 
-	if (field === 'publicationDate') return `Published ${formatDate(data)}`;
+	if (field === 'publicationDate') return `Published ${formatCalendarDate(data)}`;
 
 	if (field === 'isbn') return `ISBN: ${data}`;
 	if (field === 'copyrightYear') return `Copyright © ${data}`;
@@ -22,7 +26,7 @@ export const formattedMetadata = (field: any, data: any) => {
 	if (field === 'theme') return `${data}`;
 	if (field === 'acronym') return ` ${data}`;
 	if (field === 'location') return `${data}`;
-	if (field === 'date') return `${formatDate(data)}`;
+	if (field === 'date') return `${formatCalendarDate(data)}`;
 
 	return data;
 };

--- a/utils/dates.ts
+++ b/utils/dates.ts
@@ -55,3 +55,5 @@ export const getReadableDateInYear = (date: Date) => {
 	const dateInMonth = date.getDate();
 	return `${month} ${dateInMonth}`;
 };
+
+export const isValidDate = (date: Date) => !Number.isNaN(date.getTime());

--- a/workers/tasks/import/metadata.ts
+++ b/workers/tasks/import/metadata.ts
@@ -1,8 +1,8 @@
 import unidecode from 'unidecode';
-
 import { metaValueToString, metaValueToJsonSerializable } from '@pubpub/prosemirror-pandoc';
 
 import { getSearchUsers } from 'server/search/queries';
+import { isValidDate } from 'utils/dates';
 
 const getAuthorsArray = (author) => {
 	if (author.type === 'MetaList') {
@@ -16,7 +16,7 @@ const getAuthorsArray = (author) => {
 
 const getDateStringFromMetaValue = (metaDateString) => {
 	const date = new Date(metaValueToString(metaDateString));
-	if (!Number.isNaN(date.getTime())) {
+	if (isValidDate(date)) {
 		return date.toUTCString();
 	}
 	return null;


### PR DESCRIPTION
Resolves #1642

Quick one to make sure Collection metadata dates in a Collection Header block are always shown as the inputted date, even though they have UTC complications.

_Test plan:_
Set a Collection metadata field that's a date to `2021-11-04` and make sure that same date renders in the Collection Header block in its Layout.