### PR TITLE
update: Changes to SubmissionWorkflow model in response to design

### DIFF
--- a/client/containers/DashboardSubmissions/NewSubmissionWorkflowEditor.tsx
+++ b/client/containers/DashboardSubmissions/NewSubmissionWorkflowEditor.tsx
@@ -11,14 +11,12 @@ import StartWorkflowCallout from './StartWorkflowCallout';
 
 const createEmptyWorkflow = (): EditableSubmissionWorkflow => {
 	return {
+		title: '',
+		introText: getEmptyDoc(),
 		instructionsText: getEmptyDoc(),
 		emailText: getEmptyDoc(),
 		targetEmailAddress: '',
 		enabled: false,
-		layoutBlockContent: {
-			title: '',
-			body: getEmptyDoc(),
-		},
 	};
 };
 

--- a/client/containers/DashboardSubmissions/SubmissionWorkflowEditor.tsx
+++ b/client/containers/DashboardSubmissions/SubmissionWorkflowEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button, EditableText, InputGroup } from '@blueprintjs/core';
 
-import { Collection, SubmissionWorkflow } from 'types';
+import { Collection } from 'types';
 import { LayoutSubmissionBannerSkeleton } from 'client/components/Layout';
 import { usePageContext } from 'utils/hooks';
 import { isValidEmail } from 'utils/email';
@@ -16,8 +16,8 @@ import {
 	RecordValidator,
 	isValidDocJson,
 	isAlwaysValid,
-	isValidBannerContent,
 	validate,
+	isValidTitle,
 } from './validators';
 
 require('./submissionWorkflowEditor.scss');
@@ -30,18 +30,18 @@ type Props = {
 };
 
 const validator: RecordValidator<EditableSubmissionWorkflow> = {
+	title: isValidTitle,
+	introText: isValidDocJson,
 	instructionsText: isValidDocJson,
 	emailText: isValidDocJson,
 	targetEmailAddress: isValidEmail,
 	enabled: isAlwaysValid,
-	layoutBlockContent: isValidBannerContent,
 };
 
 const SubmissionWorkflowEditor = (props: Props) => {
 	const { collection, onUpdateWorkflow, renderCompletionButton, workflow } = props;
 	const { communityData } = usePageContext();
 	const { email: communityEmail } = communityData;
-	const { layoutBlockContent } = workflow;
 	const [{ fields: fieldValidStates, isValid }, setValidation] = useState(() =>
 		validate(workflow, validator),
 	);
@@ -59,17 +59,13 @@ const SubmissionWorkflowEditor = (props: Props) => {
 		onUpdateWorkflow(nextWorkflow);
 	};
 
-	const updateBannerContent = (update: Partial<SubmissionWorkflow['layoutBlockContent']>) => {
-		updateWorkflow({ layoutBlockContent: { ...layoutBlockContent, ...update } });
-	};
-
 	return (
 		<div className="submission-workflow-editor-component">
 			<Step
 				className="banner-step"
 				number={1}
 				title="Invite submitters from this Collection's landing page"
-				done={fieldValidStates.layoutBlockContent}
+				done={fieldValidStates.title && fieldValidStates.introText}
 			>
 				<p>
 					Visitors to {collectionLink} will see a banner inviting them to submit to this
@@ -81,15 +77,15 @@ const SubmissionWorkflowEditor = (props: Props) => {
 						<EditableText
 							className="banner-title-text"
 							placeholder="Click to add banner title"
-							value={layoutBlockContent.title}
-							onChange={(title) => updateBannerContent({ title })}
+							value={workflow.title}
+							onChange={(title) => updateWorkflow({ title })}
 						/>
 					}
 					content={
 						<WorkflowTextEditor
 							placeholder="Banner content"
-							initialContent={layoutBlockContent.body}
-							onContent={(body) => updateBannerContent({ body })}
+							initialContent={workflow.introText}
+							onContent={(introText) => updateWorkflow({ introText })}
 						/>
 					}
 				/>

--- a/client/containers/DashboardSubmissions/validators.ts
+++ b/client/containers/DashboardSubmissions/validators.ts
@@ -1,5 +1,4 @@
 import { DocJson } from 'types';
-import { LayoutBlockSubmissionBanner } from 'utils/layout';
 
 type AnyRecord = Record<string, any>;
 
@@ -16,13 +15,10 @@ export type ValidationResult<Rec extends AnyRecord> = {
 	fields: ValidatedFields<Rec>;
 };
 
+export const isValidTitle = (title: string) => title.length > 0;
+
 export const isValidDocJson = (docJson: DocJson) => {
 	return docJson.content.some((child) => child.content?.length > 0);
-};
-
-export const isValidBannerContent = (block: LayoutBlockSubmissionBanner['content']) => {
-	const { title, body } = block;
-	return title.length > 0 && isValidDocJson(body);
 };
 
 export const isAlwaysValid = () => true;

--- a/server/submissionWorkflow/__tests__/api.test.ts
+++ b/server/submissionWorkflow/__tests__/api.test.ts
@@ -1,6 +1,8 @@
 /* global it, expect, beforeAll, afterAll */
 import { setup, teardown, login, modelize } from 'stubstub';
-import { SubmissionWorkflow } from '../../models';
+
+import { getEmptyDoc } from 'client/components/Editor';
+import { SubmissionWorkflow } from 'server/models';
 
 const models = modelize`
 	Community {
@@ -8,7 +10,6 @@ const models = modelize`
 			permissions: "admin"
 			User admin {}
 		}
-
 		Member {
 			permissions: "view"
 			User collectionMember {}
@@ -18,9 +19,12 @@ const models = modelize`
 			User collectionManager {}
 		}
 		Collection collection {
-
-			SubmissionWorkflow submissionWorkflow {enabled: false}
-			SubmissionWorkflow destroyThisSubmissionWorkflow {enabled: false}
+			SubmissionWorkflow submissionWorkflow {
+				title: "Submit to me"
+			}
+			SubmissionWorkflow destroyThisSubmissionWorkflow {
+				title: "Destroy me"
+			}
 		}
 	}
 	Community {
@@ -35,6 +39,15 @@ const models = modelize`
 
 `;
 
+const sharedCreationValues = {
+	instructionsText: getEmptyDoc(),
+	emailText: getEmptyDoc(),
+	introText: getEmptyDoc(),
+	title: 'Journal of Accepting Submissions',
+	targetEmailAddress: 'finnandjakeforwvwer@adventuretime.com',
+	enabled: false,
+};
+
 setup(beforeAll, async () => {
 	await models.resolve();
 });
@@ -47,14 +60,13 @@ it('allows a Community manager to create a new submission workflow', async () =>
 	} = await agent
 		.post('/api/submissionWorkflows')
 		.send({
+			...sharedCreationValues,
 			collectionId: collection.id,
-			enabled: true,
-			targetEmailAddress: 'finnandjakeforwvwer@adventuretime.com',
 		})
 		.expect(201);
 
 	expect(collectionId).toEqual(collection.id);
-	expect(enabled).toEqual(true);
+	expect(enabled).toEqual(false);
 	expect(targetEmailAddress).toEqual('finnandjakeforwvwer@adventuretime.com');
 });
 
@@ -64,10 +76,8 @@ it('forbids a different Community manager from creating a new submission workflo
 	await agent
 		.post('/api/submissionWorkflows')
 		.send({
+			...sharedCreationValues,
 			collectionId: collection.id,
-
-			enabled: true,
-			targetEmailAddress: 'finnandjakeforwvwer@adventuretime.com',
 		})
 		.expect(403);
 });
@@ -78,10 +88,8 @@ it('forbids a random user from creating a submission workflow', async () => {
 	await agent
 		.post('/api/submissionWorkflows')
 		.send({
+			...sharedCreationValues,
 			collectionId: collection.id,
-
-			enabled: true,
-			targetEmailAddress: 'finnandjakeforwvwer@adventuretime.com',
 		})
 		.expect(403);
 
@@ -89,10 +97,8 @@ it('forbids a random user from creating a submission workflow', async () => {
 	await anotherAgent
 		.post('/api/submissionWorkflows')
 		.send({
+			...sharedCreationValues,
 			collectionId: collection.id,
-
-			enabled: true,
-			targetEmailAddress: 'finnandjakeforwvwer@adventuretime.com',
 		})
 		.expect(403);
 });
@@ -103,10 +109,8 @@ it('forbids a non mananger from creating a submission workflow', async () => {
 	await agent
 		.post('/api/submissionWorkflows')
 		.send({
+			...sharedCreationValues,
 			collectionId: collection.id,
-
-			enabled: true,
-			targetEmailAddress: 'finnandjakeforwvwer@adventuretime.com',
 		})
 		.expect(403);
 });
@@ -119,7 +123,6 @@ it('allows a Community manager to update an existing workflow', async () => {
 		.put('/api/submissionWorkflows')
 		.send({
 			collectionId: collection.id,
-
 			enabled,
 		})
 		.expect(200);

--- a/server/submissionWorkflow/model.ts
+++ b/server/submissionWorkflow/model.ts
@@ -3,11 +3,12 @@ export default (sequelize, dataTypes) => {
 		'SubmissionWorkflow',
 		{
 			id: sequelize.idType,
+			title: { type: dataTypes.TEXT, allowNull: false },
 			collectionId: { type: dataTypes.UUID, allowNull: false },
 			enabled: { type: dataTypes.BOOLEAN, allowNull: false },
 			instructionsText: { type: dataTypes.JSONB, allowNull: false },
 			emailText: { type: dataTypes.JSONB, allowNull: false },
-			layoutBlockContent: { type: dataTypes.JSONB, allowNull: false },
+			introText: { type: dataTypes.JSONB, allowNull: false },
 			targetEmailAddress: { type: dataTypes.STRING, allowNull: false },
 		},
 		{

--- a/server/submissionWorkflow/queries.ts
+++ b/server/submissionWorkflow/queries.ts
@@ -1,25 +1,26 @@
 import { SubmissionWorkflow } from 'server/models';
-import * as types from 'types';
 import { OmitSequelizeProvidedFields } from 'types/util';
+import * as types from 'types';
 
 type Props = OmitSequelizeProvidedFields<types.SubmissionWorkflow>;
-
 type Update = Partial<Props>;
 
 export const createSubmissionWorkflow = async (props: Props) => {
 	const {
 		collectionId,
 		enabled,
+		introText,
 		instructionsText,
 		emailText,
-		layoutBlockContent,
+		title,
 		targetEmailAddress,
 	} = props;
 	const submissionWorkflow = {
 		enabled,
 		instructionsText,
 		emailText,
-		layoutBlockContent,
+		introText,
+		title,
 		targetEmailAddress,
 		collectionId,
 	};
@@ -32,11 +33,19 @@ export const updateSubmissionWorkflow = async (update: Update) => {
 		enabled,
 		instructionsText,
 		emailText,
-		layoutBlockContent,
+		introText,
+		title,
 		targetEmailAddress,
 	} = update;
 	await SubmissionWorkflow.update(
-		{ enabled, instructionsText, emailText, targetEmailAddress, layoutBlockContent },
+		{
+			enabled,
+			instructionsText,
+			emailText,
+			targetEmailAddress,
+			introText,
+			title,
+		},
 		{ where: { collectionId } },
 	);
 };

--- a/stubstub/modelize/builders.js
+++ b/stubstub/modelize/builders.js
@@ -3,11 +3,12 @@ import SHA3 from 'crypto-js/sha3';
 import encHex from 'crypto-js/enc-hex';
 
 import { createCollectionPub } from 'server/collectionPub/queries';
-import { Community, Member, Release, User } from 'server/models';
+import { Community, Member, Release, SubmissionWorkflow, User } from 'server/models';
 import { createPub } from 'server/pub/queries';
 import { createCollection } from 'server/collection/queries';
 import { createDoc } from 'server/doc/queries';
 import { createPage } from 'server/page/queries';
+import { getEmptyDoc } from 'client/components/Editor';
 
 const builders = {};
 
@@ -109,5 +110,16 @@ builders.Release = async (args) => {
 };
 
 builders.CollectionPub = createCollectionPub;
+
+builders.SubmissionWorkflow = (args) => {
+	return SubmissionWorkflow.create({
+		enabled: false,
+		instructionsText: getEmptyDoc(),
+		introText: getEmptyDoc(),
+		emailText: getEmptyDoc(),
+		targetEmailAddress: 'something@somewhere.com',
+		...args,
+	});
+};
 
 export { builders };

--- a/types/submissonWorkflow.ts
+++ b/types/submissonWorkflow.ts
@@ -1,14 +1,15 @@
-import { DocJson } from 'types';
-import { LayoutBlockSubmissionBanner } from 'utils/layout';
+import { Collection, DocJson } from 'types';
 
 export type SubmissionWorkflow = {
 	id: string;
 	createdAt: string;
 	updatedAt: string;
 	enabled: boolean;
+	title: string;
+	introText: DocJson;
 	instructionsText: DocJson;
 	emailText: DocJson;
 	targetEmailAddress: string;
 	collectionId: string;
-	layoutBlockContent: LayoutBlockSubmissionBanner['content'];
+	collection?: Collection;
 };


### PR DESCRIPTION
After realizing that we want submission workflows to have a title independent of the Collection's title, I have broken the `layoutBlockContent` column of `SubmissionWorkflow` into `title` and `introText` so the title can be easily reused. I also fixed up some stuff I borked on the tests on this branch with my last commit.

_Test plan:_
```
npm run test-dev server/submissionWorkflow
```
You can also visit the Submissions tab of a Collection to make sure the workflow editor is still working.