### PR TITLE
feature(?): Top secret Release Discussions dialog

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,6 +52,7 @@
 		"import/no-unresolved": [2, { "ignore": ["\\config.js$"] }],
 		"import/prefer-default-export": 0,
 		"jsx-a11y/click-events-have-key-events": 0,
+		"jsx-a11y/accessible-emoji": 0,
 		"jsx-a11y/label-has-associated-control": [2, {"controlComponents": ["Switch"]}],
 		"lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
 		"max-classes-per-file": 0,

--- a/client/components/DialogLauncher/DialogLauncher.tsx
+++ b/client/components/DialogLauncher/DialogLauncher.tsx
@@ -1,19 +1,23 @@
 import React, { useState } from 'react';
 
-type OwnProps = {
-	children: (...args: any[]) => any;
-	renderLauncherElement: (...args: any[]) => any;
+type RenderLauncherOptions = {
+	openDialog: () => unknown;
+};
+
+type ChildrenOptions = {
+	key: number;
+	isOpen: boolean;
+	onClose: () => unknown;
+};
+
+type Props = {
+	children: (options: ChildrenOptions) => React.ReactNode;
+	renderLauncherElement: (options: RenderLauncherOptions) => React.ReactNode;
 	renderChildrenWhenClosed?: boolean;
 };
 
-const defaultProps = {
-	renderChildrenWhenClosed: true,
-};
-
-type Props = OwnProps & typeof defaultProps;
-
 const DialogLauncher = (props: Props) => {
-	const { children, renderLauncherElement, renderChildrenWhenClosed } = props;
+	const { children, renderLauncherElement, renderChildrenWhenClosed = true } = props;
 	const [isOpen, setIsOpen] = useState(false);
 	const [uniqueInstanceKey, setUniqueInstanceKey] = useState(Date.now());
 
@@ -34,5 +38,5 @@ const DialogLauncher = (props: Props) => {
 		</React.Fragment>
 	);
 };
-DialogLauncher.defaultProps = defaultProps;
+
 export default DialogLauncher;

--- a/client/containers/Pub/PubDocument/PubBottom/Discussions/DiscussionsReleaseDialog.tsx
+++ b/client/containers/Pub/PubDocument/PubBottom/Discussions/DiscussionsReleaseDialog.tsx
@@ -1,0 +1,97 @@
+import React, { useCallback, useState } from 'react';
+import { Button, Callout, Checkbox, Classes, Dialog, IDialogProps, Label } from '@blueprintjs/core';
+
+import { Community, Pub, PubPageData, PubPageDiscussion } from 'types';
+import { apiFetch } from 'client/utils/apiFetch';
+import { usePageContext } from 'utils/hooks';
+import { pubUrl } from 'utils/canonicalUrls';
+
+import Discussion from '../../PubDiscussions/Discussion';
+
+require('./discussionsReleaseDialog.scss');
+
+type Props = {
+	pubData: PubPageData;
+} & Pick<IDialogProps, 'onClose' | 'isOpen'>;
+
+type State = 'ready' | 'releasing' | 'error';
+
+const navigateToRelease = (community: Community, pub: Pub) => {
+	window.location.href = pubUrl(community, pub);
+};
+
+const DiscussionsReleaseDialog = (props: Props) => {
+	const { pubData, onClose, isOpen } = props;
+	const { discussions } = pubData;
+	const [selectedDiscussionIds, setSelectedDiscussionIds] = useState<string[]>([]);
+	const [state, setState] = useState<State>('ready');
+	const { communityData } = usePageContext();
+
+	const toggleDiscussionIdSelected = useCallback((id: string) => {
+		setSelectedDiscussionIds((discussionIds) => {
+			if (discussionIds.includes(id)) {
+				return discussionIds.filter((otherId) => otherId !== id);
+			}
+			return [...discussionIds, id];
+		});
+	}, []);
+
+	const handleReleaseDiscussions = () => {
+		setState('releasing');
+		apiFetch
+			.put('/api/discussions/release', {
+				pubId: pubData.id,
+				discussionIds: selectedDiscussionIds,
+			})
+			.then(() => navigateToRelease(communityData, pubData))
+			.catch(() => setState('error'));
+	};
+
+	const renderDiscussionEntry = (discussion: PubPageDiscussion) => {
+		const included = selectedDiscussionIds.includes(discussion.id);
+		return (
+			<Label key={discussion.id} className="discussion-entry">
+				<Checkbox
+					checked={included}
+					onClick={() => toggleDiscussionIdSelected(discussion.id)}
+				/>
+				<Discussion
+					discussionData={discussion}
+					pubData={pubData}
+					updateLocalData={() => {}}
+					canPreview
+				/>
+			</Label>
+		);
+	};
+
+	return (
+		<Dialog
+			className="discussions-release-dialog-component"
+			onClose={onClose}
+			isOpen={isOpen}
+			title="Release Discussions"
+		>
+			<div className={Classes.DIALOG_BODY}>
+				<p>
+					Select discussions to move from the draft to the latest Release. Once they're
+					moved, you won't be able to undo this action (though you may be able to ask Ian
+					to do it for you 😊)
+				</p>
+				<div className="discussions-listing">{discussions.map(renderDiscussionEntry)}</div>
+				{state === 'error' && <Callout intent="warning" title="An error occurred." />}
+			</div>
+			<div className={Classes.DIALOG_FOOTER}>
+				<Button
+					intent="primary"
+					onClick={handleReleaseDiscussions}
+					loading={state === 'releasing'}
+				>
+					Fire away!
+				</Button>
+			</div>
+		</Dialog>
+	);
+};
+
+export default DiscussionsReleaseDialog;

--- a/client/containers/Pub/PubDocument/PubBottom/Discussions/DiscussionsSection.tsx
+++ b/client/containers/Pub/PubDocument/PubBottom/Discussions/DiscussionsSection.tsx
@@ -4,10 +4,12 @@ import { Popover, Position } from '@blueprintjs/core';
 import { usePageContext } from 'utils/hooks';
 import { PubPageData } from 'types';
 import { getAnchoredDiscussionIds } from 'components/Editor/plugins/discussions';
+import { DialogLauncher } from 'client/components';
 import { usePubContext } from 'client/containers/Pub/pubHooks';
 
 import SortList from './SortList';
 import FilterMenu from './FilterMenu';
+import DiscussionsReleaseDialog from './DiscussionsReleaseDialog';
 import PubDiscussions from '../../PubDiscussions/PubDiscussions';
 import PubBottomSection, { SectionBullets, AccentedIconButton } from '../PubBottomSection';
 import { filterAndSortDiscussions } from '../../PubDiscussions/discussionUtils';
@@ -21,12 +23,12 @@ type Props = {
 
 const DiscussionsSection = (props: Props) => {
 	const { pubData, updateLocalData, sideContentRef, mainContentRef } = props;
-	const { discussions } = pubData;
+	const { discussions, isRelease } = pubData;
 	const { communityData, scopeData } = usePageContext();
 	const {
 		collabData: { editorChangeObject },
 	} = usePubContext();
-	const { canView, canManage, canCreateDiscussions } = scopeData.activePermissions;
+	const { canView, canManage, canCreateDiscussions, isSuperAdmin } = scopeData.activePermissions;
 	const [isBrowsingArchive, setIsBrowsingArchive] = useState(false);
 	const [isShowingAnchoredComments, setShowingAnchoredComments] = useState(true);
 	const [sortMode, setSortMode] = useState('newestThread');
@@ -96,6 +98,27 @@ const DiscussionsSection = (props: Props) => {
 							title="Filter comments"
 						/>
 					</Popover>
+					{isSuperAdmin && !isRelease && discussions.length > 0 && (
+						<DialogLauncher
+							renderLauncherElement={({ openDialog }) => (
+								<AccentedIconButton
+									accentColor={iconColor}
+									icon="share"
+									title="Release Discussions"
+									onClick={openDialog}
+								/>
+							)}
+						>
+							{({ isOpen, onClose, key }) => (
+								<DiscussionsReleaseDialog
+									key={key}
+									isOpen={isOpen}
+									onClose={onClose}
+									pubData={pubData}
+								/>
+							)}
+						</DialogLauncher>
+					)}
 				</React.Fragment>
 			);
 		}

--- a/client/containers/Pub/PubDocument/PubBottom/Discussions/discussionsReleaseDialog.scss
+++ b/client/containers/Pub/PubDocument/PubBottom/Discussions/discussionsReleaseDialog.scss
@@ -1,0 +1,30 @@
+.discussions-release-dialog-component {
+    .discussions-listing {
+        background: white;
+        max-height: 50vh;
+        overflow-y: scroll;
+    }
+
+    .discussion-entry {
+        display: flex;
+        align-items: center;
+        margin: 0;
+
+        .bp3-checkbox {
+            margin: 0 10px;
+        }
+
+        .discussion-component {
+            pointer-events: none;
+            user-select: none;
+        }
+
+        &:not(:last-child) {
+            border-bottom: 1px solid #eee;
+        }
+    }
+
+    .bp3-callout {
+        margin-top: 10px;
+    }
+}

--- a/server/discussion/permissions.ts
+++ b/server/discussion/permissions.ts
@@ -52,3 +52,16 @@ export const getUpdatePermissions = async ({ discussionId, userId, pubId, commun
 		canReopen: canAdmin,
 	};
 };
+
+export const canReleaseDiscussions = async ({
+	userId,
+	pubId,
+}: {
+	userId: string;
+	pubId: string;
+}) => {
+	const {
+		activePermissions: { isSuperAdmin },
+	} = await getScope({ pubId, loginId: userId });
+	return isSuperAdmin;
+};

--- a/server/discussion/utils.ts
+++ b/server/discussion/utils.ts
@@ -1,0 +1,96 @@
+import * as types from 'types';
+import { jsonToNode } from 'client/components/Editor';
+import { createFastForwarder } from 'client/components/Editor/plugins/discussions/fastForward';
+import { DiscussionInfo } from 'client/components/Editor/plugins/discussions/types';
+import { Discussion, DiscussionAnchor, Doc, Release } from 'server/models';
+import { getPubDraftRef } from 'server/utils/firebaseAdmin';
+import { indexByProperty } from 'utils/arrays';
+import { createDiscussionAnchor } from 'server/discussionAnchor/queries';
+
+type DiscussionWithAnchors = types.SequelizeModel<types.DefinitelyHas<types.Discussion, 'anchors'>>;
+
+type ExtendedDiscussionInfo = DiscussionInfo & {
+	discussionId: string;
+} & Pick<types.DiscussionAnchor, 'originalText' | 'originalTextPrefix' | 'originalTextSuffix'>;
+
+const getDiscussions = async (discussionIds: string[], pubId: string) => {
+	const discussions: DiscussionWithAnchors[] = await Discussion.findAll({
+		where: { id: discussionIds, pubId },
+		include: [{ model: DiscussionAnchor, as: 'anchors' }],
+	});
+	const discussionInfoValues: ExtendedDiscussionInfo[] = [];
+	discussions.forEach(({ anchors, id: discussionId }) => {
+		const firstAnchor = anchors.reduce(
+			(curr, next) => (curr && curr.historyKey < next.historyKey ? curr : next),
+			null as null | types.DiscussionAnchor,
+		);
+		const latestAnchor = anchors.reduce(
+			(curr, next) => (curr && curr.historyKey > next.historyKey ? curr : next),
+			null as null | types.DiscussionAnchor,
+		);
+		if (firstAnchor?.selection && latestAnchor?.selection) {
+			const {
+				historyKey: initKey,
+				selection: { anchor: initAnchor, head: initHead },
+				originalText,
+				originalTextPrefix,
+				originalTextSuffix,
+			} = firstAnchor;
+			const { historyKey: currentKey, selection } = latestAnchor;
+			discussionInfoValues.push({
+				discussionId,
+				initKey,
+				initAnchor,
+				initHead,
+				currentKey,
+				selection,
+				originalText,
+				originalTextPrefix,
+				originalTextSuffix,
+			});
+		}
+	});
+	return indexByProperty(discussionInfoValues, 'discussionId');
+};
+
+const getLatestReleaseInfo = async (pubId: string) => {
+	const release: types.DefinitelyHas<types.Release, 'doc'> = await Release.findOne({
+		where: { pubId },
+		include: [{ model: Doc, as: 'doc' }],
+		order: [['historyKey', 'DESC']],
+	});
+	if (!release) {
+		throw new Error('Pub does not have a Release');
+	}
+	return { doc: jsonToNode(release.doc.content), historyKey: release.historyKey };
+};
+
+export const createDiscussionAnchorsForLatestRelease = async (
+	pubId: string,
+	discussionIds: string[],
+) => {
+	const { doc, historyKey } = await getLatestReleaseInfo(pubId);
+	const draftRef = await getPubDraftRef(pubId);
+	const fastForward = createFastForwarder(draftRef);
+	const discussions = await getDiscussions(discussionIds, pubId);
+	const fastForwardedDiscussions = await fastForward(discussions, doc, historyKey);
+	return Promise.all(
+		Object.values(discussions).map(async (extendedDiscussionInfo) => {
+			const { originalText, originalTextPrefix, originalTextSuffix, discussionId } =
+				extendedDiscussionInfo;
+			const fastForwardedDiscussionInfo = fastForwardedDiscussions[discussionId];
+			if (fastForwardedDiscussionInfo?.selection) {
+				const { selection } = fastForwardedDiscussionInfo;
+				await createDiscussionAnchor({
+					discussionId,
+					historyKey,
+					originalText,
+					originalTextPrefix,
+					originalTextSuffix,
+					selectionJson: selection,
+					isOriginal: false,
+				});
+			}
+		}),
+	);
+};

--- a/server/discussionAnchor/__tests__/queries.test.ts
+++ b/server/discussionAnchor/__tests__/queries.test.ts
@@ -6,10 +6,7 @@ import { Fragment, Node, Slice } from 'prosemirror-model';
 import { TextSelection } from 'prosemirror-state';
 import { ReplaceStep } from 'prosemirror-transform';
 
-import {
-	createOriginalDiscussionAnchor,
-	createUpdatedDiscussionAnchorForNewSteps,
-} from '../queries';
+import { createDiscussionAnchor, createUpdatedDiscussionAnchorForNewSteps } from '../queries';
 
 const models = modelize`
 	Community {
@@ -53,7 +50,7 @@ describe('createUpdatedDiscussionAnchorForNewSteps', () => {
 		const {
 			discussion: { id: discussionId },
 		} = models;
-		const firstAnchor = await createOriginalDiscussionAnchor({
+		const firstAnchor = await createDiscussionAnchor({
 			discussionId,
 			historyKey: 1,
 			selectionJson: initialSelection as any,

--- a/server/discussionAnchor/queries.ts
+++ b/server/discussionAnchor/queries.ts
@@ -37,13 +37,14 @@ export const createUpdatedDiscussionAnchorForNewSteps = async (
 	);
 };
 
-export const createOriginalDiscussionAnchor = async ({
+export const createDiscussionAnchor = async ({
 	discussionId,
 	historyKey,
 	selectionJson,
 	originalText = '',
 	originalTextPrefix = '',
 	originalTextSuffix = '',
+	isOriginal = true,
 }: {
 	discussionId: string;
 	historyKey: number;
@@ -51,6 +52,7 @@ export const createOriginalDiscussionAnchor = async ({
 	originalText: string;
 	originalTextPrefix?: string;
 	originalTextSuffix?: string;
+	isOriginal?: boolean;
 }) => {
 	const { head, anchor } = selectionJson;
 	return DiscussionAnchor.create({
@@ -60,6 +62,6 @@ export const createOriginalDiscussionAnchor = async ({
 		originalText,
 		originalTextPrefix,
 		originalTextSuffix,
-		isOriginal: true,
+		isOriginal,
 	});
 };

--- a/tools/migrations/data/2020_12_01_createDiscussionAnchors.js
+++ b/tools/migrations/data/2020_12_01_createDiscussionAnchors.js
@@ -4,7 +4,7 @@ import { uncompressSelectionJSON } from 'prosemirror-compress-pubpub';
 
 import { Anchor, Branch, Pub, Release, Discussion } from 'server/models';
 import { getDatabaseRef } from 'server/utils/firebaseAdmin';
-import { createOriginalDiscussionAnchor } from 'server/discussionAnchor/queries';
+import { createDiscussionAnchor } from 'server/discussionAnchor/queries';
 
 import { forEach } from '../util';
 
@@ -83,7 +83,7 @@ const dedupeAnchorDescs = (descs) => {
 
 const createAnchorModelFromDesc = (desc) => {
 	const { discussionId, head, anchor, historyKey, prefix, suffix, exact } = desc;
-	return createOriginalDiscussionAnchor({
+	return createDiscussionAnchor({
 		discussionId,
 		historyKey,
 		originalText: exact,

--- a/types/visibility.ts
+++ b/types/visibility.ts
@@ -1,6 +1,8 @@
 import { Discussion } from './discussion';
 import { Review } from './review';
 
+export type VisibilityAccess = 'private' | 'members' | 'public';
+
 export type VisibilityUser = {
 	id: string;
 	visibilityId: string;
@@ -9,7 +11,7 @@ export type VisibilityUser = {
 
 export type Visibility = {
 	id: string;
-	access: 'private' | 'members' | 'public';
+	access: VisibilityAccess;
 	users: VisibilityUser[];
 };
 


### PR DESCRIPTION
Resolves #1668

In response to a recurring need from the content team to manually move discussions from draft to release, here's a little widget that does this. For now it's only for the `pubpub-team` user, but we could make it part of the release process in the future. To use it, click the little arrow-out icon in the Discussions section:

<img width="148" alt="image" src="https://user-images.githubusercontent.com/2208769/142295174-e5b5298b-475a-4d13-ad64-d49bbda9d703.png">

Then choose which ones you want to move:

<img width="500" src="https://user-images.githubusercontent.com/2208769/142294933-998c741b-c687-4a15-87b2-57781ad2b33f.png">

(Don't know why that vertical spacing is goofy but I'm out of time to fix it.)

_Test plan:_
- Open a Pub draft, add some discussions, and then make a Release. Return to the draft and use this newfangled button to move the discussions to the release
- Make sure this button does not appear if you are not logged in as the PubPub team, if there are no discussions, or if you're viewing the draft.