### PR TITLE
Remove Bluebird

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,7 +28,7 @@
 		}
 	},
 	"rules": {
-		"@typescript-eslint/no-unused-vars": ["error", {"varsIgnorePattern": "^_+$"}],
+		"@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "^_+$" }],
 		"@typescript-eslint/no-use-before-define": ["error"],
 		"@typescript-eslint/no-shadow": ["error"],
 		"arrow-body-style": 0,
@@ -41,10 +41,10 @@
 			"error",
 			"ignorePackages",
 			{
-			  "js": "never",
-			  "jsx": "never",
-			  "ts": "never",
-			  "tsx": "never"
+				"js": "never",
+				"jsx": "never",
+				"ts": "never",
+				"tsx": "never"
 			}
 		],
 		"import/no-dynamic-require": 0,
@@ -53,7 +53,7 @@
 		"import/prefer-default-export": 0,
 		"jsx-a11y/click-events-have-key-events": 0,
 		"jsx-a11y/accessible-emoji": 0,
-		"jsx-a11y/label-has-associated-control": [2, {"controlComponents": ["Switch"]}],
+		"jsx-a11y/label-has-associated-control": [2, { "controlComponents": ["Switch"] }],
 		"lines-between-class-members": ["error", "always", { "exceptAfterSingleLine": true }],
 		"max-classes-per-file": 0,
 		"no-async-promise-executor": 0,
@@ -102,6 +102,12 @@
 			"files": "client/utils/activity/renderers/*",
 			"rules": {
 				"react/prop-types": 0
+			}
+		},
+		{
+			"files": ["**/*.test.ts", "**/*.test.js"],
+			"env": {
+				"jest": true
 			}
 		}
 	]

--- a/client/components/Editor/utils/__test__/changes.test.ts
+++ b/client/components/Editor/utils/__test__/changes.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect */
 import { editFirebaseDraft } from 'stubstub';
 
 import { editorSchema } from 'components/Editor';

--- a/client/utils/__tests__/navigation.test.ts
+++ b/client/utils/__tests__/navigation.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect */
 import { defaultFooterLinks, getNavItemsForCommunityNavigation } from '../navigation';
 
 const pages = [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
 		"amqplib": "^0.5.3",
 		"aws-sdk": "^2.444.0",
 		"big-json": "^2.0.2",
-		"bluebird": "^3.5.3",
 		"body-parser": "^1.19.0",
 		"bourbon": "^5.1.0",
 		"camelcase-css": "^2.0.1",

--- a/server/activityItem/__tests__/fetch.test.ts
+++ b/server/activityItem/__tests__/fetch.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeEach, beforeAll, afterAll */
 import { modelize, setup, teardown } from 'stubstub';
 
 import { ActivityAssociations, ActivityAssociationType } from 'types';

--- a/server/collection/__tests__/api.test.ts
+++ b/server/collection/__tests__/api.test.ts
@@ -1,4 +1,3 @@
-/* global it, expect, beforeAll, afterAll */
 import { setup, teardown, login, modelize, expectCreatedActivityItem } from 'stubstub';
 import { createCollection } from '../queries';
 import { Collection } from '../../models';

--- a/server/collectionAttribution/__tests__/api.test.ts
+++ b/server/collectionAttribution/__tests__/api.test.ts
@@ -1,4 +1,3 @@
-/* global it, expect, beforeAll, afterAll */
 import { setup, teardown, login, modelize } from 'stubstub';
 import { CollectionAttribution } from 'server/models';
 

--- a/server/collectionPub/__tests__/api.test.ts
+++ b/server/collectionPub/__tests__/api.test.ts
@@ -1,4 +1,3 @@
-/* global it, expect, beforeAll, afterAll */
 import { setup, teardown, login, modelize, expectCreatedActivityItem } from 'stubstub';
 import { CollectionPub } from 'server/models';
 import { createCollectionPub } from '../queries';

--- a/server/community/__tests__/api.test.ts
+++ b/server/community/__tests__/api.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeAll, afterAll */
 import sinon from 'sinon';
 import uuid from 'uuid';
 

--- a/server/community/__tests__/queries.test.ts
+++ b/server/community/__tests__/queries.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeAll, afterAll */
 import { modelize, setup, teardown } from 'stubstub';
 import { isUserAffiliatedWithCommunity } from 'server/community/queries';
 
@@ -35,9 +34,9 @@ const models = modelize`
     Community {
         Member {
             permissions: "admin"
-            User randoCommunityAdmin {} 
+            User randoCommunityAdmin {}
         }
-        
+
     }
     User notACommunityMember {}
 `;

--- a/server/customScript/__tests__/api.test.ts
+++ b/server/customScript/__tests__/api.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
-/* global describe, it, expect, beforeAll, afterAll */
 import { setup, teardown, login, modelize } from 'stubstub';
 import { CustomScript } from 'server/models';
 

--- a/server/discussion/__tests__/api.test.ts
+++ b/server/discussion/__tests__/api.test.ts
@@ -1,4 +1,3 @@
-/* global it, expect, beforeAll */
 import uuid from 'uuid';
 
 import { setup, login, modelize } from 'stubstub';

--- a/server/discussionAnchor/__tests__/queries.test.ts
+++ b/server/discussionAnchor/__tests__/queries.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeAll */
 import { modelize, setup } from 'stubstub';
 
 import { buildSchema } from 'client/components/Editor';

--- a/server/doi/__tests__/api.test.ts
+++ b/server/doi/__tests__/api.test.ts
@@ -1,4 +1,3 @@
-/* global it, expect, beforeAll, afterAll, beforeEach, afterEach */
 import sinon from 'sinon';
 
 import { setup, teardown, login, modelize } from 'stubstub';

--- a/server/export/__tests__/api.test.ts
+++ b/server/export/__tests__/api.test.ts
@@ -1,4 +1,3 @@
-/* global it, expect, beforeAll, afterAll, afterEach */
 import { setup, teardown, login, modelize } from 'stubstub';
 
 import { Export, WorkerTask } from 'server/models';

--- a/server/featureFlag/__tests__/interface.test.ts
+++ b/server/featureFlag/__tests__/interface.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeAll */
 import { modelize, setup } from 'stubstub';
 
 import { FeatureFlag, FeatureFlagCommunity, FeatureFlagUser } from 'server/models';

--- a/server/featureFlag/__tests__/queries.test.ts
+++ b/server/featureFlag/__tests__/queries.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeAll */
 import { modelize, setup } from 'stubstub';
 
 import { getFeatureFlagForUserAndCommunity, getFeatureFlagsForUserAndCommunity } from '../queries';

--- a/server/member/__tests__/member.test.ts
+++ b/server/member/__tests__/member.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeAll, afterAll */
 import { setup, teardown, login, modelize, expectCreatedActivityItem } from 'stubstub';
 
 import { Member } from 'server/models';

--- a/server/pub/__tests__/api.test.ts
+++ b/server/pub/__tests__/api.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
-/* global describe, it, expect, beforeAll, afterAll */
 import uuid from 'uuid/v4';
 
 import { setup, teardown, login, modelize, expectCreatedActivityItem } from 'stubstub';

--- a/server/pub/queries.ts
+++ b/server/pub/queries.ts
@@ -1,5 +1,3 @@
-import Bluebird from 'bluebird';
-
 import { Collection, Community, Pub, PubAttribution, Member } from 'server/models';
 import { setPubSearchData, deletePubSearchData } from 'server/utils/search';
 import { createCollectionPub } from 'server/collectionPub/queries';
@@ -7,6 +5,7 @@ import { createDraft } from 'server/draft/queries';
 import { slugifyString } from 'utils/strings';
 import { generateHash } from 'utils/hashes';
 import { getReadableDateInYear } from 'utils/dates';
+import { asyncForEach } from 'utils/async';
 
 export const createPub = async (
 	{
@@ -58,9 +57,9 @@ export const createPub = async (
 			{ hooks: false },
 		);
 
-	const allCollectionIds = [...(defaultPubCollections || []), ...(collectionIds || [])];
+	const allCollectionIds: string[] = [...(defaultPubCollections || []), ...(collectionIds || [])];
 
-	const createCollectionPubs = Bluebird.each(
+	const createCollectionPubs = asyncForEach(
 		[...new Set(allCollectionIds)].filter((x) => x),
 		async (collectionIdToAdd) => {
 			// defaultPubCollections isn't constrained by the database in any way and might contain IDs
@@ -106,7 +105,7 @@ export const updatePub = (inputValues, updatePermissions, actorId) => {
 	});
 };
 
-export const destroyPub = (pubId, actorId) => {
+export const destroyPub = (pubId: string, actorId: string) => {
 	return Pub.destroy({
 		where: { id: pubId },
 		individualHooks: true,

--- a/server/pub/queries.ts
+++ b/server/pub/queries.ts
@@ -105,7 +105,7 @@ export const updatePub = (inputValues, updatePermissions, actorId) => {
 	});
 };
 
-export const destroyPub = (pubId: string, actorId: string) => {
+export const destroyPub = (pubId: string, actorId: null | string = null) => {
 	return Pub.destroy({
 		where: { id: pubId },
 		individualHooks: true,

--- a/server/pubEdge/__tests__/api.test.ts
+++ b/server/pubEdge/__tests__/api.test.ts
@@ -1,4 +1,3 @@
-/* global it, expect, beforeAll */
 import { setup, login, modelize, expectCreatedActivityItem } from 'stubstub';
 
 import { createPubEdge } from 'server/pubEdge/queries';

--- a/server/pubHistory/__tests__/api.test.ts
+++ b/server/pubHistory/__tests__/api.test.ts
@@ -1,4 +1,3 @@
-/* global it, expect, beforeAll, afterAll, beforeEach, afterEach */
 import sinon from 'sinon';
 import { setup, teardown, login, modelize } from 'stubstub';
 

--- a/server/release/__tests__/api.test.ts
+++ b/server/release/__tests__/api.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeAll, afterAll, afterEach */
 import {
 	setup,
 	teardown,

--- a/server/routes/__tests__/collection.test.ts
+++ b/server/routes/__tests__/collection.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeAll, afterAll */
 import { setup, teardown, login, modelize } from 'stubstub';
 
 const models = modelize`

--- a/server/routes/__tests__/pubRedirects.test.ts
+++ b/server/routes/__tests__/pubRedirects.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeAll, afterAll */
 import { setup, teardown, stubFirebaseAdmin, login, modelize } from 'stubstub';
 
 const models = modelize`

--- a/server/routes/explore.tsx
+++ b/server/routes/explore.tsx
@@ -1,4 +1,3 @@
-import Promise from 'bluebird';
 import React from 'react';
 
 import Html from 'server/Html';

--- a/server/routes/passwordReset.tsx
+++ b/server/routes/passwordReset.tsx
@@ -1,4 +1,3 @@
-import Promise from 'bluebird';
 import React from 'react';
 
 import Html from 'server/Html';

--- a/server/routes/userCreate.tsx
+++ b/server/routes/userCreate.tsx
@@ -1,4 +1,3 @@
-import Promise from 'bluebird';
 import React from 'react';
 
 import Html from 'server/Html';

--- a/server/rss/__tests__/api.test.ts
+++ b/server/rss/__tests__/api.test.ts
@@ -1,4 +1,3 @@
-/* global it, expect, beforeAll */
 import { setup, login } from 'stubstub';
 
 import { models } from './data';

--- a/server/rss/__tests__/getFeedItemForPub.test.ts
+++ b/server/rss/__tests__/getFeedItemForPub.test.ts
@@ -1,4 +1,3 @@
-/* global it, expect, beforeAll */
 import { setup, modelize } from 'stubstub';
 
 import { getPubData, getFeedItemForPub } from '../queries';
@@ -44,7 +43,7 @@ const models = modelize`
                 pubRank: "b"
                 Collection {
                    isPublic: true
-                   title: "C1" 
+                   title: "C1"
                 }
             }
             CollectionPub {
@@ -52,21 +51,21 @@ const models = modelize`
                 pubRank: "c"
                 Collection {
                    isPublic: true
-                   title: "C2" 
+                   title: "C2"
                 }
             }
             CollectionPub {
                 rank: "2"
                 pubRank: "d"
                 Collection {
-                   title: "C3" 
+                   title: "C3"
                 }
             }
             CollectionPub {
                 rank: "3"
                 pubRank: "a"
                 Collection {
-                   title: "C4" 
+                   title: "C4"
                    isPublic: true
                    CollectionAttribution {
                        name: "CA1"

--- a/server/rss/__tests__/getQueriedPubIds.test.ts
+++ b/server/rss/__tests__/getQueriedPubIds.test.ts
@@ -1,4 +1,3 @@
-/* global it, expect, beforeAll */
 import { setup } from 'stubstub';
 
 import { getQueriedPubIds } from '../queries';

--- a/server/scopeSummary/__tests__/scopeSummary.test.ts
+++ b/server/scopeSummary/__tests__/scopeSummary.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeAll, afterAll, beforeEach */
 import { setup, teardown, modelize } from 'stubstub';
 
 import { Pub, Collection, Community, ScopeSummary } from 'server/models';

--- a/server/threadComment/__tests__/api.test.ts
+++ b/server/threadComment/__tests__/api.test.ts
@@ -1,4 +1,3 @@
-/* global it, expect, beforeAll, afterAll  */
 import { setup, teardown, login, modelize, expectCreatedActivityItem } from 'stubstub';
 
 const models = modelize`

--- a/server/user/queries.ts
+++ b/server/user/queries.ts
@@ -1,5 +1,5 @@
 import { Op } from 'sequelize';
-import Promise from 'bluebird';
+import { promisify } from 'util';
 
 import { User, Signup } from 'server/models';
 import { slugifyString } from 'utils/strings';
@@ -40,7 +40,7 @@ export const createUser = (inputValues) => {
 				passwordDigest: 'sha512',
 			};
 
-			const userRegister = Promise.promisify(User.register, { context: User });
+			const userRegister = promisify(User.register.bind(User));
 			return userRegister(newUser, inputValues.password);
 		})
 		.then(() => {

--- a/server/userSubscription/pub/__tests__/pubSubscription.test.ts
+++ b/server/userSubscription/pub/__tests__/pubSubscription.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeAll, afterAll */
 import { modelize, login, setup, teardown } from 'stubstub';
 
 import { findUserSubscription } from 'server/userSubscription/shared/queries';

--- a/server/userSubscription/thread/__tests__/threadSubscription.test.ts
+++ b/server/userSubscription/thread/__tests__/threadSubscription.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeAll, afterAll */
 import { modelize, login, setup, teardown } from 'stubstub';
 
 import { UserSubscription } from 'server/models';

--- a/server/userSubscription/thread/queries.ts
+++ b/server/userSubscription/thread/queries.ts
@@ -1,8 +1,7 @@
-import Bluebird from 'bluebird';
-
 import * as types from 'types';
 import { UserSubscription } from 'server/models';
 import { canUserSeeThread } from 'server/thread/queries';
+import { asyncMap } from 'utils/async';
 
 import {
 	createUserSubscription,
@@ -34,7 +33,7 @@ export const createUserThreadSubscription = async (
 };
 
 export const updateUserThreadSubscriptions = async (threadId: string) => {
-	await Bluebird.map(
+	await asyncMap(
 		await UserSubscription.findAll({
 			where: { threadId },
 		}),

--- a/server/utils/__tests__/tokens.test.ts
+++ b/server/utils/__tests__/tokens.test.ts
@@ -1,4 +1,3 @@
-/* global it, expect, beforeAll, afterAll */
 import MockDate from 'mockdate';
 
 import { issueToken, verifyAndDecodeToken } from '../tokens';

--- a/stubstub/modelize/README.md
+++ b/stubstub/modelize/README.md
@@ -58,7 +58,6 @@ This has clear advantages, foremost among them that the nested hierarchy of the 
 Here's a handy template for test files that use Modelize:
 
 ```ts
-/* global describe, it, expect, beforeAll */
 import { modelize, setup } from 'stubstub';
 
 // Specify the models we want to use in our tests

--- a/tools/5to6/discussions/index.js
+++ b/tools/5to6/discussions/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-const Promise = require('bluebird');
 const firebaseAdmin = require('firebase-admin');
 const { buildSchema, restoreDiscussionMaps } = require('components/Editor');
 const discussionSchema = require('./simpleDiscussionSchema').default;
@@ -31,8 +30,9 @@ const main = async () => {
 				.then(async () => {
 					const branchJSON = JSON.parse(branchObject);
 					console.log(
-						`~~~~~~~~ Processing ${branchJSON.pubId}/${branchJSON.branchId} (${index +
-							1}/${arr.length}) ~~~~~~~~`,
+						`~~~~~~~~ Processing ${branchJSON.pubId}/${branchJSON.branchId} (${
+							index + 1
+						}/${arr.length}) ~~~~~~~~`,
 					);
 					const branchRef = database.ref(
 						`pub-${branchJSON.pubId}/branch-${branchJSON.branchId}`,

--- a/tools/5to6/handbookBranch/process.js
+++ b/tools/5to6/handbookBranch/process.js
@@ -3,7 +3,6 @@
 import { Op } from 'sequelize';
 import Color from 'color';
 import uuidv4 from 'uuid/v4';
-import Promise from 'bluebird';
 import firebaseAdmin from 'firebase-admin';
 import { createBranch } from 'components/Editor';
 import {
@@ -122,7 +121,7 @@ Promise.all([])
 				id: newBranchId,
 				title: channel.title,
 				shortId: 37,
-				order: Math.floor(index/array.length * 1000)/1000,
+				order: Math.floor((index / array.length) * 1000) / 1000,
 				communityAdminPermissions: 'manage',
 				viewHash: generateHash(8),
 				discussHash: generateHash(8),

--- a/tools/5to6/v5/index.js
+++ b/tools/5to6/v5/index.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable no-console */
-const Promise = require('bluebird');
 const { storage } = require('../setup');
 // const { queryPubUpdatedTimes } = require('./queryPub');
 const processPub = require('./processPub');

--- a/tools/5to6/v6/index.js
+++ b/tools/5to6/v6/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-const Promise = require('bluebird');
 const { storage } = require('../setup');
 const getPipedPubIds = require('../util/getPipedPubIds');
 

--- a/tools/5to6/wikiDiscussions/index.js
+++ b/tools/5to6/wikiDiscussions/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable */
-const Promise = require('bluebird');
 const firebaseAdmin = require('firebase-admin');
 const { buildSchema, restoreDiscussionMaps } = require('components/Editor');
 const { Pub, Branch, BranchPermission, Discussion } = require('../../../server/models');

--- a/tools/backfillCheckpoints.js
+++ b/tools/backfillCheckpoints.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console, no-restricted-syntax, import/first */
-import Promise from 'bluebird';
 import Slowdance from 'slowdance';
 import { uncompressStepJSON, compressStateJSON } from 'prosemirror-compress-pubpub';
 import { Step } from 'prosemirror-transform';

--- a/tools/branchMaintenance.js
+++ b/tools/branchMaintenance.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
-import Bluebird from 'bluebird';
-
+import { asyncMap } from 'utils/async';
 import { Community, Pub } from 'server/models';
 
 import { setBranchMaintenanceMode } from './utils/branchMaintenance';
@@ -24,10 +23,10 @@ const communityMaintenance = async (subdomain) => {
 	if (community) {
 		const pubs = await Pub.findAll({ where: { communityId: community.id } });
 		await promptOkay(`Act on ${pubs.length} Pubs?`, { throwIfNo: true });
-		await Bluebird.map(
+		await asyncMap(
 			pubs,
 			(pub) =>
-				Bluebird.map(
+				asyncMap(
 					['draft', 'public'],
 					async (branch) => {
 						console.log(`${pub.slug}.${branch}`);

--- a/tools/clone.js
+++ b/tools/clone.js
@@ -1,5 +1,3 @@
-import Bluebird from 'bluebird';
-
 import {
 	Collection,
 	CollectionPub,
@@ -18,6 +16,7 @@ import {
 	ThreadComment,
 	User,
 } from 'server/models';
+import { asyncMap } from 'utils/async';
 
 import { createDraft, getDraftFirebasePath } from 'server/draft/queries';
 import { isProd } from 'utils/environment';
@@ -172,7 +171,7 @@ const clonePub = async ({ pubId, newCommunityId, collectionIdMap }) => {
 const clonePubs = async ({ existingCommunityId, newCommunityId, collectionIdMap }) => {
 	const allPubs = await Pub.findAll({ where: { communityId: existingCommunityId } });
 	const pubIdMap = {};
-	await Bluebird.map(
+	await asyncMap(
 		allPubs,
 		async (pub) => {
 			const newPub = await clonePub({

--- a/tools/dashboardMigrations/dashCols.js
+++ b/tools/dashboardMigrations/dashCols.js
@@ -1,5 +1,7 @@
-import Promise from 'bluebird';
 import { Sequelize } from 'sequelize';
+
+import { asyncMap } from 'utils/async';
+
 import {
 	sequelize,
 	Pub,
@@ -284,7 +286,7 @@ export default async () => {
 			},
 		],
 	}).then((discussionData) => {
-		return Promise.map(
+		return asyncMap(
 			discussionData,
 			(item) => {
 				return Discussion.update(

--- a/tools/depositCollectionPubs.js
+++ b/tools/depositCollectionPubs.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import Bluebird from 'bluebird';
+import { asyncMap } from 'utils/async';
 import { Community, Collection, CollectionPub, Pub, Release } from 'server/models';
 import { setDoiData } from 'server/doi/queries';
 
@@ -42,7 +42,7 @@ const main = async () => {
 		{ communityId: community.id, collectionId: collection.id },
 		'collection',
 	);
-	await Bluebird.map(
+	await asyncMap(
 		releasedCollectionPubs.map((cp) => cp.pubId),
 		(pubId) =>
 			setAndLogDoiData(

--- a/tools/emailUsers.js
+++ b/tools/emailUsers.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import Promise from 'bluebird';
 import { User } from 'server/models';
 // import { Op } from 'sequelize';
 import mailgun from 'mailgun.js';
@@ -16,7 +15,7 @@ const emailSubject = 'Proposed Terms and Privacy Policy Updates';
 const emailBody = stripIndent(`
 Hello,
 
-We're building PubPub for readers, publishing communities, and knowledge creators. 
+We're building PubPub for readers, publishing communities, and knowledge creators.
 Not for analytics companies. We've been working hard with a legal team that specializes
 in open-source software on updating PubPub's Privacy Policy, Terms of Service, and
 Acceptable Use Policy to be easier to understand, more comprehensive, and more
@@ -33,7 +32,7 @@ These policies will replace our existing ones and go into effect two weeks from 
 Monday, February 8, 2021. In the meantime, we sincerely welcome your feedback and
 comments on our proposed policies.
 
-Please visit the following discussion thread on our new PubPub Forum to add your thoughts: 
+Please visit the following discussion thread on our new PubPub Forum to add your thoughts:
 
 https://github.com/pubpub/pubpub/discussions/1248
 
@@ -70,7 +69,7 @@ const sendEmail = async (user) => {
 		});
 		const successMessage = `SUCCEEDED: ${userEmail}`;
 		/* This is the only guaranteed log of emails sent. Promise.map does not guarantee order,
-		so this list is vital to preserve in case the wrapped promise fails or times out. 
+		so this list is vital to preserve in case the wrapped promise fails or times out.
 		Note that success = successfully sent, not delivered. */
 		console.log(successMessage);
 		return Promise.resolve(successMessage);

--- a/tools/firebaseMigrations/migrateCitations.js
+++ b/tools/firebaseMigrations/migrateCitations.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
-import Promise from 'bluebird';
 // import { Op } from 'sequelize';
+
+import { asyncMap } from 'utils/async';
+
 import { Pub, PubManager, User } from '../../server/models';
 
 const createFirebaseClient = require('../5to6/util/createFirebaseClient');
@@ -52,7 +54,7 @@ Pub.findAll({
 		const sourceReader = sourceClient.reader;
 		// const destWriter = destClient.writer;
 		let completed = 0;
-		return Promise.map(
+		return asyncMap(
 			pubIds,
 			(pubId, index, arrayLength) => {
 				return sourceReader(pubId)

--- a/tools/firebaseMigrations/migrateFootnotes.js
+++ b/tools/firebaseMigrations/migrateFootnotes.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
-import Promise from 'bluebird';
 // import { Op } from 'sequelize';
+
+import { asyncMap } from 'utils/async';
+
 import { Pub, PubManager, User } from '../../server/models';
 
 const createFirebaseClient = require('../5to6/util/createFirebaseClient');
@@ -52,7 +54,7 @@ Pub.findAll({
 		const sourceReader = sourceClient.reader;
 		// const destWriter = destClient.writer;
 		let completed = 0;
-		return Promise.map(
+		return asyncMap(
 			pubIds,
 			(pubId, index, arrayLength) => {
 				return sourceReader(pubId)

--- a/tools/flattenBranchHistory.js
+++ b/tools/flattenBranchHistory.js
@@ -1,5 +1,4 @@
 import fs from 'fs-extra';
-import Promise from 'bluebird';
 import { Node, Fragment, Slice } from 'prosemirror-model';
 import { ReplaceStep } from 'prosemirror-transform';
 

--- a/tools/migrations/2020_10_02_updateCommunityNavigation.js
+++ b/tools/migrations/2020_10_02_updateCommunityNavigation.js
@@ -1,4 +1,4 @@
-import Bluebird from 'bluebird';
+import { asyncMap } from 'utils/async';
 
 const updateCommunityNavigation = (navigation) => {
 	return navigation.map((item) => {
@@ -18,7 +18,7 @@ const updateCommunityNavigation = (navigation) => {
 module.exports = async ({ models }) => {
 	const { Community } = models;
 	const communities = await Community.findAll();
-	return Bluebird.map(
+	return asyncMap(
 		communities,
 		(community) => {
 			community.navigation = updateCommunityNavigation(community.navigation);

--- a/tools/migrations/2020_10_13_backfillDefaultCollectionLayout.js
+++ b/tools/migrations/2020_10_13_backfillDefaultCollectionLayout.js
@@ -1,10 +1,10 @@
-import Bluebird from 'bluebird';
+import { asyncMap } from 'utils/async';
 
 import { generateDefaultCollectionLayout } from 'server/collection/queries';
 
 module.exports = async ({ models }) => {
 	const { Collection } = models;
-	await Bluebird.map(
+	await asyncMap(
 		await Collection.findAll(),
 		(collection) => {
 			collection.layout = generateDefaultCollectionLayout();

--- a/tools/migrations/2020_10_19_enforceUniqueSlugs.js
+++ b/tools/migrations/2020_10_19_enforceUniqueSlugs.js
@@ -1,4 +1,4 @@
-import Bluebird from 'bluebird';
+import { asyncMap } from 'utils/async';
 import { findAcceptableSlug } from 'server/utils/slugs';
 
 const updateSlugForCollection = async (collectionModel) => {
@@ -22,7 +22,7 @@ const updateCollidingSlugsInCommunity = async (communityId, models) => {
 
 module.exports = async ({ models }) => {
 	const { Community } = models;
-	await Bluebird.map(
+	await asyncMap(
 		await Community.findAll(),
 		(community) => updateCollidingSlugsInCommunity(community.id, models),
 		{ concurrency: 10 },

--- a/tools/migrations/util/index.js
+++ b/tools/migrations/util/index.js
@@ -1,7 +1,7 @@
-import Bluebird from 'bluebird';
+import { asyncMap } from 'utils/async';
 
 export const forEach = async (items, fn, concurrency = 1) => {
-	return Bluebird.map(items, fn, { concurrency });
+	return asyncMap(items, fn, { concurrency });
 };
 
 export const forEachInstance = async (Model, fn, concurrency = 1) => {

--- a/tools/pubCrawl.js
+++ b/tools/pubCrawl.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import Promise from 'bluebird';
 import { Pub, Community } from 'server/models';
 import { Op } from 'sequelize';
 import fetch from 'node-fetch';

--- a/tools/rerankCollections.js
+++ b/tools/rerankCollections.js
@@ -1,13 +1,13 @@
-import Bluebird from 'bluebird';
-import { rerankCollection } from 'server/utils/collectionQueries';
 import { CollectionPub } from 'server/models';
+import { rerankCollection } from 'server/utils/collectionQueries';
+import { asyncMap } from 'utils/async';
 
 const main = async () => {
 	const collectionIdsMis = await CollectionPub.findAll({ where: { rank: null } });
 	const collectionIdsMissingRanks = [
 		...new Set(collectionIdsMis.map((collectionPub) => collectionPub.collectionId)),
 	];
-	await Bluebird.map(collectionIdsMissingRanks, rerankCollection, { concurrency: 5 });
+	await asyncMap(collectionIdsMissingRanks, rerankCollection, { concurrency: 5 });
 };
 
 main().finally(() => process.exit(0));

--- a/tools/searchSync.js
+++ b/tools/searchSync.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
-import Promise from 'bluebird';
 import algoliasearch from 'algoliasearch';
+
+import { asyncForEach } from 'utils/async';
 
 import { Pub, Page } from '../server/models';
 import { deletePubSearchData } from '../workers/tasks/search';
@@ -13,7 +14,7 @@ const pagesIndex = client.initIndex('pages');
 console.log('Beginning search sync');
 
 const findAndIndexPubs = async (pubIds) => {
-	await Promise.each(pubIds, deletePubSearchData);
+	await asyncForEach(pubIds, deletePubSearchData);
 	const pubSyncData = await getPubSearchData(pubIds);
 	console.log(`generated ${pubSyncData.length} entries for ${pubIds.length} Pubs`);
 	return pubsIndex.saveObjects(pubSyncData, { autoGenerateObjectIDIfNotExist: true });

--- a/tools/syncFirebase.js
+++ b/tools/syncFirebase.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
-import Promise from 'bluebird';
 // import { Op } from 'sequelize';
+import { asyncMap } from 'utils/async';
+
 import { Pub } from '../server/models';
 
 const createFirebaseClient = require('./5to6/util/createFirebaseClient');
@@ -42,7 +43,7 @@ Pub.findAll({
 		const sourceReader = sourceClient.reader;
 		const destWriter = destClient.writer;
 		let completed = 0;
-		return Promise.map(
+		return asyncMap(
 			pubIds,
 			(pubId, index, arrayLength) => {
 				return sourceReader(pubId)

--- a/types/attribution.ts
+++ b/types/attribution.ts
@@ -21,6 +21,12 @@ export type User = AttributableUser & {
 	twitter: string;
 	github: string;
 	googleScholar: string;
+	passwordDigest: string;
+	hash: string;
+	salt: string;
+	email: string;
+	resetHash: string;
+	resetHashExpiration: number;
 };
 
 export type PubAttribution = {

--- a/utils/__tests__/async.test.ts
+++ b/utils/__tests__/async.test.ts
@@ -1,0 +1,110 @@
+import { asyncForEach, asyncMap } from 'utils/async';
+
+describe('async utils', () => {
+	beforeAll(() => jest.useFakeTimers());
+	afterAll(() => jest.useRealTimers());
+	describe('asyncForEach', () => {
+		it('sequentially executes a callback for each promise with the resolved value, current index, and array length', async () => {
+			const promises = [
+				Promise.resolve(1),
+				Promise.resolve(2),
+				Promise.resolve(3),
+				Promise.resolve(4),
+			];
+			jest.runAllTimers();
+			const done: boolean[] = [];
+			const results: number[] = [];
+			let i = 0;
+			await asyncForEach(promises, (value, index, length) => {
+				expect(index).toBe(i++);
+				expect(length).toBe(promises.length);
+				if (index > 0) {
+					expect(done[index - 1]).toBe(true);
+				}
+				done[index] = true;
+				results.push(value);
+			});
+			jest.runAllTimers();
+			expect(results).toEqual([1, 2, 3, 4]);
+		});
+		it('awaits a list of promises', async () => {
+			const promises = Promise.resolve([Promise.resolve(1), Promise.resolve(2)]);
+			const results: number[] = [];
+			jest.runAllTimers();
+			await asyncForEach(promises, (value) => results.push(value));
+			expect(results).toEqual([1, 2]);
+		});
+		it('throws an error when a promise is rejected', async () => {
+			const promises = Promise.resolve([
+				Promise.resolve(1),
+				Promise.reject(2),
+				Promise.resolve(3),
+			]);
+			const results: number[] = [];
+			jest.runAllTimers();
+			await expect(asyncForEach(promises, (value) => results.push(value))).rejects.toEqual(2);
+			expect(results).toEqual([1]);
+		});
+	});
+	describe('asyncMap', () => {
+		it('produces a new array using the values returned from a function called with each resolved value of an array of promises', async () => {
+			const promises = Promise.resolve([
+				Promise.resolve(1),
+				Promise.resolve(2),
+				Promise.resolve(3),
+			]);
+			const results = await asyncMap(promises, (n) => Promise.resolve(n + 1));
+			expect(results).toEqual([2, 3, 4]);
+		});
+		it('uses its concurrency option to process multiple values in parallel', async () => {
+			const tick = () => new Promise(setImmediate);
+			const config = { concurrency: 2 };
+			const values = [0, 1, 2, 3, 4];
+			const pending: Function[] = [];
+			const resolve = (n: number) => {
+				pending[n]();
+				return tick();
+			};
+			const iteratee = (n: number) =>
+				new Promise((r) => (pending[n] = r)).then(() => delete pending[n]);
+			let done = false;
+			asyncMap(values, iteratee, config).then(() => (done = true));
+			await tick();
+			expect(pending[0]).toBeInstanceOf(Function);
+			expect(pending[1]).toBeInstanceOf(Function);
+			expect(pending[2]).toBe(undefined);
+			expect(pending[3]).toBe(undefined);
+			expect(pending[4]).toBe(undefined);
+			expect(done).toBe(false);
+			await resolve(0);
+			expect(pending[0]).toBe(undefined);
+			expect(pending[1]).toBeInstanceOf(Function);
+			expect(pending[2]).toBeInstanceOf(Function);
+			expect(pending[3]).toBe(undefined);
+			expect(pending[4]).toBe(undefined);
+			expect(done).toBe(false);
+			await resolve(1);
+			await resolve(2);
+			expect(pending[0]).toBe(undefined);
+			expect(pending[1]).toBe(undefined);
+			expect(pending[2]).toBe(undefined);
+			expect(pending[3]).toBeInstanceOf(Function);
+			expect(pending[4]).toBeInstanceOf(Function);
+			expect(done).toBe(false);
+			await resolve(4);
+			expect(pending[0]).toBe(undefined);
+			expect(pending[1]).toBe(undefined);
+			expect(pending[2]).toBe(undefined);
+			expect(pending[3]).toBeInstanceOf(Function);
+			expect(pending[4]).toBe(undefined);
+			expect(done).toBe(false);
+			await resolve(3);
+			expect(pending[0]).toBe(undefined);
+			expect(pending[1]).toBe(undefined);
+			expect(pending[2]).toBe(undefined);
+			expect(pending[3]).toBe(undefined);
+			expect(pending[4]).toBe(undefined);
+			expect(done).toBe(true);
+		});
+	});
+});

--- a/utils/__tests__/async.test.ts
+++ b/utils/__tests__/async.test.ts
@@ -35,14 +35,17 @@ describe('async utils', () => {
 			expect(results).toEqual([1, 2]);
 		});
 		it('throws an error when a promise is rejected', async () => {
+			const error = new Error();
 			const promises = Promise.resolve([
 				Promise.resolve(1),
-				Promise.reject(2),
+				Promise.reject(error),
 				Promise.resolve(3),
 			]);
 			const results: number[] = [];
 			jest.runAllTimers();
-			await expect(asyncForEach(promises, (value) => results.push(value))).rejects.toEqual(2);
+			await expect(asyncForEach(promises, (value) => results.push(value))).rejects.toEqual(
+				error,
+			);
 			expect(results).toEqual([1]);
 		});
 	});
@@ -66,9 +69,15 @@ describe('async utils', () => {
 				return tick();
 			};
 			const iteratee = (n: number) =>
-				new Promise((r) => (pending[n] = r)).then(() => delete pending[n]);
+				new Promise((r) => {
+					pending[n] = r;
+				}).then(() => {
+					delete pending[n];
+				});
 			let done = false;
-			asyncMap(values, iteratee, config).then(() => (done = true));
+			asyncMap(values, iteratee, config).then(() => {
+				done = true;
+			});
 			await tick();
 			expect(pending[0]).toBeInstanceOf(Function);
 			expect(pending[1]).toBeInstanceOf(Function);

--- a/utils/async.ts
+++ b/utils/async.ts
@@ -64,12 +64,12 @@ export async function asyncMap<T, R>(
 					cursor++;
 					pending++;
 					Promise.resolve(next)
-						.then(function onVisitedPromiseResolve(value) {
+						.then((value) => {
 							return iteratee(value, index, resolvedLength);
 						})
 						.then(
 							// eslint-disable-next-line no-loop-func
-							function onVisitedPromiseUnwrapped(value) {
+							(value) => {
 								pending--;
 								results[index] = value;
 								enqueueNextPromises();
@@ -77,7 +77,7 @@ export async function asyncMap<T, R>(
 						)
 						.catch(
 							// eslint-disable-next-line no-loop-func
-							function onVisitedPromiseReject(err) {
+							(err) => {
 								pending--;
 								reject(err);
 							},

--- a/utils/async.ts
+++ b/utils/async.ts
@@ -22,7 +22,7 @@ export async function asyncForEach<T>(
 		// eslint-disable-next-line no-await-in-loop
 		const value = await resolvedList[i];
 		results.push(value);
-		iteratee(value, i, resolvedLength);
+		await iteratee(value, i, resolvedLength);
 	}
 	return results;
 }

--- a/utils/async.ts
+++ b/utils/async.ts
@@ -1,0 +1,86 @@
+import { assert } from 'utils/assert';
+
+type AsyncIterable<T> = Iterable<T | Promise<T>> | Promise<Iterable<T | Promise<T>>>;
+type AsyncForEachIteratee<T> = (value: T, index: number, arrayLength: number) => void;
+
+/**
+ * Native port of Bluebird's Promise.prototype.each. Accepts an iterable (or
+ * Promise-wrapped iterable) of any value, and an callback function to be
+ * executed for each value that the iterable yields.
+ *
+ * If a value is a promise, `asyncForEach` will wait for it before iterating
+ * further.
+ */
+export async function asyncForEach<T>(
+	iterable: AsyncIterable<T>,
+	iteratee: AsyncForEachIteratee<T>,
+): Promise<T[]> {
+	const results: T[] = [];
+	const resolvedList = Array.from(await iterable);
+	const resolvedLength = resolvedList.length;
+	let i = 0;
+	for await (const value of resolvedList) {
+		results.push(value);
+		iteratee(value, i, resolvedLength);
+		i++;
+	}
+	return results;
+}
+
+type AsyncMapIteratee<T, R> = (value: T, index: number, arrayLength: number) => R | Promise<R>;
+type AsyncMapOptions = { concurrency?: number };
+
+export async function asyncMap<T, R>(
+	iterable: AsyncIterable<T>,
+	iteratee: AsyncMapIteratee<T, R>,
+	options?: AsyncMapOptions,
+): Promise<R[]> {
+	const concurrency = options?.concurrency ?? Infinity;
+	const resolvedList = Array.from(await iterable);
+	const resolvedLength = resolvedList.length;
+	assert(concurrency > 0);
+	return new Promise((resolve, reject) => {
+		const results: R[] = [];
+
+		let pending = 0;
+		let cursor = 0;
+
+		function enqueueNextPromises() {
+			// If we have called .then() for all values, and no promises are pending,
+			// resolve with the final array of results.
+			if (cursor === resolvedLength && pending === 0) {
+				resolve(results);
+			} else {
+				// Call .then() in batches for promises moving left->right, only
+				// executing at maximum the value of the configured concurrency.
+				while (pending < Math.min(concurrency, resolvedLength - cursor)) {
+					const index = cursor;
+					const next = resolvedList[index];
+					pending++;
+					Promise.resolve(next)
+						.then(function onVisitedPromiseResolve(value) {
+							return iteratee(value, index, resolvedLength);
+						})
+						.then(function onVisitedPromiseUnwrapped(value) {
+							results[index] = value;
+							pending--;
+						})
+						.catch(function onVisitedPromiseReject(err) {
+							reject(err);
+							pending--;
+						});
+					cursor++;
+				}
+			}
+		}
+
+		enqueueNextPromises();
+	});
+}
+
+export async function asyncMapSeries<T, R>(
+	iterable: AsyncIterable<T>,
+	iteratee: AsyncMapIteratee<T, R>,
+): Promise<R[]> {
+	return asyncMap(iterable, iteratee, { concurrency: 1 });
+}

--- a/utils/async.ts
+++ b/utils/async.ts
@@ -64,6 +64,7 @@ export async function asyncMap<T, R>(
 						.then(function onVisitedPromiseUnwrapped(value) {
 							results[index] = value;
 							pending--;
+							enqueueNextPromises();
 						})
 						.catch(function onVisitedPromiseReject(err) {
 							reject(err);

--- a/utils/async.ts
+++ b/utils/async.ts
@@ -1,7 +1,11 @@
 import { assert } from 'utils/assert';
 
 type AsyncIterable<T> = Iterable<T | Promise<T>> | Promise<Iterable<T | Promise<T>>>;
-type AsyncForEachIteratee<T> = (value: T, index: number, arrayLength: number) => void;
+type AsyncForEachIteratee<T> = (
+	value: T,
+	index: number,
+	arrayLength: number,
+) => unknown | Promise<unknown>;
 
 /**
  * Native port of Bluebird's Promise.prototype.each. Accepts an iterable (or
@@ -22,6 +26,7 @@ export async function asyncForEach<T>(
 		// eslint-disable-next-line no-await-in-loop
 		const value = await resolvedList[i];
 		results.push(value);
+		// eslint-disable-next-line no-await-in-loop
 		await iteratee(value, i, resolvedLength);
 	}
 	return results;

--- a/utils/crossref/__tests__/createDeposit.test.js
+++ b/utils/crossref/__tests__/createDeposit.test.js
@@ -1,4 +1,3 @@
-/* global describe, it, expect */
 import { mapMetadataFields } from '../../collections/metadata';
 import { getSchemaForKind } from '../../collections/schemas';
 

--- a/workers/tasks/import/bulk/publish.ts
+++ b/workers/tasks/import/bulk/publish.ts
@@ -1,5 +1,4 @@
-import Bluebird from 'bluebird';
-
+import { asyncMap } from 'utils/async';
 import { Collection } from 'server/models';
 import { createRelease } from 'server/release/queries';
 import { summarizeCollection, summarizeCommunity } from 'server/scopeSummary';
@@ -17,7 +16,7 @@ export const publishBulkImportPlan = async ({ plan, yes, actor, dryRun, createEx
 		throwIfNo: true,
 	});
 	const { collections, pubs } = getCreatedItemsFromPlan(plan);
-	await Bluebird.map(
+	await asyncMap(
 		pubs,
 		(pub) =>
 			createRelease({

--- a/workers/tasks/import/bulk/resolve.ts
+++ b/workers/tasks/import/bulk/resolve.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-syntax */
-import BluebirdPromise from 'bluebird';
+import { asyncMapSeries } from 'utils/async';
 
 import {
 	resolveCommunityDirective,
@@ -79,7 +79,7 @@ export const resolveImportPlan = async ({ importPlan, actor, parents }) => {
 	}
 
 	if (children && children.length > 0) {
-		const resolvedChildPlans = await BluebirdPromise.mapSeries(children, (childPlan) =>
+		const resolvedChildPlans = await asyncMapSeries(children, (childPlan) =>
 			resolveImportPlan({ importPlan: childPlan, actor, parents: currentParents }),
 		);
 		return { ...importPlan, resolved: resolvedValues, children: resolvedChildPlans };

--- a/workers/utils/__tests__/searchUtils.test.ts
+++ b/workers/utils/__tests__/searchUtils.test.ts
@@ -1,4 +1,3 @@
-/* global describe, it, expect, beforeAll, afterAll */
 import { stub, modelize, setup, teardown, determinize } from 'stubstub';
 import { plainDoc, fullDoc, imageDoc } from 'utils/storybook/data';
 


### PR DESCRIPTION
This PR removes our `bluebird` dependency. This should shave off a few hundred KB from our Heroku slug size. This necessitated that we port few Bluebird utilities, specifically `Promise.each`, `Promise.map` and `Promise.mapSeries`. The helpers live in a new file at utils/async.ts.

In addition, Bluebird's `promisify` was replaced with Node's `util.promisify`. As far as I can tell, the two functions work exactly the same way. 

There may be some minor risk in these changes, but I've done my best to ensure that the each/map/mapSeries ports work 1:1 with unit tests.

_Test Plan_

I think a quick smoke test should suffice. @idreyn could you maybe help me find the best code to test `Promise.map`/`asyncMap`'s concurrency option?