### PR TITLE
bug: hide 1 from citation preview 

### DIFF
--- a/client/containers/Pub/PubHeader/citationsPreview.scss
+++ b/client/containers/Pub/PubHeader/citationsPreview.scss
@@ -4,4 +4,7 @@
 	.citation-body {
 		margin-bottom: 5px;
 	}
+	.csl-left-margin {
+		display: none;
+	}
 }


### PR DESCRIPTION
removes a line from the citations preview
![image](https://user-images.githubusercontent.com/34730449/144866204-6e921f28-c33e-460f-b886-3c1eefc24756.png)


test: 
Set a pubs citation style to AMA. Go to the pub header and look at citations, the `1.` and the line break should now be gone 