### PR TITLE
Implement "notification cadence" in PubPub

### DIFF
--- a/server/userNotification/__tests__/api.test.ts
+++ b/server/userNotification/__tests__/api.test.ts
@@ -9,10 +9,10 @@ import { fetchUserNotifications } from '../queries';
 
 const communityId = uuid();
 const pubId = uuid();
-const userLastReceivedNotificationsAt = '2021-12-00:00:00.000';
+const baseTimestamp = '2021-12-00:00:00.000';
 
 const getDateForElapsedMinutes = (minutes: number) => {
-	const timestamp = new Date(userLastReceivedNotificationsAt).valueOf();
+	const timestamp = new Date(baseTimestamp).valueOf();
 	return new Date(timestamp + minutes * 60 * 1000);
 };
 

--- a/server/userNotification/__tests__/api.test.ts
+++ b/server/userNotification/__tests__/api.test.ts
@@ -3,17 +3,42 @@ import uuid from 'uuid/v4';
 
 import { UserNotification } from 'server/models';
 import { modelize, login, setup, teardown } from 'stubstub';
-import { fetchUserNotifications } from '..';
+import { PubDiscussionCommentAddedActivityItem } from 'types';
+
+import { fetchUserNotifications } from '../queries';
 
 const communityId = uuid();
 const pubId = uuid();
-const userLastReceivedNotificationsAt = '2021-12-08T01:05:00.000';
+const userLastReceivedNotificationsAt = '2021-12-00:00:00.000';
+
+const getDateForElapsedMinutes = (minutes: number) => {
+	const timestamp = new Date(userLastReceivedNotificationsAt).valueOf();
+	return new Date(timestamp + minutes * 60 * 1000);
+};
+
+const getTimestampForElapsedMinutes = (minutes: number) => {
+	return getDateForElapsedMinutes(minutes).toISOString();
+};
+
+const fakePayload: PubDiscussionCommentAddedActivityItem['payload'] = {
+	threadComment: {
+		id: uuid(),
+		text: 'hmm',
+		userId: uuid(),
+	},
+	threadId: uuid(),
+	discussionId: uuid(),
+	isReply: true,
+	pub: {
+		title: 'Fake',
+	},
+};
 
 const models = modelize`
     User user {
 		UserNotificationPreferences {
-			notificationCadence: 1
-			lastReceivedNotificationsAt: ${userLastReceivedNotificationsAt}
+			notificationCadence: 60
+			lastReceivedNotificationsAt: ${getTimestampForElapsedMinutes(65)}
 		}
 	}
     User rando {}
@@ -37,18 +62,22 @@ const models = modelize`
         communityId: ${communityId}
         pubId: ${pubId}
         kind: 'pub-discussion-comment-added'
+		payload: ${fakePayload}
     }
 
     ActivityItem activityItem2 {
         communityId: ${communityId}
         pubId: ${pubId}
         kind: 'pub-discussion-comment-added'
+		payload: ${fakePayload}
+
     }
 
     ActivityItem activityItem3 {
         communityId: ${communityId}
         pubId: ${pubId}
         kind: 'pub-discussion-comment-added'
+		payload: ${fakePayload}
     }
 
     Thread thread {
@@ -58,17 +87,17 @@ const models = modelize`
             UserNotification n1 {
                 user: user
                 activityItem: activityItem1
-				createdAt: "2021-12-08T00:00:00.000"
+				createdAt: ${getTimestampForElapsedMinutes(0)}
             }
             UserNotification n2 {
                 user: user
                 activityItem: activityItem2
-				createdAt: "2021-12-08T01:00:00.000"
+				createdAt: ${getTimestampForElapsedMinutes(60)}
             }
             UserNotification n3 {
                 user: user
                 activityItem: activityItem3
-				createdAt: "2021-12-08T01:15:00.000"
+				createdAt: ${getTimestampForElapsedMinutes(75)}
             }
         }
     }
@@ -76,6 +105,25 @@ const models = modelize`
 
 setup(beforeAll, models.resolve);
 teardown(afterAll);
+
+describe('fetchUserNotifications()', () => {
+	it("respects a user's notificationCadence", async () => {
+		const { n1, n2, n3, user } = models;
+		const { notifications: notifications80 } = await fetchUserNotifications({
+			userId: user.id,
+			now: getDateForElapsedMinutes(80),
+		});
+		// At t = 80 min, n1-n3 already exist, but because the user fetched notifications at t0 = 65
+		// and has a cadence of c = 60, we won't show notifications newer than t0 until t1 = t0 + c
+		expect(notifications80.map((n) => n.id)).toEqual([n2.id, n1.id]);
+		// Fetch the notifications again at t1 = t0 + c = 125 min
+		const { notifications: notifications125 } = await fetchUserNotifications({
+			userId: user.id,
+			now: getDateForElapsedMinutes(125),
+		});
+		expect(notifications125.map((n) => n.id)).toEqual([n3.id, n2.id, n1.id]);
+	});
+});
 
 describe('/api/userNotifications', () => {
 	it("Does not let a user manipulate another user's notifications", async () => {
@@ -134,13 +182,5 @@ describe('/api/userNotifications', () => {
 			.send({ userNotificationIds: [n1, n2, n3].map((n) => n.id) })
 			.expect(200);
 		expect(await UserNotification.count({ where: { userId: user.id } })).toEqual(0);
-	});
-});
-
-describe('fetchUserNotifications()', () => {
-	it.only("respects a user's notificationCadence", async () => {
-		const { n1, n2, n3, user } = models;
-		const { notifications } = await fetchUserNotifications({ userId: user.id });
-		expect(notifications.map((n) => n.id)).toEqual([n2, n1]);
 	});
 });

--- a/server/userNotificationPreferences/model.ts
+++ b/server/userNotificationPreferences/model.ts
@@ -5,6 +5,7 @@ export default (sequelize, dataTypes) => {
 			id: sequelize.idType,
 			userId: { type: dataTypes.UUID, allowNull: false },
 			receiveNotifications: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+			lastReceivedNotificationsAt: { type: dataTypes.DATE, allowNull: true },
 			subscribeToThreadsAsCommenter: {
 				type: dataTypes.BOOLEAN,
 				allowNull: false,

--- a/server/userNotificationPreferences/queries.ts
+++ b/server/userNotificationPreferences/queries.ts
@@ -9,6 +9,7 @@ const updatableFields = [
 	'subscribeToPubsAsContributor',
 	'notificationCadence',
 	'markReadTrigger',
+	'lastReceivedNotificationsAt',
 ] as const;
 
 type UpdateOptions = {

--- a/types/userNotification.ts
+++ b/types/userNotification.ts
@@ -26,6 +26,7 @@ export type UserNotificationPreferences = {
 	id: string;
 	createdAt: string;
 	updatedAt: string;
+	lastReceivedNotificationsAt: null | string;
 	userId: string;
 	receiveNotifications: boolean;
 	subscribeToThreadsAsCommenter: boolean;


### PR DESCRIPTION
I've had this crazy idea for a tool that prevents compulsive notification-checking for a while, that I call _notification cadence_. The rules go like this:

1. You pick a cadence `c`, which is a time interval, given in minutes, that we store
2. When you check your notifications, we mark this time as `t0`
3. Your notifications are now frozen in time — no more new ones will appear for `c` minutes
4. At `t1 >= t0 + c` you can check again and we'll show you all your notifications, including those created on `[t0, t1]`
5. Your notifications are now frozen again until `t1 + c`. The cycle continues...

(For `c = 0` you'll receive notifications instantly)

We have a field in `UserNotificationPreferences` for notification cadence, and a dropdown that lets you select one:

<img width="302" alt="image" src="https://user-images.githubusercontent.com/2208769/145306487-d5842df7-3eef-472f-9c42-031a55ad2f15.png">

This PR just implements the feature.

_Test plan:_
```
npm run test-dev server/userNotification
```