### PR TITLE
update: add issn, publisher, dates, issue, volume, elocation to jats output

### DIFF
--- a/workers/tasks/export/metadata.ts
+++ b/workers/tasks/export/metadata.ts
@@ -61,6 +61,7 @@ export const getPubMetadata = async (pubId: string): Promise<PubMetadata> => {
 	const primaryCollection = getPrimaryCollection(pubData.collectionPubs);
 	return {
 		title: pubData.title,
+		slug: pubData.slug,
 		doi: pubData.doi,
 		publishedDateString,
 		updatedDateString,

--- a/workers/tasks/export/types.ts
+++ b/workers/tasks/export/types.ts
@@ -6,6 +6,7 @@ import { RenderedStructuredValue } from 'utils/notesCore';
 
 export type PubMetadata = {
 	title: string;
+	slug: string;
 	doi: null | string;
 	publishedDateString: Maybe<string>;
 	updatedDateString: Maybe<string>;


### PR DESCRIPTION
Resolves #1688 and adds some other needed fields for Portico.

_Test plan_
1. Create a pub in a community with "publisher" and "cite as" set, in journal issue collection with all its metadata filled out.
2. Add two or more authors, one of whom has an orcid ID (you can use Gabriel Stein with the photo if needed, or create a shadow author and make one up).
3. Download a regenerated JATS file and check that all of the following are properly filled out:
- journal-title: community cite as setting
- issn (print): collection print issn setting
- issn (electronic): collection electronic issn setting
- publisher-name: community publisher setting
- author orcid id
- volume: collection volume setting
- issue: collection issue setting
- elocation-id: pub slug
- pub-dates with proper year, date, and month
- correct license string (

4. Change the license to copyright and regenerate and re-download the JATS file. Make sure the copyright is correctly attributed to the publisher in the publication year set by the issue collection.

5. Remove the community-level publish as and cite as, regenerate and re-download the JATS file. Make sure:
- journal-title: community title
- publisher-name: community title