### PR TITLE
dev: Add type definitions to `usePageContext`

### DIFF
--- a/client/components/Avatar/Avatar.tsx
+++ b/client/components/Avatar/Avatar.tsx
@@ -1,37 +1,26 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
+
 import { getResizedUrl } from 'utils/images';
 import { usePageContext } from 'utils/hooks';
 
 require('./avatar.scss');
 
-const propTypes = {
-	width: PropTypes.number.isRequired, // Integer number of pixels for avatar
-	initials: PropTypes.string,
-	avatar: PropTypes.string,
-	instanceNumber: PropTypes.number,
-	borderColor: PropTypes.string,
-	borderWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-	doesOverlap: PropTypes.bool, // Boolean on whether a lisst of avatars will be overlapping
-	isBlock: PropTypes.bool,
-	className: PropTypes.string,
+type Props = {
+	width: number;
+	initials?: string;
+	avatar?: string;
+	instanceNumber?: number;
+	borderColor?: string;
+	borderWidth?: number | string;
+	doesOverlap?: boolean;
+	isBlock?: boolean;
+	className?: string;
 };
 
-const defaultProps = {
-	initials: '?',
-	avatar: undefined,
-	instanceNumber: undefined,
-	borderColor: undefined,
-	borderWidth: undefined,
-	doesOverlap: false,
-	isBlock: false,
-	className: '',
-};
-
-const Avatar = function (props) {
+const Avatar = (props: Props) => {
 	const {
-		initials,
+		initials = '?',
 		avatar,
 		instanceNumber,
 		borderColor,
@@ -43,7 +32,7 @@ const Avatar = function (props) {
 	} = props;
 	const { communityData } = usePageContext();
 
-	const avatarStyle = {
+	const avatarStyle: React.CSSProperties = {
 		width,
 		minWidth: width,
 		height: width,
@@ -51,7 +40,7 @@ const Avatar = function (props) {
 		borderWidth: borderColor ? borderWidth || Math.floor(width / 50) + 1 : 0,
 		fontSize: isBlock ? Math.floor(width / 1.5) : Math.floor(width / 2.5),
 		backgroundColor: communityData.accentColorDark,
-		zIndex: instanceNumber ? -1 * instanceNumber : 'initial',
+		zIndex: typeof instanceNumber === 'number' ? -1 * instanceNumber : 'initial',
 		borderRadius: isBlock ? '2px' : '50%',
 	};
 
@@ -59,22 +48,17 @@ const Avatar = function (props) {
 	const resizedImageUrl = getResizedUrl(avatar, 'cover', imageSize, imageSize);
 
 	if (doesOverlap) {
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'marginRight' does not exist on type '{ w... Remove this comment to see the full error message
 		avatarStyle.marginRight = `${width * 0.45 * -1}px`;
 	}
 	if (avatar) {
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'backgroundImage' does not exist on type ... Remove this comment to see the full error message
 		avatarStyle.backgroundImage = `url("${resizedImageUrl}")`;
 	}
 
 	return (
-		// @ts-expect-error ts-migrate(2322) FIXME: Type '{ width: any; minWidth: any; height: any; bo... Remove this comment to see the full error message
 		<div className={classNames(['avatar-component', className])} style={avatarStyle}>
 			{!avatar && <div>{initials}</div>}
 		</div>
 	);
 };
 
-Avatar.defaultProps = defaultProps;
-Avatar.propTypes = propTypes;
 export default Avatar;

--- a/client/components/Footer/Footer.stories.tsx
+++ b/client/components/Footer/Footer.stories.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import { AccentStyle, Footer } from 'components';
-import { populateSocialItems } from 'client/utils/navigation';
+import { createSocialNavItems } from 'client/utils/navigation';
 import { communityData } from 'utils/storybook/data';
 
 const wrapperStyle = { margin: '1em 0em' };
 
-const socialItems = populateSocialItems({
+const socialItems = createSocialNavItems({
 	website: communityData.website,
 	twitter: communityData.twitter,
 	facebook: communityData.facebook,

--- a/client/components/Footer/Footer.tsx
+++ b/client/components/Footer/Footer.tsx
@@ -14,7 +14,7 @@ import { apiFetch } from 'client/utils/apiFetch';
 import { usePageContext } from 'utils/hooks';
 import {
 	defaultFooterLinks,
-	populateSocialItems,
+	createSocialNavItems,
 	getNavItemsForCommunityNavigation,
 	SocialItem,
 } from 'client/utils/navigation';
@@ -32,10 +32,10 @@ const defaultProps = {
 type Props = OwnProps & typeof defaultProps;
 
 const basePubPubFooterLinks = [
-	{ id: 1, title: 'Create your community', href: '/community/create' },
-	{ id: 2, title: 'Login', href: '/login' },
-	{ id: 3, title: 'Signup', href: '/signup' },
-	{ id: 4, title: 'Legal', href: '/legal' },
+	{ id: '1', title: 'Create your community', href: '/community/create' },
+	{ id: '2', title: 'Login', href: '/login' },
+	{ id: '3', title: 'Signup', href: '/signup' },
+	{ id: '4', title: 'Legal', href: '/legal' },
 ];
 
 const baseSocialItems: SocialItem[] = [
@@ -107,7 +107,7 @@ const Footer = (props: Props) => {
 			? '/static/logoBlack.svg'
 			: '/static/logoWhite.svg';
 	const wrapperClasses = isBasePubPub ? 'base-pubpub' : 'accent-background accent-color';
-	const socialItems = isBasePubPub ? baseSocialItems : populateSocialItems(communityData);
+	const socialItems = isBasePubPub ? baseSocialItems : createSocialNavItems(communityData);
 	return (
 		<div className={`footer-component ${wrapperClasses}`}>
 			<GridWrapper>

--- a/client/components/Header/Header.tsx
+++ b/client/components/Header/Header.tsx
@@ -13,6 +13,7 @@ import {
 import { usePageContext } from 'utils/hooks';
 import { getResizedUrl } from 'utils/images';
 import { apiFetch } from 'client/utils/apiFetch';
+import { CommunityHeroButton } from 'types';
 
 require('./header.scss');
 
@@ -159,8 +160,9 @@ const Header = (props: Props) => {
 	const redirectString = `?redirect=${locationData.path}${
 		locationData.queryString.length > 1 ? locationData.queryString : ''
 	}`;
-	const heroPrimaryButton = communityData.heroPrimaryButton || {};
-	const heroSecondaryButton = communityData.heroSecondaryButton || {};
+	const heroPrimaryButton: Partial<CommunityHeroButton> = communityData.heroPrimaryButton || {};
+	const heroSecondaryButton: Partial<CommunityHeroButton> =
+		communityData.heroSecondaryButton || {};
 	const isPreview = !!props.previewContext;
 
 	return (

--- a/client/components/LayoutEditor/LayoutEditor.tsx
+++ b/client/components/LayoutEditor/LayoutEditor.tsx
@@ -3,7 +3,7 @@ import { Button, Tooltip, Card } from '@blueprintjs/core';
 import stickybits from 'stickybits';
 
 import { LayoutBlock, LayoutPubsByBlock } from 'utils/layout';
-import { Pub, Community, Collection } from 'types';
+import { Pub, Community, Collection, DefinitelyHas } from 'types';
 
 import { Popover } from 'components';
 import { useLayout } from './useLayout';
@@ -23,10 +23,7 @@ type Props = {
 	initialLayout: LayoutBlock[];
 	initialLayoutPubsByBlock: LayoutPubsByBlock<Pub>;
 	collection?: Collection;
-	communityData: Community & {
-		pages: NonNullable<Community['pages']>;
-		collections: NonNullable<Community['collections']>;
-	};
+	communityData: DefinitelyHas<Community, 'pages' | 'collections'>;
 };
 
 const validBlockTypes = [

--- a/client/components/LegalBanner/LegalBanner.tsx
+++ b/client/components/LegalBanner/LegalBanner.tsx
@@ -5,15 +5,13 @@ import { Button } from '@blueprintjs/core';
 
 import { shouldShowTosUpdate, markTosUpdateSeen } from 'client/utils/legal/tosUpdate';
 import { shouldShowGdprBanner, updateGdprConsent } from 'client/utils/legal/gdprConsent';
+import { LoginData } from 'types';
 
 require('./legalBanner.scss');
 
 type Props = {
 	// eslint-disable-next-line react/no-unused-prop-types
-	loginData: {
-		id?: string;
-		gdprConsent?: boolean;
-	};
+	loginData: LoginData;
 };
 
 const banners = [

--- a/client/components/NavBar/NavBar.tsx
+++ b/client/components/NavBar/NavBar.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import {
 	NavbarItem,
 	getNavItemsForCommunityNavigation,
-	populateSocialItems,
+	createSocialNavItems,
 	isNavbarMenu,
 } from 'client/utils/navigation';
 import { usePageContext } from 'utils/hooks';
@@ -30,7 +30,7 @@ const NavBar = function (props) {
 		pages,
 		collections,
 	});
-	const socialItems = populateSocialItems(communityData);
+	const socialItems = createSocialNavItems(communityData);
 
 	const renderMenuSubitem = (subitem: NavbarItem, index: number) => {
 		if (!isNavbarMenu(subitem)) {

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { getDashUrl } from 'utils/dashboard';
 import { usePageContext } from 'utils/hooks';
 import { Avatar, Icon, IconName, MenuItem } from 'components';
@@ -10,7 +11,7 @@ type Scope = {
 	icon: IconName;
 	iconSize?: number;
 	title: string;
-	avatar: string;
+	avatar: undefined | string;
 	href: string;
 };
 

--- a/client/containers/App/SideMenu/ScopePicker.tsx
+++ b/client/containers/App/SideMenu/ScopePicker.tsx
@@ -9,7 +9,7 @@ type Scope = {
 	type: 'Community' | 'Collection' | 'Pub';
 	icon: IconName;
 	title: string;
-	avatar: string;
+	avatar?: string;
 	href: string;
 };
 

--- a/client/containers/App/usePageState.ts
+++ b/client/containers/App/usePageState.ts
@@ -18,7 +18,6 @@ export const usePageState = (initialData: InitialData, viewData: PossibleViewDat
 		locationData: initialLocationData,
 		scopeData: initialScopeData,
 		featureFlags,
-		initialNotificationsData,
 	} = initialData;
 	const { pageData: initialPageData } = viewData;
 	const [loginData] = useState(initialLoginData);

--- a/client/containers/App/usePageState.ts
+++ b/client/containers/App/usePageState.ts
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 
 import { NoteManager } from 'client/utils/notes';
-import { InitialData, Page } from 'types';
-import { PageContext } from 'types/context';
+import { InitialData, Page, PageContext } from 'types';
 
 // viewData contains container-specific props that we usually shouldn't peek at when doing
 // operations that could occur inside _any_ container -- but sometimes we cheat. This type

--- a/client/containers/App/usePageState.ts
+++ b/client/containers/App/usePageState.ts
@@ -1,14 +1,24 @@
 import { useState } from 'react';
 
 import { NoteManager } from 'client/utils/notes';
+import { InitialData, Page } from 'types';
+import { PageContext } from 'types/context';
 
-export const usePageState = (initialData, viewData) => {
+// viewData contains container-specific props that we usually shouldn't peek at when doing
+// operations that could occur inside _any_ container -- but sometimes we cheat. This type
+// defines the possible values we might check for there.
+type PossibleViewData = {
+	pageData: Page;
+};
+
+export const usePageState = (initialData: InitialData, viewData: PossibleViewData): PageContext => {
 	const {
 		loginData: initialLoginData,
 		communityData: initialCommunityData,
 		locationData: initialLocationData,
 		scopeData: initialScopeData,
 		featureFlags,
+		initialNotificationsData,
 	} = initialData;
 	const { pageData: initialPageData } = viewData;
 	const [loginData] = useState(initialLoginData);
@@ -27,9 +37,14 @@ export const usePageState = (initialData, viewData) => {
 	};
 
 	const updateCollection = (next) => {
-		if (scopeData.elements.activeCollection) {
+		const { activeCollection } = scopeData.elements;
+		if (activeCollection) {
+			if (typeof next === 'function') {
+				// eslint-disable-next-line no-param-reassign
+			}
+			next = next(activeCollection);
 			const nextCollection = {
-				...scopeData.elements.activeCollection,
+				...activeCollection,
 				...next,
 			};
 			setScopeData((current) => {

--- a/client/containers/DashboardEdges/DashboardEdges.tsx
+++ b/client/containers/DashboardEdges/DashboardEdges.tsx
@@ -121,9 +121,9 @@ const DashboardEdges = (props: Props) => {
 				<DashboardEdgesListing
 					pubData={persistedPubData}
 					pubEdges={outboundEdges}
-					onUpdateEdge={canManageEdges && updateOutboundEdge}
-					onReorderEdges={canManageEdges && reorderOutboundEdges}
-					onRemoveEdge={canManageEdges && removeOutboundEdge}
+					onUpdateEdge={canManageEdges ? updateOutboundEdge : undefined}
+					onReorderEdges={canManageEdges ? reorderOutboundEdges : undefined}
+					onRemoveEdge={canManageEdges ? removeOutboundEdge : undefined}
 					isInbound={false}
 					renderEmptyState={() =>
 						showOutboundEmptyState && (
@@ -148,7 +148,7 @@ const DashboardEdges = (props: Props) => {
 			<DashboardEdgesListing
 				pubData={persistedPubData}
 				pubEdges={inboundEdges}
-				onUpdateEdgeApproval={canManageEdges && updateInboundEdgeApproval}
+				onUpdateEdgeApproval={canManageEdges ? updateInboundEdgeApproval : undefined}
 				isInbound={true}
 				renderEmptyState={() => (
 					<NonIdealState

--- a/client/containers/DashboardEdges/DashboardEdgesListing.tsx
+++ b/client/containers/DashboardEdges/DashboardEdgesListing.tsx
@@ -2,8 +2,8 @@ import { Button, Icon, Switch } from '@blueprintjs/core';
 import classNames from 'classnames';
 import React, { useState } from 'react';
 import { DragDropContext } from 'react-beautiful-dnd';
-import { PubEdge } from 'types';
 
+import { PubEdge } from 'types';
 import { usePendingChanges } from 'utils/hooks';
 import { apiFetch } from 'client/utils/apiFetch';
 import { ConfirmDialog, DragDropListing, PubEdgeListingCard } from 'components';
@@ -13,12 +13,12 @@ import NewEdgeEditor from './NewEdgeEditor';
 export type DashboardEdgesListingProps = {
 	pubData: any;
 	onUpdateEdge?: (pubEdge: PubEdge) => unknown;
-	onRemoveEdge?: (...args: any[]) => any;
-	onReorderEdges?: (...args: any[]) => any;
-	onUpdateEdgeApproval?: (...args: any[]) => any;
+	onRemoveEdge?: (pubEdge: PubEdge) => unknown;
+	onReorderEdges?: (idxA: number, idxB: number) => unknown;
+	onUpdateEdgeApproval?: (pubEdge: PubEdge, approved: boolean) => unknown;
 	isInbound: boolean;
-	pubEdges: any[];
-	renderEmptyState: (...args: any[]) => any;
+	pubEdges: PubEdge[];
+	renderEmptyState: () => React.ReactNode;
 };
 
 const renderRemoveEdgeButton = (callback) => {

--- a/client/containers/DashboardSettings/CollectionSettings/CollectionSettings.tsx
+++ b/client/containers/DashboardSettings/CollectionSettings/CollectionSettings.tsx
@@ -19,7 +19,7 @@ const CollectionSettings = () => {
 		},
 	} = usePageContext();
 	const { collection, updateCollection, deleteCollection, slugStatus, hasChanges } =
-		useCollectionState(activeCollection);
+		useCollectionState(activeCollection!);
 
 	useUpdateEffect(() => {
 		if (!hasChanges) {

--- a/client/containers/DashboardSettings/CommunitySettings.tsx
+++ b/client/containers/DashboardSettings/CommunitySettings.tsx
@@ -20,6 +20,7 @@ import { getDashUrl } from 'utils/dashboard';
 import { communityUrl } from 'utils/canonicalUrls';
 import { isDevelopment } from 'utils/environment';
 import { apiFetch } from 'client/utils/apiFetch';
+import { CommunityHeroButton } from 'types';
 
 import NavBuilder from './NavBuilder';
 
@@ -92,10 +93,10 @@ const CommunitySettings = () => {
 	const [heroImage, setHeroImage] = useState(communityData.heroImage);
 	const [heroTitle, setHeroTitle] = useState(communityData.heroTitle);
 	const [heroText, setHeroText] = useState(communityData.heroText);
-	const [heroPrimaryButton, setHeroPrimaryButton] = useState(
+	const [heroPrimaryButton, setHeroPrimaryButton] = useState<Partial<CommunityHeroButton>>(
 		communityData.heroPrimaryButton || {},
 	);
-	const [heroSecondaryButton, setHeroSecondaryButton] = useState(
+	const [heroSecondaryButton, setHeroSecondaryButton] = useState<Partial<CommunityHeroButton>>(
 		communityData.heroSecondaryButton || {},
 	);
 	const [heroAlign, setHeroAlign] = useState(communityData.heroAlign || 'left');
@@ -459,7 +460,7 @@ const CommunitySettings = () => {
 					wrapperClassName={hideCreatePubButton ? 'disable-block' : ''}
 				>
 					<CollectionMultiSelect
-						allCollections={communityData.collections}
+						allCollections={communityData.collections as any}
 						selectedCollectionIds={defaultPubCollections || []}
 						onItemSelect={(newCollectionId) => {
 							const existingCollectionIds = defaultPubCollections || [];

--- a/client/containers/DashboardSettings/navBuilderContext.ts
+++ b/client/containers/DashboardSettings/navBuilderContext.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { Collection, Page, CommunityNavigationEntry } from 'client/utils/navigation';
+import { Collection, Page } from 'types';
+import { CommunityNavigationEntry } from 'client/utils/navigation';
 
 type NavBuilderContextType = {
 	pages: Page[];

--- a/client/containers/Pub/PubDocument/PubDiscussions/PubDiscussions.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/PubDiscussions.tsx
@@ -43,7 +43,7 @@ const PubDiscussions = (props: Props) => {
 	const prevConvertedDiscussionIds = useRef([]);
 
 	const { discussions } = pubData;
-	const { canView, canCreateDiscussions } = scopeData;
+	const { canView, canCreateDiscussions } = scopeData.activePermissions;
 	const decorations = collabData.editorChangeObject.decorations || [];
 	const groupsByLine = groupDiscussionsByLine(decorations, discussions);
 

--- a/client/containers/Pub/PubDocument/PubFileImport/MetadataEditor.tsx
+++ b/client/containers/Pub/PubDocument/PubFileImport/MetadataEditor.tsx
@@ -13,7 +13,7 @@ import { usePubContext } from '../../pubHooks';
 
 require('./metadataEditor.scss');
 
-type attributionShape = {
+type Attribution = {
 	name?: string;
 	users?: {}[];
 };
@@ -21,12 +21,12 @@ type attributionShape = {
 type MetadataEditorProps = {
 	onSetMetadataUpdater: (...args: any[]) => any;
 	proposedMetadata: {
-		attributions?: attributionShape[];
+		attributions?: Attribution[];
 	};
 };
 
 type ProposedAttributionProps = {
-	attribution: attributionShape;
+	attribution: Attribution;
 	onUpdateAttribution: (...args: any[]) => any;
 };
 

--- a/client/containers/Search/Search.tsx
+++ b/client/containers/Search/Search.tsx
@@ -43,7 +43,7 @@ const Search = (props: Props) => {
 	const { locationData, communityData } = usePageContext();
 	const [searchQuery, setSearchQuery] = useState(locationData.query.q || '');
 	const [searchResults, setSearchResults] = useState<any>([]);
-	const [isLoading, setIsLoading] = useState(locationData.query.q || false);
+	const [isLoading, setIsLoading] = useState(!!locationData.query.q || false);
 	const [page, setPage] = useState(
 		locationData.query.page ? Number(locationData.query.page) - 1 : 0,
 	);
@@ -210,7 +210,7 @@ const Search = (props: Props) => {
 							placeholder="search..."
 							value={searchQuery}
 							onChange={handleSearchChange}
-							rightElement={isLoading && <Spinner size={35} />}
+							rightElement={isLoading ? <Spinner size={35} /> : undefined}
 							inputRef={inputRef as any}
 						/>
 					</div>

--- a/client/containers/User/User.tsx
+++ b/client/containers/User/User.tsx
@@ -19,7 +19,7 @@ const User = (props: Props) => {
 		return attribution.pub;
 	});
 
-	const selfProfile = loginData.id && userData.id === loginData.id;
+	const selfProfile = !!loginData.id && userData.id === loginData.id;
 	const mode = locationData.params.mode;
 	const localCommunityId = communityData.id;
 	const communityPubs = pubs.filter((pub) => {

--- a/client/utils/activity/types.ts
+++ b/client/utils/activity/types.ts
@@ -7,7 +7,7 @@ import { IconName } from 'components';
 export type ActivityRenderContext = {
 	associations: ActivityAssociations;
 	scope: Scope;
-	userId: string;
+	userId: null | string;
 	otherActorsCount?: number;
 };
 

--- a/client/utils/navigation.ts
+++ b/client/utils/navigation.ts
@@ -1,30 +1,13 @@
-import { IconName } from 'components/Icon/Icon';
+import { IconName } from 'components';
+import * as types from 'types';
 
-type Community = {
-	website: string;
-	facebook: string;
-	email: string;
-	twitter: string;
-};
-
-export type Collection = {
-	id: string;
-	title: string;
-	slug: string;
-	kind: string;
-	isPublic: boolean;
-};
-
-export type Page = {
-	id: string;
-	title: string;
-	slug: string;
-	isPublic: boolean;
-};
+type NavBuilderCommunity = Pick<types.Community, 'website' | 'twitter' | 'facebook' | 'email'>;
+type NavBuilderPage = Pick<types.Page, 'title' | 'id' | 'isPublic' | 'slug'>;
+type NavBuilderCollection = Pick<types.Collection, 'title' | 'id' | 'isPublic' | 'slug'>;
 
 type NavBuildContext = {
-	pages: Page[];
-	collections: Collection[];
+	pages: NavBuilderPage[];
+	collections: NavBuilderCollection[];
 };
 
 type CommunityNavigationMenu = { id: string; title: string; children: CommunityNavigationChild[] };
@@ -62,8 +45,8 @@ export type SocialItem = {
 	url: string;
 };
 
-export const populateSocialItems = (communityData: Community): SocialItem[] => {
-	return [
+export const createSocialNavItems = (communityData: NavBuilderCommunity): SocialItem[] => {
+	const possibleItems = [
 		{
 			id: 'si-0',
 			icon: 'globe' as const,
@@ -92,10 +75,13 @@ export const populateSocialItems = (communityData: Community): SocialItem[] => {
 			value: communityData.email,
 			url: `mailto:${communityData.email}`,
 		},
-	].filter((item) => item.value);
+	];
+	return possibleItems.filter((item) => !!item.value) as SocialItem[];
 };
 
-const getNavbarChildForPageOrCollection = (item: Page | Collection): NavbarChild => {
+const getNavbarChildForPageOrCollection = (
+	item: NavBuilderPage | NavBuilderCollection,
+): NavbarChild => {
 	return {
 		title: item.title,
 		href: `/${item.slug}`,

--- a/types/community.ts
+++ b/types/community.ts
@@ -3,7 +3,15 @@ import { CommunityNavigationEntry } from 'client/utils/navigation';
 import { Collection } from './collection';
 import { Pub } from './pub';
 import { Page } from './page';
+
 import { ScopeSummary } from './scope';
+
+export type CommunityHeroButton = {
+	title: string;
+	url: string;
+};
+
+export type CommunityHeaderLink = { title: string; url: string; external?: boolean };
 
 export type Community = {
 	id: string;
@@ -16,11 +24,12 @@ export type Community = {
 	publishAs?: string;
 	avatar?: string;
 	favicon?: string;
-	accentColorLight?: string;
-	accentColorDark?: string;
+	accentColorLight: string;
+	accentColorDark: string;
+	accentTextColor: string;
 	hideCreatePubButton?: boolean;
 	headerLogo?: string;
-	headerLinks?: { title: string; url: string; external?: boolean }[];
+	headerLinks?: CommunityHeaderLink[];
 	headerColorType?: 'light' | 'dark' | 'custom';
 	useHeaderTextAccent?: boolean;
 	hideHero?: boolean;
@@ -33,8 +42,8 @@ export type Community = {
 	heroImage?: string;
 	heroTitle?: string;
 	heroText?: string;
-	heroPrimaryButton?: {};
-	heroSecondaryButton?: {};
+	heroPrimaryButton?: CommunityHeroButton;
+	heroSecondaryButton?: CommunityHeroButton;
 	heroAlign?: string;
 	navigation: CommunityNavigationEntry[];
 	hideNav?: boolean;
@@ -57,4 +66,5 @@ export type Community = {
 	pubs?: Pub[];
 	scopeSummaryId: null | string;
 	scopeSummary?: ScopeSummary;
+	footerLogoLink?: string;
 };

--- a/types/context.ts
+++ b/types/context.ts
@@ -1,0 +1,25 @@
+import {
+	Collection,
+	Community,
+	InitialNotificationsData,
+	LocationData,
+	LoginData,
+	Maybe,
+	Page,
+	PatchFn,
+	ScopeData,
+} from 'types';
+import { NoteManager } from 'client/utils/notes';
+
+export type PageContext = {
+	scopeData: ScopeData;
+	loginData: LoginData;
+	locationData: LocationData;
+	pageData: Maybe<Page>;
+	communityData: Community;
+	updateCommunity: PatchFn<Community>;
+	updateCollection: PatchFn<Collection>;
+	featureFlags: Record<string, boolean>;
+	noteManager: NoteManager;
+	initialNotificationsData: InitialNotificationsData;
+};

--- a/types/context.ts
+++ b/types/context.ts
@@ -1,7 +1,6 @@
 import {
 	Collection,
-	Community,
-	InitialNotificationsData,
+	InitialCommunityData,
 	LocationData,
 	LoginData,
 	Maybe,
@@ -16,10 +15,9 @@ export type PageContext = {
 	loginData: LoginData;
 	locationData: LocationData;
 	pageData: Maybe<Page>;
-	communityData: Community;
-	updateCommunity: PatchFn<Community>;
+	communityData: InitialCommunityData;
+	updateCommunity: PatchFn<InitialCommunityData>;
 	updateCollection: PatchFn<Collection>;
 	featureFlags: Record<string, boolean>;
 	noteManager: NoteManager;
-	initialNotificationsData: InitialNotificationsData;
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -2,6 +2,7 @@ export * from './activity';
 export * from './attribution';
 export * from './collection';
 export * from './community';
+export * from './context';
 export * from './customScript';
 export * from './discussion';
 export * from './doc';

--- a/types/request.ts
+++ b/types/request.ts
@@ -2,19 +2,19 @@ import { Community } from './community';
 import { Collection } from './collection';
 import { Pub } from './pub';
 import { Member, MemberPermission } from './member';
-import { DefinitelyHas, Maybe } from './util';
+import { DefinitelyHas } from './util';
 import { Scope } from './scope';
 
 export type LoginData = {
 	id: string | null;
-	initials: Maybe<string>;
-	slug: Maybe<string>;
-	fullName: Maybe<string>;
-	firstName: Maybe<string>;
-	lastName: Maybe<string>;
-	avatar: Maybe<string>;
-	title: Maybe<string>;
-	gdprConsent: Maybe<boolean>;
+	initials?: string;
+	slug?: string;
+	fullName?: string;
+	firstName?: string;
+	lastName?: string;
+	avatar?: string;
+	title?: string;
+	gdprConsent?: string;
 };
 
 export type LocationData = {
@@ -45,8 +45,13 @@ export type ScopeData = {
 		isSuperAdmin: boolean;
 	};
 	elements: {
+		activeIds: {
+			communityId: string;
+			collectionId?: string;
+			pubId?: string;
+		};
 		activeTarget: Community | Collection | Pub;
-		activeTargetType: 'community' | 'collection' | 'pub';
+		activeTargetType: 'organization' | 'community' | 'collection' | 'pub';
 		activeTargetName: string;
 		activeCommunity: Community;
 		activeCollection?: Collection;
@@ -57,10 +62,15 @@ export type ScopeData = {
 	memberData: Member[];
 };
 
+export type InitialCommunityData = DefinitelyHas<
+	Community,
+	'collections' | 'pages' | 'scopeSummary'
+>;
+
 export type InitialData = {
 	scopeData: ScopeData;
 	locationData: LocationData;
 	loginData: LoginData;
-	communityData: DefinitelyHas<Community, 'collections' | 'pages'>;
+	communityData: InitialCommunityData;
 	featureFlags: Record<string, boolean>;
 };

--- a/utils/hooks.ts
+++ b/utils/hooks.ts
@@ -1,13 +1,15 @@
 import React, { useContext, useEffect, useState, useMemo } from 'react';
 import throttle from 'lodash.throttle';
 
-export const PageContext = React.createContext({});
+import * as types from 'types';
+
+export const PageContext = React.createContext<types.PageContext>({} as types.PageContext);
 
 export const PendingChanges = React.createContext({
 	pendingPromise: (x) => x,
 });
 
-export const usePageContext = (previewContextObject) => {
+export const usePageContext = (previewContextObject: null | types.PageContext = null) => {
 	const contextObject = useContext(PageContext);
 	return previewContextObject || contextObject;
 };


### PR DESCRIPTION
The `usePageContext()` hook is everywhere but we always have to cross-reference other callsites to remind ourselves what values it provides. No longer! I have defined its return value in TypeScript and fixed all the resulting little type issues.

_Test plan:_
Going out on a bit of a limb to say there shouldn't be any behavioral changes (except for a bug I found in `PubDiscussions` that the new types caught). So a typecheck should be sufficient?