### PR TITLE
fix: Export abstract to JATS with <p> wrapping intact

### DIFF
--- a/workers/tasks/export/transforms/extractMetaContent.ts
+++ b/workers/tasks/export/transforms/extractMetaContent.ts
@@ -5,7 +5,7 @@ const extractAbstract = (pandocBlocks) => {
 		if (firstContent.type === 'Str' && firstContent.content.toLowerCase() === 'abstract') {
 			if (second.type === 'Para') {
 				return {
-					abstract: { type: 'MetaInlines', content: second.content },
+					abstract: { type: 'MetaBlocks', content: [second] },
 					body: rest,
 				};
 			}


### PR DESCRIPTION
Resolves #1695

An `<abstract>` tag in well-formed JATS should have its text wrapped in `<p>` tags. This change tweaks our exporter to make that happen.

_Test plan:_
Create a new Pub with an "Abstract" H1 and add some text to the following paragraph. The JATS XML export of the Pub should have an `<abstract>` tag containing a `<p>` tag which itself contains the abstract content.