### PR TITLE
update: Add submission accept/decline boilerplate text to workflow

### DIFF
--- a/client/components/SubmissionEmail/SubmissionEmail.tsx
+++ b/client/components/SubmissionEmail/SubmissionEmail.tsx
@@ -3,16 +3,19 @@ import React from 'react';
 import { Community } from 'types';
 import { communityUrl } from 'utils/canonicalUrls';
 
+type SubmissionEmailKind = 'received' | 'accepted' | 'declined';
+
 type Props = {
 	community: Community;
 	customText: React.ReactNode;
 	submissionTitle: string;
 	submissionUrl?: string;
 	submitterName: React.ReactNode;
+	kind: SubmissionEmailKind;
 };
 
 const SubmissionEmail = (props: Props) => {
-	const { community, customText, submissionTitle, submissionUrl, submitterName } = props;
+	const { community, customText, submissionTitle, submissionUrl, submitterName, kind } = props;
 
 	const communityLink = <a href={communityUrl(community)}>{community.title}</a>;
 
@@ -22,13 +25,31 @@ const SubmissionEmail = (props: Props) => {
 		<u>{submissionTitle}</u>
 	);
 
+	const submissionNounPhrase = (
+		<>
+			Your submission <i>{submissionLink}</i> to {communityLink}
+		</>
+	);
+
+	const renderBoilerplate = () => {
+		if (kind === 'received') {
+			return (
+				<>
+					{submissionNounPhrase} has been received. You may reply to this email thread to
+					reach us.
+				</>
+			);
+		}
+		if (kind === 'accepted') {
+			return <>{submissionNounPhrase} has been accepted.</>;
+		}
+		return <>{submissionNounPhrase} has been declined.</>;
+	};
+
 	return (
 		<div>
 			<p>Hello {submitterName},</p>
-			<p>
-				Your submission <i>{submissionLink}</i> to {communityLink} has been received. You
-				may reply to this email thread to reach us.
-			</p>
+			<p>{renderBoilerplate()}</p>
 			{customText}
 		</div>
 	);

--- a/client/containers/DashboardOverview/overviewRows/labels.tsx
+++ b/client/containers/DashboardOverview/overviewRows/labels.tsx
@@ -125,10 +125,7 @@ export const getSubmissionTimeLabel = (pub: Pub) => {
 			icon: 'time' as const,
 		};
 	}
-	return {
-		label: 'Update Status',
-		icon: 'warning-sign' as const,
-	};
+	return null;
 };
 
 export const renderLabelPairs = (iconLabelPairs: IconLabelPair[]) => {
@@ -166,7 +163,11 @@ export const renderRowDetails = (pub: Pub, hasSubmission: boolean): React.ReactN
 	if (pub.submission) {
 		const { status } = pub.submission;
 		const detailsRow = hasSubmission
-			? renderLabelPairs([getSubmissionStatusLabel(status), getSubmissionTimeLabel(pub)])
+			? renderLabelPairs(
+					[getSubmissionStatusLabel(status), getSubmissionTimeLabel(pub)].filter(
+						(x): x is IconLabelPair => !!x,
+					),
+			  )
 			: renderLabelPairs([
 					...getScopeSummaryLabels(pub.scopeSummary),
 					getPubReleasedStateLabel(pub),

--- a/client/containers/DashboardSubmissionWorkflow/EmailPreview.tsx
+++ b/client/containers/DashboardSubmissionWorkflow/EmailPreview.tsx
@@ -12,10 +12,10 @@ type Props = {
 	cc: null | string;
 	body: React.ReactNode;
 	community: Community;
-};
+} & Pick<React.ComponentProps<typeof SubmissionEmail>, 'kind'>;
 
 const EmailPreview = (props: Props) => {
-	const { from, to, cc, body, community } = props;
+	const { from, to, cc, body, community, kind } = props;
 
 	return (
 		<div className="email-preview-component">
@@ -42,6 +42,7 @@ const EmailPreview = (props: Props) => {
 					submissionTitle="My Example Submission"
 					community={community}
 					customText={body}
+					kind={kind}
 				/>
 			</div>
 		</div>

--- a/client/containers/DashboardSubmissionWorkflow/NewSubmissionWorkflowEditor.tsx
+++ b/client/containers/DashboardSubmissionWorkflow/NewSubmissionWorkflowEditor.tsx
@@ -17,6 +17,8 @@ const createEmptyWorkflow = (): EditableSubmissionWorkflow => {
 		title: '',
 		introText: getEmptyDoc(),
 		instructionsText: getEmptyDoc(),
+		acceptedText: getEmptyDoc(),
+		declinedText: getEmptyDoc(),
 		emailText: getEmptyDoc(),
 		targetEmailAddress: '',
 		enabled: false,

--- a/client/containers/DashboardSubmissionWorkflow/Step.tsx
+++ b/client/containers/DashboardSubmissionWorkflow/Step.tsx
@@ -7,7 +7,7 @@ require('./step.scss');
 
 type Props = {
 	children: React.ReactNode;
-	className: string;
+	className?: string;
 	done?: boolean;
 	number: number;
 	title: React.ReactNode;

--- a/client/containers/DashboardSubmissionWorkflow/SubmissionWorkflowEditor.tsx
+++ b/client/containers/DashboardSubmissionWorkflow/SubmissionWorkflowEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, EditableText, InputGroup } from '@blueprintjs/core';
+import { Button, EditableText, InputGroup, Tabs, Tab } from '@blueprintjs/core';
 
 import { Collection } from 'types';
 import { LayoutSubmissionBannerSkeleton } from 'client/components/Layout';
@@ -34,6 +34,8 @@ const validator: RecordValidator<EditableSubmissionWorkflow> = {
 	introText: isValidDocJson,
 	instructionsText: isValidDocJson,
 	emailText: isValidDocJson,
+	acceptedText: isAlwaysValid,
+	declinedText: isAlwaysValid,
 	targetEmailAddress: isValidEmail,
 	enabled: isAlwaysValid,
 };
@@ -57,6 +59,13 @@ const SubmissionWorkflowEditor = (props: Props) => {
 		const nextValidation = validate(nextWorkflow, validator);
 		setValidation(nextValidation);
 		onUpdateWorkflow(update);
+	};
+
+	const sharedEmailPreviewProps = {
+		community: communityData,
+		from: 'submissions@pubpub.org',
+		to: 'submitter.name@place.org',
+		cc: workflow.targetEmailAddress,
 	};
 
 	useEffect(() => void onValidateWorkflow(isValid), [onValidateWorkflow, isValid]);
@@ -109,9 +118,9 @@ const SubmissionWorkflowEditor = (props: Props) => {
 				/>
 			</Step>
 			<Step
-				className="email-step"
 				number={3}
-				title="Send an email for completed submissions"
+				title="Send a automated email when a submission is received"
+				className="email-step"
 				done={fieldValidStates.targetEmailAddress && fieldValidStates.emailText}
 			>
 				<p>
@@ -144,10 +153,8 @@ const SubmissionWorkflowEditor = (props: Props) => {
 					an expected response time:
 				</p>
 				<EmailPreview
-					community={communityData}
-					from="submissions@pubpub.org"
-					to="submitter.name@place.org"
-					cc={workflow.targetEmailAddress}
+					{...sharedEmailPreviewProps}
+					kind="received"
 					body={
 						<WorkflowTextEditor
 							placeholder="Custom email text"
@@ -156,6 +163,57 @@ const SubmissionWorkflowEditor = (props: Props) => {
 						/>
 					}
 				/>
+			</Step>
+			<Step
+				number={4}
+				title="Create a template for accepted and declined submissions"
+				className="accept-reject-step"
+				done={fieldValidStates.acceptedText && fieldValidStates.declinedText}
+			>
+				<p>
+					These are just templates. You'll be able to customize the message you send
+					before each accepted or declined submission.
+				</p>
+				<Tabs id="accepted-declined-email-templates">
+					<Tab
+						id="accepted"
+						title="Accepted"
+						panel={
+							<EmailPreview
+								{...sharedEmailPreviewProps}
+								kind="accepted"
+								body={
+									<WorkflowTextEditor
+										placeholder="Custom email text"
+										initialContent={workflow.acceptedText}
+										onContent={(content) =>
+											updateWorkflow({ acceptedText: content })
+										}
+									/>
+								}
+							/>
+						}
+					/>
+					<Tab
+						id="declined"
+						title="Declined"
+						panel={
+							<EmailPreview
+								{...sharedEmailPreviewProps}
+								kind="declined"
+								body={
+									<WorkflowTextEditor
+										placeholder="Custom email text"
+										initialContent={workflow.declinedText}
+										onContent={(content) =>
+											updateWorkflow({ declinedText: content })
+										}
+									/>
+								}
+							/>
+						}
+					/>
+				</Tabs>
 			</Step>
 		</div>
 	);

--- a/client/containers/DashboardSubmissionWorkflow/submissionWorkflowEditor.scss
+++ b/client/containers/DashboardSubmissionWorkflow/submissionWorkflowEditor.scss
@@ -22,4 +22,10 @@
             }
         }
     }
+
+    .accept-reject-step {
+        .bp3-tab-panel {
+            margin-top: 10px;
+        }
+    }
 }

--- a/server/submissionWorkflow/__tests__/api.test.ts
+++ b/server/submissionWorkflow/__tests__/api.test.ts
@@ -42,6 +42,8 @@ const models = modelize`
 const sharedCreationValues = {
 	instructionsText: getEmptyDoc(),
 	emailText: getEmptyDoc(),
+	acceptedText: getEmptyDoc(),
+	declinedText: getEmptyDoc(),
 	introText: getEmptyDoc(),
 	title: 'Journal of Accepting Submissions',
 	targetEmailAddress: 'finnandjakeforwvwer@adventuretime.com',

--- a/server/submissionWorkflow/model.ts
+++ b/server/submissionWorkflow/model.ts
@@ -7,6 +7,8 @@ export default (sequelize, dataTypes) => {
 			collectionId: { type: dataTypes.UUID },
 			enabled: { type: dataTypes.BOOLEAN, allowNull: false },
 			instructionsText: { type: dataTypes.JSONB, allowNull: false },
+			acceptedText: { type: dataTypes.JSONB, allowNull: false },
+			declinedText: { type: dataTypes.JSONB, allowNull: false },
 			emailText: { type: dataTypes.JSONB, allowNull: false },
 			introText: { type: dataTypes.JSONB, allowNull: false },
 			targetEmailAddress: { type: dataTypes.STRING, allowNull: false },

--- a/server/submissionWorkflow/queries.ts
+++ b/server/submissionWorkflow/queries.ts
@@ -2,10 +2,10 @@ import { SubmissionWorkflow } from 'server/models';
 import { OmitSequelizeProvidedFields } from 'types/util';
 import * as types from 'types';
 
-type Props = OmitSequelizeProvidedFields<types.SubmissionWorkflow>;
-type Update = Partial<Props>;
+type CreateFields = OmitSequelizeProvidedFields<types.SubmissionWorkflow>;
+type UpdateFields = Partial<CreateFields>;
 
-export const createSubmissionWorkflow = async (props: Props) => {
+export const createSubmissionWorkflow = async (props: CreateFields) => {
 	const {
 		collectionId,
 		enabled,
@@ -14,6 +14,8 @@ export const createSubmissionWorkflow = async (props: Props) => {
 		emailText,
 		title,
 		targetEmailAddress,
+		acceptedText,
+		declinedText,
 	} = props;
 	const submissionWorkflow = {
 		enabled,
@@ -23,11 +25,13 @@ export const createSubmissionWorkflow = async (props: Props) => {
 		title,
 		targetEmailAddress,
 		collectionId,
+		acceptedText,
+		declinedText,
 	};
 	return SubmissionWorkflow.create(submissionWorkflow);
 };
 
-export const updateSubmissionWorkflow = async (update: Update) => {
+export const updateSubmissionWorkflow = async (update: UpdateFields) => {
 	const {
 		collectionId,
 		enabled,
@@ -36,6 +40,8 @@ export const updateSubmissionWorkflow = async (update: Update) => {
 		introText,
 		title,
 		targetEmailAddress,
+		acceptedText,
+		declinedText,
 	} = update;
 	await SubmissionWorkflow.update(
 		{
@@ -45,6 +51,8 @@ export const updateSubmissionWorkflow = async (update: Update) => {
 			targetEmailAddress,
 			introText,
 			title,
+			acceptedText,
+			declinedText,
 		},
 		{ where: { collectionId } },
 	);

--- a/stubstub/modelize/builders.js
+++ b/stubstub/modelize/builders.js
@@ -117,6 +117,8 @@ builders.SubmissionWorkflow = (args) => {
 		instructionsText: getEmptyDoc(),
 		introText: getEmptyDoc(),
 		emailText: getEmptyDoc(),
+		acceptedText: getEmptyDoc(),
+		declinedText: getEmptyDoc(),
 		targetEmailAddress: 'something@somewhere.com',
 		...args,
 	});

--- a/types/submissonWorkflow.ts
+++ b/types/submissonWorkflow.ts
@@ -8,6 +8,8 @@ export type SubmissionWorkflow = {
 	title: string;
 	introText: DocJson;
 	instructionsText: DocJson;
+	acceptedText: DocJson;
+	declinedText: DocJson;
 	emailText: DocJson;
 	targetEmailAddress: string;
 	collectionId: string;


### PR DESCRIPTION
Resolves #1681

So we want a way for Submission managers to send custom accept/decline messages to submitters in-band. This PR adds fields for those messages and a step in the Workflow editor to compose them. Per #1683, these messages will appear as a template that managers can customize before sending each accept/reject email.

<img width="1227" alt="image" src="https://user-images.githubusercontent.com/2208769/148416121-d210c0ce-0753-465e-b6b3-655659fc2880.png">

_Test plan:_
Visit the workflow editor for a Collection and verify that you can edit the accept/decline messages.
