### PR TITLE
update: Move submission creation out of API to support login-redirect

### DIFF
--- a/client/components/Layout/LayoutSubmissionBanner.tsx
+++ b/client/components/Layout/LayoutSubmissionBanner.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useState } from 'react';
-import { Button } from '@blueprintjs/core';
+import React from 'react';
+import { AnchorButton } from '@blueprintjs/core';
 
 import { Editor, GridWrapper } from 'components';
 import { LayoutBlockSubmissionBanner } from 'utils/layout';
-import { apiFetch } from 'client/utils/apiFetch';
+import { usePageContext } from 'utils/hooks';
 
 import LayoutSubmissionBannerSkeleton from './LayoutSubmissionBannerSkeleton';
 
@@ -15,17 +15,10 @@ const LayoutSubmissionBanner = (props: Props) => {
 	const {
 		content: { body, title, submissionWorkflowId },
 	} = props;
-	const [isLoading, setIsLoading] = useState(false);
 
-	const handleSubmitClicked = useCallback(() => {
-		setIsLoading(true);
-		apiFetch
-			.post('/api/submissions', { submissionWorkflowId })
-			.then(({ pub }) => {
-				window.location.href = `/pub/${pub.slug}`;
-			})
-			.finally(() => setIsLoading(false));
-	}, [submissionWorkflowId]);
+	const {
+		loginData: { id: userId },
+	} = usePageContext();
 
 	return (
 		<div className="layout-text-component">
@@ -37,9 +30,9 @@ const LayoutSubmissionBanner = (props: Props) => {
 						content={
 							<>
 								<Editor initialContent={body} isReadOnly />
-								<Button loading={isLoading} onClick={handleSubmitClicked}>
-									Submit
-								</Button>
+								<AnchorButton href={`/submit/${submissionWorkflowId}`}>
+									{userId ? 'Submit' : 'Log in to submit'}
+								</AnchorButton>
 							</>
 						}
 					/>

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -21,6 +21,7 @@ require('./dashboardReviews');
 require('./dashboardSettings');
 require('./dashboardSubmissions');
 require('./dashboardCollectionLayout');
+require('./submit');
 
 /* Routes for PubPub */
 require('./communityCreate'); // Route: '/community/create'

--- a/server/routes/submit.tsx
+++ b/server/routes/submit.tsx
@@ -1,0 +1,28 @@
+import app from 'server/server';
+import { hostIsValid } from 'server/utils/routes';
+import { ForbiddenError, handleErrors } from 'server/utils/errors';
+import { canCreateSubmission } from 'server/submission/permissions';
+import { createSubmission } from 'server/submission/queries';
+import { getPub } from 'server/utils/queryHelpers';
+
+app.get(['/submit/:submissionWorkflowId'], async (req, res, next) => {
+	try {
+		if (!hostIsValid(req, 'community')) {
+			return next();
+		}
+		if (req.user) {
+			const { id: userId } = req.user;
+			const { submissionWorkflowId } = req.params;
+			if (await canCreateSubmission({ userId, submissionWorkflowId })) {
+				const submission = await createSubmission({ userId, submissionWorkflowId });
+				const pub = await getPub({ id: submission.pubId });
+				return res.redirect(`/pub/${pub.slug}`);
+			}
+			throw new ForbiddenError();
+		}
+		const params = new URLSearchParams({ redirect: req.url }).toString();
+		return res.redirect(`/login?${params}`);
+	} catch (err) {
+		return handleErrors(req, res, next);
+	}
+});

--- a/server/submission/api.ts
+++ b/server/submission/api.ts
@@ -17,7 +17,7 @@ app.post(
 		if (!canCreate) {
 			throw new ForbiddenError();
 		}
-		const newSubmission = await createSubmission({ userId, submissionWorkflowId }, userId);
+		const newSubmission = await createSubmission({ userId, submissionWorkflowId });
 		const pub = await getPub({ id: newSubmission.pubId });
 		return res.status(201).json({ ...newSubmission.toJSON(), pub: { slug: pub.slug } });
 	}),

--- a/server/submission/queries.ts
+++ b/server/submission/queries.ts
@@ -16,10 +16,10 @@ type CreateOptions = {
 type UpdateToStatus = typeof updateToStatuses;
 type UpdateOptions = Partial<SubmissionType> & { status: UpdateToStatus };
 
-export const createSubmission = async (
-	{ userId, submissionWorkflowId }: CreateOptions,
-	actorId: string,
-) => {
+export const createSubmission = async ({
+	userId,
+	submissionWorkflowId,
+}: CreateOptions): Promise<SequelizeModel<SubmissionType>> => {
 	const { collection } = await SubmissionWorkflow.findOne({
 		where: { id: submissionWorkflowId },
 		include: [{ model: Collection, as: 'collection' }],
@@ -37,7 +37,7 @@ export const createSubmission = async (
 			submissionWorkflowId,
 			status: 'incomplete',
 		},
-		{ actorId },
+		{ actorId: userId },
 	);
 };
 


### PR DESCRIPTION
In #1685 I created a "really basic Submissions banner" that gets added to the layout of a Collection with submissions enabled. It's still really basic, but I've fixed one major flaw — for logged-out users, instead of silently 403'ing, it will redirect you to `/login` and _then_ create the Spub after you've logged in.

I accomplished this by moving the actual Submission creation to a hard-linked route at `/submit/:submissionWorkflowId`. This will redirect you to the Pub that gets created if you're logged in, or to `/login` if you're not logged in, or throw a 403 if you're trying to pull a fast one.

![image](https://user-images.githubusercontent.com/2208769/148835663-81f08d39-8629-4c67-8d7b-f5d80f257d01.png)

Maybe I should remove the `/api/submissions` POST handler, because it no longer gets any use?

_Test plan:_
VIsit a Collection with a Submissions banner (like [this one](http://localhost:9876/dash/collection/anime-to-watch-a-visual-tour/overview)) and then:
- When logged in, verify that clicking the button takes you to the newly-created Spub
- When logged out, verify that you're redirected to `/login` and then redirected to your new Spub after logging in.