### PR TITLE
fix: allow DOI updates for Pubs without releases

### DIFF
--- a/server/doi/api.ts
+++ b/server/doi/api.ts
@@ -1,12 +1,10 @@
-import xmlbuilder from 'xmlbuilder';
-
+import { Release } from 'server/models';
 import app, { wrap } from 'server/server';
 import { ForbiddenError } from 'server/utils/errors';
-import { Release } from 'server/models';
 import { parentToSupplementNeedsDoiError } from 'utils/crossref/createDeposit';
-
-import { getDoiData, setDoiData, generateDoi } from './queries';
+import xmlbuilder from 'xmlbuilder';
 import { getPermissions } from './permissions';
+import { generateDoi, getDoiData, setDoiData } from './queries';
 
 const assertUserAuthorized = async (target, requestIds) => {
 	const permissions = await getPermissions(requestIds);
@@ -47,8 +45,8 @@ const previewOrDepositDoi = async (user, body, options = { deposit: false }) => 
 
 	await assertUserAuthorized(target, requestIds);
 
-	if (pubId) {
-		await pubExistsAndIsMissingReleases(pubId);
+	if (pubId && (await pubExistsAndIsMissingReleases(pubId))) {
+		throw new ForbiddenError();
 	}
 
 	const depositJson = await (deposit ? setDoiData : getDoiData)(

--- a/server/doi/permissions.ts
+++ b/server/doi/permissions.ts
@@ -1,13 +1,4 @@
-import { Release } from 'server/models';
 import { getScope } from 'server/utils/queryHelpers';
-
-const pubExistsAndIsMissingReleases = async (pubId) => {
-	if (!pubId) {
-		return false;
-	}
-	const releases = await Release.findAll({ where: { pubId } });
-	return releases.length === 0;
-};
 
 export const getPermissions = async ({ pubId, collectionId, userId, communityId }) => {
 	if (!userId) {
@@ -16,7 +7,6 @@ export const getPermissions = async ({ pubId, collectionId, userId, communityId 
 
 	const {
 		activePermissions: { canAdminCommunity },
-		elements: { activePub },
 	} = await getScope({
 		communityId,
 		collectionId,
@@ -24,10 +14,8 @@ export const getPermissions = async ({ pubId, collectionId, userId, communityId 
 		loginId: userId,
 	});
 
-	const missingReleases = await pubExistsAndIsMissingReleases(activePub && activePub.id);
-
 	return {
-		pub: canAdminCommunity && !missingReleases,
+		pub: canAdminCommunity,
 		collection: canAdminCommunity,
 	};
 };


### PR DESCRIPTION
Fixes #1745

This PR moves the releases check in our DOI generation's `assertUserAuthorized` function into a new function called `pubExistsAndIsMissingReleases`. Removing this check allows users to generate DOIs for Pubs without releases.

The new `pubExistsAndIsMissingReleases` function is called in the Crossref preview/deposit code because we still want to guarantee that a Pub has at least one release before depositing.

### Test Steps

* Create a new Pub. Don't release it.
* Go into the Pub settings, you should be able to generate a DOI without error!