### PR TITLE
fix: Make Editor read-only until Firebase finishes connecting

### DIFF
--- a/client/components/Editor/plugins/collaborative/document.ts
+++ b/client/components/Editor/plugins/collaborative/document.ts
@@ -40,14 +40,14 @@ export default (
 	collabDocPluginKey: PluginKey,
 	localClientId: string,
 ) => {
-	const { collaborativeOptions } = options;
+	const { collaborativeOptions, isReadOnly, onError = noop } = options;
 	const {
 		firebaseRef: ref,
 		onStatusChange = noop,
 		onUpdateLatestKey = noop,
 	} = collaborativeOptions;
 	let view;
-	let mostRecentRemoteKey = options.collaborativeOptions.initialDocKey;
+	let mostRecentRemoteKey = collaborativeOptions.initialDocKey;
 	let ongoingTransaction = false;
 	let pendingRemoteKeyables = [];
 	/* sendCollabChanges is called only from the main Editor */
@@ -65,7 +65,7 @@ export default (
 	const sendCollabChanges = (newState) => {
 		const sendable = sendableSteps(newState);
 
-		if (options.isReadOnly || ongoingTransaction || !sendable) {
+		if (isReadOnly || ongoingTransaction || !sendable) {
 			return null;
 		}
 
@@ -103,7 +103,7 @@ export default (
 			})
 			.catch((err) => {
 				console.error('Error in firebase transaction:', err);
-				options.onError?.(err);
+				onError(err);
 			});
 	};
 
@@ -139,7 +139,7 @@ export default (
 				onUpdateLatestKey(mostRecentRemoteKey);
 			} catch (err) {
 				console.error('Error in recieveCollabChanges:', err);
-				options.onError?.(err as Error);
+				onError(err as Error);
 			}
 		});
 		pendingRemoteKeyables = [];
@@ -223,7 +223,7 @@ export default (
 				return {
 					isLoaded: false,
 					localClientId,
-					localClientData: options.collaborativeOptions.clientData,
+					localClientData: collaborativeOptions.clientData,
 					sendCollabChanges,
 				};
 			},
@@ -232,7 +232,7 @@ export default (
 					isLoaded: transaction.getMeta('finishedLoading') || pluginState.isLoaded,
 					mostRecentRemoteKey,
 					localClientId,
-					localClientData: options.collaborativeOptions.clientData,
+					localClientData: collaborativeOptions.clientData,
 					sendCollabChanges,
 				};
 			},

--- a/client/components/Editor/types.ts
+++ b/client/components/Editor/types.ts
@@ -30,13 +30,20 @@ export type PluginLoader = (schema: Schema, options: PluginsOptions) => Plugin |
 
 export type EditorChangeObject = ReturnType<typeof getChangeObject>;
 
+export type CollaborativeEditorStatus =
+	| 'disconnected'
+	| 'connecting'
+	| 'connected'
+	| 'saving'
+	| 'saved';
+
 export type CollaborativeOptions = {
 	clientData: {
 		id: string;
 	};
 	firebaseRef: firebase.database.Reference;
 	initialDocKey: number;
-	onStatusChange?: (status: 'saving' | 'saved') => unknown;
+	onStatusChange?: (status: CollaborativeEditorStatus) => unknown;
 	onUpdateLatestKey?: (key: number) => unknown;
 };
 

--- a/client/components/Editor/utils/firebase.ts
+++ b/client/components/Editor/utils/firebase.ts
@@ -46,3 +46,7 @@ export const createFirebaseChange = (steps: Step[], clientId: string) => {
 		t: firebaseTimestamp,
 	};
 };
+
+export const getFirebaseConnectionMonitorRef = (ref: firebase.database.Reference) => {
+	return ref.root.child('.info/connected');
+};

--- a/client/containers/Pub/PubDocument/PubBody.tsx
+++ b/client/containers/Pub/PubDocument/PubBody.tsx
@@ -88,7 +88,8 @@ const PubBody = (props: Props) => {
 	const editorKeyHistory = isViewingHistory && historyData.historyDocKey;
 	const editorKeyCollab = firebaseDraftRef ? 'ready' : 'unready';
 	const editorKey = editorKeyHistory || editorKeyCollab;
-	const isReadOnly = pubData.isReadOnly || pubData.isInMaintenanceMode || isViewingHistory;
+	const isReadOnly =
+		pubData.isReadOnly || pubData.isInMaintenanceMode || isViewingHistory || !firebaseDraftRef;
 	const initialContent = (isViewingHistory && historyData.historyDoc) || pubData.initialDoc;
 	const loadCollaborativeOptions = !isViewingHistory && !pubData.isInMaintenanceMode;
 	const { markLastInput } = useContext(PubSuspendWhileTypingContext);

--- a/client/containers/Pub/PubSyncManager.tsx
+++ b/client/containers/Pub/PubSyncManager.tsx
@@ -7,7 +7,7 @@ import { getPubPageTitle } from 'utils/pubPageTitle';
 import { NoteManager } from 'client/utils/notes';
 import { initFirebase } from 'client/utils/firebaseClient';
 import { apiFetch } from 'client/utils/apiFetch';
-import { NodeLabelMap } from 'client/components/Editor/types';
+import { NodeLabelMap, CollaborativeEditorStatus } from 'client/components/Editor/types';
 import {
 	Maybe,
 	PatchFn,
@@ -59,7 +59,7 @@ type State = {
 	historyData: PubHistoryState;
 	collabData: {
 		editorChangeObject: any;
-		status: string;
+		status: CollaborativeEditorStatus;
 		localCollabUser: CollabUser;
 		remoteCollabUsers: CollabUser[];
 	};

--- a/client/containers/Pub/PubSyncManager.tsx
+++ b/client/containers/Pub/PubSyncManager.tsx
@@ -200,27 +200,13 @@ class PubSyncManager extends React.Component<Props, State> {
 	componentDidMount() {
 		const { draft } = this.props.pubData;
 		if (draft) {
-			initFirebase(draft.firebasePath, this.props.pubData.firebaseToken).then(
-				(firebaseRefs) => {
-					if (!firebaseRefs) {
-						return;
-					}
-					const [draftRef, connectionRef] = firebaseRefs;
-					this.setState({ firebaseDraftRef: draftRef }, () => {
-						this.state.firebaseDraftRef
-							?.child('cursors')
-							.on('value', this.syncRemoteCollabUsers);
-
-						connectionRef.on('value', (snapshot) => {
-							if (snapshot.val() === true) {
-								this.updateLocalData('collab', { status: 'connected' });
-							} else {
-								this.updateLocalData('collab', { status: 'disconnected' });
-							}
-						});
-					});
-				},
-			);
+			initFirebase(draft.firebasePath, this.props.pubData.firebaseToken!).then((rootRef) => {
+				this.setState({ firebaseDraftRef: rootRef }, () => {
+					this.state.firebaseDraftRef
+						?.child('cursors')
+						.on('value', this.syncRemoteCollabUsers);
+				});
+			});
 		}
 	}
 

--- a/client/utils/firebaseClient.ts
+++ b/client/utils/firebaseClient.ts
@@ -4,7 +4,7 @@ import 'firebase/database';
 
 import { getFirebaseConfig } from 'utils/editor/firebaseConfig';
 
-export const initFirebase = async (rootKey, authToken) => {
+export const initFirebase = async (rootKey: string, authToken: string) => {
 	const firebaseAppName = `App-${rootKey}`;
 	/* Check if we've already initialized an Firebase App with the */
 	/* same name in this local environment */
@@ -23,7 +23,7 @@ export const initFirebase = async (rootKey, authToken) => {
 		const auth = await firebase.auth(firebaseApp);
 		await auth.signOut();
 		await auth.signInWithCustomToken(authToken);
-		return [database.ref(`${rootKey}`), database.ref('.info/connected')];
+		return database.ref(rootKey);
 	} catch (err) {
 		console.error('Error authenticating firebase', err);
 		return null;


### PR DESCRIPTION
Resolves #1753

We've had a few reports of folks losing their work because `Editor` lets them add content in a stalled `connecting` state. This change makes the editor read-only until `status = 'connected'`. I've done a little work moving the responsibility for monitoring the connection around, and a little type-safety/cosmetic overhaul.

_Test plan:_

Check that:
- The editor works and persists your changes after refreshing
- You cannot type while the status bar says "Connecting..." (maybe try throttling your connection here)
- The collab-status indicator works as expected: `connecting -> connected -> (saving <-> saved) -> disconnected`