### PR TITLE
update: Some glue for Submissions

### DIFF
--- a/client/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/client/components/ConfirmDialog/ConfirmDialog.tsx
@@ -4,37 +4,40 @@
  * attached to a Button onClick handler, or anything else.
  */
 import React, { useState } from 'react';
-import { Button, Classes, Dialog } from '@blueprintjs/core';
+import { Button, Classes, Dialog, Intent } from '@blueprintjs/core';
 
-type OwnProps = {
-	children: (...args: any[]) => any;
-	cancelLabel?: string;
-	confirmLabel: string;
-	intent?: string;
-	onConfirm: (...args: any[]) => any;
+import { Callback } from 'types';
+
+type Props = {
+	cancelLabel?: React.ReactNode;
+	children: (opts: { open: Callback }) => React.ReactNode;
+	confirmLabel: React.ReactNode;
+	intent?: Intent;
+	onConfirm: () => unknown;
 	text: React.ReactNode;
+	title?: React.ReactNode;
 };
-
-const defaultProps = {
-	intent: 'danger',
-	cancelLabel: 'Cancel',
-};
-
-type Props = OwnProps & typeof defaultProps;
 
 const ConfirmDialog = (props: Props) => {
-	const { cancelLabel, children, confirmLabel, intent, onConfirm, text } = props;
+	const {
+		cancelLabel = 'Cancel',
+		children,
+		confirmLabel,
+		intent = 'danger',
+		onConfirm,
+		text,
+		title,
+	} = props;
 	const [isOpen, setIsOpen] = useState(false);
 	return (
 		<React.Fragment>
 			{children({ open: () => setIsOpen(true) })}
-			<Dialog isOpen={isOpen}>
+			<Dialog isOpen={isOpen} title={title}>
 				<div className={Classes.DIALOG_BODY}>{text}</div>
 				<div className={Classes.DIALOG_FOOTER}>
 					<div className={Classes.DIALOG_FOOTER_ACTIONS}>
 						<Button onClick={() => setIsOpen(false)}>{cancelLabel}</Button>
 						<Button
-							// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type '"none" | ... Remove this comment to see the full error message
 							intent={intent}
 							onClick={() => {
 								setIsOpen(false);
@@ -49,5 +52,5 @@ const ConfirmDialog = (props: Props) => {
 		</React.Fragment>
 	);
 };
-ConfirmDialog.defaultProps = defaultProps;
+
 export default ConfirmDialog;

--- a/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
+++ b/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
@@ -83,7 +83,6 @@ const DashboardCollectionOverview = (props: Props) => {
 	const canDragDrop = !isSearchingOrFiltering && canManage;
 
 	const {
-		allQueries: { isLoading },
 		currentQuery: { loadMorePubs, pubs: pubsFoundInCollection, hasLoadedAllPubs },
 	} = useManyPubs<PubWithCollections>({
 		initialPubs,
@@ -124,7 +123,7 @@ const DashboardCollectionOverview = (props: Props) => {
 	);
 
 	useInfiniteScroll({
-		enabled: !isLoading && !includesAllPubs,
+		enabled: !includesAllPubs,
 		useDocumentElement: true,
 		onRequestMoreItems: loadMorePubs,
 		scrollTolerance: 100,

--- a/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
+++ b/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
@@ -7,7 +7,7 @@ import { DashboardFrame, DragDropListing, DragHandle } from 'components';
 import { useManyPubs } from 'client/utils/useManyPubs';
 import { useInfiniteScroll } from 'client/utils/useInfiniteScroll';
 import { indexByProperty } from 'utils/arrays';
-import { Collection, CollectionPub, Maybe, PubsQuery, DefinitelyHas, UserScopeVisit } from 'types';
+import { Collection, CollectionPub, Maybe, DefinitelyHas, UserScopeVisit } from 'types';
 import { getSchemaForKind } from 'utils/collections/schemas';
 import { usePageContext } from 'utils/hooks';
 import { getDashUrl } from 'utils/dashboard';
@@ -19,6 +19,7 @@ import {
 	QuickActions,
 	QuickAction,
 	ScopeSummaryList,
+	OverviewSearchFilter,
 } from '../helpers';
 import { PubOverviewRow, LoadMorePubsRow, SpecialRow } from '../overviewRows';
 import { PubWithCollections } from './types';
@@ -74,10 +75,11 @@ const DashboardCollectionOverview = (props: Props) => {
 		},
 	} = usePageContext();
 	const [searchTerm, setSearchTerm] = useState('');
-	const [filter, setFilter] = useState<null | Partial<PubsQuery>>(null);
+	const [filter, setFilter] = useState<null | OverviewSearchFilter>(null);
 	const [pubsAddedToCollection, setPubsAddedToCollection] = useState<PubWithCollections[]>([]);
 	const { collection, updateCollection } = useCollectionState(initialCollection);
-	const isSearchingOrFiltering = !!searchTerm || !!filter;
+	const query = filter?.query;
+	const isSearchingOrFiltering = !!searchTerm || !!query;
 	const canDragDrop = !isSearchingOrFiltering && canManage;
 
 	const {
@@ -92,7 +94,7 @@ const DashboardCollectionOverview = (props: Props) => {
 			term: searchTerm,
 			ordering: { field: 'collectionRank', direction: 'ASC' },
 			scopedCollectionId: collection.id,
-			...filter,
+			...query,
 		},
 		pubOptions: {
 			getCollections: true,

--- a/client/containers/DashboardOverview/CommunityOverview/CommunityItems.tsx
+++ b/client/containers/DashboardOverview/CommunityOverview/CommunityItems.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { NonIdealState } from '@blueprintjs/core';
 
-import { Collection, Pub, PubsQuery } from 'types';
+import { Collection, Pub } from 'types';
 import { fuzzyMatchCollection } from 'utils/fuzzyMatch';
 import { useManyPubs } from 'client/utils/useManyPubs';
 import { useInfiniteScroll } from 'client/utils/useInfiniteScroll';
@@ -13,7 +13,7 @@ import {
 	LoadMorePubsRow,
 	SpecialRow,
 } from '../overviewRows';
-import { KindToggle, OverviewSearchGroup } from '../helpers';
+import { KindToggle, OverviewSearchFilter, OverviewSearchGroup } from '../helpers';
 
 require('./communityItems.scss');
 
@@ -36,10 +36,11 @@ const getSearchPlaceholderText = (showCollections: boolean, showPubs: boolean) =
 const CommunityItems = (props: Props) => {
 	const { collections: allCollections, initialPubs, initiallyLoadedAllPubs } = props;
 	const [searchTerm, setSearchTerm] = useState('');
-	const [filter, setFilter] = useState<null | Partial<PubsQuery>>(null);
+	const [filter, setFilter] = useState<null | OverviewSearchFilter>(null);
 	const [showPubs, setShowPubs] = useState(true);
 	const [showCollections, setShowCollections] = useState(true);
-	const isSearchingOrFiltering = !!filter || !!searchTerm;
+	const query = filter?.query;
+	const isSearchingOrFiltering = !!query || !!searchTerm;
 
 	const collections = useMemo(
 		() => allCollections.filter((collection) => fuzzyMatchCollection(collection, searchTerm)),
@@ -56,11 +57,11 @@ const CommunityItems = (props: Props) => {
 		query: {
 			term: searchTerm,
 			ordering: { field: 'title', direction: 'ASC' },
-			...filter,
+			...filter?.query,
 		},
 	});
 
-	const canShowCollections = !filter;
+	const canShowCollections = !query;
 	const canLoadMorePubs = !hasLoadedAllPubs && showPubs;
 
 	useInfiniteScroll({

--- a/client/containers/DashboardOverview/CommunityOverview/CommunityItems.tsx
+++ b/client/containers/DashboardOverview/CommunityOverview/CommunityItems.tsx
@@ -48,7 +48,7 @@ const CommunityItems = (props: Props) => {
 	);
 
 	const {
-		currentQuery: { pubs, isLoading, hasLoadedAllPubs, loadMorePubs },
+		currentQuery: { pubs, hasLoadedAllPubs, loadMorePubs },
 	} = useManyPubs({
 		isEager: isSearchingOrFiltering,
 		initialPubs,
@@ -65,7 +65,7 @@ const CommunityItems = (props: Props) => {
 	const canLoadMorePubs = !hasLoadedAllPubs && showPubs;
 
 	useInfiniteScroll({
-		enabled: !isLoading && canLoadMorePubs,
+		enabled: canLoadMorePubs,
 		useDocumentElement: true,
 		onRequestMoreItems: loadMorePubs,
 	});

--- a/client/containers/DashboardOverview/helpers/OverviewSearchGroup.tsx
+++ b/client/containers/DashboardOverview/helpers/OverviewSearchGroup.tsx
@@ -19,9 +19,10 @@ type Props = {
 	placeholder: string;
 	onUpdateSearchTerm?: SearchTermCallback;
 	onCommitSearchTerm?: SearchTermCallback;
-	onChooseFilter?: (q: null | Partial<PubsQuery>) => unknown;
+	onChooseFilter?: (q: OverviewSearchFilter) => unknown;
 	rightControls?: React.ReactNode;
 	filters?: OverviewSearchFilter[];
+	filter?: OverviewSearchFilter;
 };
 
 const defaultFilters: OverviewSearchFilter[] = [
@@ -42,6 +43,7 @@ const OverviewSearchGroup = (props: Props) => {
 		onUpdateSearchTerm,
 		rightControls,
 		onChooseFilter,
+		filter,
 		filters = defaultFilters,
 	} = props;
 	const [isSearchFocused, setIsSearchFocused] = useState(false);
@@ -69,12 +71,16 @@ const OverviewSearchGroup = (props: Props) => {
 	const handleFilterChange = useCallback(
 		(filterId: string) => {
 			if (onChooseFilter) {
-				const filter = filters.find((f) => f.id === filterId)!;
-				onChooseFilter(filter.query);
+				const nextFilter = filters.find((f) => f.id === filterId)!;
+				onChooseFilter(nextFilter);
 			}
 		},
 		[filters, onChooseFilter],
 	);
+
+	const controlledTabsProps: Partial<React.ComponentProps<typeof Tabs>> = {
+		...(filter && { selectedTabId: filter.id }),
+	};
 
 	return (
 		<div className="overview-search-group-component">
@@ -83,9 +89,10 @@ const OverviewSearchGroup = (props: Props) => {
 					className="filter-controls"
 					id="overview-search-group-filter"
 					onChange={handleFilterChange}
+					{...controlledTabsProps}
 				>
-					{filters.map((filtering) => (
-						<Tab id={filtering.id} key={filtering.id} title={filtering.title} />
+					{filters.map((f) => (
+						<Tab id={f.id} key={f.id} title={f.title} />
 					))}
 				</Tabs>
 			)}

--- a/client/containers/DashboardOverview/overviewRows/PubOverviewRow.tsx
+++ b/client/containers/DashboardOverview/overviewRows/PubOverviewRow.tsx
@@ -9,17 +9,17 @@ import { getDashUrl } from 'utils/dashboard';
 import { usePageContext } from 'utils/hooks';
 
 import OverviewRowSkeleton from './OverviewRowSkeleton';
-import { renderRowDetails } from './labels';
+import { IconLabelPair, renderLabelPairs, getTypicalPubLabels } from './labels';
 
 type Pub = DefinitelyHas<BasePub, 'attributions'>;
 
 type Props = {
 	leftIconElement?: React.ReactNode;
 	rightElement?: React.ReactNode;
+	labels?: IconLabelPair[];
 	className?: string;
 	pub: Pub;
 	inCollection?: boolean;
-	hasSubmission?: boolean;
 	isGrayscale?: boolean;
 };
 
@@ -29,11 +29,12 @@ const PubOverviewRow = (props: Props) => {
 		className,
 		inCollection,
 		isGrayscale = false,
-		hasSubmission = false,
 		leftIconElement = null,
+		labels = null,
 		rightElement: providedRightElement,
 	} = props;
 	const { communityData } = usePageContext();
+
 	const rightElement = providedRightElement || (
 		<AnchorButton
 			minimal
@@ -43,14 +44,15 @@ const PubOverviewRow = (props: Props) => {
 		/>
 	);
 
-	const details = renderRowDetails(pub, hasSubmission);
+	const allLabels = [...(labels || []), ...getTypicalPubLabels(pub)];
+
 	return (
 		<OverviewRowSkeleton
 			className={classNames('pub-overview-row-component', className)}
 			href={getDashUrl({ pubSlug: pub.slug })}
 			title={pub.title}
 			byline={<PubByline pubData={pub} linkToUsers={false} truncateAt={8} />}
-			details={details}
+			details={renderLabelPairs(allLabels)}
 			leftIcon={leftIconElement || 'pubDoc'}
 			rightElement={rightElement}
 			darkenRightIcons={inCollection}

--- a/client/containers/DashboardOverview/overviewRows/labels.tsx
+++ b/client/containers/DashboardOverview/overviewRows/labels.tsx
@@ -8,7 +8,7 @@ import { formatDate } from 'utils/dates';
 import { getPubPublishedDate, getPubSubmissionDate } from 'utils/pub/pubDates';
 import { TimeAgo, Icon, IconName } from 'components';
 
-type IconLabelPair = {
+export type IconLabelPair = {
 	icon: IconName;
 	label: string | React.ReactNode;
 	iconSize?: number;
@@ -159,24 +159,6 @@ export const renderLabelPairs = (iconLabelPairs: IconLabelPair[]) => {
 	);
 };
 
-export const renderRowDetails = (pub: Pub, hasSubmission: boolean): React.ReactNode => {
-	if (pub.submission) {
-		const { status } = pub.submission;
-		const detailsRow = hasSubmission
-			? renderLabelPairs(
-					[getSubmissionStatusLabel(status), getSubmissionTimeLabel(pub)].filter(
-						(x): x is IconLabelPair => !!x,
-					),
-			  )
-			: renderLabelPairs([
-					...getScopeSummaryLabels(pub.scopeSummary),
-					getPubReleasedStateLabel(pub),
-			  ]);
-		return detailsRow;
-	}
-
-	return renderLabelPairs([
-		...getScopeSummaryLabels(pub.scopeSummary),
-		getPubReleasedStateLabel(pub),
-	]);
+export const getTypicalPubLabels = (pub: Pub) => {
+	return [...getScopeSummaryLabels(pub.scopeSummary), getPubReleasedStateLabel(pub)];
 };

--- a/client/containers/DashboardSubmissionWorkflow/SubmissionWorkflowEditor.tsx
+++ b/client/containers/DashboardSubmissionWorkflow/SubmissionWorkflowEditor.tsx
@@ -119,7 +119,7 @@ const SubmissionWorkflowEditor = (props: Props) => {
 			</Step>
 			<Step
 				number={3}
-				title="Send a automated email when a submission is received"
+				title="Send an automated email when a submission is received"
 				className="email-step"
 				done={fieldValidStates.targetEmailAddress && fieldValidStates.emailText}
 			>

--- a/client/containers/DashboardSubmissions/ArbitrationMenu.tsx
+++ b/client/containers/DashboardSubmissions/ArbitrationMenu.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Button } from '@blueprintjs/core';
+import { Button, Tooltip } from '@blueprintjs/core';
 
 import { DefinitelyHas, Pub, SubmissionStatus, DocJson } from 'types';
-import { ConfirmDialog, Icon, IconName, DialogLauncher } from 'client/components';
+import { ConfirmDialog, DialogLauncher } from 'client/components';
 import { apiFetch } from 'client/utils/apiFetch';
 import VerdictDialog from './VerdictDialog';
 
@@ -10,86 +10,71 @@ require('./arbitrationMenu.scss');
 
 type Props = {
 	pub: DefinitelyHas<Pub, 'submission'>;
-	onJudgePub: (pubId: string, status: SubmissionStatus) => void;
+	onDeletePub: () => unknown;
+	onJudgePub: (status: SubmissionStatus) => unknown;
 };
 
 const ArbitrationMenu = (props: Props) => (
 	<div className="arbitration-menu-component">
-		<div style={{ gridColumn: 1 }}>
-			<ConfirmDialog
-				confirmLabel="Delete"
-				text="Are you sure you want to delete this submission?"
-				onConfirm={() =>
-					apiFetch
-						.delete('/api/pubs', {
-							pubId: props.pub.id,
-						})
-						.then(() => props.onJudgePub(props.pub.id, props.pub.submission.status))
-				}
-			>
-				{({ open }) => (
-					<Button
-						minimal
-						small
-						icon={<Icon icon="cross" iconSize={20} />}
-						onClick={open}
-					/>
-				)}
-			</ConfirmDialog>
-		</div>
 		{[
-			{ presentTense: 'Decline', pastTense: 'declined', iconName: 'thumbs-down' },
-			{ presentTense: 'Accept', pastTense: 'accepted', iconName: 'endorsed' },
+			{ presentTense: 'Decline', pastTense: 'declined', iconName: 'thumbs-down' as const },
+			{ presentTense: 'Accept', pastTense: 'accepted', iconName: 'endorsed' as const },
 		].map(
-			({ presentTense, pastTense, iconName }, index) =>
+			({ presentTense, pastTense, iconName }) =>
 				props.pub.submission.status !== pastTense && (
-					<div style={{ gridColumn: index + 2 }} key={pastTense}>
-						<DialogLauncher
-							renderLauncherElement={({ openDialog }) => (
-								<Button
-									minimal
-									small
-									icon={<Icon icon={iconName as IconName} iconSize={20} />}
-									onClick={openDialog}
-								/>
-							)}
-						>
-							{({ isOpen, onClose }) => (
-								<VerdictDialog
-									isOpen={isOpen}
-									onClose={onClose}
-									shouldOfferEmail={true}
-									actionTitle={presentTense}
-									completedName={pastTense}
-									status={pastTense as SubmissionStatus}
-									initialEmailText={
-										props.pub.submission.submissionWorkflow?.[
-											`${pastTense}Text`
-										]
-									}
-									onSubmit={(
-										customEmailText?: DocJson,
-										shouldSendEmail?: boolean,
-									) =>
-										apiFetch.put('/api/submissions', {
-											id: props.pub.submission.id,
-											status: pastTense,
-											skipEmail: !shouldSendEmail,
-											customEmailText:
-												customEmailText ||
-												props.pub.submission.submissionWorkflow?.[
-													`${pastTense}Text`
-												],
-										})
-									}
-									pub={props.pub}
-									onJudgePub={props.onJudgePub}
-								/>
-							)}
-						</DialogLauncher>
-					</div>
+					<DialogLauncher
+						key={pastTense}
+						renderLauncherElement={({ openDialog }) => (
+							<Tooltip content={presentTense}>
+								<Button minimal icon={iconName} onClick={openDialog} />
+							</Tooltip>
+						)}
+					>
+						{({ isOpen, onClose }) => (
+							<VerdictDialog
+								isOpen={isOpen}
+								onClose={onClose}
+								shouldOfferEmail={true}
+								actionTitle={presentTense}
+								completedName={pastTense}
+								status={pastTense as SubmissionStatus}
+								initialEmailText={
+									props.pub.submission.submissionWorkflow?.[`${pastTense}Text`]
+								}
+								onSubmit={(customEmailText?: DocJson, shouldSendEmail?: boolean) =>
+									apiFetch.put('/api/submissions', {
+										id: props.pub.submission.id,
+										status: pastTense,
+										skipEmail: !shouldSendEmail,
+										customEmailText:
+											customEmailText ||
+											props.pub.submission.submissionWorkflow?.[
+												`${pastTense}Text`
+											],
+									})
+								}
+								onJudgePub={props.onJudgePub}
+							/>
+						)}
+					</DialogLauncher>
 				),
 		)}
+		<ConfirmDialog
+			confirmLabel="Delete Pub"
+			title="Delete this Pub?"
+			text="If you delete this Pub, it will be gone forever. Neither you nor its submitters will be able to access it."
+			onConfirm={() =>
+				apiFetch
+					.delete('/api/pubs', { pubId: props.pub.id })
+					.then(() => props.onDeletePub())
+			}
+		>
+			{({ open }) => (
+				<Tooltip content="Delete Pub">
+					<Button minimal icon="trash" onClick={open} />
+				</Tooltip>
+			)}
+		</ConfirmDialog>
 	</div>
 );
 

--- a/client/containers/DashboardSubmissions/DashboardSubmissions.tsx
+++ b/client/containers/DashboardSubmissions/DashboardSubmissions.tsx
@@ -2,16 +2,17 @@ import React, { useState } from 'react';
 
 import { DashboardFrame } from 'components';
 import { usePageContext } from 'utils/hooks';
-import { Pub, SubmissionWorkflow, DefinitelyHas } from 'types';
+import { SubmissionWorkflow } from 'types';
 
 import SubmissionItems from './SubmissionItems';
 import AcceptSubmissionsToggle from './AcceptSubmissionsToggle';
 import SubmissionWorkflowButton from './SubmissionWorkflowButton';
+import { PubWithSubmission } from './types';
 
 require('./dashboardSubmissions.scss');
 
 type Props = {
-	initialPubs: Pub[];
+	initialPubs: PubWithSubmission[];
 	initiallyLoadedAllPubs: boolean;
 	initialSubmissionWorkflow: SubmissionWorkflow;
 };
@@ -43,7 +44,7 @@ const DashboardSubmissions = (props: Props) => {
 			}
 		>
 			<SubmissionItems
-				initialPubs={initialPubs as DefinitelyHas<Pub, 'submission'>[]}
+				initialPubs={initialPubs}
 				collection={activeCollection}
 				initiallyLoadedAllPubs={initiallyLoadedAllPubs}
 			/>

--- a/client/containers/DashboardSubmissions/SubmissionRow.tsx
+++ b/client/containers/DashboardSubmissions/SubmissionRow.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+
+import {
+	getSubmissionStatusLabel,
+	getSubmissionTimeLabel,
+	IconLabelPair,
+} from '../DashboardOverview/overviewRows/labels';
+import { PubOverviewRow } from '../DashboardOverview/overviewRows';
+import { PubWithSubmission } from './types';
+import ArbitrationMenu from './ArbitrationMenu';
+
+type Props = {
+	pub: PubWithSubmission;
+};
+
+const SubmissionRow = (props: Props) => {
+	const { pub } = props;
+	const [status, setStatus] = useState(pub.submission.status);
+	const [isDeleted, setIsDeleted] = useState(false);
+
+	const labels = [getSubmissionStatusLabel(status), getSubmissionTimeLabel(pub)].filter(
+		(x): x is IconLabelPair => !!x,
+	);
+
+	if (isDeleted) {
+		return null;
+	}
+
+	return (
+		<PubOverviewRow
+			pub={pub}
+			leftIconElement="manually-entered-data"
+			isGrayscale={status === 'declined'}
+			labels={labels}
+			rightElement={
+				<ArbitrationMenu
+					pub={pub}
+					onJudgePub={setStatus}
+					onDeletePub={() => setIsDeleted(true)}
+				/>
+			}
+		/>
+	);
+};
+
+export default SubmissionRow;

--- a/client/containers/DashboardSubmissions/VerdictDialog.tsx
+++ b/client/containers/DashboardSubmissions/VerdictDialog.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { Callout, Button, Dialog, Classes, Checkbox } from '@blueprintjs/core';
 
-import { DefinitelyHas, SubmissionStatus, Pub, DocJson } from 'types';
+import { SubmissionStatus, DocJson } from 'types';
 import { Icon } from 'components';
 import { getEmptyDoc } from 'client/components/Editor/utils/doc';
+
 import WorkflowTextEditor from '../DashboardSubmissionWorkflow/WorkflowTextEditor';
 
 require('./verdictDialog.scss');
@@ -11,14 +12,13 @@ require('./verdictDialog.scss');
 type Props = {
 	isOpen: boolean;
 	shouldOfferEmail?: boolean;
-	onClose: () => unknown;
 	actionTitle: string;
 	completedName: string;
-	onSubmit: (customEmailText?: DocJson, shouldSendEmail?: boolean) => any;
 	status: SubmissionStatus;
 	initialEmailText?: DocJson;
-	pub: DefinitelyHas<Pub, 'submission'>;
-	onJudgePub: (pubId: string, status: SubmissionStatus) => void;
+	onClose: () => unknown;
+	onJudgePub: (status: SubmissionStatus) => void;
+	onSubmit: (customEmailText?: DocJson, shouldSendEmail?: boolean) => any;
 };
 
 type PreStatusChangeBodyProps = {
@@ -117,7 +117,7 @@ const VerdictDialog = (props: Props) => {
 				setUpdatedSubmission(submissionRes);
 				setIsHandlingSubmission(false);
 			})
-			.then(() => props.onJudgePub(props.pub.id, props.status))
+			.then(() => props.onJudgePub(props.status))
 			.catch((err) => {
 				setSubmissionError(err);
 				setIsHandlingSubmission(false);

--- a/client/containers/DashboardSubmissions/arbitrationMenu.scss
+++ b/client/containers/DashboardSubmissions/arbitrationMenu.scss
@@ -1,6 +1,9 @@
 .arbitration-menu-component {
-	display: grid;
-	grid-template-columns: repeat(3, 1fr);
-	grid-template-rows: 1fr;
-	grid-column-gap: 40px;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+
+	> *:not(:first-child) {
+		margin-left: 20px;
+	}
 }

--- a/client/containers/DashboardSubmissions/types.ts
+++ b/client/containers/DashboardSubmissions/types.ts
@@ -1,0 +1,3 @@
+import { DefinitelyHas, Pub } from 'types';
+
+export type PubWithSubmission = DefinitelyHas<Pub, 'submission'>;

--- a/client/utils/useLazyRef.ts
+++ b/client/utils/useLazyRef.ts
@@ -1,0 +1,13 @@
+import { useRef } from 'react';
+
+const noValueSignal = Symbol(0);
+
+export const useLazyRef = <T>(initializer: () => T) => {
+	const value = useRef<T>(noValueSignal as unknown as T);
+
+	if (value.current === (noValueSignal as unknown as T)) {
+		value.current = initializer();
+	}
+
+	return value;
+};

--- a/client/utils/useManyPubs/types.ts
+++ b/client/utils/useManyPubs/types.ts
@@ -41,6 +41,7 @@ export type ManyPubsOptions = {
 	query?: PartialQuery;
 	batchSize?: number;
 	isEager?: boolean;
+	cacheQueries?: boolean;
 };
 
 export type ManyPubsReturnValues<P> = {

--- a/client/utils/useManyPubs/useManyPubs.ts
+++ b/client/utils/useManyPubs/useManyPubs.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useUpdateEffect } from 'react-use';
+import { useUpdate, useUpdateEffect } from 'react-use';
 
 import { Pub } from 'types';
 import { usePageContext } from 'utils/hooks';
 import { indexByProperty } from 'utils/arrays';
 import { apiFetch } from 'client/utils/apiFetch';
+import { useLazyRef } from 'client/utils/useLazyRef';
 
 import {
 	getStartLoadingPubsState,
@@ -14,7 +15,6 @@ import {
 } from './state';
 import {
 	KeyedPubsQuery,
-	ManyPubsState,
 	ManyPubsQuery,
 	ManyPubsApiResult,
 	ManyPubsOptions,
@@ -54,8 +54,10 @@ export const useManyPubs = <P extends Pub = Pub>(
 		initiallyLoadedAllPubs = false,
 		cacheQueries = true,
 	} = options;
+
 	const { communityData } = usePageContext();
 	const [pubOptions] = useState(initialPubOptions);
+	const update = useUpdate();
 
 	const keyQuery: KeyedPubsQuery = {
 		term: optionsQuery.term,
@@ -65,88 +67,92 @@ export const useManyPubs = <P extends Pub = Pub>(
 		submissionStatuses: optionsQuery.submissionStatuses,
 	};
 
+	const pubsById = useLazyRef(() => indexByProperty(initialPubs, 'id'));
 	const queryKey = getQueryKey(keyQuery);
-
-	const [pubsById, setPubsById] = useState<Record<string, Pub>>(() =>
-		indexByProperty(initialPubs, 'id'),
-	);
-
-	const [manyPubsState, setManyPubsState] = useState<ManyPubsState>(() => {
-		if (Object.keys(pubsById).length > 0 || initiallyLoadedAllPubs) {
+	const manyPubsState = useLazyRef(() => {
+		if (Object.keys(pubsById.current).length > 0 || initiallyLoadedAllPubs) {
 			return {
-				[queryKey]: getInitialPubsState(keyQuery, pubsById, initiallyLoadedAllPubs),
+				[queryKey]: getInitialPubsState(keyQuery, pubsById.current, initiallyLoadedAllPubs),
 			};
 		}
 		return {};
 	});
 
-	const state = manyPubsState[queryKey] || initialQueryState;
+	const getCurrentQueryState = useCallback(() => {
+		return manyPubsState.current[queryKey] || initialQueryState;
+	}, [queryKey, manyPubsState]);
 
-	const setState = useCallback(
+	const setCurrentQueryState = useCallback(
 		(next: QueryState) => {
-			setManyPubsState((currentState) => {
-				return {
-					...currentState,
-					[queryKey]: next,
-				};
-			});
+			manyPubsState.current = {
+				...manyPubsState.current,
+				[queryKey]: next,
+			};
+			update();
 		},
-		[queryKey],
+		[queryKey, update, manyPubsState],
 	);
 
 	const loadMorePubs = async () => {
-		if (state.isLoading) {
+		const queryState = getCurrentQueryState();
+		const { isLoading, hasLoadedAllPubs, offset } = queryState;
+
+		if (isLoading || hasLoadedAllPubs) {
 			return;
 		}
-
-		const nextState = getStartLoadingPubsState(state, batchSize);
-		setState(nextState);
 
 		const query: ManyPubsQuery = {
 			...keyQuery,
 			...optionsQuery,
 			limit: batchSize,
-			offset: state.offset,
+			offset,
 			communityId: communityData.id,
 		};
+
+		const nextQueryState = getStartLoadingPubsState(queryState, batchSize);
+		setCurrentQueryState(nextQueryState);
+
 		const result: ManyPubsApiResult = await apiFetch.post('/api/pubs/many', {
 			query,
 			pubOptions,
-			alreadyFetchedPubIds: Object.keys(pubsById),
+			alreadyFetchedPubIds: Object.keys(pubsById.current),
 		});
 
 		const { loadedAllPubs, pubsById: newPubsById, pubIds } = result;
-		const nextPubsById = { ...pubsById, ...newPubsById };
+		const nextPubsById = { ...pubsById.current, ...newPubsById };
 		const resolvedPubs = pubIds.map((id) => nextPubsById[id]);
 		const resolvedPubsById = indexByProperty(resolvedPubs, 'id');
-		setState(getFinishedLoadingPubsState(nextState, query, resolvedPubsById, loadedAllPubs));
-		setPubsById(nextPubsById);
+		pubsById.current = nextPubsById;
+		setCurrentQueryState(
+			getFinishedLoadingPubsState(nextQueryState, query, resolvedPubsById, loadedAllPubs),
+		);
 	};
 
 	useUpdateEffect(() => {
 		if (!cacheQueries) {
-			setManyPubsState({
-				[queryKey]: initialQueryState,
-			});
+			pubsById.current = {};
+			manyPubsState.current = { [queryKey]: initialQueryState };
 		}
 	}, [cacheQueries, queryKey]);
 
 	useEffect(() => {
-		if (isEager && state.offset === 0) {
+		const queryState = getCurrentQueryState();
+		if (isEager && queryState.offset === 0) {
 			loadMorePubs();
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isEager, queryKey, state.offset]);
+	}, [isEager, queryKey]);
 
+	const currentQueryState = getCurrentQueryState();
 	return {
 		currentQuery: {
 			loadMorePubs,
-			isLoading: state.isLoading,
-			hasLoadedAllPubs: state.hasLoadedAllPubs,
-			pubs: state.orderedPubs.pubsInOrder as P[],
+			isLoading: currentQueryState.isLoading,
+			hasLoadedAllPubs: currentQueryState.hasLoadedAllPubs,
+			pubs: currentQueryState.orderedPubs.pubsInOrder as P[],
 		},
 		allQueries: {
-			isLoading: Object.values(manyPubsState).some((s) => s.isLoading),
+			isLoading: Object.values(manyPubsState.current).some((s) => s.isLoading),
 		},
 	};
 };

--- a/client/utils/useManyPubs/useManyPubs.ts
+++ b/client/utils/useManyPubs/useManyPubs.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useUpdateEffect } from 'react-use';
 
 import { Pub } from 'types';
 import { usePageContext } from 'utils/hooks';
@@ -51,6 +52,7 @@ export const useManyPubs = <P extends Pub = Pub>(
 		isEager = true,
 		initialPubs = [],
 		initiallyLoadedAllPubs = false,
+		cacheQueries = true,
 	} = options;
 	const { communityData } = usePageContext();
 	const [pubOptions] = useState(initialPubOptions);
@@ -120,6 +122,14 @@ export const useManyPubs = <P extends Pub = Pub>(
 		setState(getFinishedLoadingPubsState(nextState, query, resolvedPubsById, loadedAllPubs));
 		setPubsById(nextPubsById);
 	};
+
+	useUpdateEffect(() => {
+		if (!cacheQueries) {
+			setManyPubsState({
+				[queryKey]: initialQueryState,
+			});
+		}
+	}, [cacheQueries, queryKey]);
 
 	useEffect(() => {
 		if (isEager && state.offset === 0) {

--- a/types/util.ts
+++ b/types/util.ts
@@ -14,6 +14,8 @@ export type Diff<T> = { from: T; to: T };
 export type WithId = { id: string };
 export type IdIndex<T extends WithId> = Record<string, T>;
 
+export type Callback<T = void> = T extends void ? () => unknown : (t: T) => unknown;
+
 export type DeepPartial<T> = {
 	[P in keyof T]?: T[P] extends Array<infer I> ? Array<DeepPartial<I>> : DeepPartial<T[P]>;
 };


### PR DESCRIPTION
This PR chamfers some edges on the Submissions dashboard that's coming together across tasks.

- Move a bunch of state management for individual Spubs out of `PubRow` and `SubmissionItems` into a new `SubmissionRow` that wraps `PubRow`. This component is responsible for managing its own `submission.status` state, and hiding itself if the Pub has been deleted. It also renders Submission-specific details (like the status) instead of delegating that to the more general `PubRow`.
- Add a `cacheQueries` option to the `useManyPubs()` monstrosity. By default the hook caches Pubs from different filters/queries to `/api/pubs/many` — these filters correspond to e.g. the Pending and Accepted tabs of the Submissions listing. This is a great experience on the Overview dashboard tab but creates problems in the Submissions tab, where Pubs may move _between_ filters. Setting `cacheQueries: false` forces to hook to re-fetch Pubs on every filter change, which is closer to ideal here.
- Make the `OverviewSearchGroup` filter tabs take an `OverviewSearchFilter` instead of `Partial<PubsQuery>` as its list of filters (so we can reference them by id) and work as either a controlled or uncontrolled component by adding a `filter` prop — together these are helpful for a parent component that needs to know which tab is currently selected.
- Some copy changes

_Test plan:_
- In the Submissions dashboard, move Pubs between the Pending, Accepted, and Rejected tabs. Verify that when you switch tabs a reload of all Pubs in the new tab occurs, and the _updated_ list of Pubs in that tab's submission state is always shown
- Also check that the filter tabs on the Community and Collection overview pages are working
