### PR TITLE
Add dialog popup for submission to preview tab

### DIFF
--- a/client/containers/Pub/SpubHeader/PreviewTab/PreviewTab.tsx
+++ b/client/containers/Pub/SpubHeader/PreviewTab/PreviewTab.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Icon } from '@blueprintjs/core';
 
-import { PubPageData } from 'types';
-import { GridWrapper, PubByline } from 'components';
+import { PubPageData, Submission, DefinitelyHas } from 'types';
+import { GridWrapper, PubByline, DialogLauncher } from 'components';
 import { usePageContext } from 'utils/hooks';
 
+import SubmitDialog from './SubmitDialog';
 import PubHeaderBackground from '../../PubHeader/PubHeaderBackground';
 import ResponsiveHeaderButton from '../../PubHeader/ResponsiveHeaderButton';
 import { getHistoryButtonLabelForTimestamp } from '../../PubHeader/DraftReleaseButtons';
@@ -14,7 +15,7 @@ require('../../PubHeader/draftReleaseButtons.scss');
 type Props = {
 	historyData: any;
 	updateHistoryData: any;
-	pubData: PubPageData;
+	pubData: PubPageData & { submission: DefinitelyHas<Submission, 'submissionWorkflow'> };
 };
 
 const PreviewTab = (props: Props) => {
@@ -56,12 +57,34 @@ const PreviewTab = (props: Props) => {
 									})
 								}
 							/>
-							<ResponsiveHeaderButton
-								// @ts-expect-error ts-migrate(2322) FIXME: Type '{ icon: string; tagName: string; href: strin... Remove this comment to see the full error message
-								className="submit-button"
-								icon={<Icon iconSize={13} className="submit-icon" icon="saved" />}
-								label={{ top: 'Submit Pub', bottom: 'finish your submission' }}
-							/>
+							<DialogLauncher
+								renderLauncherElement={({ openDialog }) => (
+									<ResponsiveHeaderButton
+										// @ts-expect-error ts-migrate(2322) FIXME: Type '{ icon: string; tagName: string; href: strin... Remove this comment to see the full error message
+										className="submit-button"
+										onClick={openDialog}
+										icon={
+											<Icon
+												iconSize={13}
+												className="submit-icon"
+												icon="saved"
+											/>
+										}
+										label={{
+											top: 'Submit Pub',
+											bottom: 'finish your submission',
+										}}
+									/>
+								)}
+							>
+								{({ isOpen, onClose }) => (
+									<SubmitDialog
+										submission={props.pubData.submission}
+										isOpen={isOpen}
+										onClose={onClose}
+									/>
+								)}
+							</DialogLauncher>
 						</div>
 					</div>
 				</div>

--- a/client/containers/Pub/SpubHeader/PreviewTab/SubmitDialog.tsx
+++ b/client/containers/Pub/SpubHeader/PreviewTab/SubmitDialog.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+
+// import { Callout, Button, Dialog, Classes, Checkbox } from '@blueprintjs/core';
+import { Callout, Button, Classes, Dialog } from '@blueprintjs/core';
+import { apiFetch } from 'client/utils/apiFetch';
+import { Submission, SubmissionStatus, DefinitelyHas } from 'types';
+
+type Props = {
+	submission: DefinitelyHas<Submission, 'submissionWorkflow'>;
+	isOpen: boolean;
+	onClose: () => any;
+};
+
+const SubmitDialog = (props: Props) => {
+	const [isHandlingSubmission, setIsHandlingSubmission] = useState(false);
+	const [updatedSubmission, setUpdatedSubmission] = useState(null);
+	const [submissionErr, setSubmissionErr] = useState(null);
+	const onSubmit = () => {
+		setIsHandlingSubmission(true);
+		apiFetch
+			.put('/api/submissions', {
+				id: props.submission.id,
+				status: 'pending' as SubmissionStatus,
+			})
+			.then((submissionRes) => setUpdatedSubmission(submissionRes))
+			.catch((err) => setSubmissionErr(err))
+			.finally(() => setIsHandlingSubmission(false));
+	};
+	// add me to the success message: {props.submission.submissionWorkflow.emailText || null}
+	return (
+		<Dialog isOpen={props.isOpen} onClose={props.onClose}>
+			{submissionErr ? (
+				<Callout intent="warning" title="There was an error updating this submission." />
+			) : updatedSubmission ? (
+				<>
+					<div className={Classes.DIALOG_BODY}>
+						<Callout intent="success" title="Submitted!">
+							Your pub has been submitted and is under review.
+						</Callout>
+					</div>
+					<div className={Classes.DIALOG_FOOTER}>
+						<div className={Classes.DIALOG_FOOTER_ACTIONS}>
+							<Button onClick={props.onClose} disabled={isHandlingSubmission}>
+								Close
+							</Button>
+							<Button
+								onClick={() => window.location.reload()}
+								loading={isHandlingSubmission}
+								intent="primary"
+							>
+								View Submission
+							</Button>
+						</div>
+					</div>
+				</>
+			) : (
+				<>
+					<div className={Classes.DIALOG_BODY}>
+						<p>Are you sure you're reade to submit this Pub?</p>
+					</div>
+					<div className={Classes.DIALOG_FOOTER}>
+						<div className={Classes.DIALOG_FOOTER_ACTIONS}>
+							<Button onClick={props.onClose} disabled={isHandlingSubmission}>
+								Cancel
+							</Button>
+							<Button
+								onClick={onSubmit}
+								loading={isHandlingSubmission}
+								intent="primary"
+							>
+								Submit
+							</Button>
+						</div>
+					</div>
+				</>
+			)}
+		</Dialog>
+	);
+};
+
+export default SubmitDialog;


### PR DESCRIPTION
#1731

WIP, missing (only, I think) the email text display, which may or may not be desirable. If anyone is reading this, please comment below, should we include the 'thanks for submitting' email text in the success `Callout` after a contributor hit's submit?