### PR TITLE
feature: pub release dialog

### DIFF
--- a/client/components/PubReleaseDialog/PubReleaseDialog.tsx
+++ b/client/components/PubReleaseDialog/PubReleaseDialog.tsx
@@ -17,16 +17,17 @@ import { usePageContext } from 'utils/hooks';
 
 import { apiFetch } from 'client/utils/apiFetch';
 import { ClickToCopyButton, MinimalEditor } from 'components';
-import { Release, PubPageData } from 'types';
+import { Release, PubPageData, Pub } from 'types';
 
 require('./pubReleaseDialog.scss');
 
 type Props = {
-	historyData: {
+	historyKey?: number;
+	historyData?: {
 		latestKey?: number;
 	};
 	isOpen: boolean;
-	pubData: PubPageData;
+	pubData: PubPageData | Pub;
 	onClose: () => unknown;
 	onCreateRelease: (r: Release) => unknown;
 };
@@ -61,7 +62,7 @@ const PubReleaseDialog = (props: Props) => {
 			pubId: pubData.id,
 			noteContent: noteData.content,
 			noteText: noteData.text,
-			historyKey: historyData.latestKey,
+			historyKey: historyData?.latestKey,
 		})
 			.then((release) => {
 				setReleleaseError(null);

--- a/client/components/PubReleaseDialog/PubReleaseDialog.tsx
+++ b/client/components/PubReleaseDialog/PubReleaseDialog.tsx
@@ -65,7 +65,7 @@ const PubReleaseDialog = (props: Props) => {
 				setReleleaseError(null);
 				setCreatedRelease(release);
 				setIsCreatingRelease(false);
-				if (typeof onCreateRelease === 'function') onCreateRelease(release);
+				onCreateRelease?.(release);
 			})
 			.catch((err) => {
 				setReleleaseError(err);

--- a/client/components/PubReleaseDialog/PubReleaseDialog.tsx
+++ b/client/components/PubReleaseDialog/PubReleaseDialog.tsx
@@ -17,19 +17,16 @@ import { usePageContext } from 'utils/hooks';
 
 import { apiFetch } from 'client/utils/apiFetch';
 import { ClickToCopyButton, MinimalEditor } from 'components';
-import { Release, PubPageData, Pub } from 'types';
+import { Release, Pub } from 'types';
 
 require('./pubReleaseDialog.scss');
 
 type Props = {
 	historyKey?: number;
-	historyData?: {
-		latestKey?: number;
-	};
+	pub: Pub;
 	isOpen: boolean;
-	pubData: PubPageData | Pub;
 	onClose: () => unknown;
-	onCreateRelease: (r: Release) => unknown;
+	onCreateRelease?: (r: Release) => unknown;
 };
 
 const createRelease = ({ historyKey, pubId, communityId, noteContent, noteText }) =>
@@ -45,13 +42,13 @@ const createRelease = ({ historyKey, pubId, communityId, noteContent, noteText }
 	});
 
 const PubReleaseDialog = (props: Props) => {
-	const { isOpen, onClose, historyData, pubData, onCreateRelease } = props;
+	const { isOpen, onClose, historyKey, pub, onCreateRelease } = props;
 	const { communityData } = usePageContext();
 	const [noteData, setNoteData] = useState<{ content?: {}; text?: string }>({});
 	const [isCreatingRelease, setIsCreatingRelease] = useState(false);
 	const [createdRelease, setCreatedRelease] = useState(false);
 	const [releaseError, setReleleaseError] = useState(null);
-	const { releases } = pubData;
+	const { releases } = pub;
 	const releaseCount = releases ? releases.length : 0;
 	const latestRelease = releases[releaseCount - 1]!;
 
@@ -59,16 +56,16 @@ const PubReleaseDialog = (props: Props) => {
 		setIsCreatingRelease(true);
 		createRelease({
 			communityId: communityData.id,
-			pubId: pubData.id,
+			pubId: pub.id,
 			noteContent: noteData.content,
 			noteText: noteData.text,
-			historyKey: historyData?.latestKey,
+			historyKey,
 		})
 			.then((release) => {
 				setReleleaseError(null);
 				setCreatedRelease(release);
 				setIsCreatingRelease(false);
-				onCreateRelease(release);
+				if (typeof onCreateRelease === 'function') onCreateRelease(release);
 			})
 			.catch((err) => {
 				setReleleaseError(err);
@@ -77,7 +74,7 @@ const PubReleaseDialog = (props: Props) => {
 	};
 
 	const renderLatestReleaseInfo = (release) => {
-		const releaseUrl = pubUrl(communityData, pubData, { releaseNumber: releaseCount });
+		const releaseUrl = pubUrl(communityData, pub, { releaseNumber: releaseCount });
 
 		return (
 			<React.Fragment>
@@ -136,7 +133,7 @@ const PubReleaseDialog = (props: Props) => {
 						</p>
 						{renderURLForCopy(
 							'Link that always points to the latest Release for this pub:',
-							pubUrl(communityData, pubData),
+							pubUrl(communityData, pub),
 						)}
 					</React.Fragment>
 				);
@@ -147,7 +144,7 @@ const PubReleaseDialog = (props: Props) => {
 					includeTime: true,
 					includePreposition: true,
 				});
-				const releaseUrl = pubUrl(communityData, pubData, {
+				const releaseUrl = pubUrl(communityData, pub, {
 					releaseNumber: releaseCount,
 				});
 				return (
@@ -167,7 +164,7 @@ const PubReleaseDialog = (props: Props) => {
 						)}
 						{renderURLForCopy(
 							'Link that always points to the latest Release for this pub:',
-							pubUrl(communityData, pubData),
+							pubUrl(communityData, pub),
 						)}
 						<p className="text-info">
 							Older Releases can be viewed using the{' '}
@@ -200,7 +197,7 @@ const PubReleaseDialog = (props: Props) => {
 		return (
 			<React.Fragment>
 				<Button onClick={onClose}>Return to draft</Button>
-				<AnchorButton intent="primary" href={pubUrl(communityData, pubData)}>
+				<AnchorButton intent="primary" href={pubUrl(communityData, pub)}>
 					Go to latest Release
 				</AnchorButton>
 			</React.Fragment>

--- a/client/components/PubReleaseDialog/PubReleaseDialog.tsx
+++ b/client/components/PubReleaseDialog/PubReleaseDialog.tsx
@@ -1,3 +1,5 @@
+import React, { useState } from 'react';
+import TimeAgo from 'react-timeago';
 import {
 	AnchorButton,
 	Button,
@@ -8,8 +10,6 @@ import {
 	Icon,
 	InputGroup,
 } from '@blueprintjs/core';
-import React, { useState } from 'react';
-import TimeAgo from 'react-timeago';
 
 import { pubUrl } from 'utils/canonicalUrls';
 import { formatDate, timeAgoBaseProps } from 'utils/dates';
@@ -98,7 +98,7 @@ const PubReleaseDialog = (props: Props) => {
 			<div>
 				<p className="text-info">{label}</p>
 				<ControlGroup className="url-select">
-					<InputGroup className="display-url" value={url} fill small />
+					<InputGroup className="display-url" value={url} fill small disabled />
 					<ClickToCopyButton
 						minimal={true}
 						copyString={url}

--- a/client/components/PubReleaseDialog/pubReleaseDialog.scss
+++ b/client/components/PubReleaseDialog/pubReleaseDialog.scss
@@ -1,37 +1,42 @@
 .pub-release-dialog-component {
-    .bp3-callout {
-      margin-bottom: 10px;
-      .release-date {
-        font-size: 12px;
-      }
-    }
-    .notes-header {
-      text-transform: uppercase;
-      font-size: 12px;
-      color: #888;
-      margin-bottom: 5px;
-    }
-    .text-info {
-      margin-top: 20px;
-      margin-bottom: 5px;
-    }
-    .url-select {
-      .bp3-button {
-        min-height: 24px;
-        max-height: 24px;
-        margin-left: 10px;
-      }
-    }
-    .minimal-editor-component {
-        height: 150px;
-        overflow: auto;
-        .editor-wrapper {
-            min-height: 100%;
-            .ProseMirror {
-              .prosemirror-placeholder {
-                white-space: break-spaces;
-              }
-            }
-        }
-    }
+	.bp3-callout {
+		margin-bottom: 10px;
+		.release-date {
+			font-size: 12px;
+		}
+	}
+	.notes-header {
+		text-transform: uppercase;
+		font-size: 12px;
+		color: #888;
+		margin-bottom: 5px;
+	}
+	.text-info {
+		margin-top: 20px;
+		margin-bottom: 5px;
+	}
+	.url-select {
+		.bp3-button {
+			min-height: 24px;
+			max-height: 24px;
+			margin-left: 10px;
+		}
+		.bp3-input-group.bp3-disabled .bp3-input {
+			background: white;
+			color: inherit;
+			cursor: text;
+		}
+	}
+	.minimal-editor-component {
+		height: 150px;
+		overflow: auto;
+		.editor-wrapper {
+			min-height: 100%;
+			.ProseMirror {
+				.prosemirror-placeholder {
+					white-space: break-spaces;
+				}
+			}
+		}
+	}
 }

--- a/client/containers/DashboardSubmissions/ArbitrationMenu.tsx
+++ b/client/containers/DashboardSubmissions/ArbitrationMenu.tsx
@@ -16,26 +16,21 @@ type Props = {
 
 const ArbitrationMenu = (props: Props) => (
 	<div className="arbitration-menu-component">
-		{props.pub.submission.status === 'accepted' && (
+		{props.pub.submission.status === 'accepted' && !props.pub.releases.length && (
 			<DialogLauncher
 				renderLauncherElement={({ openDialog }) => (
 					<Tooltip content="Release Pub">
 						<Button
 							minimal
 							small
-							icon={<Icon icon="social-media" iconSize={20} />}
+							icon={<Icon icon="document-share" iconSize={20} />}
 							onClick={openDialog}
 						/>
 					</Tooltip>
 				)}
 			>
 				{({ isOpen, onClose }) => (
-					<PubReleaseDialog
-						isOpen={isOpen}
-						onClose={onClose}
-						pub={props.pub}
-						onCreateRelease={() => {}}
-					/>
+					<PubReleaseDialog isOpen={isOpen} onClose={onClose} pub={props.pub} />
 				)}
 			</DialogLauncher>
 		)}

--- a/client/containers/DashboardSubmissions/ArbitrationMenu.tsx
+++ b/client/containers/DashboardSubmissions/ArbitrationMenu.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button } from '@blueprintjs/core';
 
 import { DefinitelyHas, Pub, SubmissionStatus, DocJson } from 'types';
-import { ConfirmDialog, Icon, IconName, DialogLauncher } from 'client/components';
+import { ConfirmDialog, Icon, IconName, DialogLauncher, PubReleaseDialog } from 'components';
 import { apiFetch } from 'client/utils/apiFetch';
 import VerdictDialog from './VerdictDialog';
 
@@ -37,6 +37,27 @@ const ArbitrationMenu = (props: Props) => (
 				)}
 			</ConfirmDialog>
 		</div>
+		{props.pub.submission.status === 'accepted' && (
+			<DialogLauncher
+				renderLauncherElement={({ openDialog }) => (
+					<Button
+						minimal
+						small
+						icon={<Icon icon="social-media" iconSize={20} />}
+						onClick={openDialog}
+					/>
+				)}
+			>
+				{({ isOpen, onClose }) => (
+					<PubReleaseDialog
+						isOpen={isOpen}
+						onClose={onClose}
+						pubData={props.pub}
+						onCreateRelease={() => {}}
+					/>
+				)}
+			</DialogLauncher>
+		)}
 		{[
 			{ presentTense: 'Decline', pastTense: 'declined', iconName: 'thumbs-down' },
 			{ presentTense: 'Accept', pastTense: 'accepted', iconName: 'endorsed' },

--- a/client/containers/DashboardSubmissions/ArbitrationMenu.tsx
+++ b/client/containers/DashboardSubmissions/ArbitrationMenu.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, Tooltip } from '@blueprintjs/core';
 
 import { DefinitelyHas, Pub, SubmissionStatus, DocJson } from 'types';
-import { ConfirmDialog, Icon, IconName, DialogLauncher, PubReleaseDialog } from 'components';
+import { ConfirmDialog, Icon, DialogLauncher, PubReleaseDialog } from 'components';
 import { apiFetch } from 'client/utils/apiFetch';
 import VerdictDialog from './VerdictDialog';
 
@@ -16,6 +16,29 @@ type Props = {
 
 const ArbitrationMenu = (props: Props) => (
 	<div className="arbitration-menu-component">
+		{props.pub.submission.status === 'accepted' && (
+			<DialogLauncher
+				renderLauncherElement={({ openDialog }) => (
+					<Tooltip content="Release Pub">
+						<Button
+							minimal
+							small
+							icon={<Icon icon="social-media" iconSize={20} />}
+							onClick={openDialog}
+						/>
+					</Tooltip>
+				)}
+			>
+				{({ isOpen, onClose }) => (
+					<PubReleaseDialog
+						isOpen={isOpen}
+						onClose={onClose}
+						pub={props.pub}
+						onCreateRelease={() => {}}
+					/>
+				)}
+			</DialogLauncher>
+		)}
 		{[
 			{ presentTense: 'Decline', pastTense: 'declined', iconName: 'thumbs-down' as const },
 			{ presentTense: 'Accept', pastTense: 'accepted', iconName: 'endorsed' as const },

--- a/client/containers/Pub/PubHeader/DraftReleaseButtons.tsx
+++ b/client/containers/Pub/PubHeader/DraftReleaseButtons.tsx
@@ -159,8 +159,8 @@ const DraftReleaseButtons = (props: DraftReleaseButtonsProps) => {
 								key={key}
 								isOpen={isOpen}
 								onClose={onClose}
-								pubData={pubData}
-								historyData={historyData}
+								pub={pubData}
+								historyKey={historyData?.latestKey}
 								onCreateRelease={(release) =>
 									updatePubData((currentPubData) => {
 										return {


### PR DESCRIPTION
#1684

Adds a 'release pub' button to the Submission Overview Rows for `accepted` spubs.

_Test plan:_

1. navigate to Submissions Overview
2. filter pubs based on `accepted`  status
3. click "social-media" icon for releasing pubs
4. proceed through pub-release process, same as from a pub draft

If it differs in any way from the release experience in the pub draft view, that's a problem.