### PR TITLE
Two citation fixes

### DIFF
--- a/client/components/Editor/schemas/citation.ts
+++ b/client/components/Editor/schemas/citation.ts
@@ -32,12 +32,13 @@ export default {
 						id: node.getAttribute('id'),
 						value: node.getAttribute('data-value') || '',
 						unstructuredValue: node.getAttribute('data-unstructured-value') || '',
+						customLabel: node.getAttribute('data-custom-label') || '',
 					};
 				},
 			},
 		],
 		toDOM: (node) => {
-			const { href, id, value, unstructuredValue } = node.attrs;
+			const { href, id, value, unstructuredValue, customLabel } = node.attrs;
 			return [
 				href ? 'a' : 'span',
 				{
@@ -46,6 +47,7 @@ export default {
 					'data-node-type': 'citation',
 					'data-value': value,
 					'data-unstructured-value': unstructuredValue,
+					'data-custom-label': customLabel,
 					class: 'citation',
 				},
 				getCitationInlineLabel(node),

--- a/client/components/Editor/utils/notes.ts
+++ b/client/components/Editor/utils/notes.ts
@@ -1,3 +1,4 @@
+import { Node } from 'prosemirror-model';
 import striptags from 'striptags';
 
 export type Note = {
@@ -6,7 +7,7 @@ export type Note = {
 	unstructuredValue: string;
 };
 
-export const getNotes = (doc) => {
+export const getNotes = (doc: Node) => {
 	const citationCounts = {};
 	const footnoteItems: Note[] = [];
 	const citationItems: Note[] = [];

--- a/client/components/Editor/utils/notes.ts
+++ b/client/components/Editor/utils/notes.ts
@@ -1,3 +1,5 @@
+import striptags from 'striptags';
+
 export type Note = {
 	id: string;
 	structuredValue: string;
@@ -18,14 +20,16 @@ export const getNotes = (doc) => {
 			});
 		}
 		if (node.type.name === 'citation') {
-			const key = `${node.attrs.value}-${node.attrs.unstructuredValue}`;
+			const { unstructuredValue, value } = node.attrs;
+			const strippedUnstructuredValue = unstructuredValue ? striptags(unstructuredValue) : '';
+			const key = `${value}-${strippedUnstructuredValue}`;
 			const existingCount = citationCounts[key];
 			if (!existingCount) {
 				citationCounts[key] = true;
 				citationItems.push({
 					id: node.attrs.id,
-					structuredValue: node.attrs.value,
-					unstructuredValue: node.attrs.unstructuredValue,
+					structuredValue: value,
+					unstructuredValue,
 				});
 			}
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -37738,6 +37738,11 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
+		"striptags": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
+			"integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw=="
+		},
 		"stubs": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
 		"slowdance": "0.0.2",
 		"stickybits": "^3.6.5",
 		"strip-indent": "^3.0.0",
+		"striptags": "^3.2.0",
 		"styled-components": "^5.3.0",
 		"throng": "^4.0.0",
 		"tmp-promise": "^2.0.1",


### PR DESCRIPTION
This PR fixes two problems with citations:

- Citations with identical `unstructuredValue` are no longer deduped because the `ids` plugin is now generating random identifiers for each paragraph in the unstructured content HTML. To restore this behavior, I have added the [`striptags`](https://www.npmjs.com/package/striptags) package to get raw text from this HTML. We now dedupe on the basis of that raw text. This will restore the correct behavior retroactively to Pubs created since this breaking change.
- The citation `customLabel` attribute doesn't get preserved in copy+paste. Well, it does now!

_Test plan:_
- Create two separate citations with the same unstructured content and verify that they are deduped in the Pub bottom citations section. Refresh the page and make sure this works on the server during initial SSR.
- Create a citation with a custom label (using the control in the lower right side of the citation editor) and verify that this custom label survives a copy+paste round trip.