### PR TITLE
fix: Activity digest emails not sending due to deleted associations

### DIFF
--- a/server/utils/email/digest.tsx
+++ b/server/utils/email/digest.tsx
@@ -36,7 +36,7 @@ const getAffectedObject = (item: ActivityItem, associations: ActivityAssociation
 		const { id, title } = item.payload.page;
 		return { id, title };
 	}
-	// We can be reasonable sure that this Community still exists since we're sending its digest
+	// We can be reasonably sure that this Community still exists since we're sending its digest
 	const { title } = associations.community[item.communityId];
 	return {
 		id: item.communityId,

--- a/tools/emailActivityDigest.ts
+++ b/tools/emailActivityDigest.ts
@@ -40,18 +40,23 @@ async function main() {
 			return asyncMap(
 				members,
 				async ({ user }) => {
-					// eslint-disable-next-line no-console
-					console.log(`user ${user.id} ${user.email}`);
-					// Create an activity digest email
-					const scope = { communityId: community.id };
-					const digest = await renderDigestEmail(community, { scope, user });
-					if (digest === null) return Promise.resolve();
-					return mg.messages.create('mg.pubpub.org', {
-						from: 'PubPub Team <hello@pubpub.org>',
-						to: [user.email],
-						subject: `${community.title} daily activity digest`,
-						html: digest,
-					});
+					try {
+						// eslint-disable-next-line no-console
+						console.log(`user ${user.id} ${user.email}`);
+						// Create an activity digest email
+						const scope = { communityId: community.id };
+						const digest = await renderDigestEmail(community, { scope, user });
+						if (digest === null) return;
+						await mg.messages.create('mg.pubpub.org', {
+							from: 'PubPub Team <hello@pubpub.org>',
+							to: [user.email],
+							subject: `${community.title} daily activity digest`,
+							html: digest,
+						});
+					} catch (err) {
+						// eslint-disable-next-line no-console
+						console.log(`sending email failed: ${err}`);
+					}
 				},
 				{ concurrency: 10 },
 			);


### PR DESCRIPTION
This PR fixes a bug that would crash the Activity digest sending script when it encountered an object in `ActivityAssociations` that was deleted after its Activity items were created. I also added a try/catch wrapper around the code that renders and sends an individual email, so if one fails the script will plow on undeterred.

_Test plan:_
Let's land this and see whether it works tonight. 