### PR TITLE
Submission Contributors

### DIFF
--- a/client/components/PubAttributionEditor/PubAttributionEditor.tsx
+++ b/client/components/PubAttributionEditor/PubAttributionEditor.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { AttributionEditor } from 'components';
 import { usePendingChanges } from 'utils/hooks';
 
+import { PubPageData } from 'types';
+
 type Props = {
 	canEdit: boolean;
 	communityData: {
@@ -12,7 +14,7 @@ type Props = {
 		id?: string;
 		attributions?: any[];
 	};
-	updatePubData: (...args: any[]) => any;
+	updatePubData: (pub: Partial<PubPageData>) => unknown;
 };
 
 const PubAttributionEditor = (props: Props) => {

--- a/client/containers/Pub/SpubHeader/SpubHeader.tsx
+++ b/client/containers/Pub/SpubHeader/SpubHeader.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { Tab, Tabs, TabId, Icon, IconName } from '@blueprintjs/core';
 
-import { Submission, Pub, DefinitelyHas, PubHistoryState, PubPageData } from 'types';
+import { DocJson, DefinitelyHas, PubHistoryState, PubPageData } from 'types';
 import { assert } from 'utils/assert';
+import { apiFetch } from 'client/utils/apiFetch';
+import { getEmptyDoc } from 'components/Editor';
 
 import InstructionsTab from './InstructionsTab';
 import SubmissionTab from './SubmissionTab';
@@ -12,10 +14,11 @@ require('./spubHeader.scss');
 
 type Props = {
 	historyData: PubHistoryState;
-	updateLocalData: (type: string, patch: Partial<PubPageData>) => unknown;
+	updateLocalData: (
+		type: string,
+		patch: Partial<PubPageData> | Partial<PubHistoryState>,
+	) => unknown;
 	pubData: DefinitelyHas<PubPageData, 'submission'>;
-	onUpdatePub?: (pub: Partial<Pub>) => unknown;
-	onUpdateSubmission?: (submission: Partial<Submission>) => unknown;
 };
 
 export const renderInstructionTabTitle = (icon: IconName, title: string) => {
@@ -27,22 +30,44 @@ export const renderInstructionTabTitle = (icon: IconName, title: string) => {
 };
 
 const SpubHeader = (props: Props) => {
-	const {
-		pubData: {
-			submission: { submissionWorkflow },
-		},
-		onUpdatePub,
-		onUpdateSubmission,
-	} = props;
+	const { pubData, historyData, updateLocalData } = props;
+	const { submissionWorkflow } = props.pubData.submission;
+
 	const [selectedTab, setSelectedTab] = useState<TabId>('instructions');
+	const [abstract, setAbstract] = useState(pubData.submission.abstract || getEmptyDoc());
+
+	const updateAbstract = async (newAbstract: DocJson) => {
+		return apiFetch('/api/submissions', {
+			method: 'PUT',
+			body: JSON.stringify({
+				abstract: newAbstract,
+				id: pubData.submission.id,
+				status: pubData.submission.status,
+			}),
+		}).then(() => setAbstract(newAbstract));
+	};
+
+	const updateAndSavePubData = async (newPubData: Partial<PubPageData>) => {
+		const oldPubData = { ...pubData };
+		updateLocalData('pub', newPubData);
+		return apiFetch('/api/pubs', {
+			method: 'PUT',
+			body: JSON.stringify({
+				...newPubData,
+				pubId: pubData.id,
+				communityId: pubData.communityId,
+			}),
+		}).catch(() => updateLocalData('pub', oldPubData));
+	};
 	assert(props.pubData.submission.submissionWorkflow !== undefined);
+
+	const updateHistoryData = (newHistoryData: Partial<PubHistoryState>) => {
+		return updateLocalData('history', newHistoryData);
+	};
 
 	const instructionTabTitle = renderInstructionTabTitle('align-left', 'Instructions');
 	const submissionTabTitle = renderInstructionTabTitle('manually-entered-data', 'Submission');
 	const previewTabTitle = renderInstructionTabTitle('eye-open', 'Preview & Submit');
-	const updateHistoryData = (newHistoryData) => {
-		return props.updateLocalData('history', newHistoryData);
-	};
 
 	return (
 		<Tabs
@@ -63,8 +88,10 @@ const SpubHeader = (props: Props) => {
 				title={submissionTabTitle}
 				panel={
 					<SubmissionTab
-						onUpdatePub={onUpdatePub}
-						onUpdateSubmission={onUpdateSubmission}
+						abstract={abstract}
+						onUpdatePub={updateAndSavePubData}
+						onUpdateAbstract={updateAbstract}
+						pub={pubData}
 					/>
 				}
 				className="tab-panel tab"
@@ -75,8 +102,8 @@ const SpubHeader = (props: Props) => {
 				panel={
 					<PreviewTab
 						updateHistoryData={updateHistoryData}
-						historyData={props.historyData}
-						pubData={props.pubData}
+						historyData={historyData}
+						pubData={pubData}
 					/>
 				}
 				className="tab preview-tab"

--- a/client/containers/Pub/SpubHeader/SubmissionTab/Contributors.tsx
+++ b/client/containers/Pub/SpubHeader/SubmissionTab/Contributors.tsx
@@ -1,13 +1,17 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { PubAttributionEditor } from 'components';
 
-import { pubData, communityData } from 'utils/storybook/data';
+import { usePageContext } from 'utils/hooks';
+import { PubPageData, DefinitelyHas } from 'types';
 
-const Contributors = () => {
-	const [persistedPubData, setPersistedPubData] = useState(pubData);
-	const updatePersistedPubData = (values) => {
-		setPersistedPubData({ ...persistedPubData, ...values });
-	};
+type Props = {
+	pubData: DefinitelyHas<PubPageData, 'submission'>;
+	onUpdatePub: (pub: Partial<PubPageData>) => unknown;
+};
+
+const Contributors = (props: Props) => {
+	const { onUpdatePub, pubData } = props;
+	const { communityData } = usePageContext();
 
 	const renderAttributions = () => {
 		return (
@@ -20,7 +24,7 @@ const Contributors = () => {
 					<PubAttributionEditor
 						pubData={pubData}
 						communityData={communityData}
-						updatePubData={updatePersistedPubData}
+						updatePubData={onUpdatePub}
 						canEdit={true}
 					/>
 				</div>

--- a/client/containers/Pub/SpubHeader/SubmissionTab/SubmissionTab.tsx
+++ b/client/containers/Pub/SpubHeader/SubmissionTab/SubmissionTab.tsx
@@ -1,19 +1,21 @@
 import React, { useState } from 'react';
 import { Tab, Tabs } from '@blueprintjs/core';
 
-import { Submission, Pub } from 'types';
+import { PubPageData, DefinitelyHas, DocJson } from 'types';
 
 import TitleDescriptionAbstract from './TitleDescriptionAbstract';
 import Contributors from './Contributors';
 import SpubSettings from './SpubSettings';
 
 type Props = {
-	onUpdatePub?: (pub: Partial<Pub>) => unknown;
-	onUpdateSubmission?: (submission: Partial<Submission>) => unknown;
+	pub: DefinitelyHas<PubPageData, 'submission'>;
+	abstract: DocJson;
+	onUpdatePub: (pub: Partial<PubPageData>) => unknown;
+	onUpdateAbstract: (abstract: DocJson) => Promise<unknown>;
 };
 
 const SubmissionTab = (props: Props) => {
-	const { onUpdatePub, onUpdateSubmission } = props;
+	const { onUpdatePub, onUpdateAbstract, pub, abstract } = props;
 	const [selectedTab, setSelectedTab] = useState('title');
 
 	return (
@@ -30,12 +32,18 @@ const SubmissionTab = (props: Props) => {
 					title="Title, Description & Abstract"
 					panel={
 						<TitleDescriptionAbstract
+							pub={pub}
+							abstract={abstract}
 							onUpdatePub={onUpdatePub}
-							onUpdateSubmission={onUpdateSubmission}
+							onUpdateAbstract={onUpdateAbstract}
 						/>
 					}
 				/>
-				<Tab id="contributors" title="Contributors" panel={<Contributors />} />
+				<Tab
+					id="contributors"
+					title="Contributors"
+					panel={<Contributors pubData={pub} onUpdatePub={onUpdatePub} />}
+				/>
 				<Tab id="spubsettings" title="Pub Settings" panel={<SpubSettings />} />
 			</Tabs>
 		</div>

--- a/client/containers/Pub/SpubHeader/SubmissionTab/TitleDescriptionAbstract.tsx
+++ b/client/containers/Pub/SpubHeader/SubmissionTab/TitleDescriptionAbstract.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { FormGroup, InputGroup } from '@blueprintjs/core';
-import { Submission, Pub } from 'types';
+import { Pub, PubPageData, DocJson } from 'types';
 
 type Props = {
-	onUpdatePub?: (pub: Partial<Pub>) => unknown;
-	onUpdateSubmission?: (submission: Partial<Submission>) => unknown;
+	pub: Pub;
+	abstract: DocJson;
+	onUpdatePub: (pub: Partial<PubPageData>) => unknown;
+	onUpdateAbstract: (abstract: DocJson) => Promise<unknown>;
 };
 
 const TitleDescriptionAbstract = (props: Props) => {
 	// TODO: weave these in to actually manage the spub
-	const { onUpdatePub: _, onUpdateSubmission: __ } = props;
+	const { onUpdatePub: _, onUpdateAbstract: __, abstract: ___, pub: ____ } = props;
 
 	return (
 		<>

--- a/types/pub.ts
+++ b/types/pub.ts
@@ -122,10 +122,7 @@ export type PubPageDiscussion = DefinitelyHas<Discussion, 'anchors'> & {
 	};
 };
 
-export type PubPageData = DefinitelyHas<
-	Omit<Pub, 'discussions'>,
-	'attributions' | 'collectionPubs'
-> &
+export type PubPageData = DefinitelyHas<Omit<Pub, 'discussions'>, 'collectionPubs'> &
 	PubDocInfo & {
 		discussions: PubPageDiscussion[];
 		viewHash: Maybe<string>;


### PR DESCRIPTION
This adds contributor functionality to the submission tab in the spub header

<img width="1088" alt="image" src="https://user-images.githubusercontent.com/34730449/154485200-7e1781e7-a5f0-44c2-a02a-7a59f0360805.png">

test
Run local environment and add contributors. refresh page to be sure contributors are still saved
