### PR TITLE
fix: Use regex instead of XML parser to insert mixed-citation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21441,14 +21441,6 @@
 			"resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.2.tgz",
 			"integrity": "sha512-5rQdinSsycpzvAoHga2EDn+LRX1d5xLFsuNG0Kg61JrAT/tASXcLL0nf/33v+sAxlQcfYmWbTURa1mmAf55jGw=="
 		},
-		"fast-xml-parser": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.2.tgz",
-			"integrity": "sha512-3GOSbMTZxxrPPQ+aURM7Wia10bi71HBbiG/3mOEEkRSAkRtg4m7UhMSnB2rzOhBeRHyJUWsllOfyNnjTT1b85w==",
-			"requires": {
-				"strnum": "^1.0.5"
-			}
-		},
 		"fastest-stable-stringify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-1.0.1.tgz",
@@ -37745,11 +37737,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
 			"integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw=="
-		},
-		"strnum": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
 		},
 		"stubs": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
 		"express": "^4.16.4",
 		"express-session": "^1.14.1",
 		"express-sslify": "^1.2.0",
-		"fast-xml-parser": "^4.0.2",
 		"file-saver": "^2.0.2",
 		"filesize": "^4.1.2",
 		"firebase": "^7.5.2",


### PR DESCRIPTION
Our attempt to insert JATS `mixed-citation` elements using an XML parse/write roundtrip (in #1795) stripped too much important info from the XML. So in this PR I use regex to accomplish the same thing 🙃 I also limited the tags that can go inside a `mixed-citation` so that the JATS will validate.

_Test plan:_
Create a document with multiple unstructured citations and at least one structured one (`/pub/7w7jd9y9/draft` will do nicely) and check the JATS export:
- `element-citation` elements should remain for structured citations
- `mixed-citation` elements should appear for unstructured citations
- The only rich text content allowed inside `mixed-citation` should be `bold`, `italic`, and `ext-link`. `p` tags should be stripped.