### PR TITLE
fix: privacy link on signup/community page

### DIFF
--- a/client/containers/CommunityCreate/CommunityCreate.tsx
+++ b/client/containers/CommunityCreate/CommunityCreate.tsx
@@ -154,7 +154,7 @@ const CommunityCreate = () => {
 										Terms of Service
 									</a>{' '}
 									and{' '}
-									<a href="legal/privacy" target="_blank">
+									<a href="/legal/privacy" target="_blank">
 										Privacy Policy
 									</a>
 									.

--- a/client/containers/UserCreate/UserCreate.tsx
+++ b/client/containers/UserCreate/UserCreate.tsx
@@ -336,7 +336,7 @@ const UserCreate = (props: Props) => {
 									Terms of Service
 								</a>{' '}
 								and{' '}
-								<a href="legal/privacy" target="_blank">
+								<a href="/legal/privacy" target="_blank">
 									Privacy Policy
 								</a>
 								.


### PR DESCRIPTION
Fixes a 🤦 I did when I updated this form.

_Test plan_
Technically, you should visit the community creation page and follow the privacy links, and do the same for a user signup.