### PR TITLE
feat: add digest links; fix discussion overflow

### DIFF
--- a/client/components/Email/digest/ActivityBundle.tsx
+++ b/client/components/Email/digest/ActivityBundle.tsx
@@ -15,7 +15,7 @@ type StyleProps = {
 	accentColorDark?: string;
 };
 
-type PropTypes = {
+type Props = {
 	isWithTitle?: boolean;
 	accentColorDark: string;
 	groupedItems: DedupedActivityItems;
@@ -31,6 +31,12 @@ const H3Style = styled.h3`
 	text-align: left;
 	letter-spacing: 0.01em;
 	display: inline-block;
+	a {
+		text-decoration: none;
+	}
+	a:hover {
+		text-decoration: underline;
+	}
 `;
 
 const ListItemStyle = styled.li`
@@ -42,24 +48,26 @@ const SpanStyle = styled.span<StyleProps>`
 	padding-right: 9px;
 `;
 
-export const ActivityBundle = (props: PropTypes) => (
-	<ListItemStyle>
-		{props.isWithTitle && (
-			<>
-				<SpanStyle>
-					<Icon
-						iconSize={12}
-						icon={props.groupedItems.icon}
-						color={props.accentColorDark}
-					/>
-				</SpanStyle>
-				<H3Style>{truncate(props.groupedItems.title)}</H3Style>
-			</>
-		)}
-		<ActivityBundleRow
-			associations={props.associations}
-			userId={props.userId}
-			items={Object.values(props.groupedItems.items)}
-		/>
-	</ListItemStyle>
-);
+export const ActivityBundle = (props: Props) => {
+	const {
+		groupedItems: { icon, items, title, url },
+	} = props;
+	const truncatedTitle = truncate(title);
+	return (
+		<ListItemStyle>
+			{props.isWithTitle && (
+				<>
+					<SpanStyle>
+						<Icon iconSize={12} icon={icon} color={props.accentColorDark} />
+					</SpanStyle>
+					<H3Style>{url ? <a href={url}>{truncatedTitle}</a> : truncatedTitle}</H3Style>
+				</>
+			)}
+			<ActivityBundleRow
+				associations={props.associations}
+				userId={props.userId}
+				items={Object.values(items)}
+			/>
+		</ListItemStyle>
+	);
+};

--- a/client/components/Email/digest/ActivityBundle.tsx
+++ b/client/components/Email/digest/ActivityBundle.tsx
@@ -34,9 +34,6 @@ const H3Style = styled.h3`
 	a {
 		text-decoration: none;
 	}
-	a:hover {
-		text-decoration: underline;
-	}
 `;
 
 const ListItemStyle = styled.li`

--- a/client/components/Email/digest/ActivityBundleRow.tsx
+++ b/client/components/Email/digest/ActivityBundleRow.tsx
@@ -16,8 +16,7 @@ type ActivityBundleRowProps = {
 };
 
 const ExcerptSpanStyle = styled.span`
-	display: inline-block;
-	width: 460px;
+	display: block;
 	margin: 10px 0 0;
 	overflow: hidden;
 	padding: 8px 11px 7px;
@@ -100,7 +99,7 @@ export const ActivityBundleRow = (props: ActivityBundleRowProps) => {
 							</tr>
 							{renderedItem.excerpt && (
 								<tr>
-									<td>
+									<td colSpan={2}>
 										<ExcerptSpanStyle>{renderedItem.excerpt}</ExcerptSpanStyle>
 									</td>
 								</tr>

--- a/client/components/Email/digest/Digest.tsx
+++ b/client/components/Email/digest/Digest.tsx
@@ -16,6 +16,7 @@ type AffectedObjectId = string;
 export type DedupedActivityItems = {
 	items: Record<DisplayKey, ActivityItem>;
 	title: string;
+	url: string;
 	icon: IconName;
 };
 

--- a/server/routes/email.tsx
+++ b/server/routes/email.tsx
@@ -71,7 +71,10 @@ app.get('/email/:templateSlug', async (req, res, next) => {
 			render(
 				component({
 					community,
-					...(await prepData(initialData)),
+					...(await prepData({
+						scope: initialData.scopeData.scope,
+						user: initialData.loginData,
+					})),
 				}),
 			),
 		);

--- a/server/utils/email/digest.tsx
+++ b/server/utils/email/digest.tsx
@@ -11,6 +11,7 @@ import { ActivityAssociations, ActivityItem, Community, Scope, User } from 'type
 import { Digest } from 'components/Email';
 import { globals, reset } from 'components/Email/styles';
 import { fetchActivityItems } from 'server/activityItem/fetch';
+import { collectionUrl, pubUrl } from 'utils/canonicalUrls';
 
 type KeyedActivityItem = ActivityItem & {
 	displayKey: string;
@@ -42,6 +43,17 @@ const getAffectedObject = (item: ActivityItem, associations: ActivityAssociation
 		id: item.communityId,
 		title,
 	};
+};
+
+const getAffectedObjectUrl = (item: ActivityItem, associations: ActivityAssociations) => {
+	const community = Object.values(associations.community)[0];
+	if (item.pubId) {
+		return pubUrl(community, associations.pub[item.pubId]);
+	}
+	if (item.collectionId) {
+		return collectionUrl(community, associations.collection[item.collectionId]);
+	}
+	return undefined;
 };
 
 const getAffectedObjectIcon = (item: ActivityItem) =>
@@ -84,6 +96,7 @@ const dedupActivityItems =
 						),
 					title: getAffectedObject(items[0], associations)?.title,
 					icon: getAffectedObjectIcon(items[0]),
+					url: getAffectedObjectUrl(items[0], associations),
 				},
 			}),
 			{},

--- a/server/utils/email/digest.tsx
+++ b/server/utils/email/digest.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
 
-import { ActivityAssociations, ActivityItem, Community, Scope, User, Pub, Collection } from 'types';
+import { ActivityAssociations, ActivityItem, Community, Scope, User } from 'types';
 import { Digest } from 'components/Email';
 import { globals, reset } from 'components/Email/styles';
 import { fetchActivityItems } from 'server/activityItem/fetch';

--- a/server/utils/email/digest.tsx
+++ b/server/utils/email/digest.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
 
-import { ActivityAssociations, ActivityItem, Community, Scope, User } from 'types';
+import { ActivityAssociations, ActivityItem, Community, Scope, User, Pub, Collection } from 'types';
 import { Digest } from 'components/Email';
 import { globals, reset } from 'components/Email/styles';
 import { fetchActivityItems } from 'server/activityItem/fetch';
@@ -46,14 +46,17 @@ const getAffectedObject = (item: ActivityItem, associations: ActivityAssociation
 };
 
 const getAffectedObjectUrl = (item: ActivityItem, associations: ActivityAssociations) => {
+	const { pubId, collectionId } = item;
 	const community = Object.values(associations.community)[0];
-	if (item.pubId) {
-		return pubUrl(community, associations.pub[item.pubId]);
+	const pub = pubId && associations.pub[pubId];
+	const collection = collectionId && associations.collection[collectionId];
+	if (pub) {
+		return pubUrl(community, pub);
 	}
-	if (item.collectionId) {
-		return collectionUrl(community, associations.collection[item.collectionId]);
+	if (collection) {
+		return collectionUrl(community, collection);
 	}
-	return undefined;
+	return null;
 };
 
 const getAffectedObjectIcon = (item: ActivityItem) =>


### PR DESCRIPTION
Resolves #1793

This PR
* adds links to Pub and Collection activity item titles in digest emails
* uses `colspan` to prevent discussion snippets from overflowing

*Test Steps*

* Visit http://localhost:9876/email/digest
* Verify that Pub and Collection titles are clickable and take you to the correct URL
* Verify that discussion snippets are contained within the width of the email (i.e. they do not overflow to the right).