### PR TITLE
fix: Always show Collection-level contributors in Collection browser and CitationsModal

### DIFF
--- a/server/collectionPub/queries.ts
+++ b/server/collectionPub/queries.ts
@@ -7,6 +7,7 @@ import {
 	PubAttribution,
 	Release,
 	includeUserModel,
+	CollectionAttribution,
 } from 'server/models';
 import { getCollectionPubsInCollection } from 'server/utils/collectionQueries';
 
@@ -20,6 +21,24 @@ export const getPubsInCollection = async ({ communityId, collectionId, userId })
 				as: 'pub',
 				include: [
 					{ model: Release, as: 'releases', attributes: ['id'] },
+					{
+						model: CollectionPub,
+						as: 'collectionPubs',
+						separate: true,
+						include: [
+							{
+								model: Collection,
+								as: 'collection',
+								include: [
+									{
+										model: CollectionAttribution,
+										as: 'attributions',
+										include: [includeUserModel({ as: 'user' })],
+									},
+								],
+							},
+						],
+					},
 					{
 						model: PubAttribution,
 						as: 'attributions',

--- a/server/utils/queryHelpers/pubSanitize.ts
+++ b/server/utils/queryHelpers/pubSanitize.ts
@@ -1,16 +1,28 @@
 import ensureUserForAttribution from 'utils/ensureUserForAttribution';
-import { CollectionPub, Discussion, Pub, PubAttribution, Release } from 'types';
+import {
+	Collection,
+	CollectionPub,
+	DefinitelyHas,
+	Discussion,
+	Pub,
+	PubAttribution,
+	Release,
+} from 'types';
 
 import sanitizeDiscussions from './discussionsSanitize';
 import sanitizeReviews from './reviewsSanitize';
 import { sanitizePubEdges } from './sanitizePubEdge';
+
+type CollectionPubWithAttributions = CollectionPub & {
+	collection: DefinitelyHas<Collection, 'attributions'>;
+};
 
 export type SanitizedPubData = Pub & {
 	viewHash: string | null;
 	editHash: string | null;
 	attributions: PubAttribution[];
 	discussions: Discussion[];
-	collectionPubs: CollectionPub[];
+	collectionPubs: CollectionPubWithAttributions[];
 	isReadOnly: boolean;
 	isRelease: boolean;
 	releases: Release[];

--- a/workers/tasks/export/metadata.ts
+++ b/workers/tasks/export/metadata.ts
@@ -1,7 +1,6 @@
 import dateFormat from 'dateformat';
 
 import * as types from 'types';
-import ensureUserForAttribution from 'utils/ensureUserForAttribution';
 import { getPubPublishedDate, getPubUpdatedDate } from 'utils/pub/pubDates';
 import { getPrimaryCollection } from 'utils/collections/primary';
 import { renderJournalCitation } from 'utils/citations';
@@ -12,10 +11,12 @@ import {
 	Pub,
 	PubAttribution,
 	Release,
+	CollectionAttribution,
 	includeUserModel,
 } from 'server/models';
 
 import { getLicenseForPub } from 'utils/licenses';
+import { getAllPubContributors } from 'utils/contributors';
 import { PubMetadata } from './types';
 
 const getPrimaryCollectionMetadata = (collectionPubs: types.CollectionPub[]) => {
@@ -38,6 +39,13 @@ export const getPubMetadata = async (pubId: string): Promise<PubMetadata> => {
 					{
 						model: Collection,
 						as: 'collection',
+						include: [
+							{
+								model: CollectionAttribution,
+								as: 'attributions',
+								include: [includeUserModel({ as: 'user' })],
+							},
+						],
 					},
 				],
 			},
@@ -59,6 +67,7 @@ export const getPubMetadata = async (pubId: string): Promise<PubMetadata> => {
 	const publishedDateString = publishedDate && dateFormat(publishedDate, 'mmm dd, yyyy');
 	const updatedDateString = updatedDate && dateFormat(updatedDate, 'mmm dd, yyyy');
 	const primaryCollection = getPrimaryCollection(pubData.collectionPubs);
+	const attributions = getAllPubContributors(pubData);
 	return {
 		title: pubData.title,
 		slug: pubData.slug,
@@ -71,11 +80,7 @@ export const getPubMetadata = async (pubId: string): Promise<PubMetadata> => {
 			pubData.community.title,
 		),
 		accentColor: pubData.community.accentColorDark,
-		attributions: pubData.attributions
-			.concat()
-			.sort((a, b) => a.order - b.order)
-			.filter((attr) => attr.isAuthor)
-			.map((attr) => ensureUserForAttribution(attr)),
+		attributions,
 		citationStyle: pubData.citationStyle,
 		citationInlineStyle: pubData.citationInlineStyle,
 		nodeLabels: pubData.nodeLabels,


### PR DESCRIPTION
A Pub's byline will include the contributors to its primary Collection, but there are two places in the Pub header where we don't incorporate that information:

1. the Collection browser:

![image](https://user-images.githubusercontent.com/2208769/156259986-e24d392c-24ae-4ed5-9069-098b798b4a1a.png)

2. the Cite dropdown:

![image](https://user-images.githubusercontent.com/2208769/156260066-755d44e4-9a6a-4047-959a-8dcfc507b84c.png)

This PR fixes that problem, resolving #1807. This is kind of a cheap fix — what I would really like to do is create a computed/materialized `primaryCollection` association from `Pub` to `Collection` so we don't have to load _all_ a Pub's Collections and compute the primary collection in business logic — but after reading the documentation for a while, I can't figure out how to do this from Sequelize.

_Test plan:_
Create a public, non-Tag Collection and add attributions in Settings. Create a Pub inside that Collection and verify that you see those attributions:
- In the Cite dropdown from that Pub's header
- In the Collection browser from _another_ Pub in the same Collection.
