### PR TITLE
fix: use YYYY for export publication date; include electronic issn

### DIFF
--- a/workers/tasks/export/pandoc.ts
+++ b/workers/tasks/export/pandoc.ts
@@ -94,7 +94,7 @@ const createYamlMetadataFile = async (pubMetadata: PubMetadata, pandocTarget: Pa
 			date: {
 				day: dateFormat(publishedDateString, 'dd'),
 				month: dateFormat(publishedDateString, 'mm'),
-				year: dateFormat(publishedDateString, 'yy'),
+				year: dateFormat(publishedDateString, 'yyyy'),
 			},
 		}),
 		journal: {
@@ -103,7 +103,7 @@ const createYamlMetadataFile = async (pubMetadata: PubMetadata, pandocTarget: Pa
 				...(primaryCollectionMetadata.printIssn && {
 					pissn: primaryCollectionMetadata.printIssn,
 				}),
-				...(primaryCollectionMetadata.printIssn && {
+				...(primaryCollectionMetadata.electronicIssn && {
 					eissn: primaryCollectionMetadata.electronicIssn,
 				}),
 			}),


### PR DESCRIPTION
A few fixes for JATS exports. This PR:
- Fixes a bug where we were checking for the existence of a print ISSN in order to render an electronic ISSN
- Uses YYYY date formatting instead of YY