### PR TITLE
Create expandable tab wrapper

### DIFF
--- a/client/components/GridWrapper/GridWrapper.tsx
+++ b/client/components/GridWrapper/GridWrapper.tsx
@@ -1,28 +1,20 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-const propTypes = {
-	containerClassName: PropTypes.string,
-	columnClassName: PropTypes.string,
-	children: PropTypes.node,
+type Props = {
+	containerClassName?: string;
+	columnClassName?: string;
+	children?: React.ReactNode;
 };
 
-const defaultProps = {
-	containerClassName: '',
-	columnClassName: '',
-	children: null,
-};
-
-const GridWrapper = function (props) {
+const GridWrapper = (props: Props) => {
+	const { containerClassName = '', columnClassName = '', children = null } = props;
 	return (
-		<div className={`container ${props.containerClassName}`}>
+		<div className={`container ${containerClassName}`}>
 			<div className="row">
-				<div className={`col-12 ${props.columnClassName}`}>{props.children}</div>
+				<div className={`col-12 ${columnClassName}`}>{children}</div>
 			</div>
 		</div>
 	);
 };
 
-GridWrapper.defaultProps = defaultProps;
-GridWrapper.propTypes = propTypes;
 export default GridWrapper;

--- a/client/components/PubShareDialog/PubShareDialog.tsx
+++ b/client/components/PubShareDialog/PubShareDialog.tsx
@@ -95,7 +95,6 @@ const MembersOptions = (props: MembersOptionsProps) => {
 			membersData: { members },
 		},
 	} = props;
-	// @ts-expect-error ts-migrate(2339) FIXME: Property 'pendingCount' does not exist on type '{ ... Remove this comment to see the full error message
 	const { pendingCount } = usePendingChanges();
 	const { scopeData } = usePageContext();
 	const { canManage } = scopeData.activePermissions;

--- a/client/containers/Pub/SpubHeader/SpubHeaderTab.stories.tsx
+++ b/client/containers/Pub/SpubHeader/SpubHeaderTab.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import SpubHeaderTab from 'containers/Pub/SpubHeader/SpubHeaderTab';
+
+storiesOf('containers/Pub/SpubHeader/SpubHeaderTab', module).add('default', () => (
+	<SpubHeaderTab expandToFold>
+		<div>spubheader tab content</div>
+	</SpubHeaderTab>
+));

--- a/client/containers/Pub/SpubHeader/SpubHeaderTab.tsx
+++ b/client/containers/Pub/SpubHeader/SpubHeaderTab.tsx
@@ -1,0 +1,36 @@
+import React, { useRef, useState, useEffect } from 'react';
+
+import { useViewport } from 'client/utils/useViewport';
+
+require('./spubHeaderTab.scss');
+
+type Props = {
+	children?: React.ReactNode;
+	expandToFold: boolean;
+};
+
+const SpubHeaderTabWrapper = (props: Props) => {
+	const elementRef = useRef<HTMLDivElement>(null);
+	const [minHeight, setMinHeight] = useState(0);
+	const { viewportHeight } = useViewport();
+	useEffect(() => {
+		if (elementRef.current) {
+			setMinHeight(
+				(viewportHeight || 0) -
+					elementRef.current.getBoundingClientRect().top -
+					window.scrollY,
+			);
+		}
+	}, [viewportHeight]);
+	return (
+		<div
+			style={{ ...(props.expandToFold && { minHeight }) }}
+			className="spub-header-tab-component"
+			ref={elementRef}
+		>
+			{props.children}
+		</div>
+	);
+};
+
+export default SpubHeaderTabWrapper;

--- a/client/containers/Pub/SpubHeader/SpubHeaderTab.tsx
+++ b/client/containers/Pub/SpubHeader/SpubHeaderTab.tsx
@@ -9,7 +9,7 @@ type Props = {
 	expandToFold: boolean;
 };
 
-const SpubHeaderTabWrapper = (props: Props) => {
+const SpubHeaderTab = (props: Props) => {
 	const elementRef = useRef<HTMLDivElement>(null);
 	const [minHeight, setMinHeight] = useState(0);
 	const { viewportHeight } = useViewport();
@@ -33,4 +33,4 @@ const SpubHeaderTabWrapper = (props: Props) => {
 	);
 };
 
-export default SpubHeaderTabWrapper;
+export default SpubHeaderTab;

--- a/client/containers/Pub/SpubHeader/SpubHeaderTab.tsx
+++ b/client/containers/Pub/SpubHeader/SpubHeaderTab.tsx
@@ -6,7 +6,7 @@ require('./spubHeaderTab.scss');
 
 type Props = {
 	children?: React.ReactNode;
-	expandToFold: boolean;
+	expandToFold?: boolean;
 };
 
 const SpubHeaderTab = (props: Props) => {

--- a/client/containers/Pub/SpubHeader/SpubHeaderTab.tsx
+++ b/client/containers/Pub/SpubHeader/SpubHeaderTab.tsx
@@ -1,11 +1,12 @@
 import React, { useRef, useState, useEffect } from 'react';
 
 import { useViewport } from 'client/utils/useViewport';
+import { GridWrapper } from 'components';
 
 require('./spubHeaderTab.scss');
 
 type Props = {
-	children?: React.ReactNode;
+	children: React.ReactNode;
 	expandToFold?: boolean;
 };
 
@@ -23,13 +24,11 @@ const SpubHeaderTab = (props: Props) => {
 		}
 	}, [viewportHeight]);
 	return (
-		<div
-			style={{ ...(props.expandToFold && { minHeight }) }}
-			className="spub-header-tab-component"
-			ref={elementRef}
-		>
-			{props.children}
-		</div>
+		<GridWrapper containerClassName="spub-header-tab-component">
+			<div ref={elementRef} style={{ ...(props.expandToFold && { minHeight }) }}>
+				{props.children}
+			</div>
+		</GridWrapper>
 	);
 };
 

--- a/client/containers/Pub/SpubHeader/spubHeaderTab.scss
+++ b/client/containers/Pub/SpubHeader/spubHeaderTab.scss
@@ -1,0 +1,4 @@
+.spub-header-tab-component {
+	background-color: #f8f8f8;
+	padding: 30px 0;
+}

--- a/client/utils/useViewport.ts
+++ b/client/utils/useViewport.ts
@@ -1,18 +1,14 @@
 import { useEffect, useState } from 'react';
 
 export const useViewport = () => {
-	const [viewportWidth, setViewportWidth] = useState(null);
-	const [viewportHeight, setViewportHeight] = useState(null);
+	const [viewportWidth, setViewportWidth] = useState<number | null>(null);
+	const [viewportHeight, setViewportHeight] = useState<number | null>(null);
 
 	useEffect(() => {
-		// @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message
 		setViewportWidth(window.innerWidth);
-		// @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message
 		setViewportHeight(window.innerHeight);
 		const listener = () => {
-			// @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message
 			setViewportHeight(window.innerHeight);
-			// @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message
 			setViewportWidth(window.innerWidth);
 		};
 		window.addEventListener('resize', listener);

--- a/client/utils/useViewport.ts
+++ b/client/utils/useViewport.ts
@@ -2,15 +2,22 @@ import { useEffect, useState } from 'react';
 
 export const useViewport = () => {
 	const [viewportWidth, setViewportWidth] = useState(null);
+	const [viewportHeight, setViewportHeight] = useState(null);
 
 	useEffect(() => {
 		// @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message
 		setViewportWidth(window.innerWidth);
 		// @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message
-		const listener = () => setViewportWidth(window.innerWidth);
+		setViewportHeight(window.innerHeight);
+		const listener = () => {
+			// @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message
+			setViewportHeight(window.innerHeight);
+			// @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message
+			setViewportWidth(window.innerWidth);
+		};
 		window.addEventListener('resize', listener);
 		return () => window.removeEventListener('resize', listener);
 	}, []);
 
-	return { viewportWidth };
+	return { viewportWidth, viewportHeight };
 };


### PR DESCRIPTION
Implements #1849

Test: view in storybook. To check the expanded size behavior, open inspector (or like) with dimensions:responsive and monitor the `min-height` css property on the wrapper div while changing the viewport; the light-grey background wrapper should resize to fill to the bottom of the viewport.