### PR TITLE
fix: Don't pass `NaN` as history key from `/api/pubHistory`

### DIFF
--- a/server/pubHistory/api.ts
+++ b/server/pubHistory/api.ts
@@ -5,12 +5,14 @@ import { getPermissions } from './permissions';
 
 const getRequestIds = (req) => {
 	const user = req.user || {};
-	const { pubId, communityId, historyKey, accessHash } = req.query;
+	const { pubId, communityId, historyKey: providedHistoryKey, accessHash } = req.query;
+	const historyKeyInt = parseInt(providedHistoryKey, 10);
+	const historyKey = Number.isNaN(historyKeyInt) ? null : historyKeyInt;
 	return {
 		userId: user.id,
 		pubId,
 		communityId,
-		historyKey: parseInt(historyKey, 10),
+		historyKey,
 		accessHash,
 	};
 };


### PR DESCRIPTION
`/api/pubHistory` currently expects a `historyKey` GET param — but when that value is not specified, it becomes `NaN`, which is passed deep into our Firebase code and eventually prevents us from using a checkpoint to load a Firebase document. Without a checkpoint, we have to load every individual change in the document, which can cause major hangs.

Instead, we want to use `null` as a fallback. When we pass `historyKey = null` into the Firebase draft retrieval code, it's interpreted to mean "the latest key", and the API will retrieve the latest document as expected.

_Test plan:_
(We tested this synchronously on a call)
Call `/api/pubHistory` without a `historyKey` GET param (e.g. by opening and then closing the Pub History viewer) and verify that `getRequestIds` returns `{ historyKey: null }`.