### PR TITLE
bugfix: display correct submittedAt time ago

### DIFF
--- a/client/containers/DashboardOverview/overviewRows/labels.tsx
+++ b/client/containers/DashboardOverview/overviewRows/labels.tsx
@@ -5,7 +5,7 @@ import { ScopeSummary, Collection, Pub, SubmissionStatus } from 'types';
 import { capitalize } from 'utils/strings';
 import { getSchemaForKind } from 'utils/collections/schemas';
 import { formatDate } from 'utils/dates';
-import { getPubPublishedDate, getPubSubmissionDate } from 'utils/pub/pubDates';
+import { getPubPublishedDate } from 'utils/pub/pubDates';
 import { TimeAgo, Icon, IconName } from 'components';
 
 export type IconLabelPair = {
@@ -114,10 +114,10 @@ export const getSubmissionStatusLabel = (
 };
 
 export const getSubmissionTimeLabel = (pub: Pub) => {
-	const submissionDate = getPubSubmissionDate(pub);
+	const submissionDate = pub.submission?.submittedAt;
 	if (submissionDate) {
 		return {
-			label: <>Submitted&nbsp;{getDateLabelPart(submissionDate)}</>,
+			label: <>Submitted&nbsp;{getDateLabelPart(new Date(submissionDate))}</>,
 			icon: 'time' as const,
 		};
 	}

--- a/client/containers/DashboardOverview/overviewRows/labels.tsx
+++ b/client/containers/DashboardOverview/overviewRows/labels.tsx
@@ -117,11 +117,7 @@ export const getSubmissionTimeLabel = (pub: Pub) => {
 	const submissionDate = getPubSubmissionDate(pub);
 	if (submissionDate) {
 		return {
-			label: (
-				<>
-					<em>Submitted</em>&nbsp;{getDateLabelPart(submissionDate)}
-				</>
-			),
+			label: <>Submitted&nbsp;{getDateLabelPart(submissionDate)}</>,
 			icon: 'time' as const,
 		};
 	}

--- a/utils/dates.ts
+++ b/utils/dates.ts
@@ -49,10 +49,7 @@ export const getLocalDateMatchingUtcCalendarDate = (utcDate: Date | string) => {
 	const formattedUtcDate = dateFormat(utcDate, 'UTC:yyyy-mm-dd');
 	const localDateOnSameDay = new Date(formattedUtcDate);
 	const returnDate = new Date(utcDate);
-	const isSameTimezone =
-		returnDate.getTimezoneOffset() === localDateOnSameDay.getTimezoneOffset();
-	if (!isSameTimezone)
-		returnDate.setMinutes(returnDate.getMinutes() + localDateOnSameDay.getTimezoneOffset());
+	returnDate.setMinutes(returnDate.getMinutes() + localDateOnSameDay.getTimezoneOffset());
 	return returnDate;
 };
 

--- a/utils/dates.ts
+++ b/utils/dates.ts
@@ -49,7 +49,10 @@ export const getLocalDateMatchingUtcCalendarDate = (utcDate: Date | string) => {
 	const formattedUtcDate = dateFormat(utcDate, 'UTC:yyyy-mm-dd');
 	const localDateOnSameDay = new Date(formattedUtcDate);
 	const returnDate = new Date(utcDate);
-	returnDate.setMinutes(returnDate.getMinutes() + localDateOnSameDay.getTimezoneOffset());
+	const isSameTimezone =
+		returnDate.getTimezoneOffset() === localDateOnSameDay.getTimezoneOffset();
+	if (!isSameTimezone)
+		returnDate.setMinutes(returnDate.getMinutes() + localDateOnSameDay.getTimezoneOffset());
 	return returnDate;
 };
 

--- a/utils/pub/pubDates.ts
+++ b/utils/pub/pubDates.ts
@@ -82,10 +82,3 @@ export const getPubCopyrightYear = (
 	const pubPublishedDate = getPubPublishedDate(pub);
 	return pubPublishedDate ? dateFormat(pubPublishedDate, 'yyyy') : dateFormat('yyyy');
 };
-
-export const getPubSubmissionDate = (pub: Pub) => {
-	if (pub.submission?.submittedAt) {
-		return getLocalDateMatchingUtcCalendarDate(pub.submission?.submittedAt);
-	}
-	return null;
-};


### PR DESCRIPTION
addresses #1887

Now when you submit a pub, it shows as having just submitted:

![Screenshot from 2022-03-23 14-03-51](https://user-images.githubusercontent.com/14115194/159766281-443d86a3-c156-467a-9e9b-0535abc437d2.png)

## _Test plan_

1. create a spub
1. submit it
2. check the submitted at line