### PR TITLE
feat: add pub word count button to formatting bar

### DIFF
--- a/client/containers/Pub/PubDocument/PubHeaderFormatting.tsx
+++ b/client/containers/Pub/PubDocument/PubHeaderFormatting.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import { usePageContext } from 'utils/hooks';
 import { useSticky } from 'client/utils/useSticky';
-import { FormattingBar, buttons } from 'components/FormattingBar';
+import { buttons, FormattingBar } from 'components/FormattingBar';
+import { usePageContext } from 'utils/hooks';
+
 import PubHeaderCollaborators from './PubHeaderCollaborators';
+import PubWordCountButton from './PubWordCountButton';
 
 require('./pubHeaderFormatting.scss');
 
@@ -29,6 +31,8 @@ const PubHeaderFormatting = (props: Props) => {
 		return null;
 	}
 
+	const state = props.collabData.editorChangeObject.view?.state;
+
 	return (
 		<div className={classNames('pub-draft-header-component', disabled && 'disabled')}>
 			<FormattingBar
@@ -42,6 +46,7 @@ const PubHeaderFormatting = (props: Props) => {
 			/>
 			<div className="right-content">
 				<PubHeaderCollaborators collabData={props.collabData} />
+				{state && <PubWordCountButton doc={state.doc} />}
 				<span className={`collab-status ${collabData.status}`}>
 					{collabData.status}
 					{collabData.status === 'saving' || collabData.status === 'connecting'
@@ -52,4 +57,5 @@ const PubHeaderFormatting = (props: Props) => {
 		</div>
 	);
 };
+
 export default PubHeaderFormatting;

--- a/client/containers/Pub/PubDocument/PubWordCountButton.tsx
+++ b/client/containers/Pub/PubDocument/PubWordCountButton.tsx
@@ -12,9 +12,7 @@ type Props = {
 const getWordAndCharacterCountsFromDoc = (node: Node) => {
 	const text = node.textBetween(0, node.content.size, ' ', ' ');
 	const words = text.split(' ').filter((word) => word !== '');
-	const wordCount = words.length;
-	const characterCount = words.reduce((a, x) => a + x.length, 0);
-	return [wordCount, characterCount];
+	return [words.length, text.length];
 };
 
 const PubHeaderFormattingWordCountButton = (props: Props) => {

--- a/client/containers/Pub/PubDocument/PubWordCountButton.tsx
+++ b/client/containers/Pub/PubDocument/PubWordCountButton.tsx
@@ -17,18 +17,23 @@ const getWordAndCharacterCountsFromDoc = (node: Node) => {
 
 const PubHeaderFormattingWordCountButton = (props: Props) => {
 	const { doc } = props;
-	const [wordCount, characterCount] = useMemo(() => getWordAndCharacterCountsFromDoc(doc), []);
 	const [open, setOpen] = useState(false);
-	const content = (
+	const counts = useMemo(() => {
+		if (open) {
+			return getWordAndCharacterCountsFromDoc(doc);
+		}
+		return null;
+	}, [open, doc]);
+	const content = counts ? (
 		<div className="pub-word-count-button-popover-content">
 			<dl>
 				<dt>Words</dt>
-				<dd>{wordCount.toLocaleString()}</dd>
+				<dd>{counts[0]}</dd>
 				<dt>Characters</dt>
-				<dd>{characterCount.toLocaleString()}</dd>
+				<dd>{counts[1]}</dd>
 			</dl>
 		</div>
-	);
+	) : undefined;
 
 	return (
 		<Popover

--- a/client/containers/Pub/PubDocument/PubWordCountButton.tsx
+++ b/client/containers/Pub/PubDocument/PubWordCountButton.tsx
@@ -24,16 +24,16 @@ const PubHeaderFormattingWordCountButton = (props: Props) => {
 		}
 		return null;
 	}, [open, doc]);
-	const content = counts ? (
+	const content = (
 		<div className="pub-word-count-button-popover-content">
 			<dl>
 				<dt>Words</dt>
-				<dd>{counts[0]}</dd>
+				<dd>{counts?.[0]}</dd>
 				<dt>Characters</dt>
-				<dd>{counts[1]}</dd>
+				<dd>{counts?.[1]}</dd>
 			</dl>
 		</div>
-	) : undefined;
+	);
 
 	return (
 		<Popover

--- a/client/containers/Pub/PubDocument/PubWordCountButton.tsx
+++ b/client/containers/Pub/PubDocument/PubWordCountButton.tsx
@@ -1,0 +1,56 @@
+import React, { useMemo, useState } from 'react';
+import { Popover, Button, Icon } from '@blueprintjs/core';
+
+import { Node } from 'prosemirror-model';
+
+require('./pubWordCountButton.scss');
+
+export type Props = {
+	doc: Node;
+};
+
+const getWordAndCharacterCountsFromDoc = (node: Node) => {
+	const text = node.textBetween(0, node.content.size, ' ', ' ');
+	const words = text.split(' ').filter((word) => word !== '');
+	const wordCount = words.length;
+	const characterCount = words.reduce((a, x) => a + x.length, 0);
+	return [wordCount, characterCount];
+};
+
+const PubHeaderFormattingWordCountButton = (props: Props) => {
+	const { doc } = props;
+	const [wordCount, characterCount] = useMemo(() => getWordAndCharacterCountsFromDoc(doc), [doc]);
+	const [open, setOpen] = useState(false);
+	const content = (
+		<div className="pub-word-count-button-popover-content">
+			<dl>
+				<dt>Words</dt>
+				<dd>{wordCount.toLocaleString()}</dd>
+				<dt>Characters</dt>
+				<dd>{characterCount.toLocaleString()}</dd>
+			</dl>
+		</div>
+	);
+
+	return (
+		<Popover
+			content={content}
+			isOpen={open}
+			minimal
+			position="bottom-right"
+			popoverClassName="pub-word-count-button-popover"
+			targetClassName="pub-word-count-button-target"
+		>
+			<Button
+				role="button"
+				className="bp3-button bp3-minimal"
+				onClick={() => setOpen(!open)}
+				onBlur={() => setOpen(false)}
+			>
+				<Icon icon="timeline-line-chart" />
+			</Button>
+		</Popover>
+	);
+};
+
+export default PubHeaderFormattingWordCountButton;

--- a/client/containers/Pub/PubDocument/PubWordCountButton.tsx
+++ b/client/containers/Pub/PubDocument/PubWordCountButton.tsx
@@ -28,9 +28,9 @@ const PubHeaderFormattingWordCountButton = (props: Props) => {
 		<div className="pub-word-count-button-popover-content">
 			<dl>
 				<dt>Words</dt>
-				<dd>{counts?.[0]}</dd>
+				<dd>{counts?.[0].toLocaleString()}</dd>
 				<dt>Characters</dt>
-				<dd>{counts?.[1]}</dd>
+				<dd>{counts?.[1].toLocaleString()}</dd>
 			</dl>
 		</div>
 	);

--- a/client/containers/Pub/PubDocument/PubWordCountButton.tsx
+++ b/client/containers/Pub/PubDocument/PubWordCountButton.tsx
@@ -5,7 +5,7 @@ import { Node } from 'prosemirror-model';
 
 require('./pubWordCountButton.scss');
 
-export type Props = {
+type Props = {
 	doc: Node;
 };
 
@@ -19,7 +19,7 @@ const getWordAndCharacterCountsFromDoc = (node: Node) => {
 
 const PubHeaderFormattingWordCountButton = (props: Props) => {
 	const { doc } = props;
-	const [wordCount, characterCount] = useMemo(() => getWordAndCharacterCountsFromDoc(doc), [doc]);
+	const [wordCount, characterCount] = useMemo(() => getWordAndCharacterCountsFromDoc(doc), []);
 	const [open, setOpen] = useState(false);
 	const content = (
 		<div className="pub-word-count-button-popover-content">

--- a/client/containers/Pub/PubDocument/pubWordCountButton.scss
+++ b/client/containers/Pub/PubDocument/pubWordCountButton.scss
@@ -1,0 +1,37 @@
+.pub-word-count-button-target {
+	margin-right: 4px;
+}
+
+.pub-word-count-button-popover {
+	background-color: #fff;
+	z-index: 999;
+	padding: 1em;
+}
+
+.pub-word-count-button-popover-content {
+	padding: 0 4px;
+
+	dl {
+		display: flex;
+		flex-flow: row;
+		flex-wrap: wrap;
+		width: 144px;
+		overflow: visible;
+		margin: 0;
+		padding: 0;
+	}
+
+	dl dt {
+		flex: 0 0 60%;
+		text-overflow: ellipsis;
+		overflow: hidden;
+	}
+
+	dl dd {
+		flex: 0 0 40%;
+		margin-left: auto;
+		text-align: center;
+		text-overflow: ellipsis;
+		overflow: hidden;
+	}
+}


### PR DESCRIPTION
Closes #1769 

This PR adds a button to the `PubHeaderFormatting` component that can be used to perform a one-off calculation of the total word and character count of the Pub. A line chart icon was chosen for this button because it represents statistical... stuff. But I'm not totally happy with it so I'm open to other ideas.

<img width="206" alt="Screen Shot 2022-03-24 at 2 05 18 PM" src="https://user-images.githubusercontent.com/6402908/159981602-b729daf5-8955-4b4c-b61a-d0a6e9e2d5d7.png">

When clicked, a popover containing word and character count should appear immediately below the button.

<img width="198" alt="Screen Shot 2022-03-24 at 2 05 52 PM" src="https://user-images.githubusercontent.com/6402908/159981694-eb6fe170-148d-41cb-a85e-c34a5411116c.png">

These counts are computed only once when the popover component mounts. Clicking on the page or changing focus from the button immediately hides the popover.

### Test Plan

1. Make a new Pub.
2. Type some words and add some figures.
3. Things that *should not* be included in the word or character counts:
   - Whitespace and punctuation (except punctuation surrounded by spaces, e.g. "  ...  ")
   - Citations
   - Figure captions
   - Equation contents
   - Anything that's not in a heading, paragraph, list, or blockquote
4. The popover should hide if you click the screen or give focus to another element using the tab key.

