### PR TITLE
dev: Add posthog tracking

### DIFF
--- a/client/utils/hydrateWrapper.tsx
+++ b/client/utils/hydrateWrapper.tsx
@@ -7,6 +7,7 @@ import { setEnvironment, setAppCommit } from 'utils/environment';
 
 import { getClientInitialData } from './initialData';
 import { setupHeap } from './heap';
+import { setupPosthog } from './posthog';
 
 const isStorybookEnv = (windowObj) =>
 	windowObj.location.origin === 'http://localhost:9001' || windowObj.STORYBOOK_ENV === 'react';
@@ -37,8 +38,9 @@ export const hydrateWrapper = (Component) => {
 			// @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
 			document.getElementById('chunk-name').getAttribute('data-json'),
 		);
+		setupPosthog(initialData);
+		setupHeap(initialData);
 		if (!isLocalEnv(window)) {
-			setupHeap(initialData);
 			// @ts-expect-error ts-migrate(2339) FIXME: Property 'sentryIsActive' does not exist on type '... Remove this comment to see the full error message
 			window.sentryIsActive = true;
 			Sentry.init({

--- a/client/utils/legal/gdprConsent.ts
+++ b/client/utils/legal/gdprConsent.ts
@@ -1,4 +1,5 @@
 import Cookies from 'js-cookie';
+import posthog from 'posthog-js';
 
 import { apiFetch } from '../apiFetch';
 
@@ -14,6 +15,7 @@ const deleteOdiousCookies = () => {
 	// @ts-expect-error ts-migrate(2339) FIXME: Property 'heap' does not exist on type 'Window & t... Remove this comment to see the full error message
 	window.heap.clearEventProperties();
 	odiousCookies.map((key) => Cookies.remove(key, { path: '' }));
+	posthog.reset();
 };
 
 export const gdprCookiePersistsSignup = () => Cookies.get(persistSignupCookieKey) === 'yes';
@@ -49,6 +51,9 @@ export const updateGdprConsent = (loginData, doesUserConsent) => {
 			window.heap.identify(Math.random());
 		}
 		deleteOdiousCookies();
+		posthog.opt_out_capturing();
+	} else {
+		posthog.opt_in_capturing();
 	}
 	if (loggedIn) {
 		return apiFetch('/api/users', {

--- a/client/utils/posthog.ts
+++ b/client/utils/posthog.ts
@@ -1,0 +1,36 @@
+/* eslint-disable */
+import posthog from 'posthog-js';
+import { isProd } from 'utils/environment';
+
+import { getGdprConsentElection } from './legal/gdprConsent';
+
+export const setupPosthog = (initialData) => {
+	const { communityData, collectionData, pubData, loginData } = initialData;
+	const hasGdprConsent = getGdprConsentElection(loginData);
+	const posthogProjectId = isProd()
+		? '422727431'
+		: 'phc_Wb3dZyz5euH5Z61etqU6SKaxRW5DOhB7ia43O8Z3UK1';
+	const customEventData = {
+		communityId: null,
+		pageId: null,
+		pubId: null,
+	};
+	if (communityData) {
+		customEventData.communityId = communityData.id;
+	}
+	if (collectionData) {
+		customEventData.pageId = collectionData.id;
+	}
+	if (pubData) {
+		customEventData.pubId = pubData.id;
+	}
+	posthog.init(posthogProjectId, {
+		api_host: 'https://app.posthog.com',
+		loaded: function (posthog) {
+			if (hasGdprConsent && loginData.id) {
+				posthog.identify(loginData.id);
+				posthog.register({ ...customEventData });
+			}
+		},
+	});
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -21489,6 +21489,11 @@
 				"pend": "~1.2.0"
 			}
 		},
+		"fflate": {
+			"version": "0.4.8",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+			"integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
+		},
 		"figgy-pudding": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -33549,6 +33554,23 @@
 				"xtend": "^4.0.0"
 			}
 		},
+		"posthog-js": {
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.20.0.tgz",
+			"integrity": "sha512-Vjyx6p3pJ+d8MOTDHDvEpGMmjMiYR+PSPs3y+LqS54XVxNnUgTppbj+HcF2inla7IBzIbIsip5pN/xC1O1QsTA==",
+			"requires": {
+				"@sentry/types": "^6.11.0",
+				"fflate": "^0.4.1",
+				"rrweb-snapshot": "^1.1.7"
+			},
+			"dependencies": {
+				"@sentry/types": {
+					"version": "6.19.2",
+					"resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.2.tgz",
+					"integrity": "sha512-XO5qmVBdTs+7PdCz7fAwn1afWxSnRE2KLBFg5/vOdKosPSSHsSHUURSkxiEZc2QsR+JpRB4AeQ26AkIRX38qTg=="
+				}
+			}
+		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -36138,6 +36160,11 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.2.tgz",
 			"integrity": "sha512-ku6MFrwEVSVmXLvy3dYph3LAMNS0890K7fabn+0YIRQ2T96T9F4gkFf0vf0WW0JUraNWwGRtInEpH7yO4tbQZg=="
+		},
+		"rrweb-snapshot": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-1.1.13.tgz",
+			"integrity": "sha512-lv4vBSJ5orBcRoJnjLvtly6cSsctC+TNm5orVzYRL9SH3LmtSpQ+wI4bw7eh4AcyKoUf0x4pe1Bn632GggmKWQ=="
 		},
 		"rss": {
 			"version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
 		"passport-local-sequelize": "^0.9.0",
 		"pg": "^7.10.0",
 		"popper.js": "^1.15.0",
+		"posthog-js": "^1.20.0",
 		"pretty-bytes": "^5.6.0",
 		"prompt": "^1.0.0",
 		"prop-types": "^15.7.2",


### PR DESCRIPTION
Adds posthog, including setting properties for pub, community, and collection id on each pageview. And adds rudimentary opt-out settings.

_To test_:
- Does not collect any data once opted out.
- Collects data again once opted in.
- Resets user id on logout.
- Collects correct user, community, collection ID
- Switches user, community, collection ID correctly as user browses (while preserving old ones in old events)

_To do_:
- Run posthog identify when user logs in / reset on logout (technically the former isn't needed, as eventually it will link old events to the user once an identify event is set. But it would be nice to do).