### PR TITLE
fix: equate ordering of review items on review and overview pages

### DIFF
--- a/client/components/Timeline/Timeline.stories.tsx
+++ b/client/components/Timeline/Timeline.stories.tsx
@@ -4,18 +4,12 @@ import { storiesOf } from '@storybook/react';
 import { Timeline, TimelineItem, TimelineCondenser } from 'components';
 
 storiesOf('components/Timeline', module).add('default', () => (
-	// @ts-expect-error ts-migrate(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message
 	<Timeline accentColor="slateblue">
 		<TimelineItem
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'boolean' is not assignable to type 'never'.
 			large
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 			accentColor="limegreen"
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 			icon="clean"
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 			title="A first thing"
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'Element' is not assignable to type 'never'.
 			subtitle={
 				<>
 					<div>One</div>
@@ -27,30 +21,19 @@ storiesOf('components/Timeline', module).add('default', () => (
 				</>
 			}
 		/>
-		{/* @ts-expect-error ts-migrate(2786) FIXME: 'TimelineCondenser' cannot be used as a JSX compon... Remove this comment to see the full error message */}
 		<TimelineCondenser shownItemsLimit={2}>
-			{/* @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'. */}
 			<TimelineItem icon="star" title="A smaller thing" subtitle="Hmmm" />
-			{/* @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'. */}
 			<TimelineItem icon="star" title="Another smaller thing" subtitle="Yes" />
-			{/* @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'. */}
 			<TimelineItem icon="star" title="Yet another smaller thing" subtitle="Yes" />
 			<TimelineItem
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'boolean' is not assignable to type 'never'.
 				large
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'boolean' is not assignable to type 'never'.
 				hollow
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 				title="A bigger thing again"
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 				accentColor="orange"
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 				icon="document-share"
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 				subtitle="Oh wow"
 			/>
 		</TimelineCondenser>
-		{/* @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'. */}
 		<TimelineItem title="One more smaller thing" subtitle="Yawn" icon="moon" />
 	</Timeline>
 ));

--- a/client/components/Timeline/Timeline.tsx
+++ b/client/components/Timeline/Timeline.tsx
@@ -16,7 +16,7 @@ const defaultProps = {
 	className: '',
 };
 
-type Props = OwnProps & typeof defaultProps;
+type Props = OwnProps;
 
 const Timeline = (props: Props) => {
 	const { accentColor, children, className } = props;

--- a/client/components/Timeline/TimelineCondenser.tsx
+++ b/client/components/Timeline/TimelineCondenser.tsx
@@ -13,26 +13,25 @@ export const TimelineCondenser = (props: Props) => {
 	const { children, shownItemsLimit, ...restProps } = props;
 	const childrenArr = React.Children.toArray(children);
 	if (childrenArr.length > shownItemsLimit && !isExpanded) {
-		return [
-			...childrenArr.slice(0, shownItemsLimit),
-			<TimelineItem
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
-				key="__timeline-condenser-expand-element__"
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'boolean' is not assignable to type 'never'.
-				hollow
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
-				icon="expand-all"
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'Element' is not assignable to type 'never'.
-				title={<i>{childrenArr.length - shownItemsLimit} more hidden</i>}
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'Element' is not assignable to type 'never'.
-				controls={
-					<Button outlined onClick={() => setIsExpanded(true)} {...restProps}>
-						Show all
-					</Button>
-				}
-			/>,
-		];
+		return (
+			<>
+				{[
+					...childrenArr.slice(0, shownItemsLimit),
+					<TimelineItem
+						key="__timeline-condenser-expand-element__"
+						hollow
+						icon="expand-all"
+						title={<i>{childrenArr.length - shownItemsLimit} more hidden</i>}
+						controls={
+							<Button outlined onClick={() => setIsExpanded(true)} {...restProps}>
+								Show all
+							</Button>
+						}
+					/>,
+				]}
+			</>
+		);
 	}
-	return children;
+	return <>{children}</>;
 };
 export default TimelineCondenser;

--- a/client/components/Timeline/TimelineItem.tsx
+++ b/client/components/Timeline/TimelineItem.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { Icon } from 'components';
 
 import { TimelineContext } from './util';
+import { IconName } from '../Icon/Icon';
 
 type OwnProps = {
 	accentColor?: string;
@@ -11,7 +12,7 @@ type OwnProps = {
 	controls?: React.ReactNode;
 	hollow?: boolean;
 	large?: boolean;
-	icon?: string | React.ReactNode;
+	icon?: IconName;
 	title?: React.ReactNode;
 	subtitle?: React.ReactNode;
 };
@@ -27,7 +28,7 @@ const defaultProps = {
 	subtitle: null,
 };
 
-type Props = OwnProps & typeof defaultProps;
+type Props = OwnProps;
 
 const TimelineItem = (props: Props) => {
 	const {

--- a/client/components/Timeline/util.ts
+++ b/client/components/Timeline/util.ts
@@ -1,5 +1,5 @@
 import React from 'react';
 
-export const TimelineContext = React.createContext<{ accentColor: string | undefined }>({
+export const TimelineContext = React.createContext<{ accentColor?: string }>({
 	accentColor: undefined,
 });

--- a/client/components/Timeline/util.ts
+++ b/client/components/Timeline/util.ts
@@ -1,3 +1,5 @@
 import React from 'react';
 
-export const TimelineContext = React.createContext({ accentColor: null });
+export const TimelineContext = React.createContext<{ accentColor: string | undefined }>({
+	accentColor: undefined,
+});

--- a/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
+++ b/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import dateFormat from 'dateformat';
 import { Menu, MenuItem, Tag } from '@blueprintjs/core';
 
-import { ContributorsList, DashboardFrame, PubHeaderBackground } from 'components';
 import { Review, SanitizedPubData } from 'types';
+import { ContributorsList, DashboardFrame, PubHeaderBackground } from 'components';
+import CitationsPreview from 'containers/Pub/PubHeader/CitationsPreview';
 import { formatDate } from 'utils/dates';
+import { getAllPubContributors } from 'utils/contributors';
+import { getDashUrl } from 'utils/dashboard';
 import { getPubPublishedDate, getPubLatestReleaseDate } from 'utils/pub/pubDates';
 import { usePageContext } from 'utils/hooks';
-import CitationsPreview from 'containers/Pub/PubHeader/CitationsPreview';
 
-import { getAllPubContributors } from 'utils/contributors';
 import PubTimeline from './PubTimeline';
-import { getDashUrl } from 'utils/dashboard';
 
 require('./pubOverview.scss');
 

--- a/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
+++ b/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import dateFormat from 'dateformat';
 import { Menu, MenuItem, Tag } from '@blueprintjs/core';
 
-import { usePageContext } from 'utils/hooks';
-import { getPubPublishedDate, getPubLatestReleaseDate } from 'utils/pub/pubDates';
-import { formatDate } from 'utils/dates';
-import CitationsPreview from 'containers/Pub/PubHeader/CitationsPreview';
 import { ContributorsList, DashboardFrame, PubHeaderBackground } from 'components';
+import { DefinitelyHas, PubPageData } from 'types';
+import { formatDate } from 'utils/dates';
+import { getPubPublishedDate, getPubLatestReleaseDate } from 'utils/pub/pubDates';
+import { usePageContext } from 'utils/hooks';
+import CitationsPreview from 'containers/Pub/PubHeader/CitationsPreview';
 
 import { getAllPubContributors } from 'utils/contributors';
 import PubTimeline from './PubTimeline';
@@ -14,7 +15,7 @@ import PubTimeline from './PubTimeline';
 require('./pubOverview.scss');
 
 type Props = {
-	pubData: any;
+	pubData: DefinitelyHas<PubPageData, 'reviews'>;
 };
 
 const PubOverview = (props: Props) => {
@@ -58,8 +59,8 @@ const PubOverview = (props: Props) => {
 				{pubData.collectionPubs.map((cp, index) => {
 					return (
 						<span key={cp.id}>
-							<a href={`/dash/collection/${cp.collection.slug}`}>
-								{cp.collection.title}
+							<a href={`/dash/collection/${cp.collection!.slug}`}>
+								{cp.collection!.title}
 							</a>
 							{index !== pubData.collectionPubs.length - 1 && <span>, </span>}
 						</span>
@@ -75,7 +76,7 @@ const PubOverview = (props: Props) => {
 				<div className="section-header">Reviews</div>
 				<Menu className="list-content">
 					{pubData.reviews
-						.sort((a, b) => a.createdAt - b.createdAt)
+						.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
 						.map((review) => {
 							return (
 								<MenuItem

--- a/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
+++ b/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
@@ -3,7 +3,7 @@ import dateFormat from 'dateformat';
 import { Menu, MenuItem, Tag } from '@blueprintjs/core';
 
 import { ContributorsList, DashboardFrame, PubHeaderBackground } from 'components';
-import { DefinitelyHas, PubPageData } from 'types';
+import { Review, SanitizedPubData } from 'types';
 import { formatDate } from 'utils/dates';
 import { getPubPublishedDate, getPubLatestReleaseDate } from 'utils/pub/pubDates';
 import { usePageContext } from 'utils/hooks';
@@ -11,11 +11,12 @@ import CitationsPreview from 'containers/Pub/PubHeader/CitationsPreview';
 
 import { getAllPubContributors } from 'utils/contributors';
 import PubTimeline from './PubTimeline';
+import { getDashUrl } from 'utils/dashboard';
 
 require('./pubOverview.scss');
 
 type Props = {
-	pubData: DefinitelyHas<PubPageData, 'reviews'>;
+	pubData: SanitizedPubData;
 };
 
 const PubOverview = (props: Props) => {
@@ -59,7 +60,7 @@ const PubOverview = (props: Props) => {
 				{pubData.collectionPubs.map((cp, index) => {
 					return (
 						<span key={cp.id}>
-							<a href={`/dash/collection/${cp.collection!.slug}`}>
+							<a href={getDashUrl({ collectionSlug: cp.collection!.slug })}>
 								{cp.collection!.title}
 							</a>
 							{index !== pubData.collectionPubs.length - 1 && <span>, </span>}
@@ -70,12 +71,12 @@ const PubOverview = (props: Props) => {
 		);
 	};
 
-	const renderReviews = () => {
+	const renderReviews = (reviews: Review[]) => {
 		return (
 			<div className="section list">
 				<div className="section-header">Reviews</div>
 				<Menu className="list-content">
-					{pubData.reviews
+					{reviews
 						.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
 						.map((review) => {
 							return (
@@ -140,7 +141,7 @@ const PubOverview = (props: Props) => {
 					{pubData.doi && renderSection('DOI', pubData.doi)}
 					{renderContributors()}
 					{renderCollections()}
-					{!!pubData.reviews.length && renderReviews()}
+					{!!pubData.reviews?.length && renderReviews(pubData.reviews)}
 				</div>
 				<div className="column">
 					<PubTimeline pubData={pubData} />

--- a/client/containers/DashboardOverview/PubOverview/PubTimeline.tsx
+++ b/client/containers/DashboardOverview/PubOverview/PubTimeline.tsx
@@ -6,12 +6,12 @@ import { Icon, Timeline, TimelineItem, TimelineCondenser } from 'components';
 import { usePageContext } from 'utils/hooks';
 import { formatDate } from 'utils/dates';
 import { pubUrl } from 'utils/canonicalUrls';
-import { PubPageData } from 'types';
+import { SanitizedPubData } from 'types';
 
 require('./pubTimeline.scss');
 
 type Props = {
-	pubData: PubPageData;
+	pubData: SanitizedPubData;
 };
 
 const PubTimeline = (props: Props) => {
@@ -34,17 +34,11 @@ const PubTimeline = (props: Props) => {
 
 	const draftItem = (canView || canViewDraft) && (
 		<TimelineItem
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'boolean' is not assignable to type 'never'.
 			large
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'boolean' is not assignable to type 'never'.
 			hollow={hasDraftContent}
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 			icon="edit"
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 			title="Pub draft"
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 			subtitle={draftLastEditedNotice}
-			// @ts-expect-error ts-migrate(2322) FIXME: Type 'Element' is not assignable to type 'never'.
 			controls={
 				<AnchorButton outlined href={pubUrl(communityData, pubData, { isDraft: true })}>
 					Go to draft
@@ -56,15 +50,10 @@ const PubTimeline = (props: Props) => {
 	const renderReleaseItem = (release, number, isLatest = false) => {
 		return (
 			<TimelineItem
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'boolean' is not assignable to type 'never'.
 				hollow
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'boolean' is not assignable to type 'never'.
 				large={isLatest}
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 				icon="document-share"
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'any' is not assignable to type 'never'.
 				key={release.id}
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'Element' is not assignable to type 'never'.
 				title={
 					<a
 						className="release-link"
@@ -76,9 +65,7 @@ const PubTimeline = (props: Props) => {
 						{isLatest && ' (latest)'}
 					</a>
 				}
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 				subtitle={formatDate(release.createdAt, { includeTime: true })}
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'Element' is not assignable to type 'never'.
 				controls={
 					canManage &&
 					release.noteText && (
@@ -106,15 +93,10 @@ const PubTimeline = (props: Props) => {
 
 		return (
 			<TimelineItem
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'boolean' is not assignable to type 'never'.
 				large
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 				icon="document-share"
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'Element' is not assignable to type 'never'.
 				title={<i>No releases yet</i>}
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 				subtitle="Create a Release to share this Pub with the world."
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'Element' is not assignable to type 'never'.
 				controls={
 					<Popover
 						content={popoverContent}
@@ -128,27 +110,20 @@ const PubTimeline = (props: Props) => {
 	};
 
 	return (
-		// @ts-expect-error ts-migrate(2746) FIXME: This JSX tag's 'children' prop expects a single ch... Remove this comment to see the full error message
 		<Timeline className="pub-timeline-component" accentColor={communityData.accentColorDark}>
 			{releases.length === 0 && hasDraftContent && renderNoReleasesItem()}
 			{draftItem}
 			{latestRelease && renderReleaseItem(latestRelease, releases.length, true)}
-			{/* @ts-expect-error ts-migrate(2786) FIXME: 'TimelineCondenser' cannot be used as a JSX compon... Remove this comment to see the full error message */}
 			<TimelineCondenser shownItemsLimit={4}>
 				{olderReleases
 					.map((release, index) => renderReleaseItem(release, index + 1))
 					.reverse()}
 			</TimelineCondenser>
 			<TimelineItem
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'boolean' is not assignable to type 'never'.
 				hollow
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'boolean' is not assignable to type 'never'.
 				large
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 				title="Pub created"
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 				subtitle={formatDate(pubData.createdAt, { includeTime: true })}
-				// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'never'.
 				icon="clean"
 			/>
 		</Timeline>

--- a/client/containers/DashboardReviews/DashboardReviews.tsx
+++ b/client/containers/DashboardReviews/DashboardReviews.tsx
@@ -48,15 +48,7 @@ const DashboardReviews = (props: Props) => {
 						)}
 						<Menu className="list-content">
 							{pub.reviews
-								.sort((foo, bar) => {
-									if (foo.createdAt < bar.createdAt) {
-										return 1;
-									}
-									if (foo.createdAt > bar.createdAt) {
-										return -1;
-									}
-									return 0;
-								})
+								.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
 								.map((review) => {
 									const reviewUrl = getDashUrl({
 										collectionSlug: activeCollection

--- a/server/pub/queryMany.ts
+++ b/server/pub/queryMany.ts
@@ -2,8 +2,8 @@ import { QueryTypes, Op } from 'sequelize';
 import { QueryBuilder } from 'knex';
 
 import { knex, sequelize, Pub } from 'server/models';
-import { buildPubOptions, sanitizePub, SanitizedPubData } from 'server/utils/queryHelpers';
-import { InitialData, PubsQuery, PubGetOptions } from 'types';
+import { buildPubOptions, sanitizePub } from 'server/utils/queryHelpers';
+import { InitialData, PubsQuery, PubGetOptions, SanitizedPubData } from 'types';
 
 const defaultColumns = {
 	pubId: 'Pubs.id',

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -9,8 +9,6 @@ import { getPrimaryCollection } from 'utils/collections/primary';
 import { renderJournalCitationForCitations } from 'utils/citations';
 import { getAllPubContributors } from 'utils/contributors';
 
-import { SanitizedPubData } from '../queryHelpers';
-
 const getDatePartsObject = (date) => ({
 	'date-parts': [date.getFullYear(), date.getMonth() + 1, date.getDate()],
 });
@@ -42,7 +40,7 @@ const getCollectionLevelData = (collection) => {
 };
 
 export const generateCitationHtml = async (
-	pubData: SanitizedPubData,
+	pubData: types.SanitizedPubData,
 	communityData: types.Community,
 ) => {
 	// TODO: We need to set the updated times properly, which are likely stored in firebase.

--- a/server/utils/layouts/layoutPubs.ts
+++ b/server/utils/layouts/layoutPubs.ts
@@ -1,5 +1,4 @@
 import { queryPubIds, getPubsById } from 'server/pub/queryMany';
-import { SanitizedPubData } from 'server/utils/queryHelpers';
 import {
 	LayoutBlockPubs,
 	LayoutBlock,
@@ -7,7 +6,7 @@ import {
 	PubSortOrder,
 	maxPubsPerBlock,
 } from 'utils/layout';
-import { InitialData, Maybe, PubsQueryOrdering } from 'types';
+import { InitialData, Maybe, PubsQueryOrdering, SanitizedPubData } from 'types';
 
 type BlockContent = LayoutBlockPubs['content'];
 

--- a/server/utils/queryHelpers/communityOverview.ts
+++ b/server/utils/queryHelpers/communityOverview.ts
@@ -1,10 +1,9 @@
 import { Collection, ScopeSummary } from 'server/models';
 import { getManyPubs } from 'server/pub/queryMany';
 import { getUserScopeVisits } from 'server/userScopeVisit/queries';
-import { Collection as CollectionType, InitialData } from 'types';
+import { Collection as CollectionType, InitialData, SanitizedPubData } from 'types';
 
 import sanitizeCollection from './collectionSanitize';
-import { SanitizedPubData } from './pubSanitize';
 
 type Options = {
 	loadPubs?: number;

--- a/server/utils/queryHelpers/index.ts
+++ b/server/utils/queryHelpers/index.ts
@@ -13,7 +13,7 @@ export {
 	getPubCitations,
 	getPubEdges,
 } from './pubEnrich';
-export { default as sanitizePub, SanitizedPubData } from './pubSanitize';
+export { default as sanitizePub } from './pubSanitize';
 export { default as getScope } from './scopeGet';
 export { default as getUser } from './userGet';
 export { default as getReview } from './reviewGet';

--- a/server/utils/queryHelpers/pubEnrich.ts
+++ b/server/utils/queryHelpers/pubEnrich.ts
@@ -3,9 +3,8 @@ import { Op } from 'sequelize';
 import { Doc, Draft, PubEdge } from 'server/models';
 import { generateCitationHtml, getStructuredCitationsForPub } from 'server/utils/citations';
 import { getPubDraftDoc, getFirebaseToken } from 'server/utils/firebaseAdmin';
-import { Pub as PubType, DefinitelyHas, PubDocInfo, InitialData } from 'types';
+import { Pub as PubType, DefinitelyHas, PubDocInfo, InitialData, SanitizedPubData } from 'types';
 
-import { SanitizedPubData } from './pubSanitize';
 import { sanitizePubEdge } from './sanitizePubEdge';
 import { getPubEdgeIncludes } from './pubEdgeOptions';
 

--- a/server/utils/queryHelpers/pubSanitize.ts
+++ b/server/utils/queryHelpers/pubSanitize.ts
@@ -1,33 +1,9 @@
 import ensureUserForAttribution from 'utils/ensureUserForAttribution';
-import {
-	Collection,
-	CollectionPub,
-	DefinitelyHas,
-	Discussion,
-	Pub,
-	PubAttribution,
-	Release,
-} from 'types';
+import { Discussion, SanitizedPubData } from 'types';
 
 import sanitizeDiscussions from './discussionsSanitize';
 import sanitizeReviews from './reviewsSanitize';
 import { sanitizePubEdges } from './sanitizePubEdge';
-
-type CollectionPubWithAttributions = CollectionPub & {
-	collection: DefinitelyHas<Collection, 'attributions'>;
-};
-
-export type SanitizedPubData = Pub & {
-	viewHash: string | null;
-	editHash: string | null;
-	attributions: PubAttribution[];
-	discussions: Discussion[];
-	collectionPubs: CollectionPubWithAttributions[];
-	isReadOnly: boolean;
-	isRelease: boolean;
-	releases: Release[];
-	releaseNumber: number | null;
-};
 
 const sanitizeHashes = (pubData, activePermissions) => {
 	const { editHash, viewHash } = pubData;

--- a/tools/layoutcheck/query.ts
+++ b/tools/layoutcheck/query.ts
@@ -1,8 +1,9 @@
 import { Op } from 'sequelize';
 
+import { SanitizedPubData } from 'types';
 import { CollectionPub, Pub } from 'server/models';
 
-import sanitizePub, { SanitizedPubData } from 'server/utils/queryHelpers/pubSanitize';
+import sanitizePub from 'server/utils/queryHelpers/pubSanitize';
 import buildPubOptions from 'server/utils/queryHelpers/pubOptions';
 
 const getPubIdsForCollectionIds = async (collectionIds) => {

--- a/types/pub.ts
+++ b/types/pub.ts
@@ -2,7 +2,7 @@ import { NodeLabelMap } from 'components/Editor';
 import { CitationInlineStyleKind, CitationStyleKind } from 'utils/citations';
 
 import { PubAttribution } from './attribution';
-import { CollectionPub } from './collection';
+import { Collection, CollectionPub } from './collection';
 import { Community } from './community';
 import { Discussion } from './discussion';
 import { DocJson } from './doc';
@@ -146,4 +146,20 @@ export type PubHistoryState = {
 	outstandingRequests: number;
 	latestKeyReceivedAt: Maybe<number>;
 	timestamps: Record<string, number>;
+};
+
+type CollectionPubWithAttributions = CollectionPub & {
+	collection: DefinitelyHas<Collection, 'attributions'>;
+};
+
+export type SanitizedPubData = Pub & {
+	viewHash: string | null;
+	editHash: string | null;
+	attributions: PubAttribution[];
+	discussions: Discussion[];
+	collectionPubs: CollectionPubWithAttributions[];
+	isReadOnly: boolean;
+	isRelease: boolean;
+	releases: Release[];
+	releaseNumber: number | null;
 };


### PR DESCRIPTION
Closes #1913

A quick PR that matches the ordering of the reviews on a Pub's Overview dashboard page to the order on the Reviews page (time descending).