### PR TITLE
fix: use hello@mg.pubpub.org in digest messages to prevent spam alert

### DIFF
--- a/tools/emailActivityDigest.ts
+++ b/tools/emailActivityDigest.ts
@@ -48,10 +48,11 @@ async function main() {
 						const digest = await renderDigestEmail(community, { scope, user });
 						if (digest === null) return;
 						await mg.messages.create('mg.pubpub.org', {
-							from: 'PubPub Team <hello@pubpub.org>',
+							from: 'PubPub Team <hello@mg.pubpub.org>',
 							to: [user.email],
 							subject: `${community.title} daily activity digest`,
 							html: digest,
+							'h:Reply-To': 'hello@pubpub.org',
 						});
 					} catch (err) {
 						// eslint-disable-next-line no-console


### PR DESCRIPTION
Quick fix to remove the spam header on activity digest emails.

Before:
<img width="718" alt="Screen Shot 2022-03-31 at 8 25 53 AM" src="https://user-images.githubusercontent.com/6402908/161054324-585b97cf-6d8e-4375-bce7-ac83b3f0688a.png">

After:
<img width="728" alt="Screen Shot 2022-03-31 at 8 26 07 AM" src="https://user-images.githubusercontent.com/6402908/161054349-deca2e57-2743-425d-9891-6f45e56dd797.png">

