### PR TITLE
fix: use prosemirror ids in citations; don't de-dupe exported citations

### DIFF
--- a/client/containers/Pub/usePubNotes.ts
+++ b/client/containers/Pub/usePubNotes.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 
-import { getNotes } from 'components/Editor/utils';
+import { citationFingerprintStripTags, getNotes } from 'components/Editor/utils';
 
 import { usePubContext } from './pubHooks';
 
@@ -18,7 +18,9 @@ export const usePubNotes = () => {
 	const [notes, setNotes] = useState(noteManager.notes);
 
 	const view = editorChangeObject!.view;
-	const { citations = [], footnotes = [] } = view ? getNotes(view.state.doc) : {};
+	const { citations = [], footnotes = [] } = view
+		? getNotes(view.state.doc, citationFingerprintStripTags)
+		: {};
 
 	const isNumberList = noteManager.citationInlineStyleKind === 'count';
 	const renderedFootnotes = footnotes.map((footnote, index) => ({

--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -4,7 +4,7 @@ import crypto from 'crypto';
 import Cite from 'citation-js';
 
 import { DocJson, Pub } from 'types';
-import { getNotes, jsonToNode } from 'components/Editor';
+import { citationFingerprintStripTags, getNotes, jsonToNode } from 'components/Editor';
 import { citationStyles, CitationStyleKind, CitationInlineStyleKind } from 'utils/citations';
 import { StructuredValue, RenderedStructuredValue } from 'utils/notesCore';
 import { expiringPromise } from 'utils/promises';
@@ -125,7 +125,7 @@ export const getStructuredCitations = async (
 export const getStructuredCitationsForPub = (pubData: Pub, pubDoc: DocJson) => {
 	const pubDocNode = jsonToNode(pubDoc);
 	const { citationStyle = 'apa', citationInlineStyle = 'count' } = pubData;
-	const { footnotes, citations } = getNotes(pubDocNode);
+	const { footnotes, citations } = getNotes(pubDocNode, citationFingerprintStripTags);
 	const structuredValuesInDoc = [
 		...new Set([...footnotes, ...citations].map((note) => note.structuredValue)),
 	];

--- a/workers/tasks/export/pandoc.ts
+++ b/workers/tasks/export/pandoc.ts
@@ -7,7 +7,7 @@ import { fromProsemirror, emitPandocJson } from '@pubpub/prosemirror-pandoc';
 import dateFormat from 'dateformat';
 
 import { DocJson } from 'types';
-import { editorSchema, getReactedDocFromJson, Note } from 'components/Editor';
+import { editorSchema, getReactedDocFromJson } from 'components/Editor';
 import { getPathToCslFileForCitationStyleKind } from 'server/utils/citations';
 import { PandocTarget } from 'utils/export/formats';
 

--- a/workers/tasks/export/pandoc.ts
+++ b/workers/tasks/export/pandoc.ts
@@ -18,7 +18,6 @@ import { runTransforms } from './transforms';
 import {
 	getPandocNotesByHash,
 	getCslJsonForPandocNotes,
-	getHashForNote,
 	PandocNotes,
 	modifyJatsContentToIncludeUnstructuredNotes,
 } from './notes';
@@ -136,10 +135,8 @@ const createYamlMetadataFile = async (pubMetadata: PubMetadata, pandocTarget: Pa
 
 const createResources = (pandocNotes: PandocNotes) => {
 	return {
-		note: (note: Pick<Note, 'unstructuredValue' | 'structuredValue'>) => {
-			const { structuredValue, unstructuredValue } = note;
-			const hash = getHashForNote({ structuredValue, unstructuredValue });
-			return pandocNotes[hash];
+		note: (id: string) => {
+			return pandocNotes[id];
 		},
 	};
 };


### PR DESCRIPTION
Resolves #1932

This PR fixes an issue where citations with identical unstructured content (rich text) were ignored during export as a consequence of the de-duplication we do in the Pub draft/release views. This leads to an error when the ignored citations ultimately [resolve to pandoc-prosemirror as `undefined`](https://github.com/pubpub/pubpub/pull/1948/files#diff-ea11e8b0c7b2344f85a556dc5c0c1495381fc968175db446821607c75c35b99eR137).

I solve this issue by making the de-duplication (in [`getNotes`](https://github.com/pubpub/pubpub/pull/1948/files#diff-526150d6dea117144c9fddffcf0444902a5a7bcd7b4971f8610004135bb1a54eR33)) optional. `getNotes` now accepts an optional `CitationFingerprintFn` that, when provided, skips duplicate citations that produce the same fingerprint. All citations are processed if a fingerprint function is not provided, as should be the case during export.

This PR also swaps the citation content-hash id implementation with our prosemirror id plugin ids to (hopefully) simplify the export code a bit.

*Test Plan*
1. Checkout this branch locally.
2. Start the workers task with a unique name, e.g. `PUBPUB_LOCAL_TASK_QUEUE=qwelian npm run workers-dev`
3. Start PubPub with the same env variable set, e.g. `PUBPUB_LOCAL_TASK_QUEUE=eric2 npm start`
4. Visit http://localhost:9876/pub/5nth8yhs/draft – note that both citations share the same rich text content.
5. Change the contents of the Pub (but don't touch the citations)
6. Export as LaTeX – it should work!