### PR TITLE
fix: Render Submissions Banner on Workflow Enabled 

### DIFF
--- a/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
+++ b/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
@@ -38,7 +38,7 @@ type Props = {
 		userScopeVisits: UserScopeVisit[];
 		includesAllPubs: boolean;
 	};
-	hasSubmissionWorkflow: Number;
+	hasEnabledSubmissionWorkflow: boolean;
 };
 
 const getQuickActionsForCollection = (collection: Collection): QuickAction[] => {
@@ -63,7 +63,7 @@ const getQuickActionsForCollection = (collection: Collection): QuickAction[] => 
 };
 
 const DashboardCollectionOverview = (props: Props) => {
-	const { overviewData, hasSubmissionWorkflow } = props;
+	const { overviewData, hasEnabledSubmissionWorkflow } = props;
 	const {
 		pubs: initialPubs,
 		collectionPubs: initialCollectionPubs,
@@ -263,7 +263,7 @@ const DashboardCollectionOverview = (props: Props) => {
 	};
 
 	const submissionBanner =
-		hasSubmissionWorkflow && canManage
+		hasEnabledSubmissionWorkflow && canManage
 			? renderBanner('Submissions are now open for this collection!')
 			: null;
 

--- a/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
+++ b/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
@@ -144,11 +144,6 @@ const DashboardCollectionOverview = (props: Props) => {
 		addCollectionPub(pub);
 	};
 
-	const lighterAccentColor = useMemo(
-		() => Color(communityData.accentColorDark).alpha(0.1),
-		[communityData.accentColorDark],
-	);
-
 	const renderCollectionPubRow = (
 		collectionPub: CollectionPub,
 		dragHandleProps: Maybe<DraggableProvidedDragHandleProps>,
@@ -237,6 +232,11 @@ const DashboardCollectionOverview = (props: Props) => {
 			</>
 		);
 	};
+
+	const lighterAccentColor = useMemo(
+		() => Color(communityData.accentColorDark).alpha(0.1),
+		[communityData.accentColorDark],
+	);
 
 	const renderRightElement = (
 		<AnchorButton

--- a/server/routes/dashboardCollectionOverview.tsx
+++ b/server/routes/dashboardCollectionOverview.tsx
@@ -10,9 +10,13 @@ import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
 import { getCollectionOverview } from 'server/utils/queryHelpers';
 import { createUserScopeVisit } from 'server/userScopeVisit/queries';
 import { SubmissionWorkflow } from 'server/models';
+import { SubmissionWorkflow as SubmissionWorkflowType } from 'types';
 
-const collectionHasSubmissionWorkflow = (collectionId: string): Promise<Number> => {
-	return SubmissionWorkflow.count({ where: { collectionId } }) as Promise<number>;
+const collectionHasSubmissionWorkflow = (collectionId: string): SubmissionWorkflowType => {
+	const submissionWorkflow: SubmissionWorkflowType = SubmissionWorkflow.findOne({
+		where: { collectionId },
+	});
+	return submissionWorkflow;
 };
 
 app.get('/dash/collection/:collectionSlug', (req, res) => {
@@ -43,9 +47,10 @@ app.get('/dash/collection/:collectionSlug/overview', async (req, res, next) => {
 		}
 
 		const overviewData = await getCollectionOverview(initialData);
-		const hasSubmissionWorkflow = await collectionHasSubmissionWorkflow(
+		const submissionWorkFlow = await collectionHasSubmissionWorkflow(
 			overviewData.collection.id,
 		);
+		const hasSubmissionWorkflow = submissionWorkFlow && submissionWorkFlow.enabled;
 
 		const {
 			communityData: { id: communityId },

--- a/server/routes/dashboardCollectionOverview.tsx
+++ b/server/routes/dashboardCollectionOverview.tsx
@@ -12,11 +12,10 @@ import { createUserScopeVisit } from 'server/userScopeVisit/queries';
 import { SubmissionWorkflow } from 'server/models';
 import { SubmissionWorkflow as SubmissionWorkflowType } from 'types';
 
-const collectionHasSubmissionWorkflow = (collectionId: string): SubmissionWorkflowType => {
-	const submissionWorkflow: SubmissionWorkflowType = SubmissionWorkflow.findOne({
+const getSubmissionWorkflow = (collectionId: string): Promise<SubmissionWorkflowType> => {
+	return SubmissionWorkflow.findOne({
 		where: { collectionId },
 	});
-	return submissionWorkflow;
 };
 
 app.get('/dash/collection/:collectionSlug', (req, res) => {
@@ -47,10 +46,9 @@ app.get('/dash/collection/:collectionSlug/overview', async (req, res, next) => {
 		}
 
 		const overviewData = await getCollectionOverview(initialData);
-		const submissionWorkFlow = await collectionHasSubmissionWorkflow(
-			overviewData.collection.id,
-		);
-		const hasSubmissionWorkflow = submissionWorkFlow && submissionWorkFlow.enabled;
+		const submissionWorkflow = await getSubmissionWorkflow(overviewData.collection.id);
+
+		const hasEnabledSubmissionWorkflow = submissionWorkflow && submissionWorkflow.enabled;
 
 		const {
 			communityData: { id: communityId },
@@ -67,7 +65,7 @@ app.get('/dash/collection/:collectionSlug/overview', async (req, res, next) => {
 			<Html
 				chunkName="DashboardCollectionOverview"
 				initialData={initialData}
-				viewData={{ overviewData, hasSubmissionWorkflow }}
+				viewData={{ overviewData, hasEnabledSubmissionWorkflow }}
 				headerComponents={generateMetaComponents({
 					initialData,
 					title: `Overview · ${title}`,


### PR DESCRIPTION
This fix adresses #1947 

The submission banner should now be present when submissions are enabled and not when they are not.

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/34730449/163434686-ed276927-cf4e-4a7e-b65e-2d1f85563f5b.png">

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/34730449/163434802-0aa3a8c1-24e8-4eb1-a44d-d6b777376a40.png">

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/34730449/163434841-ed2d8607-fabf-4ba2-9f3c-38f564b9e514.png">

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/34730449/163434893-80a2bece-fab3-47a0-9c16-ad9b80c041ee.png">
