### PR TITLE
Fix: show only native submissions in submissions overview

### DIFF
--- a/client/containers/DashboardSubmissions/SubmissionItems.tsx
+++ b/client/containers/DashboardSubmissions/SubmissionItems.tsx
@@ -58,7 +58,7 @@ const SubmissionItems = (props: Props) => {
 	const isSearchingOrFiltering = !!filter || !!searchTerm;
 
 	const {
-		currentQuery: { pubs, isLoading, hasLoadedAllPubs, loadMorePubs },
+		currentQuery: { pubs: foundPubs, isLoading, hasLoadedAllPubs, loadMorePubs },
 	} = useManyPubs<PubWithSubmission>({
 		isEager: isSearchingOrFiltering,
 		initialPubs,
@@ -71,6 +71,11 @@ const SubmissionItems = (props: Props) => {
 			scopedCollectionId: collection.id,
 			...filter?.query,
 		},
+	});
+
+	const pubs = foundPubs.filter((pub) => {
+		const submittedCollectionId = pub.submission?.submissionWorkflow?.collectionId;
+		return submittedCollectionId && submittedCollectionId === collection.id;
 	});
 
 	const canLoadMorePubs = !hasLoadedAllPubs;

--- a/client/containers/DashboardSubmissions/SubmissionItems.tsx
+++ b/client/containers/DashboardSubmissions/SubmissionItems.tsx
@@ -73,10 +73,9 @@ const SubmissionItems = (props: Props) => {
 		},
 	});
 
-	const pubs = foundPubs.filter((pub) => {
-		const submittedCollectionId = pub.submission?.submissionWorkflow?.collectionId;
-		return submittedCollectionId && submittedCollectionId === collection.id;
-	});
+	const pubs = foundPubs.filter(
+		(pub) => pub.submission?.submissionWorkflow?.collectionId === collection.id,
+	);
 
 	const canLoadMorePubs = !hasLoadedAllPubs;
 	useInfiniteScroll({


### PR DESCRIPTION
For some collection X, when viewing the Submissions tab of X's overview, only show spubs submitted directly to X, filtering out spubs that were added to the collection from elsewhere.