### PR TITLE
fix: extra height on sticky banner in Pub release view

### DIFF
--- a/client/containers/Pub/PubHeader/DraftReleaseButtons.tsx
+++ b/client/containers/Pub/PubHeader/DraftReleaseButtons.tsx
@@ -56,7 +56,6 @@ const DraftReleaseButtons = (props: DraftReleaseButtonsProps) => {
 			<React.Fragment>
 				{(canView || canViewDraft) && (
 					<ResponsiveHeaderButton
-						// @ts-expect-error ts-migrate(2322) FIXME: Type '{ icon: string; tagName: string; href: strin... Remove this comment to see the full error message
 						icon="edit"
 						tagName="a"
 						href={pubUrl(communityData, pubData, { isDraft: true })}
@@ -71,7 +70,6 @@ const DraftReleaseButtons = (props: DraftReleaseButtonsProps) => {
 					aria-label="Choose a historical release of this Pub"
 					disclosure={
 						<ResponsiveHeaderButton
-							// @ts-expect-error ts-migrate(2322) FIXME: Type '{ icon: string; showCaret: true; outerLabel:... Remove this comment to see the full error message
 							icon="history"
 							showCaret={true}
 							// @ts-expect-error ts-migrate(2554) FIXME: Expected 3 arguments, but got 2.
@@ -117,9 +115,9 @@ const DraftReleaseButtons = (props: DraftReleaseButtonsProps) => {
 		return (
 			<React.Fragment>
 				<ResponsiveHeaderButton
-					// @ts-expect-error ts-migrate(2322) FIXME: Type '{ icon: string; className: string; active: a... Remove this comment to see the full error message
 					icon="history"
 					className="draft-history-button"
+					// @ts-expect-error
 					active={historyData.isViewingHistory}
 					outerLabel={getHistoryButtonLabelForTimestamp(
 						latestTimestamp,
@@ -135,7 +133,6 @@ const DraftReleaseButtons = (props: DraftReleaseButtonsProps) => {
 				/>
 				{!!latestRelease && (
 					<ResponsiveHeaderButton
-						// @ts-expect-error ts-migrate(2322) FIXME: Type '{ icon: string; tagName: string; href: strin... Remove this comment to see the full error message
 						icon="globe"
 						tagName="a"
 						href={pubUrl(communityData, pubData)}
@@ -146,7 +143,6 @@ const DraftReleaseButtons = (props: DraftReleaseButtonsProps) => {
 					<DialogLauncher
 						renderLauncherElement={({ openDialog }) => (
 							<ResponsiveHeaderButton
-								// @ts-expect-error ts-migrate(2322) FIXME: Type '{ disabled: boolean; icon: string; onClick: ... Remove this comment to see the full error message
 								disabled={!canRelease}
 								icon="document-share"
 								onClick={openDialog}
@@ -176,7 +172,6 @@ const DraftReleaseButtons = (props: DraftReleaseButtonsProps) => {
 					<DialogLauncher
 						renderLauncherElement={({ openDialog }) => (
 							<ResponsiveHeaderButton
-								// @ts-expect-error ts-migrate(2322) FIXME: Type '{ disabled: boolean; icon: string; onClick: ... Remove this comment to see the full error message
 								disabled={!canRelease}
 								icon="social-media"
 								onClick={openDialog}

--- a/client/containers/Pub/PubHeader/ResponsiveHeaderButton.tsx
+++ b/client/containers/Pub/PubHeader/ResponsiveHeaderButton.tsx
@@ -4,9 +4,9 @@ import { useViewport } from 'client/utils/useViewport';
 
 import { mobileViewportCutoff } from './constants';
 import LargeHeaderButton from './LargeHeaderButton';
-import SmallHeaderButton from './SmallHeaderButton';
+import SmallHeaderButton, { Props as SmallHeaderButtonProps } from './SmallHeaderButton';
 
-type Props = {
+type Props = SmallHeaderButtonProps & {
 	simpleLabel?: React.ReactNode;
 	showCaret?: boolean;
 	outerLabel?: any;
@@ -17,13 +17,9 @@ const ResponsiveHeaderButton = React.forwardRef((props: Props, ref) => {
 	const { labelPosition, outerLabel, showCaret = false, simpleLabel, ...sharedProps } = props;
 	const largeOnlyProps = { outerLabel, showCaret };
 	const smallOnlyProps = { labelPosition };
-
 	const { viewportWidth } = useViewport();
 
-	if (viewportWidth === null) {
-		return null;
-	}
-	if (viewportWidth > mobileViewportCutoff) {
+	if (viewportWidth === null || viewportWidth > mobileViewportCutoff) {
 		return (
 			<LargeHeaderButton
 				{...sharedProps}
@@ -33,7 +29,7 @@ const ResponsiveHeaderButton = React.forwardRef((props: Props, ref) => {
 			/>
 		);
 	}
-	// @ts-expect-error ts-migrate(2322) FIXME: Type 'ReactNode' is not assignable to type 'string... Remove this comment to see the full error message
+
 	return <SmallHeaderButton {...sharedProps} {...smallOnlyProps} label={simpleLabel} ref={ref} />;
 });
 

--- a/client/containers/Pub/PubHeader/SmallHeaderButton.tsx
+++ b/client/containers/Pub/PubHeader/SmallHeaderButton.tsx
@@ -6,12 +6,12 @@ import { Icon } from 'components';
 
 require('./smallHeaderButton.scss');
 
-type Props = {
+export type Props = {
 	className?: string;
 	disabled?: boolean;
 	href?: null | string;
 	icon: React.ReactNode;
-	label?: null | string;
+	label?: React.ReactNode;
 	labelPosition?: 'left' | 'right';
 	onClick?: () => unknown;
 	tagName?: string;


### PR DESCRIPTION
Resolves #1952

Test Plan
1. Load a Pub release
2. Scroll the page so the sticky banner appears and sticks to the top of the viewport.
3. The banner should not have extra "padding" at the top.