### PR TITLE
bug: Fixes Submission Modal Flicker

### DIFF
--- a/client/containers/Pub/SpubHeader/SpubHeaderToolBar/SpubHeaderToolbar.tsx
+++ b/client/containers/Pub/SpubHeader/SpubHeaderToolBar/SpubHeaderToolbar.tsx
@@ -84,9 +84,10 @@ const SpubHeaderToolbar = (props: Props) => {
 		}
 		return (
 			<DialogLauncher
-				renderLauncherElement={({ openDialog }) => (
-					<Button {...sharedProps} onClick={openDialog} />
-				)}
+				renderLauncherElement={({ openDialog }) =>
+					// hide the submit button but keep the modal open
+					showSubmitButton ? <Button {...sharedProps} onClick={openDialog} /> : null
+				}
 			>
 				{({ isOpen, onClose }) => (
 					<SubmitDialog submission={submission} isOpen={isOpen} onClose={onClose} />
@@ -118,13 +119,6 @@ const SpubHeaderToolbar = (props: Props) => {
 		return null;
 	};
 
-	const renderRight = () => {
-		if (showSubmitButton) {
-			return renderSubmitButton();
-		}
-		return renderStatus();
-	};
-
 	return (
 		<div style={{ background: lighterAccentColor }} className="spub-header-toolbar-component">
 			<GridWrapper containerClassName="toolbar-container pub">
@@ -135,7 +129,8 @@ const SpubHeaderToolbar = (props: Props) => {
 						<Tab id="contributors" title={contributorsTabTitle} />
 						<Tab id="preview" title={previewTabTitle} />
 					</Tabs>
-					{renderRight()}
+					{renderSubmitButton()}
+					{renderStatus()}
 				</div>
 			</GridWrapper>
 		</div>


### PR DESCRIPTION
fixess #1946 

issue: On submit `submision.status` will change accordingly. This causes `Spubheader` to rerender. In order to show the modal element, we will simply hide the button on submit. 

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/34730449/164086182-cdcfb9d2-bec7-47e7-ab50-d25fb20dfbf9.png">

<img width="1221" alt="image" src="https://user-images.githubusercontent.com/34730449/164086386-bdd2e2c1-2f7f-4c49-8763-ead884daf8cb.png">



