### PR TITLE
fix: use pandoc tmp file output instead of reading from stdout

### DIFF
--- a/workers/tasks/export/notes.ts
+++ b/workers/tasks/export/notes.ts
@@ -6,7 +6,6 @@ import { jsonToNode, getNotes, Note } from 'components/Editor';
 import { NoteManager } from 'client/utils/notes';
 import { getStructuredCitations } from 'server/utils/citations';
 import { RenderedStructuredValues } from 'utils/notesCore';
-import { PandocTarget } from 'utils/export/formats';
 
 import { NotesData, NoteWithStructuredHtml, PubMetadata } from './types';
 

--- a/workers/tasks/export/notes.ts
+++ b/workers/tasks/export/notes.ts
@@ -127,42 +127,35 @@ const emptyElementCitation =
 
 export const modifyJatsContentToIncludeUnstructuredNotes = (
 	documentContent: string,
-	target: PandocTarget,
 	notes: PandocNotes,
 ) => {
-	if (target === 'jats_archiving') {
-		return documentContent.replace(
-			emptyElementCitation,
-			(match, id, spaceBefore, spaceAfter) => {
-				const note = notes[id];
-				if (note && !note.hasStructuredContent && note.unstructuredHtml) {
-					// HTML with just these tags is also valid JATS
-					const unstructuredContentAsJats = sanitizeHtml(note.unstructuredHtml, {
-						allowedTags: ['bold', 'italic', 'a', 'ext-link'],
-						allowedAttributes: {
-							'ext-link': ['ext-link-type', 'xlink:title', 'xlink:href'],
-						},
-						transformTags: {
-							em: 'italic',
-							strong: 'bold',
-							a: (_, { href }) => {
-								return {
-									tagName: 'ext-link',
-									attribs: {
-										'ext-link-type': 'uri',
-										'xlink:title': 'null',
-										'xlink:href': href,
-									},
-								};
+	return documentContent.replace(emptyElementCitation, (match, id, spaceBefore, spaceAfter) => {
+		const note = notes[id];
+		if (note && !note.hasStructuredContent && note.unstructuredHtml) {
+			// HTML with just these tags is also valid JATS
+			const unstructuredContentAsJats = sanitizeHtml(note.unstructuredHtml, {
+				allowedTags: ['bold', 'italic', 'a', 'ext-link'],
+				allowedAttributes: {
+					'ext-link': ['ext-link-type', 'xlink:title', 'xlink:href'],
+				},
+				transformTags: {
+					em: 'italic',
+					strong: 'bold',
+					a: (_, { href }) => {
+						return {
+							tagName: 'ext-link',
+							attribs: {
+								'ext-link-type': 'uri',
+								'xlink:title': 'null',
+								'xlink:href': href,
 							},
-						},
-					});
-					const content = `<mixed-citation>${unstructuredContentAsJats}</mixed-citation>`;
-					return `<ref id="ref-${id}">${spaceBefore}${content}${spaceAfter}</ref>`;
-				}
-				return match;
-			},
-		);
-	}
-	return documentContent;
+						};
+					},
+				},
+			});
+			const content = `<mixed-citation>${unstructuredContentAsJats}</mixed-citation>`;
+			return `<ref id="ref-${id}">${spaceBefore}${content}${spaceAfter}</ref>`;
+		}
+		return match;
+	});
 };

--- a/workers/tasks/export/pandoc.ts
+++ b/workers/tasks/export/pandoc.ts
@@ -165,6 +165,7 @@ const reactPubDoc = (options: ExportWithPandocOptions) => {
 const callPandoc = (pandocJson: object, args: string[]) => {
 	const proc = spawnSync('pandoc', args, {
 		input: JSON.stringify(pandocJson),
+		maxBuffer: 1024 * 1024 * 25,
 	});
 	return proc.stderr.toString();
 };

--- a/workers/tasks/export/pandoc.ts
+++ b/workers/tasks/export/pandoc.ts
@@ -35,6 +35,7 @@ const getTemplatePath = (pandocTarget: string) => {
 const createPandocArgs = (
 	pandocTarget: PandocTarget,
 	pandocFlags: PandocFlag[],
+	tmpFilePath: string,
 	metadataFilePath?: string,
 	bibliographyFilePath?: string,
 ) => {
@@ -45,6 +46,7 @@ const createPandocArgs = (
 	return [
 		['-f', 'json'],
 		['-t', targetPlusFlags],
+		['-o', tmpFilePath],
 		template && [`--template=${getTemplatePath(pandocTarget)}`],
 		metadataFilePath && [`--metadata-file=${metadataFilePath}`],
 		bibliographyFilePath && [`--bibliography=${bibliographyFilePath}`],
@@ -161,14 +163,10 @@ const reactPubDoc = (options: ExportWithPandocOptions) => {
 };
 
 const callPandoc = (pandocJson: object, args: string[]) => {
-	const pandocJsonString = JSON.stringify(pandocJson);
 	const proc = spawnSync('pandoc', args, {
-		input: pandocJsonString,
-		maxBuffer: 1024 * 1024 * 25,
+		input: JSON.stringify(pandocJson),
 	});
-	const output = proc.stdout.toString();
-	const error = proc.stderr.toString();
-	return { output, error };
+	return proc.stderr.toString();
 };
 
 type ExportWithPandocOptions = {
@@ -186,21 +184,31 @@ export const exportWithPandoc = async (options: ExportWithPandocOptions) => {
 	const metadataFile = await createYamlMetadataFile(pubMetadata, pandocTarget);
 	const bibliographyFile = await createCslJsonBibliographyFile(pandocNotes);
 	const pandocFlags = getPandocFlags(options);
-	const pandocArgs = createPandocArgs(pandocTarget, pandocFlags, metadataFile, bibliographyFile);
+	const pandocArgs = createPandocArgs(
+		pandocTarget,
+		pandocFlags,
+		tmpFile.path,
+		metadataFile,
+		bibliographyFile,
+	);
 	const preTransformedPandocAst = fromProsemirror(pubDoc, rules, {
 		prosemirrorDocWidth: 675,
 		resources: createResources(pandocNotes),
 	}).asNode();
 	const pandocAst = runTransforms(preTransformedPandocAst);
 	const pandocJson = emitPandocJson(pandocAst);
-	const { output, error } = callPandoc(pandocJson, pandocArgs);
+	const error = callPandoc(pandocJson, pandocArgs);
 	if (error) {
 		throw new Error(error);
 	}
-	const transformedOutput = modifyJatsContentToIncludeUnstructuredNotes(
-		output,
-		pandocTarget,
-		pandocNotes,
-	);
-	fs.writeFileSync(tmpFile.path, transformedOutput);
+	// At this point, pandoc has written the document to our temp file. Here
+	// we do some additional post-processing.
+	if (pandocTarget === 'jats_archiving') {
+		const pandocOutput = fs.readFileSync(tmpFile.path).toString();
+		const transformedOutput = modifyJatsContentToIncludeUnstructuredNotes(
+			pandocOutput,
+			pandocNotes,
+		);
+		fs.writeFileSync(tmpFile.path, transformedOutput);
+	}
 };


### PR DESCRIPTION
Resolves #1943

Test Plan
1. Create a Pub. Add a structured citation and an unstructured citation.
2. Download the Pub as a Word document.
3. Open the file using a word processor like Pages (mac)/Word
4. Repeat steps 2-3 for epub, open with an epub viewer like Books (mac).
5. Repeat steps 2-3 for a text format like markdown and an XML format like JATS.
6. The JATS export should have one `mixed-citation` and one `element-citation`.