### PR TITLE
fix: Citations including non-byline pub-level contributors

### DIFF
--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -8,6 +8,7 @@ import { pubUrl } from 'utils/canonicalUrls';
 import { getPrimaryCollection } from 'utils/collections/primary';
 import { renderJournalCitationForCitations } from 'utils/citations';
 import { getAllPubContributors } from 'utils/contributors';
+import { ControlsButton } from 'client/components/FormattingBar/controlComponents/ControlsButton';
 
 const getDatePartsObject = (date) => ({
 	'date-parts': [date.getFullYear(), date.getMonth() + 1, date.getDate()],
@@ -47,11 +48,14 @@ export const generateCitationHtml = async (
 	const pubIssuedDate = getPubPublishedDate(pubData);
 	const pubLink = pubUrl(communityData, pubData);
 	const primaryCollection = getPrimaryCollection(pubData.collectionPubs);
-	const authors = getAllPubContributors(pubData).map(({ user }) => {
-		return {
-			given: user.firstName,
-			family: user.lastName,
-		};
+	const authors = getAllPubContributors(pubData).map((attribution) => {
+		if (attribution.collectionId || (attribution.pubId && attribution.isAuthor)) {
+			return {
+				given: attribution.user.firstName,
+				family: attribution.user.lastName,
+			};
+		}
+		return {};
 	});
 	const authorEntry = authors.length ? { author: authors } : {};
 	const commonData = {

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -8,7 +8,6 @@ import { pubUrl } from 'utils/canonicalUrls';
 import { getPrimaryCollection } from 'utils/collections/primary';
 import { renderJournalCitationForCitations } from 'utils/citations';
 import { getAllPubContributors } from 'utils/contributors';
-import { ControlsButton } from 'client/components/FormattingBar/controlComponents/ControlsButton';
 
 const getDatePartsObject = (date) => ({
 	'date-parts': [date.getFullYear(), date.getMonth() + 1, date.getDate()],
@@ -49,7 +48,10 @@ export const generateCitationHtml = async (
 	const pubLink = pubUrl(communityData, pubData);
 	const primaryCollection = getPrimaryCollection(pubData.collectionPubs);
 	const authors = getAllPubContributors(pubData).map((attribution) => {
-		if (attribution.collectionId || (attribution.pubId && attribution.isAuthor)) {
+		if (
+			types.isCollectionAttribution(attribution) ||
+			(types.isPubAttribution(attribution) && attribution.isAuthor)
+		) {
 			return {
 				given: attribution.user.firstName,
 				family: attribution.user.lastName,

--- a/types/attribution.ts
+++ b/types/attribution.ts
@@ -58,6 +58,7 @@ export type CollectionAttribution = {
 	userId?: string;
 	user?: AttributableUser;
 	createdAt: string;
+	collectionId: string;
 };
 
 export type Attribution = CollectionAttribution | PubAttribution;
@@ -66,3 +67,10 @@ export type AttributionWithUser = Attribution & { user: AttributableUser | User 
 export const isAttributionWithUser = (
 	attribution: Attribution,
 ): attribution is AttributionWithUser => 'user' in attribution && !!attribution.user;
+
+export const isCollectionAttribution = (
+	attribution: Attribution,
+): attribution is CollectionAttribution => 'collectionId' in attribution;
+
+export const isPubAttribution = (attribution: Attribution): attribution is PubAttribution =>
+	'pubId' in attribution;


### PR DESCRIPTION
In making some collection-level attribution changes, we introduced a small regression that was including all Pub-level contributors who were not marked as "byline" contributors in citations. This fixes that so that only authors at the Pub level, or contributors at the collection level, are shown in Pub-level citations.

Thanks to @3mcd for the fancy type-guarding.

_Test plan_
1. Create a pub.
2. Add a contributor and uncheck "display on byline"
3. Add the pub to a collection
4. Add a contributor to the collection
5. Verify: pub-level citation shows only collection-level contributor and any pub-level contributors with "byline" checked, but not pub-level contributors without "byline" checked.