### PR TITLE
fix: hide submit button on submitted spubs

### DIFF
--- a/client/containers/Pub/SpubHeader/SpubHeaderToolBar/SpubHeaderToolbar.tsx
+++ b/client/containers/Pub/SpubHeader/SpubHeaderToolBar/SpubHeaderToolbar.tsx
@@ -75,7 +75,7 @@ const SpubHeaderToolbar = (props: Props) => {
 			disabled: !!savingText,
 		};
 
-		if (invalidNotice) {
+		if (invalidNotice && showSubmitButton) {
 			return (
 				<Tooltip content={invalidNotice}>
 					<Button {...sharedProps} disabled />


### PR DESCRIPTION
Nothing fancy, just hiding the submission button when the spub is not 'incomplete'.

when bugged:
![Screenshot from 2022-04-25 10-43-53](https://user-images.githubusercontent.com/14115194/165118183-ab89f190-c275-4d44-9b99-95a248fcfd99.png)