### PR TITLE
Map Contributor Roles to Citations

### DIFF
--- a/client/components/AssignDoi/AssignDoiPreview.tsx
+++ b/client/components/AssignDoi/AssignDoiPreview.tsx
@@ -203,10 +203,6 @@ const renderBookPreview = (body) => {
 
 const renderConferencePreview = (body) => {
 	const {
-		// contributors come from the contributors(lists all)
-		// and conference_paper(list the primary content contributor) field
-		// not which to use. could reduce a list of dupes or make a set.
-		// for now i'll just use contributors
 		conference: {
 			contributors,
 			conference_paper: {
@@ -250,8 +246,6 @@ const renderConferencePreview = (body) => {
 	);
 };
 
-// the contributors are returned in when logging out in contributors.js but
-// just one gets appended
 const renderPreprintPreview = (body) => {
 	const {
 		posted_content: { contributors, titles, 'rel:program': relationships, posted_date },

--- a/client/components/AssignDoi/AssignDoiPreview.tsx
+++ b/client/components/AssignDoi/AssignDoiPreview.tsx
@@ -91,17 +91,18 @@ const renderContributors = (contributors) => {
 	if (!contributors) {
 		return null;
 	}
-
-	const contributorNames = contributors.person_name.map(
-		(contributor) =>
-			`${contributor.given_name} ${contributor.surname} (${contributor['@contributor_role']})`,
-	);
-
 	return (
 		<>
 			<dt>Contributors</dt>
 			<dd>
-				<ul>{contributorNames}</ul>
+				{contributors.map((contributor) => {
+					return (
+						<ul key={contributor.surname}>
+							{contributor.given_name} {contributor.surname}{' '}
+							{contributor['@contributor_role']}
+						</ul>
+					);
+				})}
 			</dd>
 		</>
 	);
@@ -127,12 +128,13 @@ const renderArticlePreview = (body) => {
 			journal_article: {
 				titles,
 				publication_date,
-				contributors,
+				contributors: content,
 				'rel:program': relationships,
 			},
 			journal_metadata: {
 				full_title: journalFullTitle,
 				doi_data: { doi: journalDoi },
+				contributors: metadata,
 			},
 			journal_issue,
 		},
@@ -144,7 +146,7 @@ const renderArticlePreview = (body) => {
 			<dl>
 				{renderTitles(titles)}
 				{renderPublicationDate(publication_date)}
-				{renderContributors(contributors)}
+				{renderContributors([...content.person_name, ...metadata.person_name])}
 			</dl>
 			<h6>Journal Metadata</h6>
 			<dl>
@@ -167,10 +169,11 @@ const renderBookPreview = (body) => {
 				edition_number,
 				publisher,
 				publication_date: bookPublicationDate,
+				contributors: metadata,
 			},
 			content_item: {
 				titles: contentTitles,
-				contributors,
+				contributors: content,
 				publication_date: contentPublicationDate,
 				'rel:program': relationships,
 			},
@@ -190,7 +193,7 @@ const renderBookPreview = (body) => {
 			<h6>Content</h6>
 			<dl>
 				{renderTitles(contentTitles)}
-				{renderContributors(contributors)}
+				{renderContributors([...content.person_name, ...metadata.person_name])}
 				{renderPublicationDate(contentPublicationDate)}
 			</dl>
 			{renderRelationships(relationships)}
@@ -200,8 +203,13 @@ const renderBookPreview = (body) => {
 
 const renderConferencePreview = (body) => {
 	const {
+		// contributors come from the contributors(lists all)
+		// and conference_paper(list the primary content contributor) field
+		// not which to use. could reduce a list of dupes or make a set.
+		// for now i'll just use contributors
 		conference: {
-			conference_paper: { contributors, titles, 'rel:program': relationships },
+			contributors,
+			conference_paper: { titles, 'rel:program': relationships },
 			event_metadata: {
 				conference_name,
 				conference_date: { '#text': conferenceDate },
@@ -209,13 +217,12 @@ const renderConferencePreview = (body) => {
 			proceedings_metadata: { proceedings_title, publication_date, publisher },
 		},
 	} = body;
-
 	return (
 		<>
 			<h6>Conference Paper</h6>
 			<dl>
 				{renderTitles(titles)}
-				{renderContributors(contributors)}
+				{renderContributors(contributors.person_name)}
 			</dl>
 			<h6>Event Metadata</h6>
 			<dl>
@@ -236,17 +243,18 @@ const renderConferencePreview = (body) => {
 	);
 };
 
+// the contributors are returned in when logging out in contributors.js but
+// just one gets appended
 const renderPreprintPreview = (body) => {
 	const {
 		posted_content: { contributors, titles, 'rel:program': relationships, posted_date },
 	} = body;
-
 	return (
 		<>
 			<h6>Preprint</h6>
 			<dl>
 				{renderTitles(titles)}
-				{renderContributors(contributors)}
+				{renderContributors(contributors.person_name)}
 				{renderPublicationDate(posted_date, 'Posted Date')}
 			</dl>
 			{renderRelationships(relationships)}
@@ -265,13 +273,12 @@ const renderPeerReviewPreview = (body) => {
 			review_date,
 		},
 	} = body;
-
 	return (
 		<>
 			<h6>Peer Review</h6>
 			<dl>
 				{renderTitles(titles)}
-				{renderContributors(contributors)}
+				{renderContributors(contributors.person_name)}
 				{renderPublicationDate(review_date, 'Review Date')}
 				{type && (
 					<>
@@ -310,7 +317,7 @@ const renderSupplementPreview = (body) => {
 				<dt>Parent Relation</dt>
 				<dd>isPartOf</dd>
 				{renderTitles(titles)}
-				{renderContributors(contributors)}
+				{renderContributors(contributors.person_name)}
 				{renderPublicationDate(publication_date)}
 			</dl>
 		</>

--- a/client/components/AssignDoi/AssignDoiPreview.tsx
+++ b/client/components/AssignDoi/AssignDoiPreview.tsx
@@ -98,8 +98,8 @@ const renderContributors = (contributors) => {
 				{contributors.map((contributor) => {
 					return (
 						<ul key={contributor.surname}>
-							{contributor.given_name} {contributor.surname}{' '}
-							{contributor['@contributor_role']}
+							{contributor.given_name} {contributor.surname} (
+							{contributor['@contributor_role']})
 						</ul>
 					);
 				})}
@@ -117,6 +117,7 @@ const renderJournalIssue = (journal_issue) => {
 			<dl>
 				{renderTitles(titles)}
 				{renderPublicationDate(publication_date)}
+				{renderContributors(journal_issue.contributors.person_name)}
 			</dl>
 		</>
 	);
@@ -138,14 +139,13 @@ const renderArticlePreview = (body) => {
 			journal_issue,
 		},
 	} = body;
-	const journal_issue_contributors = journal_issue && journal_issue.contributors.person_name;
 	return (
 		<>
 			<h6>Journal Article</h6>
 			<dl>
 				{renderTitles(titles)}
 				{renderPublicationDate(publication_date)}
-				{renderContributors([...content.person_name, ...journal_issue_contributors])}
+				{renderContributors(content.person_name)}
 			</dl>
 			<h6>Journal Metadata</h6>
 			<dl>
@@ -187,12 +187,13 @@ const renderBookPreview = (body) => {
 				<dt>Edition Number</dt>
 				<dd>{edition_number}</dd>
 				{renderPublisher(publisher)}
+				{renderContributors(metadata.person_name)}
 				{renderPublicationDate(bookPublicationDate)}
 			</dl>
 			<h6>Content</h6>
 			<dl>
 				{renderTitles(contentTitles)}
-				{renderContributors([...content.person_name, ...metadata.person_name])}
+				{renderContributors(content.person_name)}
 				{renderPublicationDate(contentPublicationDate)}
 			</dl>
 			{renderRelationships(relationships)}
@@ -208,7 +209,11 @@ const renderConferencePreview = (body) => {
 		// for now i'll just use contributors
 		conference: {
 			contributors,
-			conference_paper: { titles, 'rel:program': relationships },
+			conference_paper: {
+				titles,
+				contributors: conference_contributors,
+				'rel:program': relationships,
+			},
 			event_metadata: {
 				conference_name,
 				conference_date: { '#text': conferenceDate },
@@ -216,12 +221,13 @@ const renderConferencePreview = (body) => {
 			proceedings_metadata: { proceedings_title, publication_date, publisher },
 		},
 	} = body;
+
 	return (
 		<>
 			<h6>Conference Paper</h6>
 			<dl>
 				{renderTitles(titles)}
-				{renderContributors(contributors.person_name)}
+				{renderContributors(conference_contributors.person_name)}
 			</dl>
 			<h6>Event Metadata</h6>
 			<dl>
@@ -237,6 +243,8 @@ const renderConferencePreview = (body) => {
 				{renderPublicationDate(publication_date)}
 				{renderPublisher(publisher)}
 			</dl>
+			<h6>Contributors</h6>
+			<dl>{renderContributors(contributors.person_name)}</dl>
 			{renderRelationships(relationships)}
 		</>
 	);

--- a/client/components/AssignDoi/AssignDoiPreview.tsx
+++ b/client/components/AssignDoi/AssignDoiPreview.tsx
@@ -134,19 +134,18 @@ const renderArticlePreview = (body) => {
 			journal_metadata: {
 				full_title: journalFullTitle,
 				doi_data: { doi: journalDoi },
-				contributors: metadata,
 			},
 			journal_issue,
 		},
 	} = body;
-
+	const journal_issue_contributors = journal_issue && journal_issue.contributors.person_name;
 	return (
 		<>
 			<h6>Journal Article</h6>
 			<dl>
 				{renderTitles(titles)}
 				{renderPublicationDate(publication_date)}
-				{renderContributors([...content.person_name, ...metadata.person_name])}
+				{renderContributors([...content.person_name, ...journal_issue_contributors])}
 			</dl>
 			<h6>Journal Metadata</h6>
 			<dl>

--- a/client/components/AttributionEditor/roles.ts
+++ b/client/components/AttributionEditor/roles.ts
@@ -17,6 +17,10 @@ const DEFAULT_ROLES = [
 	'Peer Review',
 	'Funding Acquisition',
 	'Illustrator',
+	'Editor',
+	'Series Editor',
+	'Translator',
+	'Chair',
 ];
 
 // eslint-disable-next-line import/prefer-default-export

--- a/client/components/PubByline/PubByline.tsx
+++ b/client/components/PubByline/PubByline.tsx
@@ -21,7 +21,7 @@ type Props = OwnPubBylineProps & typeof defaultProps;
 
 const PubByline = (props: Props) => {
 	const { pubData, hideAuthors = false, hideContributors = false } = props;
-	const authors = getAllPubContributors(pubData, hideAuthors, hideContributors);
+	const authors = getAllPubContributors(pubData, 'contributors', hideAuthors, hideContributors);
 	return <Byline {...props} contributors={authors} />;
 };
 PubByline.defaultProps = defaultProps;

--- a/client/components/PubPreview/ManyAuthorsByline.tsx
+++ b/client/components/PubPreview/ManyAuthorsByline.tsx
@@ -15,7 +15,7 @@ type Props = Omit<BylineProps, 'contributors'> & {
 
 const ManyAuthorsByline = (props: Props) => {
 	const { pubData, truncateAt, isExpanded, ...restProps } = props;
-	const authors = getAllPubContributors(pubData, false, true);
+	const authors = getAllPubContributors(pubData, 'contributors', false, true);
 	const isTruncating = authors.length > truncateAt;
 
 	if (authors.length === 0) {

--- a/client/components/PubPreview/PubPreview.tsx
+++ b/client/components/PubPreview/PubPreview.tsx
@@ -138,7 +138,7 @@ const PubPreview = (props: Props) => {
 
 					{showContributors && (
 						<ContributorAvatars
-							attributions={getAllPubContributors(pubData)}
+							attributions={getAllPubContributors(pubData, 'contributors')}
 							truncateAt={6}
 							className="contributor-avatars"
 						/>

--- a/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
+++ b/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
@@ -113,7 +113,7 @@ const PubOverview = (props: Props) => {
 		return (
 			<div className="section">
 				<div className="section-header">Contributors</div>
-				<ContributorsList attributions={getAllPubContributors(pubData)} />
+				<ContributorsList attributions={getAllPubContributors(pubData, 'contributors')} />
 			</div>
 		);
 	};

--- a/client/containers/Pub/PubHeader/details/PubDetails.tsx
+++ b/client/containers/Pub/PubHeader/details/PubDetails.tsx
@@ -22,7 +22,7 @@ type Props = {
 const PubDetails = (props: Props) => {
 	const { communityData, onCloseHeaderDetails, pubData } = props;
 	const { collectionPubs } = pubData;
-	const contributors = getAllPubContributors(pubData);
+	const contributors = getAllPubContributors(pubData, 'contributors');
 	const { scopeData } = usePageContext();
 	const { canView } = scopeData.activePermissions;
 

--- a/server/routes/pubDocument.tsx
+++ b/server/routes/pubDocument.tsx
@@ -36,6 +36,7 @@ const renderPubDocument = (res, pubData, initialData, customScripts) => {
 	// getting collection pub attribution
 	const { collectionPubs } = pubData;
 	const primaryCollection = collectionPubs && getPrimaryCollection(collectionPubs);
+	const collectionAttributions = primaryCollection ? primaryCollection.attributions : [];
 	return renderToNodeStream(
 		res,
 		<Html
@@ -44,10 +45,7 @@ const renderPubDocument = (res, pubData, initialData, customScripts) => {
 			viewData={{ pubData }}
 			customScripts={customScripts}
 			headerComponents={generateMetaComponents({
-				attributions: [
-					...pubData.attributions,
-					...(primaryCollection && primaryCollection.attributions),
-				],
+				attributions: [...pubData.attributions, ...collectionAttributions],
 				collection: chooseCollectionForPub(pubData, initialData.locationData),
 				contextTitle: getPubPageContextTitle(pubData, initialData.communityData),
 				description: pubData.description,

--- a/server/routes/pubDocument.tsx
+++ b/server/routes/pubDocument.tsx
@@ -36,7 +36,7 @@ const renderPubDocument = (res, pubData, initialData, customScripts) => {
 	// getting collection pub attribution
 	const { collectionPubs } = pubData;
 	const primaryCollection = collectionPubs && getPrimaryCollection(collectionPubs);
-	const collectionAttributions = primaryCollection ? primaryCollection.attributions : [];
+	const collectionAttributions = primaryCollection?.attributions ?? [];
 	return renderToNodeStream(
 		res,
 		<Html

--- a/server/routes/pubDocument.tsx
+++ b/server/routes/pubDocument.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import slowDown from 'express-slow-down';
 
 import { getPubPageContextTitle } from 'utils/pubPageTitle';
 import { getPdfDownloadUrl, getTextAbstract, getGoogleScholarNotes } from 'utils/pub/metadata';
@@ -25,6 +24,7 @@ import {
 import { createUserScopeVisit } from 'server/userScopeVisit/queries';
 import { InitialData } from 'types';
 import { findUserSubscription } from 'server/userSubscription/shared/queries';
+import { getPrimaryCollection } from 'utils/collections/primary';
 
 const renderPubDocument = (res, pubData, initialData, customScripts) => {
 	const {
@@ -113,14 +113,7 @@ const getEnrichedPubData = async ({
 	};
 };
 
-const speedLimiter = slowDown({
-	windowMs: 60000, // 1 minute for requests to be kept in memory. value of 60000ms is default but expressed here for clarity
-	delayAfter: 60, // allow 60 requests per minute, then...
-	delayMs: 100, // 60th request has a 100ms delay, 7th has a 200ms delay, 8th gets 300ms, etc.
-	maxDelay: 20000, // max time of request delay will be 20secs
-});
-
-app.get('/pub/:pubSlug/release/:releaseNumber', speedLimiter, async (req, res, next) => {
+app.get('/pub/:pubSlug/release/:releaseNumber', async (req, res, next) => {
 	if (!hostIsValid(req, 'community')) {
 		return next();
 	}
@@ -145,7 +138,7 @@ app.get('/pub/:pubSlug/release/:releaseNumber', speedLimiter, async (req, res, n
 	}
 });
 
-app.get('/pub/:pubSlug/release-id/:releaseId', speedLimiter, async (req, res, next) => {
+app.get('/pub/:pubSlug/release-id/:releaseId', async (req, res, next) => {
 	if (!hostIsValid(req, 'community')) {
 		return next();
 	}
@@ -190,44 +183,41 @@ app.get('/pub/:pubSlug/discussion-id/:discussionId', async (req, res, next) => {
 	}
 });
 
-app.get(
-	['/pub/:pubSlug/draft', '/pub/:pubSlug/draft/:historyKey'],
-	speedLimiter,
-	async (req, res, next) => {
-		if (!hostIsValid(req, 'community')) {
-			return next();
+app.get(['/pub/:pubSlug/draft', '/pub/:pubSlug/draft/:historyKey'], async (req, res, next) => {
+	if (!hostIsValid(req, 'community')) {
+		return next();
+	}
+	try {
+		const initialData = await getInitialData(req);
+		const { historyKey: historyKeyString, pubSlug } = req.params;
+		const { canViewDraft, canView } = initialData.scopeData.activePermissions;
+		const hasHistoryKey = historyKeyString !== undefined;
+		const historyKey = parseInt(historyKeyString, 10);
+		const isHistoryKeyInvalid = hasHistoryKey && Number.isNaN(historyKey);
+
+		if (isHistoryKeyInvalid) {
+			throw new NotFoundError();
 		}
-		try {
-			const initialData = await getInitialData(req);
-			const { historyKey: historyKeyString, pubSlug } = req.params;
-			const { canViewDraft, canView } = initialData.scopeData.activePermissions;
-			const hasHistoryKey = historyKeyString !== undefined;
-			const historyKey = parseInt(historyKeyString, 10);
-			const isHistoryKeyInvalid = hasHistoryKey && Number.isNaN(historyKey);
 
-			if (isHistoryKeyInvalid) {
-				throw new NotFoundError();
-			}
-
-			if (!canViewDraft && !canView) {
-				throw new NotFoundError();
-			}
-
-			const pubData = await Promise.all([
-				getEnrichedPubData({
-					pubSlug,
-					initialData,
-					historyKey: hasHistoryKey ? historyKey : null,
-				}),
-				getMembers(initialData),
-			]).then(([enrichedPubData, membersData]) => ({
-				...enrichedPubData,
-				membersData,
-			}));
-			const customScripts = await getCustomScriptsForCommunity(initialData.communityData.id);
-			return renderPubDocument(res, pubData, initialData, customScripts);
-		} catch (err) {
-			return handleErrors(req, res, next)(err);
+		if (!canViewDraft && !canView) {
+			throw new NotFoundError();
 		}
-	},
-);
+
+		const pubData = await Promise.all([
+			getEnrichedPubData({
+				pubSlug,
+				initialData,
+				historyKey: hasHistoryKey ? historyKey : null,
+			}),
+			getMembers(initialData),
+		]).then(([enrichedPubData, membersData]) => ({
+			...enrichedPubData,
+			membersData,
+		}));
+		const customScripts = await getCustomScriptsForCommunity(initialData.communityData.id);
+
+		return renderPubDocument(res, pubData, initialData, customScripts);
+	} catch (err) {
+		return handleErrors(req, res, next)(err);
+	}
+});

--- a/server/routes/pubDocument.tsx
+++ b/server/routes/pubDocument.tsx
@@ -32,6 +32,12 @@ const renderPubDocument = (res, pubData, initialData, customScripts) => {
 		loginData: { id: userId },
 	} = initialData;
 	createUserScopeVisit({ userId, communityId, pubId: pubData.id });
+	const { collectionPubs } = pubData;
+	const primaryCollection = collectionPubs && getPrimaryCollection(collectionPubs);
+	// console.log([
+	// 	...pubData.attributions,
+	// 	...(primaryCollection && primaryCollection.attributions),
+	// ]);
 	return renderToNodeStream(
 		res,
 		<Html
@@ -40,7 +46,10 @@ const renderPubDocument = (res, pubData, initialData, customScripts) => {
 			viewData={{ pubData }}
 			customScripts={customScripts}
 			headerComponents={generateMetaComponents({
-				attributions: pubData.attributions,
+				attributions: [
+					...pubData.attributions,
+					...(primaryCollection && primaryCollection.attributions),
+				],
 				collection: chooseCollectionForPub(pubData, initialData.locationData),
 				contextTitle: getPubPageContextTitle(pubData, initialData.communityData),
 				description: pubData.description,

--- a/server/routes/pubDocument.tsx
+++ b/server/routes/pubDocument.tsx
@@ -33,7 +33,6 @@ const renderPubDocument = (res, pubData, initialData, customScripts) => {
 		loginData: { id: userId },
 	} = initialData;
 	createUserScopeVisit({ userId, communityId, pubId: pubData.id });
-	// getting collection pub attribution
 	const { collectionPubs } = pubData;
 	const primaryCollection = collectionPubs && getPrimaryCollection(collectionPubs);
 	const collectionAttributions = primaryCollection?.attributions ?? [];

--- a/server/routes/pubDocument.tsx
+++ b/server/routes/pubDocument.tsx
@@ -32,12 +32,9 @@ const renderPubDocument = (res, pubData, initialData, customScripts) => {
 		loginData: { id: userId },
 	} = initialData;
 	createUserScopeVisit({ userId, communityId, pubId: pubData.id });
+	// getting collection pub attribution
 	const { collectionPubs } = pubData;
 	const primaryCollection = collectionPubs && getPrimaryCollection(collectionPubs);
-	// console.log([
-	// 	...pubData.attributions,
-	// 	...(primaryCollection && primaryCollection.attributions),
-	// ]);
 	return renderToNodeStream(
 		res,
 		<Html

--- a/server/rss/queries.ts
+++ b/server/rss/queries.ts
@@ -229,7 +229,7 @@ export const getFeedItemForPub = (pubData, communityData) => {
 		// @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
 		categories: sortByPrimaryStatus(collectionPubs).map(({ collection }) => collection.title),
 		custom_elements: [
-			...getAllPubContributors(pubData, false, true).map((attribution) => {
+			...getAllPubContributors(pubData, 'contributors', false, true).map((attribution) => {
 				return {
 					'dc:creator': getContributorName(attribution),
 				};

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -60,11 +60,25 @@ export const generateCitationHtml = async (
 		return {};
 	});
 	const authorEntry = authors.length ? { author: authors } : {};
+	const editors = { editor: [{ given: 'Lamont', family: 'Tier' }] };
+	const illustrators = { illustrator: [{ given: 'Pablo', family: 'Picasso' }] };
+	const translators = { translator: [{ given: 'qweliannnn', family: 'another one' }] };
+	const collectionEditors = {
+		'collection-editor': [{ given: 'Testname', family: 'Testfamilyname' }],
+	};
+	const chairs = { chair: [{ given: 'James', family: 'Pearson' }] };
+
+	// for role[0] provide a atrribution appropriate to the CSL-JSON output
 	const commonData = {
 		// @ts-expect-error ts-migrate(2783) FIXME: 'type' is specified more than once, so this usage ... Remove this comment to see the full error message
 		type: 'article-journal',
 		title: pubData.title,
 		...authorEntry,
+		...editors,
+		...illustrators,
+		...collectionEditors,
+		...chairs,
+		...translators,
 		...renderJournalCitationForCitations(
 			primaryCollection?.kind,
 			communityData.citeAs,

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -118,7 +118,6 @@ export const generateCitationHtml = async (
 			return {};
 		},
 	);
-
 	const collectionEditorEntry = collectionEditors.length
 		? { 'collection-editor': collectionEditors }
 		: {};

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -39,6 +39,18 @@ const getCollectionLevelData = (collection) => {
 	};
 };
 
+const getContributorName = (attribution: types.Attribution) =>
+	(types.isCollectionAttribution(attribution) || types.isPubAttribution(attribution)) &&
+	attribution.isAuthor &&
+	// TODO: attribution.user check is confusing because these have a user
+	// object but ssr.tsx metadata attributions do not
+	// could use type.DefinitelyHas<type.Attribution, 'user> but...
+	// would rather fix the attribution model to have consistent behavior for user objects
+	// ian mentioned this in AttributionRow.tsx
+	attribution.user
+		? { given: attribution.user.firstName, family: attribution.user.lastName }
+		: {};
+
 export const generateCitationHtml = async (
 	pubData: types.SanitizedPubData,
 	communityData: types.Community,
@@ -47,93 +59,26 @@ export const generateCitationHtml = async (
 	const pubIssuedDate = getPubPublishedDate(pubData);
 	const pubLink = pubUrl(communityData, pubData);
 	const primaryCollection = getPrimaryCollection(pubData.collectionPubs);
-	const authors = getAllPubContributors(pubData).map((attribution) => {
-		if (
-			(types.isCollectionAttribution(attribution) || types.isPubAttribution(attribution)) &&
-			attribution.isAuthor
-		) {
-			return {
-				given: attribution.user.firstName,
-				family: attribution.user.lastName,
-			};
-		}
-		return {};
-	});
+	const authors = getAllPubContributors(pubData).map(getContributorName);
 	const authorEntry = authors.length ? { author: authors } : {};
 
-	const editors = getAllPubContributorsRoles(pubData, 'editor').map((attribution) => {
-		if (
-			(types.isCollectionAttribution(attribution) || types.isPubAttribution(attribution)) &&
-			attribution.isAuthor
-		) {
-			return {
-				given: attribution.user.firstName,
-				family: attribution.user.lastName,
-			};
-		}
-		return {};
-	});
+	const editors = getAllPubContributorsRoles(pubData, 'editor').map(getContributorName);
 	const editorEntry = editors.length ? { editor: editors } : {};
 
-	const illustrators = getAllPubContributorsRoles(pubData, 'illustrator').map((attribution) => {
-		if (
-			(types.isCollectionAttribution(attribution) || types.isPubAttribution(attribution)) &&
-			attribution.isAuthor
-		) {
-			return {
-				given: attribution.user.firstName,
-				family: attribution.user.lastName,
-			};
-		}
-		return {};
-	});
+	const illustrators = getAllPubContributorsRoles(pubData, 'illustrator').map(getContributorName);
 	const illustratorEntry = illustrators.length ? { illustrator: illustrators } : {};
 
-	const translators = getAllPubContributorsRoles(pubData, 'Translator').map((attribution) => {
-		if (
-			(types.isCollectionAttribution(attribution) || types.isPubAttribution(attribution)) &&
-			attribution.isAuthor
-		) {
-			return {
-				given: attribution.user.firstName,
-				family: attribution.user.lastName,
-			};
-		}
-		return {};
-	});
+	const translators = getAllPubContributorsRoles(pubData, 'Translator').map(getContributorName);
 	const translatorEntry = translators.length ? { translator: translators } : {};
 
 	const collectionEditors = getAllPubContributorsRoles(pubData, 'Series Editor').map(
-		(attribution) => {
-			if (
-				(types.isCollectionAttribution(attribution) ||
-					types.isPubAttribution(attribution)) &&
-				attribution.isAuthor
-			) {
-				return {
-					given: attribution.user.firstName,
-					family: attribution.user.lastName,
-				};
-			}
-			return {};
-		},
+		getContributorName,
 	);
 	const collectionEditorEntry = collectionEditors.length
 		? { 'collection-editor': collectionEditors }
 		: {};
 
-	const chairs = getAllPubContributorsRoles(pubData, 'Chair').map((attribution) => {
-		if (
-			(types.isCollectionAttribution(attribution) || types.isPubAttribution(attribution)) &&
-			attribution.isAuthor
-		) {
-			return {
-				given: attribution.user.firstName,
-				family: attribution.user.lastName,
-			};
-		}
-		return {};
-	});
+	const chairs = getAllPubContributorsRoles(pubData, 'Chair').map(getContributorName);
 	const chairEntry = chairs.length ? { chair: chairs } : {};
 
 	const commonData = {

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -7,7 +7,7 @@ import { getPubPublishedDate } from 'utils/pub/pubDates';
 import { pubUrl } from 'utils/canonicalUrls';
 import { getPrimaryCollection } from 'utils/collections/primary';
 import { renderJournalCitationForCitations } from 'utils/citations';
-import { getAllPubContributors, getAllPubContributorsRoles } from 'utils/contributors';
+import { getAllPubContributors } from 'utils/contributors';
 
 const getDatePartsObject = (date) => ({
 	'date-parts': [date.getFullYear(), date.getMonth() + 1, date.getDate()],
@@ -59,26 +59,26 @@ export const generateCitationHtml = async (
 	const pubIssuedDate = getPubPublishedDate(pubData);
 	const pubLink = pubUrl(communityData, pubData);
 	const primaryCollection = getPrimaryCollection(pubData.collectionPubs);
-	const authors = getAllPubContributors(pubData).map(getContributorName);
+	const authors = getAllPubContributors(pubData, 'author').map(getContributorName);
 	const authorEntry = authors.length ? { author: authors } : {};
 
-	const editors = getAllPubContributorsRoles(pubData, 'editor').map(getContributorName);
+	const editors = getAllPubContributors(pubData, 'editor').map(getContributorName);
 	const editorEntry = editors.length ? { editor: editors } : {};
 
-	const illustrators = getAllPubContributorsRoles(pubData, 'illustrator').map(getContributorName);
+	const illustrators = getAllPubContributors(pubData, 'illustrator').map(getContributorName);
 	const illustratorEntry = illustrators.length ? { illustrator: illustrators } : {};
 
-	const translators = getAllPubContributorsRoles(pubData, 'Translator').map(getContributorName);
+	const translators = getAllPubContributors(pubData, 'Translator').map(getContributorName);
 	const translatorEntry = translators.length ? { translator: translators } : {};
 
-	const collectionEditors = getAllPubContributorsRoles(pubData, 'Series Editor').map(
+	const collectionEditors = getAllPubContributors(pubData, 'Series Editor').map(
 		getContributorName,
 	);
 	const collectionEditorEntry = collectionEditors.length
 		? { 'collection-editor': collectionEditors }
 		: {};
 
-	const chairs = getAllPubContributorsRoles(pubData, 'Chair').map(getContributorName);
+	const chairs = getAllPubContributors(pubData, 'Chair').map(getContributorName);
 	const chairEntry = chairs.length ? { chair: chairs } : {};
 
 	const commonData = {

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -118,9 +118,10 @@ export const generateCitationHtml = async (
 			return {};
 		},
 	);
-	const collectionEditorEntry = {
-		'collection-editor': [{ given: 'Testname', family: 'Testfamilyname' }],
-	};
+
+	const collectionEditorEntry = collectionEditors.length
+		? { 'collection-editor': collectionEditors }
+		: {};
 
 	const chairs = getAllPubContributorsRoles(pubData, 'Chair').map((attribution) => {
 		if (
@@ -134,10 +135,8 @@ export const generateCitationHtml = async (
 		}
 		return {};
 	});
-	const chairEntry = { chair: [{ given: 'James', family: 'Pearson' }] };
+	const chairEntry = chairs.length ? { chair: chairs } : {};
 
-	console.log(collectionEditors, chairs);
-	// for role[0] provide a atrribution appropriate to the CSL-JSON output
 	const commonData = {
 		// @ts-expect-error ts-migrate(2783) FIXME: 'type' is specified more than once, so this usage ... Remove this comment to see the full error message
 		type: 'article-journal',

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -49,8 +49,8 @@ export const generateCitationHtml = async (
 	const primaryCollection = getPrimaryCollection(pubData.collectionPubs);
 	const authors = getAllPubContributors(pubData).map((attribution) => {
 		if (
-			types.isCollectionAttribution(attribution) ||
-			(types.isPubAttribution(attribution) && attribution.isAuthor)
+			(types.isCollectionAttribution(attribution) || types.isPubAttribution(attribution)) &&
+			attribution.isAuthor
 		) {
 			return {
 				given: attribution.user.firstName,

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -7,7 +7,7 @@ import { getPubPublishedDate } from 'utils/pub/pubDates';
 import { pubUrl } from 'utils/canonicalUrls';
 import { getPrimaryCollection } from 'utils/collections/primary';
 import { renderJournalCitationForCitations } from 'utils/citations';
-import { getAllPubContributors } from 'utils/contributors';
+import { getAllPubContributors, getAllPubContributorsRoles } from 'utils/contributors';
 
 const getDatePartsObject = (date) => ({
 	'date-parts': [date.getFullYear(), date.getMonth() + 1, date.getDate()],
@@ -60,13 +60,81 @@ export const generateCitationHtml = async (
 		return {};
 	});
 	const authorEntry = authors.length ? { author: authors } : {};
-	const editors = { editor: [{ given: 'Lamont', family: 'Tier' }] };
-	const illustrators = { illustrator: [{ given: 'Pablo', family: 'Picasso' }] };
-	const translators = { translator: [{ given: 'qweliannnn', family: 'another one' }] };
-	const collectionEditors = {
+
+	const editors = getAllPubContributorsRoles(pubData, 'editor').map((attribution) => {
+		if (
+			(types.isCollectionAttribution(attribution) || types.isPubAttribution(attribution)) &&
+			attribution.isAuthor
+		) {
+			return {
+				given: attribution.user.firstName,
+				family: attribution.user.lastName,
+			};
+		}
+		return {};
+	});
+	const editorEntry = editors.length ? { editor: editors } : {};
+
+	const illustrators = getAllPubContributorsRoles(pubData, 'illustrator').map((attribution) => {
+		if (
+			(types.isCollectionAttribution(attribution) || types.isPubAttribution(attribution)) &&
+			attribution.isAuthor
+		) {
+			return {
+				given: attribution.user.firstName,
+				family: attribution.user.lastName,
+			};
+		}
+		return {};
+	});
+	const illustratorEntry = illustrators.length ? { illustrator: illustrators } : {};
+
+	const translators = getAllPubContributorsRoles(pubData, 'Translator').map((attribution) => {
+		if (
+			(types.isCollectionAttribution(attribution) || types.isPubAttribution(attribution)) &&
+			attribution.isAuthor
+		) {
+			return {
+				given: attribution.user.firstName,
+				family: attribution.user.lastName,
+			};
+		}
+		return {};
+	});
+	const translatorEntry = translators.length ? { translator: translators } : {};
+
+	const collectionEditors = getAllPubContributorsRoles(pubData, 'Series Editor').map(
+		(attribution) => {
+			if (
+				(types.isCollectionAttribution(attribution) ||
+					types.isPubAttribution(attribution)) &&
+				attribution.isAuthor
+			) {
+				return {
+					given: attribution.user.firstName,
+					family: attribution.user.lastName,
+				};
+			}
+			return {};
+		},
+	);
+	const collectionEditorEntry = {
 		'collection-editor': [{ given: 'Testname', family: 'Testfamilyname' }],
 	};
-	const chairs = { chair: [{ given: 'James', family: 'Pearson' }] };
+
+	const chairs = getAllPubContributorsRoles(pubData, 'Chair').map((attribution) => {
+		if (
+			(types.isCollectionAttribution(attribution) || types.isPubAttribution(attribution)) &&
+			attribution.isAuthor
+		) {
+			return {
+				given: attribution.user.firstName,
+				family: attribution.user.lastName,
+			};
+		}
+		return {};
+	});
+	const chairEntry = { chair: [{ given: 'James', family: 'Pearson' }] };
 
 	// for role[0] provide a atrribution appropriate to the CSL-JSON output
 	const commonData = {
@@ -74,11 +142,11 @@ export const generateCitationHtml = async (
 		type: 'article-journal',
 		title: pubData.title,
 		...authorEntry,
-		...editors,
-		...illustrators,
-		...collectionEditors,
-		...chairs,
-		...translators,
+		...editorEntry,
+		...illustratorEntry,
+		...collectionEditorEntry,
+		...chairEntry,
+		...translatorEntry,
 		...renderJournalCitationForCitations(
 			primaryCollection?.kind,
 			communityData.citeAs,

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -42,11 +42,6 @@ const getCollectionLevelData = (collection) => {
 const getContributorName = (attribution: types.Attribution) =>
 	(types.isCollectionAttribution(attribution) || types.isPubAttribution(attribution)) &&
 	attribution.isAuthor &&
-	// TODO: attribution.user check is confusing because these have a user
-	// object but ssr.tsx metadata attributions do not
-	// could use type.DefinitelyHas<type.Attribution, 'user> but...
-	// would rather fix the attribution model to have consistent behavior for user objects
-	// ian mentioned this in AttributionRow.tsx
 	attribution.user
 		? { given: attribution.user.firstName, family: attribution.user.lastName }
 		: {};

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -136,6 +136,7 @@ export const generateCitationHtml = async (
 	});
 	const chairEntry = { chair: [{ given: 'James', family: 'Pearson' }] };
 
+	console.log(collectionEditors, chairs);
 	// for role[0] provide a atrribution appropriate to the CSL-JSON output
 	const commonData = {
 		// @ts-expect-error ts-migrate(2783) FIXME: 'type' is specified more than once, so this usage ... Remove this comment to see the full error message

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -220,7 +220,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			.filter((contributor) => {
 				return (
 					contributor.roles &&
-					(contributor.roles[0] === 'Series Editor' ||
+					(contributor.roles[0] === 'Writing - Review & Editing' ||
 						contributor.roles[0] === 'Editor' ||
 						contributor.roles[0] === 'Series Editor')
 				);

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import * as ReactBeautifulDnD from 'react-beautiful-dnd';
-import { Collection, InitialData } from 'types';
+import { Collection, InitialData, Attribution } from 'types';
 
 export const renderToNodeStream = (res, reactElement) => {
 	res.setHeader('content-type', 'text/html');
@@ -26,6 +26,8 @@ type MetaProps = {
 	notes?: string[];
 	canonicalUrl?: string;
 };
+
+const contributorRoles = ['Writing – Review & Editing', 'Editor', 'Series Editor'];
 
 export const generateMetaComponents = (metaProps: MetaProps) => {
 	const {
@@ -201,6 +203,8 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			.filter((item) => {
 				return item.isAuthor;
 			});
+
+		const getPrimaryRole = (contributor: Attribution) => contributor.roles?.[0];
 		const contributors = attributions
 			.sort((foo, bar) => {
 				if (foo.order < bar.order) {
@@ -218,12 +222,9 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 				return 0;
 			})
 			.filter((contributor) => {
+				const primaryRole = getPrimaryRole(contributor);
 				return (
-					contributor.isAuthor &&
-					contributor.roles &&
-					(contributor.roles[0] === 'Writing – Review & Editing' ||
-						contributor.roles[0] === 'Editor' ||
-						contributor.roles[0] === 'Series Editor')
+					contributor.isAuthor && primaryRole && contributorRoles.includes(primaryRole)
 				);
 			});
 

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -201,6 +201,31 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			.filter((item) => {
 				return item.isAuthor;
 			});
+		const contributors = attributions
+			.sort((foo, bar) => {
+				if (foo.order < bar.order) {
+					return -1;
+				}
+				if (foo.order > bar.order) {
+					return 1;
+				}
+				if (foo.createdAt < bar.createdAt) {
+					return 1;
+				}
+				if (foo.createdAt > bar.createdAt) {
+					return -1;
+				}
+				return 0;
+			})
+			.filter((contributor) => {
+				return (
+					contributor.roles &&
+					(contributor.roles[0] === 'Series Editor' ||
+						contributor.roles[0] === 'Editor' ||
+						contributor.roles[0] === 'Series Editor')
+				);
+			});
+
 		const citationAuthorTags = authors.map((author) => {
 			return (
 				<meta
@@ -219,7 +244,21 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 				/>
 			);
 		});
-		outputComponents = [...outputComponents, citationAuthorTags, dcAuthorTags];
+		const contributorRoleTags = contributors.map((contributor) => {
+			return (
+				<meta
+					key={`editor-cite-${contributor.id}`}
+					name="citation_editor"
+					content={contributor.user.fullName}
+				/>
+			);
+		});
+		outputComponents = [
+			...outputComponents,
+			citationAuthorTags,
+			dcAuthorTags,
+			contributorRoleTags,
+		];
 	}
 
 	if (publishedAt) {

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -227,29 +227,50 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			});
 
 		const citationAuthorTags = authors.map((author) => {
+			if (author.user) {
+				return (
+					<meta
+						key={`author-cite-${author.id}`}
+						name="citation_author"
+						content={author.user.fullName}
+					/>
+				);
+			}
 			return (
 				<meta
 					key={`author-cite-${author.id}`}
 					name="citation_author"
-					content={author.user.fullName}
+					content={author.name}
 				/>
 			);
 		});
 		const dcAuthorTags = authors.map((author) => {
-			return (
-				<meta
-					key={`author-dc-${author.id}`}
-					name="dc.creator"
-					content={author.user.fullName}
-				/>
-			);
+			if (author.user) {
+				return (
+					<meta
+						key={`author-dc-${author.id}`}
+						name="dc.creator"
+						content={author.user.fullName}
+					/>
+				);
+			}
+			return <meta key={`author-dc-${author.id}`} name="dc.creator" content={author.name} />;
 		});
 		const contributorRoleTags = contributors.map((contributor) => {
+			if (contributor.user) {
+				return (
+					<meta
+						key={`editor-cite-${contributor.id}`}
+						name="citation_editor"
+						content={contributor.user.fullName}
+					/>
+				);
+			}
 			return (
 				<meta
 					key={`editor-cite-${contributor.id}`}
 					name="citation_editor"
-					content={contributor.user.fullName}
+					content={contributor.name}
 				/>
 			);
 		});

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -201,7 +201,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 				return 0;
 			})
 			.filter((item) => {
-				return item.isAuthor;
+				return item.isAuthor && !item.roles;
 			});
 
 		const getPrimaryRole = (contributor: Attribution) => contributor.roles?.[0];

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -275,7 +275,6 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 				/>
 			);
 		});
-		console.log(contributorRoleTags);
 		outputComponents = [
 			...outputComponents,
 			citationAuthorTags,

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -28,6 +28,21 @@ type MetaProps = {
 };
 
 const contributorRoles = ['Writing – Review & Editing', 'Editor', 'Series Editor'];
+const sortAttributions = (foo, bar) => {
+	if (foo.order < bar.order) {
+		return -1;
+	}
+	if (foo.order > bar.order) {
+		return 1;
+	}
+	if (foo.createdAt < bar.createdAt) {
+		return 1;
+	}
+	if (foo.createdAt > bar.createdAt) {
+		return -1;
+	}
+	return 0;
+};
 
 export const generateMetaComponents = (metaProps: MetaProps) => {
 	const {
@@ -184,49 +199,15 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 	}
 
 	if (attributions) {
-		const authors = attributions
-			.sort((foo, bar) => {
-				if (foo.order < bar.order) {
-					return -1;
-				}
-				if (foo.order > bar.order) {
-					return 1;
-				}
-				if (foo.createdAt < bar.createdAt) {
-					return 1;
-				}
-				if (foo.createdAt > bar.createdAt) {
-					return -1;
-				}
-				return 0;
-			})
-			.filter((item) => {
-				return item.isAuthor && !item.roles;
-			});
+		const authors = attributions.sort(sortAttributions).filter((item) => {
+			return item.isAuthor && !item.roles;
+		});
 
 		const getPrimaryRole = (contributor: Attribution) => contributor.roles?.[0];
-		const contributors = attributions
-			.sort((foo, bar) => {
-				if (foo.order < bar.order) {
-					return -1;
-				}
-				if (foo.order > bar.order) {
-					return 1;
-				}
-				if (foo.createdAt < bar.createdAt) {
-					return 1;
-				}
-				if (foo.createdAt > bar.createdAt) {
-					return -1;
-				}
-				return 0;
-			})
-			.filter((contributor) => {
-				const primaryRole = getPrimaryRole(contributor);
-				return (
-					contributor.isAuthor && primaryRole && contributorRoles.includes(primaryRole)
-				);
-			});
+		const contributors = attributions.sort(sortAttributions).filter((item) => {
+			const primaryRole = getPrimaryRole(item);
+			return item.isAuthor && primaryRole && contributorRoles.includes(primaryRole);
+		});
 
 		const citationAuthorTags = authors.map((author) => {
 			if (author.user) {

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -219,8 +219,9 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			})
 			.filter((contributor) => {
 				return (
+					contributor.isAuthor &&
 					contributor.roles &&
-					(contributor.roles[0] === 'Writing - Review & Editing' ||
+					(contributor.roles[0] === 'Writing – Review & Editing' ||
 						contributor.roles[0] === 'Editor' ||
 						contributor.roles[0] === 'Series Editor')
 				);
@@ -274,6 +275,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 				/>
 			);
 		});
+		console.log(contributorRoleTags);
 		outputComponents = [
 			...outputComponents,
 			citationAuthorTags,

--- a/utils/contributors.ts
+++ b/utils/contributors.ts
@@ -14,6 +14,11 @@ const orderedContributors = (maybeContributors: Attribution[] | undefined | null
 		return 0;
 	});
 
+const editorRoles = ['Editor', 'Writing – Review & Editing'];
+const illustratorRoles = ['Illustrator', 'Visualization'];
+const getPrimaryRole = (contributor: AttributionWithUser) =>
+	contributor.roles ? contributor.roles[0] : '';
+
 const resolveContributors = (
 	contributors: AttributionWithUser[],
 	hideAuthors: boolean,
@@ -71,25 +76,19 @@ export const getAllPubContributorsRoles = (
 	// filter if role is present on contributor
 	if (role === 'editor') {
 		const contributorsWithRoles = contributors.filter((contributor) => {
-			return (
-				(contributor.roles && contributor.roles[0] === 'Editor') ||
-				(contributor.roles && contributor.roles[0] === 'Writing – Review & Editing')
-			);
+			return editorRoles.includes(getPrimaryRole(contributor));
 		});
 		return resolveContributors(contributorsWithRoles, hideAuthors, hideNonAuthors);
 	}
 	if (role === 'illustrator') {
 		const contributorsWithRoles = contributors.filter((contributor) => {
-			return (
-				(contributor.roles && contributor.roles[0] === 'Illustrator') ||
-				(contributor.roles && contributor.roles[0] === 'Visualization')
-			);
+			return illustratorRoles.includes(getPrimaryRole(contributor));
 		});
 
 		return resolveContributors(contributorsWithRoles, hideAuthors, hideNonAuthors);
 	}
 	const contributorsWithRoles = contributors.filter((contributor) => {
-		return contributor.roles && contributor.roles[0] === role;
+		return getPrimaryRole(contributor) === role;
 	});
 	return resolveContributors(contributorsWithRoles, hideAuthors, hideNonAuthors);
 };

--- a/utils/contributors.ts
+++ b/utils/contributors.ts
@@ -46,13 +46,54 @@ export const getAllPubContributors = (
 ) => {
 	const { collectionPubs } = pubData;
 	const primaryCollection = collectionPubs && getPrimaryCollection(collectionPubs);
-
 	const contributors = [
 		...orderedContributors(pubData.attributions),
 		...orderedContributors(primaryCollection && primaryCollection.attributions),
 	].map(ensureUserForAttribution);
 
 	return resolveContributors(contributors, hideAuthors, hideNonAuthors);
+};
+
+export const getAllPubContributorsRoles = (
+	pubData: Pub,
+	field: string,
+	hideAuthors = false,
+	hideNonAuthors = false,
+) => {
+	const { collectionPubs } = pubData;
+	const primaryCollection = collectionPubs && getPrimaryCollection(collectionPubs);
+
+	const contributors = [
+		...orderedContributors(pubData.attributions),
+		...orderedContributors(primaryCollection && primaryCollection.attributions),
+	].map(ensureUserForAttribution);
+
+	// check if role is present on contributor
+	// remove from array
+	// return array
+	if (field === 'editor') {
+		const contributorsWithRoles = contributors.filter((contributor) => {
+			return (
+				(contributor.roles && contributor.roles[0] === 'Editor') ||
+				(contributor.roles && contributor.roles[0] === 'Writing – Review & Editing')
+			);
+		});
+		return resolveContributors(contributorsWithRoles, hideAuthors, hideNonAuthors);
+	}
+	if (field === 'illustrator') {
+		const contributorsWithRoles = contributors.filter((contributor) => {
+			return (
+				(contributor.roles && contributor.roles[0] === 'Illustrator') ||
+				(contributor.roles && contributor.roles[0] === 'Visualization')
+			);
+		});
+
+		return resolveContributors(contributorsWithRoles, hideAuthors, hideNonAuthors);
+	}
+	const contributorsWithRoles = contributors.filter((contributor) => {
+		return contributor.roles && contributor.roles[0] === field;
+	});
+	return resolveContributors(contributorsWithRoles, hideAuthors, hideNonAuthors);
 };
 
 export const getAllCollectionContributors = (

--- a/utils/contributors.ts
+++ b/utils/contributors.ts
@@ -73,6 +73,10 @@ export const getAllPubContributors = (
 		...orderedContributors(primaryCollection && primaryCollection.attributions),
 	].map(ensureUserForAttribution);
 
+	if (role === 'contributors') {
+		return resolveContributors(contributors, hideAuthors, hideNonAuthors);
+	}
+
 	// author is not a 'role' but bare with me
 	if (role === 'author') {
 		const contributorsWithRoles = contributors.filter((contributor) => {
@@ -121,6 +125,6 @@ export const getContributorName = (attribution: Attribution) => {
 };
 
 export const getAuthorString = (pub) => {
-	const contributors = getAllPubContributors(pub, false, true);
+	const contributors = getAllPubContributors(pub, 'author', false, true);
 	return joinOxford(contributors.map((c) => c.user.fullName));
 };

--- a/utils/contributors.ts
+++ b/utils/contributors.ts
@@ -56,7 +56,7 @@ export const getAllPubContributors = (
 
 export const getAllPubContributorsRoles = (
 	pubData: Pub,
-	field: string,
+	role: string,
 	hideAuthors = false,
 	hideNonAuthors = false,
 ) => {
@@ -68,10 +68,8 @@ export const getAllPubContributorsRoles = (
 		...orderedContributors(primaryCollection && primaryCollection.attributions),
 	].map(ensureUserForAttribution);
 
-	// check if role is present on contributor
-	// remove from array
-	// return array
-	if (field === 'editor') {
+	// filter if role is present on contributor
+	if (role === 'editor') {
 		const contributorsWithRoles = contributors.filter((contributor) => {
 			return (
 				(contributor.roles && contributor.roles[0] === 'Editor') ||
@@ -80,7 +78,7 @@ export const getAllPubContributorsRoles = (
 		});
 		return resolveContributors(contributorsWithRoles, hideAuthors, hideNonAuthors);
 	}
-	if (field === 'illustrator') {
+	if (role === 'illustrator') {
 		const contributorsWithRoles = contributors.filter((contributor) => {
 			return (
 				(contributor.roles && contributor.roles[0] === 'Illustrator') ||
@@ -91,7 +89,7 @@ export const getAllPubContributorsRoles = (
 		return resolveContributors(contributorsWithRoles, hideAuthors, hideNonAuthors);
 	}
 	const contributorsWithRoles = contributors.filter((contributor) => {
-		return contributor.roles && contributor.roles[0] === field;
+		return contributor.roles && contributor.roles[0] === role;
 	});
 	return resolveContributors(contributorsWithRoles, hideAuthors, hideNonAuthors);
 };

--- a/utils/contributors.ts
+++ b/utils/contributors.ts
@@ -62,7 +62,6 @@ export const getAllPubContributors = (
 		return resolveContributors(contributors, hideAuthors, hideNonAuthors);
 	}
 
-	// author is not a 'role' but bare with me
 	if (role === 'author') {
 		const contributorsWithRoles = contributors.filter((contributor) => {
 			return !contributor.roles;
@@ -70,7 +69,6 @@ export const getAllPubContributors = (
 		return resolveContributors(contributorsWithRoles, hideAuthors, hideNonAuthors);
 	}
 
-	// filter if role is present on contributor
 	if (role === 'editor') {
 		const contributorsWithRoles = contributors.filter((contributor) => {
 			return editorRoles.includes(getPrimaryRole(contributor));

--- a/utils/contributors.ts
+++ b/utils/contributors.ts
@@ -44,22 +44,22 @@ const resolveContributors = (
 	});
 };
 
+// export const getAllPubContributors = (
+// 	pubData: Pub,
+// 	hideAuthors = false,
+// 	hideNonAuthors = false,
+// ) => {
+// 	const { collectionPubs } = pubData;
+// 	const primaryCollection = collectionPubs && getPrimaryCollection(collectionPubs);
+// 	const contributors = [
+// 		...orderedContributors(pubData.attributions),
+// 		...orderedContributors(primaryCollection && primaryCollection.attributions),
+// 	].map(ensureUserForAttribution);
+
+// 	return resolveContributors(contributors, hideAuthors, hideNonAuthors);
+// };
+
 export const getAllPubContributors = (
-	pubData: Pub,
-	hideAuthors = false,
-	hideNonAuthors = false,
-) => {
-	const { collectionPubs } = pubData;
-	const primaryCollection = collectionPubs && getPrimaryCollection(collectionPubs);
-	const contributors = [
-		...orderedContributors(pubData.attributions),
-		...orderedContributors(primaryCollection && primaryCollection.attributions),
-	].map(ensureUserForAttribution);
-
-	return resolveContributors(contributors, hideAuthors, hideNonAuthors);
-};
-
-export const getAllPubContributorsRoles = (
 	pubData: Pub,
 	role: string,
 	hideAuthors = false,
@@ -72,6 +72,14 @@ export const getAllPubContributorsRoles = (
 		...orderedContributors(pubData.attributions),
 		...orderedContributors(primaryCollection && primaryCollection.attributions),
 	].map(ensureUserForAttribution);
+
+	// author is not a 'role' but bare with me
+	if (role === 'author') {
+		const contributorsWithRoles = contributors.filter((contributor) => {
+			return !contributor.roles;
+		});
+		return resolveContributors(contributorsWithRoles, hideAuthors, hideNonAuthors);
+	}
 
 	// filter if role is present on contributor
 	if (role === 'editor') {

--- a/utils/contributors.ts
+++ b/utils/contributors.ts
@@ -44,21 +44,6 @@ const resolveContributors = (
 	});
 };
 
-// export const getAllPubContributors = (
-// 	pubData: Pub,
-// 	hideAuthors = false,
-// 	hideNonAuthors = false,
-// ) => {
-// 	const { collectionPubs } = pubData;
-// 	const primaryCollection = collectionPubs && getPrimaryCollection(collectionPubs);
-// 	const contributors = [
-// 		...orderedContributors(pubData.attributions),
-// 		...orderedContributors(primaryCollection && primaryCollection.attributions),
-// 	].map(ensureUserForAttribution);
-
-// 	return resolveContributors(contributors, hideAuthors, hideNonAuthors);
-// };
-
 export const getAllPubContributors = (
 	pubData: Pub,
 	role: string,

--- a/utils/crossref/schema/contributors.js
+++ b/utils/crossref/schema/contributors.js
@@ -10,11 +10,10 @@ const roleList = {
 	Chair: 'chair',
 };
 
-function checkRole(attribution) {
-	return attribution.roles && attribution.roles[0] in roleList
-		? roleList[attribution.roles[0]]
-		: 'author';
-}
+const checkRole = (attribution) => {
+	return roleList[attribution.roles?.[0]] ?? 'author';
+};
+
 export default (attributions) => {
 	if (attributions.length === 0) {
 		return {};

--- a/utils/crossref/schema/contributors.js
+++ b/utils/crossref/schema/contributors.js
@@ -1,6 +1,20 @@
 /**
  * Renders a list of contributors
  */
+
+const roleList = {
+	'Writing – Review & Editing': 'editor',
+	Editor: 'editor',
+	'Series Editor': 'editor',
+	Translator: 'translator',
+	Chair: 'chair',
+};
+
+function checkRole(attribution) {
+	return attribution.roles && attribution.roles[0] in roleList
+		? roleList[attribution.roles[0]]
+		: 'author';
+}
 export default (attributions) => {
 	if (attributions.length === 0) {
 		return {};
@@ -9,7 +23,7 @@ export default (attributions) => {
 		contributors: {
 			person_name: attributions.map((attribution, attributionIndex) => {
 				const personNameOutput = {
-					'@contributor_role': attribution.isAuthor ? 'author' : 'reader',
+					'@contributor_role': attribution.isAuthor ? checkRole(attribution) : 'reader',
 					'@sequence': attributionIndex === 0 ? 'first' : 'additional',
 					given_name: attribution.user.lastName ? attribution.user.firstName : '',
 					surname: attribution.user.lastName

--- a/utils/pubEdge/helpers.ts
+++ b/utils/pubEdge/helpers.ts
@@ -70,7 +70,7 @@ export const getValuesFromPubEdge = (
 		return {
 			displayedPubId: displayedPub.id,
 			avatar,
-			contributors: getAllPubContributors(displayedPub, false, true),
+			contributors: getAllPubContributors(displayedPub, 'contributors', false, true),
 			description,
 			publishedAt: publishedDate && formatDate(publishedDate),
 			title,

--- a/workers/tasks/export/metadata.ts
+++ b/workers/tasks/export/metadata.ts
@@ -67,7 +67,7 @@ export const getPubMetadata = async (pubId: string): Promise<PubMetadata> => {
 	const publishedDateString = publishedDate && dateFormat(publishedDate, 'mmm dd, yyyy');
 	const updatedDateString = updatedDate && dateFormat(updatedDate, 'mmm dd, yyyy');
 	const primaryCollection = getPrimaryCollection(pubData.collectionPubs);
-	const attributions = getAllPubContributors(pubData, 'contributors');
+	const attributions = getAllPubContributors(pubData, 'contributors', false, true);
 	return {
 		title: pubData.title,
 		slug: pubData.slug,

--- a/workers/tasks/export/metadata.ts
+++ b/workers/tasks/export/metadata.ts
@@ -67,7 +67,7 @@ export const getPubMetadata = async (pubId: string): Promise<PubMetadata> => {
 	const publishedDateString = publishedDate && dateFormat(publishedDate, 'mmm dd, yyyy');
 	const updatedDateString = updatedDate && dateFormat(updatedDate, 'mmm dd, yyyy');
 	const primaryCollection = getPrimaryCollection(pubData.collectionPubs);
-	const attributions = getAllPubContributors(pubData);
+	const attributions = getAllPubContributors(pubData, 'contributors');
 	return {
 		title: pubData.title,
 		slug: pubData.slug,


### PR DESCRIPTION
addresses #1972 
 
Putting the mapping here again bc it may be useful
# Mapping:
| PubPub Role List | CSL-JSON | HTML Meta | Crossref contributor_role |
| --- | --- | --- | --- |
| none selected (default) | author | citation_author | author |
| --- | --- | --- | --- |
| Illustrator | illustrator | n/a | n/a |
| --- | --- | --- | --- |
| Visualization | illustrator | n/a | n/a |
| --- | --- | --- | --- |
| Writing - Review & Editing | editor | citation_editor | editor |
| --- | --- | --- | --- |
| Editor | editor | citation_editor | editor |
| --- | --- | --- | --- |
| Series Editor | collection-editor | citation_editor | editor |
| --- | --- | --- | --- |
| Translator | translator | n/a | translator |
| --- | --- | --- | --- |
| Chair | chair | n/a | chair |


### **Problems**
- Collection level contributors are listed in the citation 
- The collection level citations should be listed with their roles on the pubs
    - and ONLY if they are contributors with list on byline checked and role filled in
- Only people at the pub level have roles specified in metadata. This should extend to collection level contributors 
- How do citations get generated?
    - For starters, there are PubAttributions and CollectionAttributions 
    - Users list themselves as attributors in the collection or pub dashboard.
    - and a call is made to the API setting each one
    - an onChange function gets passed from [AttributionEditor.tsx](https://www.remnote.io/doc/7x8EpDCt4H8As6DvD) into [AttributionDetailControls.tsx](https://www.remnote.io/doc/fCtroafPKN76cCCum) and will persist attributors if isAuthor is checked. this is done in [generateCitationHtml.ts](https://www.remnote.io/doc/S7EmcZJksiEkXXJTT) 
    - if isAuthor and the type is a collection or pub attribution the author will merge into the citation list of authors

### **Solutions**
- Had to change use of parenthesis on lines 51 to 54 in `generateCitationHTML.tsx`
- How do i map roles to citations?
     - query for contributors with matching role field using `getAllPubContributorsRoles` in `generateCitationHTML.tsx` and `contributors.tsx`
- How to add roles to metadata?
    - include contributors in metadata using `contributorRoleTags()` found in `ssr.tsx` if attributions are passed in 


### **Expectations**
- Only collection level contributors with list in byline selected will appear in citations, html-metadata, crossref, exports, and rss feed
    - this means pretty much anywhere getAllPubContributors(...) is used with the exception of PubPreview.tsx, PubOverview.tsx, and PubDetails.tsx 
- Contributors are now listed in crossref deposit preview alongside their roles
    - contributors without list in byline checked will still appear in crossref deposits as a reader
- If the contributor has a role:
    - the first role they choose will be the role used for citations, crossref, and metadata
    - this role will map according to the table above

<img width="727" alt="image" src="https://user-images.githubusercontent.com/34730449/166748931-4a8513f7-0e8d-4081-9cd7-22d5614b24cd.png">

<img width="1242" alt="image" src="https://user-images.githubusercontent.com/34730449/166748906-65fb2c5d-424e-42bb-8347-f42641a3ee60.png">

<img width="727" alt="image" src="https://user-images.githubusercontent.com/34730449/166749383-679d5e72-bc52-47d1-872d-56768ab10ada.png">

![image](https://user-images.githubusercontent.com/34730449/166750991-11b4fd7a-fda0-452d-b560-3251daeacde7.png)

![image](https://user-images.githubusercontent.com/34730449/166752038-bf7a145c-7075-4732-affd-75c418a5fdcf.png)


<img width="878" alt="image" src="https://user-images.githubusercontent.com/34730449/166749690-4f295f88-031e-446c-88b5-fc38bcb2a3ce.png">



### **Test**
- visit a collection, i used [this](http://localhost:9876/dash/collection/a-mid-book-tbh/settings). be sure it has contributors, one is an editor, some have roles, some have none, and some have multiple roles
- click list on collection byline for a random number of contributors
- view the collection preview and be sure the byline has the right contributors
- view the pub preview and be sure only the list on byline contributors have citation credits
- view the pub copy citations button and the pub citations in the PubHeader to be sure citations are consistent
- open up the console and be sure `citation_editor` tag exists for any editor
- for any pub in a collection with multiple contributors be sure when generating a crossref deposit that
     - contributors with a role have the correct role mapping in the crossref preview and xml
     - the (primary author? content maker?) idk has the right role listed if they have one 