### PR TITLE
fix: show custom layout banner button text

### DIFF
--- a/client/components/Layout/LayoutBanner.tsx
+++ b/client/components/Layout/LayoutBanner.tsx
@@ -16,6 +16,19 @@ type Props = {
 
 type State = any;
 
+export const getButtonText = (
+	buttonType: 'create-pub' | 'signup' | 'link' | null,
+	customButtonText: string,
+	isLoggedIn = true,
+): string | undefined => {
+	if (!isLoggedIn && buttonType === 'create-pub') return 'Login to Create Pub';
+	if (customButtonText) return customButtonText;
+	if (isLoggedIn && buttonType === 'create-pub') return 'Create Pub';
+	if (buttonType === 'signup') return 'Create an Account';
+	if (buttonType === 'link') return 'Go to Link';
+	return undefined;
+};
+
 const createPubFailureText =
 	'Error creating a new Pub. You may want to refresh the page and try again.';
 
@@ -60,19 +73,7 @@ class LayoutBanner extends Component<Props, State> {
 		const buttonType =
 			this.props.content.buttonType || (this.props.content.showButton && 'create-pub');
 
-		const buttonText =
-			!isLoggedIn && buttonType === 'create-pub'
-				? 'Login to Create Pub'
-				: this.props.content.buttonText
-				? this.props.content.buttonText
-				: isLoggedIn && buttonType === 'create-pub'
-				? 'Create Pub'
-				: buttonType === 'signup'
-				? 'Create an Account'
-				: buttonType === 'link'
-				? 'Go to Link'
-				: undefined;
-
+		const buttonText = getButtonText(buttonType, this.props.content.buttonText, isLoggedIn);
 		const buttonUrl =
 			buttonType === 'link'
 				? this.props.content.buttonUrl

--- a/client/components/Layout/LayoutBanner.tsx
+++ b/client/components/Layout/LayoutBanner.tsx
@@ -84,7 +84,7 @@ class LayoutBanner extends Component<Props, State> {
 				: undefined;
 
 		const onButtonClick =
-			(buttonType === 'create-pub' && isLoggedIn && this.createPub) || undefined;
+			(isLoggedIn && buttonType === 'create-pub' && this.createPub) || undefined;
 
 		const button = (
 			<AnchorButton

--- a/client/components/Layout/LayoutBanner.tsx
+++ b/client/components/Layout/LayoutBanner.tsx
@@ -51,35 +51,39 @@ class LayoutBanner extends Component<Props, State> {
 
 	renderButton() {
 		const { buttonError } = this.state;
+		const isLoggedIn = !!this.props.loginData.id;
 
 		if (!this.props.content.showButton) {
 			return null;
 		}
 
 		const buttonType =
-			this.props.content.buttonType ||
-			(this.props.content.showButton ? 'create-pub' : undefined);
+			this.props.content.buttonType || (this.props.content.showButton && 'create-pub');
+
 		const buttonText =
-			buttonType === 'create-pub' && !this.props.loginData.id
-				? 'Login to Create Pub' || this.props.content.buttonText
-				: buttonType === 'create-pub' && this.props.loginData.id
+			!isLoggedIn && buttonType === 'create-pub'
+				? 'Login to Create Pub'
+				: this.props.content.buttonText
+				? this.props.content.buttonText
+				: isLoggedIn && buttonType === 'create-pub'
 				? 'Create Pub'
 				: buttonType === 'signup'
 				? 'Create an Account'
 				: buttonType === 'link'
 				? 'Go to Link'
 				: undefined;
+
 		const buttonUrl =
 			buttonType === 'link'
 				? this.props.content.buttonUrl
-				: buttonType === 'create-pub' && !this.props.loginData.id
+				: isLoggedIn && buttonType === 'create-pub'
 				? `/login?redirect=${this.props.locationData.path}`
 				: buttonType === 'signup'
 				? '/signup'
 				: undefined;
 
 		const onButtonClick =
-			buttonType === 'create-pub' && this.props.loginData.id ? this.createPub : undefined;
+			(buttonType === 'create-pub' && isLoggedIn && this.createPub) || undefined;
 
 		const button = (
 			<AnchorButton

--- a/client/components/LayoutEditor/LayoutEditorBanner.tsx
+++ b/client/components/LayoutEditor/LayoutEditorBanner.tsx
@@ -7,6 +7,7 @@ import InputField from 'components/InputField/InputField';
 import ImageUpload from 'components/ImageUpload/ImageUpload';
 import ColorInput from 'components/ColorInput/ColorInput';
 import { getResizedUrl } from 'utils/images';
+import { getButtonText } from '../Layout/LayoutBanner';
 
 require('./layoutEditorBanner.scss');
 
@@ -142,6 +143,7 @@ class LayoutEditorBanner extends Component<Props> {
 
 		const buttonType =
 			this.props.content.buttonType || (this.props.content.showButton && 'create-pub');
+		const buttonText = getButtonText(buttonType, this.props.content.buttonText);
 
 		return (
 			<div className="layout-editor-banner-component">
@@ -309,12 +311,7 @@ class LayoutEditorBanner extends Component<Props> {
 									<Button
 										className="bp3-large"
 										onClick={() => {}}
-										text={
-											this.props.content.buttonText ||
-											(buttonType === 'create-pub' && 'Create Pub') ||
-											(buttonType === 'signup' && 'Create an Account') ||
-											(buttonType === 'link' && 'Go to Link')
-										}
+										text={buttonText}
 									/>
 								)}
 							</div>


### PR DESCRIPTION
fixes #1974

_Test plan_

1. visit page at slug `banner-buttons-custom-text-fix` on the demo community
2. confirm that the button text reads "If you read this custom text, the bug has been fixed up."