### PR TITLE
Bh/add discussion tooltip

### DIFF
--- a/client/components/Editor/plugins/keymap.ts
+++ b/client/components/Editor/plugins/keymap.ts
@@ -121,6 +121,7 @@ export default (schema) => {
 	if (schema.nodes.heading) {
 		for (let index = 1; index <= 6; index += 1) {
 			bind(`Shift-Ctrl-${index}`, setBlockType(schema.nodes.heading, { level: index }));
+			bind(`Alt-Ctrl-${index}`, setBlockType(schema.nodes.heading, { level: index }));
 		}
 	}
 	if (schema.nodes.horizontal_rule) {

--- a/client/containers/Pub/PubDocument/PubInlineMenu.tsx
+++ b/client/containers/Pub/PubDocument/PubInlineMenu.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import uuidv4 from 'uuid/v4';
-import { Button } from '@blueprintjs/core';
+import { Button, Tooltip, Position } from '@blueprintjs/core';
 
 import { pubUrl } from 'utils/canonicalUrls';
 import { usePageContext } from 'utils/hooks';
@@ -63,15 +63,17 @@ const PubInlineMenu = () => {
 		>
 			{renderFormattingBar()}
 			{(canView || canCreateDiscussions) && (
-				<Button
-					minimal={true}
-					icon={<Icon icon="chat" />}
-					onClick={() => {
-						const view = collabData.editorChangeObject!.view;
-						setLocalHighlight(view, selection.from, selection.to, uuidv4());
-						moveToEndOfSelection(collabData.editorChangeObject!.view);
-					}}
-				/>
+				<Tooltip content="Start a discussion" position={Position.TOP}>
+					<Button
+						minimal={true}
+						icon={<Icon icon="chat" />}
+						onClick={() => {
+							const view = collabData.editorChangeObject!.view;
+							setLocalHighlight(view, selection.from, selection.to, uuidv4());
+							moveToEndOfSelection(collabData.editorChangeObject!.view);
+						}}
+					/>
+				</Tooltip>
 			)}
 			<ClickToCopyButton
 				className="click-to-copy"

--- a/client/containers/Pub/PubDocument/PubInlineMenu.tsx
+++ b/client/containers/Pub/PubDocument/PubInlineMenu.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import uuidv4 from 'uuid/v4';
-import { Button, Tooltip, Position } from '@blueprintjs/core';
+import { Button } from '@blueprintjs/core';
 
 import { pubUrl } from 'utils/canonicalUrls';
 import { usePageContext } from 'utils/hooks';
@@ -63,17 +63,17 @@ const PubInlineMenu = () => {
 		>
 			{renderFormattingBar()}
 			{(canView || canCreateDiscussions) && (
-				<Tooltip content="Start a discussion" position={Position.TOP}>
-					<Button
-						minimal={true}
-						icon={<Icon icon="chat" />}
-						onClick={() => {
-							const view = collabData.editorChangeObject!.view;
-							setLocalHighlight(view, selection.from, selection.to, uuidv4());
-							moveToEndOfSelection(collabData.editorChangeObject!.view);
-						}}
-					/>
-				</Tooltip>
+				<Button
+					aria-label="Start a discussion"
+					title="Start a discussion"
+					minimal={true}
+					icon={<Icon icon="chat" />}
+					onClick={() => {
+						const view = collabData.editorChangeObject!.view;
+						setLocalHighlight(view, selection.from, selection.to, uuidv4());
+						moveToEndOfSelection(collabData.editorChangeObject!.view);
+					}}
+				/>
 			)}
 			<ClickToCopyButton
 				className="click-to-copy"


### PR DESCRIPTION
Tiny improvements, adding tooltip on hover to inline discussion button and ctrl + alt + [number] mapping to setting heading levels
![Screenshot from 2022-04-26 22-08-13](https://user-images.githubusercontent.com/14115194/165424053-fc5ac7cb-9f87-4ecd-adb2-68f5e0285784.png)

_Test plan_

- (tooltip) go to any released pub, select some pub body text, hover over discussion icon
- (heading keys) Go to any pub draft, select some pub body text, and press `ctrl-alt-1` (or `2` or `3`), text should format to heading of the specified number. Behavior should be consistent with previously existing `shift-alt-[number]`