### PR TITLE
fix: Don't include draft/release info in copied node links from Pub body

### DIFF
--- a/client/containers/Pub/PubDocument/PubDocument.tsx
+++ b/client/containers/Pub/PubDocument/PubDocument.tsx
@@ -145,7 +145,7 @@ const PubDocument = (props: Props) => {
 					/>
 				)}
 			</PubSuspendWhileTyping>
-			<PubLinkController locationData={locationData} mainContentRef={mainContentRef} />
+			<PubLinkController mainContentRef={mainContentRef} />
 		</div>
 	);
 };

--- a/client/containers/Pub/PubDocument/PubDocument.tsx
+++ b/client/containers/Pub/PubDocument/PubDocument.tsx
@@ -37,7 +37,7 @@ const PubDocument = (props: Props) => {
 	const { submissionState } = usePubContext();
 	const { canEdit, canEditDraft } = scopeData.activePermissions;
 	const [areDiscussionsShown, setDiscussionsShown] = useState(true);
-	const mainContentRef = useRef(null);
+	const mainContentRef = useRef<null | HTMLDivElement>(null);
 	const sideContentRef = useRef(null);
 	const editorWrapperRef = useRef(null);
 

--- a/client/containers/Pub/PubDocument/PubLinkController/LinkPopover.tsx
+++ b/client/containers/Pub/PubDocument/PubLinkController/LinkPopover.tsx
@@ -4,21 +4,22 @@ import Popper from 'popper.js';
 import { ClickToCopyButton } from 'components';
 import { getLowestAncestorWithId } from 'client/utils/dom';
 import { usePageContext } from 'utils/hooks';
+import { pubUrl } from 'utils/canonicalUrls';
 
 import { usePubData } from '../../pubHooks';
 
-export type HeaderPopoverProps = {
-	locationData: any;
-	element: any;
-	mainContentRef: any;
+type Props = {
+	element: Element;
+	mainContentRef: React.MutableRefObject<any>;
 };
 
-const LinkPopover = (props: HeaderPopoverProps) => {
-	const { element, mainContentRef, locationData } = props;
+const LinkPopover = (props: Props) => {
+	const { element, mainContentRef } = props;
 	const parent = getLowestAncestorWithId(element);
 	const popoverRef = useRef<null | HTMLDivElement>(null);
 	const pubData = usePubData();
 	const {
+		communityData,
 		scopeData: {
 			activePermissions: { canManage },
 		},
@@ -56,7 +57,7 @@ const LinkPopover = (props: HeaderPopoverProps) => {
 				className="click-to-copy"
 			>
 				<ClickToCopyButton
-					copyString={`https://${locationData.hostname}${locationData.path}#${parent?.id}`}
+					copyString={pubUrl(communityData, pubData, { hash: parent?.id })}
 					beforeCopyPrompt={managersEnableLinksPrompt}
 					disabled={unstableLink}
 				/>

--- a/client/containers/Pub/PubDocument/PubLinkController/LinkPopover.tsx
+++ b/client/containers/Pub/PubDocument/PubLinkController/LinkPopover.tsx
@@ -10,7 +10,7 @@ import { usePubData } from '../../pubHooks';
 
 type Props = {
 	element: Element;
-	mainContentRef: React.MutableRefObject<any>;
+	mainContentRef: React.MutableRefObject<null | HTMLDivElement>;
 };
 
 const LinkPopover = (props: Props) => {

--- a/client/containers/Pub/PubDocument/PubLinkController/PubLinkController.tsx
+++ b/client/containers/Pub/PubDocument/PubLinkController/PubLinkController.tsx
@@ -5,7 +5,7 @@ import { getHighestAncestorWithId } from 'client/utils/dom';
 import LinkPopover from './LinkPopover';
 
 type Props = {
-	mainContentRef: React.MutableRefObject<any>;
+	mainContentRef: React.MutableRefObject<null | HTMLDivElement>;
 };
 
 const clickToCopySelector = '.click-to-copy, .click-to-copy *';

--- a/client/containers/Pub/PubDocument/PubLinkController/PubLinkController.tsx
+++ b/client/containers/Pub/PubDocument/PubLinkController/PubLinkController.tsx
@@ -4,9 +4,8 @@ import { getHighestAncestorWithId } from 'client/utils/dom';
 
 import LinkPopover from './LinkPopover';
 
-export type PubMouseEventProps = {
-	locationData: any;
-	mainContentRef: any;
+type Props = {
+	mainContentRef: React.MutableRefObject<any>;
 };
 
 const clickToCopySelector = '.click-to-copy, .click-to-copy *';
@@ -36,8 +35,8 @@ function isValidLinkTarget(element: Element | null): element is Element {
 	return true;
 }
 
-const PubLinkController = (props: PubMouseEventProps) => {
-	const { mainContentRef, locationData } = props;
+const PubLinkController = (props: Props) => {
+	const { mainContentRef } = props;
 	const [hoverTargets, hoverElemsDispatch] = useReducer(
 		(state: PubLinkControllertate, action: PubMouseEventAction) => {
 			return {
@@ -101,13 +100,9 @@ const PubLinkController = (props: PubMouseEventProps) => {
 	const clickToCopyTarget = hoverTargets[HoverTargetTypes.ClickToCopy];
 
 	return (
-		<div className="pub-mouse-events-component">
+		<div className="pub-link-controller-component">
 			{clickToCopyTarget && (
-				<LinkPopover
-					locationData={locationData}
-					element={clickToCopyTarget}
-					mainContentRef={mainContentRef}
-				/>
+				<LinkPopover element={clickToCopyTarget} mainContentRef={mainContentRef} />
 			)}
 		</div>
 	);

--- a/client/utils/dom.ts
+++ b/client/utils/dom.ts
@@ -16,8 +16,8 @@ export const getHighestAncestorWithId = (node: Element, root: Element = document
 	return highestAncestorWithId;
 };
 
-export const getLowestAncestorWithId = (node: HTMLElement) => {
-	let ancestor: HTMLElement | null = node;
+export const getLowestAncestorWithId = (element: Element) => {
+	let ancestor: Element | null = element;
 
 	while (ancestor && !ancestor.hasAttribute('id')) {
 		ancestor = ancestor.parentElement;


### PR DESCRIPTION
Fixes #1905 by using `pubUrl()` instead of `locationData` to pick a base URL for Pub body permalinks

Test plan:
- Visit a Pub draft and copy a link to a header, paragraph, etc.
- Verify that the link doesn't have `/draft` in it
- Verify that the link still takes you back to the intended page element
- Repeat the same process with a Release.
