### PR TITLE
fix: wsod when removing abstract from submitted submission; add warning

### DIFF
--- a/client/containers/Pub/SpubHeader/AbstractEditor.tsx
+++ b/client/containers/Pub/SpubHeader/AbstractEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { Callback, DocJson } from 'types';
 import { MinimalEditor } from 'components';
@@ -30,6 +30,12 @@ const AbstractEditor = (props: Props) => {
 		return { readOnlyAbstractDoc: null, readOnlyEditorKey: Date.now() };
 	}, [isReadOnly, editorChangeObject, initialDoc]);
 
+	useEffect(() => {
+		if (isReadOnly) {
+			onUpdateAbstract(readOnlyAbstractDoc as DocJson);
+		}
+	}, [isReadOnly, readOnlyAbstractDoc]);
+
 	const sharedProps = {
 		customNodes: { doc: { content: 'paragraph' } },
 		constrainHeight: true,
@@ -58,5 +64,4 @@ const AbstractEditor = (props: Props) => {
 		/>
 	);
 };
-
 export default AbstractEditor;

--- a/client/containers/Pub/SpubHeader/AbstractEditor.tsx
+++ b/client/containers/Pub/SpubHeader/AbstractEditor.tsx
@@ -30,11 +30,15 @@ const AbstractEditor = (props: Props) => {
 		return { readOnlyAbstractDoc: null, readOnlyEditorKey: Date.now() };
 	}, [isReadOnly, editorChangeObject, initialDoc]);
 
-	useEffect(() => {
-		if (isReadOnly) {
-			onUpdateAbstract(readOnlyAbstractDoc as DocJson);
-		}
-	}, [isReadOnly, readOnlyAbstractDoc]);
+	useEffect(
+		() => {
+			if (isReadOnly) {
+				onUpdateAbstract(readOnlyAbstractDoc as DocJson);
+			}
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[isReadOnly, readOnlyAbstractDoc],
+	);
 
 	const sharedProps = {
 		customNodes: { doc: { content: 'paragraph' } },

--- a/client/containers/Pub/SpubHeader/DetailsTab.tsx
+++ b/client/containers/Pub/SpubHeader/DetailsTab.tsx
@@ -70,9 +70,13 @@ const DetailsTab = (props: Props) => {
 				<SpubHeaderField
 					title="Abstract"
 					instructions={
-						hasSubmitted ? 'Update the abstract from the submission body.' : null
+						hasSubmitted
+							? validatedFields.abstract
+								? 'Update the abstract from the submission body.'
+								: 'The abstract was removed from the submission body after submission and may need to be re-added before release.'
+							: null
 					}
-					valid={hasSubmitted || validatedFields.abstract}
+					valid={validatedFields.abstract}
 					invalidNotice="Abstract must not be empty"
 				>
 					<AbstractEditor

--- a/utils/pub/abstract.ts
+++ b/utils/pub/abstract.ts
@@ -6,16 +6,12 @@ export const getAbstractDocFromPubDoc = (doc: DocJson): null | DocJson => {
 	} = doc;
 
 	if (firstChild && secondChild) {
-		const {
-			type: firstChildType,
-			attrs,
-			content: [firstTextItem],
-		} = firstChild;
+		const { type: firstChildType, attrs, content } = firstChild;
 
 		const hasCorrectHeading =
 			firstChildType === 'heading' &&
 			attrs?.level === 1 &&
-			firstTextItem?.text?.toLowerCase?.() === 'abstract';
+			content?.[0]?.text?.toLowerCase()?.trim() === 'abstract';
 
 		if (hasCorrectHeading) {
 			if (secondChild.type === 'paragraph') {


### PR DESCRIPTION
Resolves #1970

*Test Plan*
1. Create a submission with an abstract.
2. Submit it.
3. Go back to the Submission tab and remove the abstract from the Pub body.
4. The editor should not crash, and you should see the message "The abstract was removed from the submission body after submission and may need to be re-added before release." above the workflow's abstract field.
5. Add another abstract using `# Abstract` (be sure to add some content in a paragraph below the heading).
6. The warning message should disappear, and the text content of the abstract should appear in the workflow's abstract field.