### PR TITLE
Bh/unpublish custom date thumbnails

### DIFF
--- a/client/components/Menu/MenuSelect.tsx
+++ b/client/components/Menu/MenuSelect.tsx
@@ -40,6 +40,7 @@ export const MenuSelect = <Values extends number | string>(props: Props<Values>)
 		defaultLabel = 'Select...',
 	} = props;
 	const selectedItem = value !== null ? items.find((item) => item.value === value) : null;
+
 	return (
 		<MenuButton
 			disabled={disabled}
@@ -54,6 +55,7 @@ export const MenuSelect = <Values extends number | string>(props: Props<Values>)
 		>
 			{items.map((item) => (
 				<MenuItem
+					key={item.value}
 					icon={showTickIcon && (item === selectedItem ? 'tick' : 'blank')}
 					active={item === selectedItem}
 					onClick={() => onSelectValue(item.value)}

--- a/client/components/PubPreview/PubPreview.tsx
+++ b/client/components/PubPreview/PubPreview.tsx
@@ -149,6 +149,7 @@ const PubPreview = (props: Props) => {
 							{publishedDate ? (
 								<span className="date">
 									Published: {dateFormat(publishedDate, 'mmm dd, yyyy')}
+									{pubData.releases.length === 0 && ' (Not yet released)'}
 								</span>
 							) : (
 								<span className="date">Unpublished</span>

--- a/client/components/PubPreview/PubPreview.tsx
+++ b/client/components/PubPreview/PubPreview.tsx
@@ -4,7 +4,7 @@ import dateFormat from 'dateformat';
 
 import { Pub, Community } from 'types';
 import { getResizedUrl } from 'utils/images';
-import { getPubPublishedDate } from 'utils/pub/pubDates';
+import { getPubPublishedDateString } from 'utils/pub/pubDates';
 import { isPubPublic } from 'utils/pub/permissions';
 import { getAllPubContributors } from 'utils/contributors';
 import { communityUrl, bestPubUrl } from 'utils/canonicalUrls';
@@ -60,7 +60,7 @@ const PubPreview = (props: Props) => {
 	const contentRef = useRef<HTMLDivElement>(null);
 	const resizedHeaderLogo =
 		communityData && getResizedUrl(communityData.headerLogo, 'inside', 125, 35);
-	const publishedDate = getPubPublishedDate(pubData);
+	const publishedDateString = getPubPublishedDateString(pubData);
 	const isPrivate = !isPubPublic(pubData, scopeData);
 	const showBannerImage = ['large', 'medium'].includes(size);
 	const showUpperByline = !hideByline && ['minimal'].includes(size);
@@ -146,11 +146,8 @@ const PubPreview = (props: Props) => {
 
 					{showDates && (
 						<div className="date-details">
-							{publishedDate ? (
-								<span className="date">
-									Published: {dateFormat(publishedDate, 'mmm dd, yyyy')}
-									{pubData.releases.length === 0 && ' (Not yet released)'}
-								</span>
+							{publishedDateString ? (
+								<span className="date">Published: {publishedDateString}</span>
 							) : (
 								<span className="date">Unpublished</span>
 							)}

--- a/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
+++ b/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
@@ -36,7 +36,11 @@ const PubOverview = (props: Props) => {
 	const renderPubDates = () => {
 		const publishedDate = getPubPublishedDate(pubData);
 		const latestReleaseDate = getPubLatestReleaseDate(pubData, { excludeFirstRelease: true });
-		const publishedOnString = publishedDate ? formatDate(publishedDate) : <i>Unpublished</i>;
+		const publishedOnString = publishedDate ? (
+			`${formatDate(publishedDate)}${pubData.releases.length === 0 && ' (Not yet released)'}`
+		) : (
+			<i>Unpublished</i>
+		);
 		return (
 			<div className="pub-dates">
 				{renderSection('Created on', formatDate(pubData.createdAt))}

--- a/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
+++ b/client/containers/DashboardOverview/PubOverview/PubOverview.tsx
@@ -8,7 +8,7 @@ import CitationsPreview from 'containers/Pub/PubHeader/CitationsPreview';
 import { formatDate } from 'utils/dates';
 import { getAllPubContributors } from 'utils/contributors';
 import { getDashUrl } from 'utils/dashboard';
-import { getPubPublishedDate, getPubLatestReleaseDate } from 'utils/pub/pubDates';
+import { getPubPublishedDateString, getPubLatestReleaseDate } from 'utils/pub/pubDates';
 import { usePageContext } from 'utils/hooks';
 
 import PubTimeline from './PubTimeline';
@@ -34,17 +34,12 @@ const PubOverview = (props: Props) => {
 	};
 
 	const renderPubDates = () => {
-		const publishedDate = getPubPublishedDate(pubData);
+		const publishedDateString = getPubPublishedDateString(pubData);
 		const latestReleaseDate = getPubLatestReleaseDate(pubData, { excludeFirstRelease: true });
-		const publishedOnString = publishedDate ? (
-			`${formatDate(publishedDate)}${pubData.releases.length === 0 && ' (Not yet released)'}`
-		) : (
-			<i>Unpublished</i>
-		);
 		return (
 			<div className="pub-dates">
 				{renderSection('Created on', formatDate(pubData.createdAt))}
-				{renderSection('Published on', publishedOnString)}
+				{renderSection('Published on', publishedDateString || <i>Unpublished</i>)}
 				{latestReleaseDate &&
 					renderSection('Last released on', formatDate(latestReleaseDate))}
 			</div>

--- a/client/containers/DashboardOverview/overviewRows/labels.tsx
+++ b/client/containers/DashboardOverview/overviewRows/labels.tsx
@@ -72,7 +72,7 @@ const getDateLabelPart = (date: Date) => {
 
 export const getPubReleasedStateLabel = (pub: Pub) => {
 	const publishedDate = getPubPublishedDate(pub, false);
-	if (publishedDate) {
+	if (publishedDate && pub.releases.length > 0) {
 		return {
 			label: <>Published&nbsp;{getDateLabelPart(publishedDate)}</>,
 			icon: 'globe' as const,

--- a/client/containers/Pub/PubHeader/EditableHeaderText.tsx
+++ b/client/containers/Pub/PubHeader/EditableHeaderText.tsx
@@ -40,7 +40,6 @@ const EditableHeaderText = (props: EditableHeaderTextProps) => {
 					onConfirm={(newText) => updateText(newText.replace(/\n/g, ''))}
 					onChange={setIntermediateValue}
 					value={intermediateValue}
-					multiline={true}
 					confirmOnEnterKey={true}
 					maxLength={maxLength}
 				/>

--- a/client/containers/Pub/PubHeader/PubHeaderContent.tsx
+++ b/client/containers/Pub/PubHeader/PubHeaderContent.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import { ClickToCopyButton } from 'components';
-import { getPubPublishedDate } from 'utils/pub/pubDates';
-import { formatDate } from 'utils/dates';
+import { getPubPublishedDateString } from 'utils/pub/pubDates';
 import { usePageContext } from 'utils/hooks';
 import { apiFetch } from 'client/utils/apiFetch';
 import { PubPageData } from 'types';
@@ -26,7 +25,7 @@ const PubHeaderContent = (props: Props) => {
 	const { doi, isInMaintenanceMode } = pubData;
 	const { communityData } = usePageContext();
 	const { submissionState } = usePubContext();
-	const publishedDate = getPubPublishedDate(pubData);
+	const publishedDateString = getPubPublishedDateString(pubData);
 	const isSubmission = !!submissionState;
 
 	const updatePubData = (newPubData) => {
@@ -58,11 +57,10 @@ const PubHeaderContent = (props: Props) => {
 				)}
 				<div className="basic-details">
 					<span className="metadata-pair">
-						{publishedDate ? (
+						{publishedDateString ? (
 							<>
 								<b className="pub-header-themed-secondary">Published on </b>
-								{formatDate(publishedDate)}
-								{pubData.releases.length === 0 && ' (Not yet released)'}
+								{publishedDateString}
 							</>
 						) : (
 							<i>Unpublished</i>

--- a/client/containers/Pub/PubHeader/PubHeaderContent.tsx
+++ b/client/containers/Pub/PubHeader/PubHeaderContent.tsx
@@ -58,10 +58,15 @@ const PubHeaderContent = (props: Props) => {
 				)}
 				<div className="basic-details">
 					<span className="metadata-pair">
-						{publishedDate && (
-							<b className="pub-header-themed-secondary">Published on</b>
+						{publishedDate ? (
+							<>
+								<b className="pub-header-themed-secondary">Published on </b>
+								{formatDate(publishedDate)}
+								{pubData.releases.length === 0 && ' (Not yet released)'}
+							</>
+						) : (
+							<i>Unpublished</i>
 						)}
-						{publishedDate ? formatDate(publishedDate) : <i>Unpublished</i>}
 					</span>
 					{doi && (
 						<span className="metadata-pair doi-pair">

--- a/client/containers/Pub/PubHeader/TitleGroup.tsx
+++ b/client/containers/Pub/PubHeader/TitleGroup.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 
 import { PubByline, DialogLauncher, PubAttributionDialog } from 'components';
 import { usePageContext } from 'utils/hooks';
-import { getPubPublishedDate } from 'utils/pub/pubDates';
-import { formatDate } from 'utils/dates';
+import { getPubPublishedDateString } from 'utils/pub/pubDates';
 import { PatchFn, Pub, PubPageData } from 'types';
 
 import BylineEditButton from './BylineEditButton';
@@ -23,7 +22,7 @@ const TitleGroup = (props: Props) => {
 	const isUnsubmitted = submissionState?.submission.status === 'incomplete';
 	const { canManage } = scopeData.activePermissions;
 	const canModify = canManage && !isRelease && !isUnsubmitted;
-	const publishedDate = getPubPublishedDate(pubData);
+	const publishedDateString = getPubPublishedDateString(pubData);
 
 	const renderBylineEditor = () => {
 		if (!canModify) {
@@ -84,13 +83,10 @@ const TitleGroup = (props: Props) => {
 				renderSuffix={() => !isRelease && renderBylineEditor()}
 				renderEmptyState={renderBylineEmptyState}
 			/>
-			{publishedDate && (
+			{publishedDateString && (
 				<div className="published-date">
 					<span className="pub-header-themed-secondary">Published on</span>
-					<span>
-						{formatDate(publishedDate)}
-						{pubData.releases.length === 0 && ' (Not yet released)'}
-					</span>
+					<span>{publishedDateString}</span>
 				</div>
 			)}
 		</div>

--- a/client/containers/Pub/PubHeader/TitleGroup.tsx
+++ b/client/containers/Pub/PubHeader/TitleGroup.tsx
@@ -87,7 +87,10 @@ const TitleGroup = (props: Props) => {
 			{publishedDate && (
 				<div className="published-date">
 					<span className="pub-header-themed-secondary">Published on</span>
-					<span>{formatDate(publishedDate)}</span>
+					<span>
+						{formatDate(publishedDate)}
+						{pubData.releases.length === 0 && ' (Not yet released)'}
+					</span>
 				</div>
 			)}
 		</div>

--- a/client/containers/Pub/PubHeader/details/PubDetails.tsx
+++ b/client/containers/Pub/PubHeader/details/PubDetails.tsx
@@ -27,8 +27,8 @@ const PubDetails = (props: Props) => {
 	const { canView } = scopeData.activePermissions;
 
 	const createdAt = getPubCreatedDate(pubData);
-	const publishedAt = getPubPublishedDate(pubData);
-	const updatedAt = getPubUpdatedDate({ pub: pubData });
+	const publishedDate = getPubPublishedDate(pubData);
+	const updatedDate = getPubUpdatedDate({ pub: pubData });
 
 	return (
 		<div className="pub-details-component">
@@ -56,13 +56,20 @@ const PubDetails = (props: Props) => {
 					)}
 					<h6 className="pub-header-themed-secondary">Published</h6>
 					<div className="full-height-date">
-						{publishedAt ? dateFormat(publishedAt, 'mmm dd, yyyy') : <i>Unpublished</i>}
+						{publishedDate ? (
+							<>
+								{dateFormat(publishedDate, 'mmm dd, yyyy')}
+								{pubData.releases.length === 0 && ' (Not yet released)'}
+							</>
+						) : (
+							<i>Unpublished</i>
+						)}
 					</div>
-					{updatedAt && updatedAt !== publishedAt && (
+					{updatedDate && updatedDate !== publishedDate && (
 						<React.Fragment>
 							<h6 className="pub-header-themed-secondary">Updated</h6>
 							<div className="full-height-date">
-								{dateFormat(updatedAt, 'mmm dd, yyyy')}
+								{dateFormat(updatedDate, 'mmm dd, yyyy')}
 							</div>
 						</React.Fragment>
 					)}

--- a/client/containers/Pub/PubHeader/details/PubDetails.tsx
+++ b/client/containers/Pub/PubHeader/details/PubDetails.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import dateFormat from 'dateformat';
 
 import { collectionUrl } from 'utils/canonicalUrls';
-import { getPubPublishedDate, getPubUpdatedDate, getPubCreatedDate } from 'utils/pub/pubDates';
+import {
+	getPubPublishedDateString,
+	getPubPublishedDate,
+	getPubUpdatedDate,
+	getPubCreatedDate,
+} from 'utils/pub/pubDates';
 import { ClickToCopyButton, ContributorsList } from 'components';
 import { getAllPubContributors } from 'utils/contributors';
 import { usePageContext } from 'utils/hooks';
@@ -27,6 +32,7 @@ const PubDetails = (props: Props) => {
 	const { canView } = scopeData.activePermissions;
 
 	const createdAt = getPubCreatedDate(pubData);
+	const publishedDateString = getPubPublishedDateString(pubData);
 	const publishedDate = getPubPublishedDate(pubData);
 	const updatedDate = getPubUpdatedDate({ pub: pubData });
 
@@ -56,14 +62,7 @@ const PubDetails = (props: Props) => {
 					)}
 					<h6 className="pub-header-themed-secondary">Published</h6>
 					<div className="full-height-date">
-						{publishedDate ? (
-							<>
-								{dateFormat(publishedDate, 'mmm dd, yyyy')}
-								{pubData.releases.length === 0 && ' (Not yet released)'}
-							</>
-						) : (
-							<i>Unpublished</i>
-						)}
+						{publishedDateString || <i>Unpublished</i>}
 					</div>
 					{updatedDate && updatedDate !== publishedDate && (
 						<React.Fragment>

--- a/client/containers/Pub/PubHeader/details/PubDetails.tsx
+++ b/client/containers/Pub/PubHeader/details/PubDetails.tsx
@@ -106,6 +106,7 @@ const PubDetails = (props: Props) => {
 							if (collection) {
 								return (
 									<a
+										key={collection.title}
 										className="collection-list-entry hoverline"
 										href={collectionUrl(communityData, collection)}
 									>

--- a/utils/pub/pubDates.ts
+++ b/utils/pub/pubDates.ts
@@ -1,7 +1,8 @@
 import dateFormat from 'dateformat';
 
+import { formatDate, getLocalDateMatchingUtcCalendarDate, isValidDate } from 'utils/dates';
 import { getPrimaryCollection } from 'utils/collections/primary';
-import { getLocalDateMatchingUtcCalendarDate, isValidDate } from 'utils/dates';
+
 import { DefinitelyHas, Maybe, CollectionPub, Pub } from 'types';
 
 export const getPubLatestReleasedDate = (pub: Pub) => {
@@ -29,6 +30,15 @@ export const getPubPublishedDate = (pub: Pub, includeCustomPublishedAt = true) =
 		return new Date(firstRelease.createdAt);
 	}
 	return null;
+};
+
+export const getPubPublishedDateString = (pub: Pub): string => {
+	const publishedDate = pub.customPublishedAt || pub.releases[0]?.createdAt;
+	let publishedDateString = '';
+	if (publishedDate)
+		publishedDateString = formatDate(getLocalDateMatchingUtcCalendarDate(publishedDate));
+	if (publishedDate && pub.releases.length === 0) publishedDateString += ' (Not yet released)';
+	return publishedDateString;
 };
 
 export const getPubLatestReleaseDate = (pub: Pub, { excludeFirstRelease = false } = {}) => {

--- a/utils/pub/pubDates.ts
+++ b/utils/pub/pubDates.ts
@@ -32,13 +32,12 @@ export const getPubPublishedDate = (pub: Pub, includeCustomPublishedAt = true) =
 	return null;
 };
 
-export const getPubPublishedDateString = (pub: Pub): string => {
-	const publishedDate = pub.customPublishedAt || pub.releases[0]?.createdAt;
+export const getPubPublishedDateString = (pub: Pub): string | null => {
+	const publishedDate = getPubPublishedDate(pub, true);
 	let publishedDateString = '';
-	if (publishedDate)
-		publishedDateString = formatDate(getLocalDateMatchingUtcCalendarDate(publishedDate));
+	if (publishedDate) publishedDateString = formatDate(publishedDate);
 	if (publishedDate && pub.releases.length === 0) publishedDateString += ' (Not yet released)';
-	return publishedDateString;
+	return publishedDateString || null;
 };
 
 export const getPubLatestReleaseDate = (pub: Pub, { excludeFirstRelease = false } = {}) => {


### PR DESCRIPTION
addresses #1882

I'm not 100% clear on the distinction we draw between `published` and `released`.
For example, in the label for a pub's `OverviewRow`, we show either 'Unreleased' or else 'Published: [date]'. which suggests they are comparable, but in the `getPubPublishedDate` function the distinction is explicitly one of the parameters. It is important to represent the distinction to the user, particularly when they have specified a custom published date for their pub but haven't yet released it. See images below for my crack at representing the distinction.

_Test plan_
Confirm the visual representation of the four combinations of un/released + with/out custom date:
+ unreleased
+ released
+ unreleased w/ custom date
+ released w/ custom date

(see images below for what it ought to look like)

I have prepped four pubs in the collection `published/released/custom` to represent the four pub states

### overview rows
![Screenshot from 2022-05-04 10-28-40](https://user-images.githubusercontent.com/14115194/166703254-3a8cc1c9-294d-4a53-b40c-05c9ea5ccbb0.png)

### pubs block
![Screenshot from 2022-05-04 10-31-46](https://user-images.githubusercontent.com/14115194/166703949-c52344f0-f4de-476d-8ed0-6a58a718d23b.png)

### pub details (expanded)
![Screenshot from 2022-05-04 10-36-26](https://user-images.githubusercontent.com/14115194/166705065-0ea19934-fd92-4993-8bcd-e1169e25b4e5.png)
![Screenshot from 2022-05-04 10-36-16](https://user-images.githubusercontent.com/14115194/166705069-2d530876-9df7-4200-a11f-ea1d1c65cc1e.png)
![Screenshot from 2022-05-04 10-36-09](https://user-images.githubusercontent.com/14115194/166705073-f521f884-34c3-46e4-b245-05663ae6be87.png)
![Screenshot from 2022-05-04 10-36-01](https://user-images.githubusercontent.com/14115194/166705074-7b29103e-6bd6-4627-96af-adca016646e0.png)


### pub header title content
![Screenshot from 2022-05-03 14-32-01](https://user-images.githubusercontent.com/14115194/166521566-9878cf52-7b11-457c-bf38-a913b4d492dc.png)
![Screenshot from 2022-05-03 14-31-53](https://user-images.githubusercontent.com/14115194/166521567-7a41e7d2-1449-4c77-aa6d-11a9cff888e4.png)
![Screenshot from 2022-05-03 14-31-47](https://user-images.githubusercontent.com/14115194/166521568-5b9c7655-faa3-4bbc-867f-7e937735b205.png)
