### PR TITLE
fix: don't clear attrs of target node when splitting block

### DIFF
--- a/client/components/Editor/commands/textAlign.ts
+++ b/client/components/Editor/commands/textAlign.ts
@@ -101,9 +101,13 @@ export const splitBlockPreservingTextAlign = (state: EditorState, dispatch?: Dis
 	return splitBlock(state, (tr) => {
 		if (dispatch) {
 			const targetNodePosition = tr.selection.$from.before();
+			const targetNode = tr.doc.nodeAt(targetNodePosition);
 			const sourceNode = previousSelectionFrom.node();
 			const { [alignAttr]: textAlign } = sourceNode.attrs;
-			tr.setNodeMarkup(targetNodePosition, undefined, { [alignAttr]: textAlign });
+			tr.setNodeMarkup(targetNodePosition, undefined, {
+				...targetNode?.attrs,
+				[alignAttr]: textAlign,
+			});
 			dispatch(tr);
 		}
 	});


### PR DESCRIPTION
Resolves #1978 

Simple fix for a tricky bug!

*Test Plan*
- Create a non-`h1` heading
- Move your cursor to the beginning of the heading node/line
- Hit 'Enter'
- The heading should not be converted into an `h1`