### PR TITLE
View Level Permissions

### DIFF
--- a/server/utils/queryHelpers/communitySanitize.ts
+++ b/server/utils/queryHelpers/communitySanitize.ts
@@ -7,7 +7,7 @@ export default (communityData, locationData, loginData, scopeData) => {
 		.filter((item) => {
 			/* Collection access is granted when */
 			/* 1. it is public collection, or */
-			/* 2. the user can view a community or */
+			/* 2. the user has view permission in a community or */
 			/* 3. the user has explicit permissions on the collection */
 			const hasCollectionMemberAccess = item.members.find((member) => {
 				return member.userId === loginData.id;

--- a/server/utils/queryHelpers/communitySanitize.ts
+++ b/server/utils/queryHelpers/communitySanitize.ts
@@ -7,7 +7,7 @@ export default (communityData, locationData, loginData, scopeData) => {
 		.filter((item) => {
 			/* Collection access is granted when */
 			/* 1. it is public collection, or */
-			/* 2. the user is a community manager, or */
+			/* 2. the user can view a community or */
 			/* 3. the user has explicit permissions on the collection */
 			const hasCollectionMemberAccess = item.members.find((member) => {
 				return member.userId === loginData.id;

--- a/server/utils/queryHelpers/communitySanitize.ts
+++ b/server/utils/queryHelpers/communitySanitize.ts
@@ -1,6 +1,6 @@
 export default (communityData, locationData, loginData, scopeData) => {
 	const cleanedData = { ...communityData };
-	const { canManageCommunity } = scopeData.activePermissions;
+	const { canManageCommunity, canViewCommunity } = scopeData.activePermissions;
 	const availablePages = {};
 
 	cleanedData.collections = cleanedData.collections
@@ -12,7 +12,7 @@ export default (communityData, locationData, loginData, scopeData) => {
 			const hasCollectionMemberAccess = item.members.find((member) => {
 				return member.userId === loginData.id;
 			});
-			return canManageCommunity || item.isPublic || hasCollectionMemberAccess;
+			return canViewCommunity || item.isPublic || hasCollectionMemberAccess;
 		})
 		.map((collection) => {
 			if (!collection.pageId) {

--- a/server/utils/queryHelpers/scopeGet.ts
+++ b/server/utils/queryHelpers/scopeGet.ts
@@ -331,14 +331,11 @@ getActivePermissions = async (
 	const canEditCommunity =
 		isSuperAdmin ||
 		canAdminCommunity ||
-		canManageCommunity ||
 		scopeMemberData.find((member) => member.communityId && member.permissions === 'edit');
 
 	const canViewCommunity =
 		isSuperAdmin ||
 		canAdminCommunity ||
-		canManageCommunity ||
-		canEditCommunity ||
 		scopeMemberData.find((member) => member.communityId && member.permissions === 'view');
 
 	const booleanOr = (precedent, value) => {

--- a/server/utils/queryHelpers/scopeGet.ts
+++ b/server/utils/queryHelpers/scopeGet.ts
@@ -397,6 +397,7 @@ getActivePermissions = async (
 		canAdminCommunity,
 		canManageCommunity,
 		canViewCommunity,
+		canEditCommunity,
 		...activePublicPermissions,
 		canCreateReviews,
 	};

--- a/server/utils/queryHelpers/scopeGet.ts
+++ b/server/utils/queryHelpers/scopeGet.ts
@@ -328,10 +328,17 @@ getActivePermissions = async (
 		canAdminCommunity ||
 		scopeMemberData.find((member) => member.communityId && member.permissions === 'manage');
 
+	const canEditCommunity =
+		isSuperAdmin ||
+		canAdminCommunity ||
+		canManageCommunity ||
+		scopeMemberData.find((member) => member.communityId && member.permissions === 'edit');
+
 	const canViewCommunity =
 		isSuperAdmin ||
 		canAdminCommunity ||
 		canManageCommunity ||
+		canEditCommunity ||
 		scopeMemberData.find((member) => member.communityId && member.permissions === 'view');
 
 	const booleanOr = (precedent, value) => {

--- a/server/utils/queryHelpers/scopeGet.ts
+++ b/server/utils/queryHelpers/scopeGet.ts
@@ -328,6 +328,12 @@ getActivePermissions = async (
 		canAdminCommunity ||
 		scopeMemberData.find((member) => member.communityId && member.permissions === 'manage');
 
+	const canViewCommunity =
+		isSuperAdmin ||
+		canAdminCommunity ||
+		canManageCommunity ||
+		scopeMemberData.find((member) => member.communityId && member.permissions === 'view');
+
 	const booleanOr = (precedent, value) => {
 		/* Don't inherit value from null */
 		return typeof value === 'boolean' ? value : precedent;
@@ -383,6 +389,7 @@ getActivePermissions = async (
 		canAdmin: permissionLevelIndex > 2,
 		canAdminCommunity,
 		canManageCommunity,
+		canViewCommunity,
 		...activePublicPermissions,
 		canCreateReviews,
 	};


### PR DESCRIPTION
addresses issue #1998 

Community scoped members with view permissions can view private collections that are descendants of the community scope

<img width="820" alt="image" src="https://user-images.githubusercontent.com/34730449/167689117-8c469085-f84d-449d-ac8a-176ced014065.png">


<img width="820" alt="image" src="https://user-images.githubusercontent.com/34730449/167688711-b4a8b75c-3f25-41fa-8bec-10cdcae7b774.png">




test:
login as a user with view permissions
from the community dashboard be sure you can see collections that are private
navigate to a collection with a collection layout that has private collections: [here](http://localhost:9876/erics-submission-collection)
hopefully, you can see those