### PR TITLE
enhancement: Az byline for Arcadia

### DIFF
--- a/client/components/Byline/Byline.tsx
+++ b/client/components/Byline/Byline.tsx
@@ -4,11 +4,13 @@ import ensureUserForAttribution from 'utils/ensureUserForAttribution';
 import { joinOxford, naivePluralize } from 'utils/strings';
 import { AttributableUser, User } from 'types';
 
+require('./byline.scss');
+
 const isFullUser = (u: AttributableUser): u is User => 'slug' in u;
 
 export type BylineProps = {
 	ampersand?: boolean;
-	bylinePrefix?: null | string;
+	bylinePrefix?: React.ReactNode;
 	contributors: (string | {})[] | string;
 	linkToUsers?: boolean;
 	renderEmptyState?: () => React.ReactNode;

--- a/client/components/Byline/byline.scss
+++ b/client/components/Byline/byline.scss
@@ -1,0 +1,6 @@
+.byline {
+	.byline-icon {
+		position: relative;
+		bottom: 1px;
+	}
+}

--- a/client/components/Layout/LayoutCollectionHeader.tsx
+++ b/client/components/Layout/LayoutCollectionHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from 'reakit/Button';
 
-import { Byline, GridWrapper, ContributorAvatars, Icon, ClickToCopyButton } from 'components';
+import { GridWrapper, ContributorAvatars, Icon, ClickToCopyButton } from 'components';
 import { Collection } from 'types';
 import { LayoutBlockCollectionHeader } from 'utils/layout/types';
 import { getAllCollectionContributors } from 'utils/contributors';
@@ -13,6 +13,7 @@ import {
 	getOrderedCollectionMetadataFields,
 	formattedMetadata,
 } from 'utils/collections/getMetadata';
+import WithinCommunityByline from '../WithinCommunityByline/WithinCommunityByline';
 
 require('./layoutCollectionHeader.scss');
 
@@ -99,7 +100,7 @@ const LayoutCollectionHeader = (props: Props) => {
 			<GridWrapper columnClassName="inner">
 				<h1>{collection.title}</h1>
 				{bylineContributors && !hideByline && (
-					<Byline
+					<WithinCommunityByline
 						contributors={bylineContributors}
 						renderSuffix={() => {
 							return (

--- a/client/components/PubByline/PubByline.tsx
+++ b/client/components/PubByline/PubByline.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import Byline, { BylineProps } from 'components/Byline/Byline';
+import { BylineProps } from 'components/Byline/Byline';
 import { getAllPubContributors } from 'utils/contributors';
 import { Pub } from 'types';
+import WithinCommunityByline from '../WithinCommunityByline/WithinCommunityByline';
 
 type OwnProps = {
 	pubData: Pub;
@@ -22,7 +23,7 @@ type Props = OwnPubBylineProps & typeof defaultProps;
 const PubByline = (props: Props) => {
 	const { pubData, hideAuthors = false, hideContributors = false } = props;
 	const authors = getAllPubContributors(pubData, 'contributors', hideAuthors, hideContributors);
-	return <Byline {...props} contributors={authors} />;
+	return <WithinCommunityByline {...props} contributors={authors} />;
 };
 PubByline.defaultProps = defaultProps;
 export default PubByline;

--- a/client/components/PubEdge/PubEdge.tsx
+++ b/client/components/PubEdge/PubEdge.tsx
@@ -5,8 +5,10 @@ import { Byline } from 'components';
 import { usePageContext } from 'utils/hooks';
 import { getHostnameForUrl, getValuesFromPubEdge } from 'utils/pubEdge';
 
+import { AttributionWithUser } from 'types';
 import PubEdgeLayout from './PubEdgeLayout';
 import PubEdgeDescriptionButton from './PubEdgeDescriptionButton';
+import WithinCommunityByline from '../WithinCommunityByline/WithinCommunityByline';
 
 require('./pubEdge.scss');
 
@@ -32,7 +34,7 @@ const PubEdge = (props: PubEdgeProps) => {
 		communityData,
 		viewingFromTarget,
 	);
-
+	const { externalPublication } = pubEdge;
 	const detailsElementId = `edge-details-${pubEdge.id}`;
 	const detailsElement = description && (
 		<details open={open} id={detailsElementId}>
@@ -93,7 +95,14 @@ const PubEdge = (props: PubEdgeProps) => {
 			})}
 			titleElement={maybeLink(title)}
 			bylineElement={
-				contributors && contributors.length > 0 && <Byline contributors={contributors} />
+				contributors &&
+				contributors.length > 0 &&
+				(externalPublication ? (
+					<Byline contributors={contributors} />
+				) : (
+					// I know there's a better way to do this with a typeguard.
+					<WithinCommunityByline contributors={contributors as AttributionWithUser[]} />
+				))
 			}
 			metadataElements={[
 				description && (

--- a/client/components/PubPreview/ManyAuthorsByline.tsx
+++ b/client/components/PubPreview/ManyAuthorsByline.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import Byline, { BylineProps } from 'components/Byline/Byline';
-import { naivePluralize } from 'utils/strings';
+import { BylineProps } from 'components/Byline/Byline';
 import { getAllPubContributors } from 'utils/contributors';
 import { Pub } from 'types';
+import WithinCommunityByline from '../WithinCommunityByline/WithinCommunityByline';
 
 require('./manyAuthorsByline.scss');
 
@@ -25,20 +25,12 @@ const ManyAuthorsByline = (props: Props) => {
 	if (isExpanded && isTruncating) {
 		return (
 			<>
-				<Byline
-					contributors={authors}
-					bylinePrefix={`by ${authors.length} ${naivePluralize(
-						'author',
-						authors.length,
-					)}: `}
-					renderUserLabel={(user, index) => `(${index + 1}) ${user.fullName}`}
-					linkToUsers={false}
-				/>
+				<WithinCommunityByline contributors={authors} linkToUsers={false} />
 			</>
 		);
 	}
 	return (
-		<Byline
+		<WithinCommunityByline
 			contributors={authors}
 			renderTruncation={(n) => `${n} more`}
 			truncateAt={truncateAt}

--- a/client/components/PubPreview/PubPreview.tsx
+++ b/client/components/PubPreview/PubPreview.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
 import classNames from 'classnames';
-import dateFormat from 'dateformat';
 
 import { Pub, Community } from 'types';
 import { getResizedUrl } from 'utils/images';

--- a/client/components/PubPreview/PubPreviewEdges.tsx
+++ b/client/components/PubPreview/PubPreviewEdges.tsx
@@ -28,9 +28,7 @@ const getChildEdges = (pubData: Pub) => {
 			}
 			return false;
 		}),
-		...outboundEdges.filter(
-			(edge) => edge.pubIsParent && (edge.targetPub || edge.externalPublication),
-		),
+		...outboundEdges.filter((edge) => edge.pubIsParent),
 	];
 };
 
@@ -44,7 +42,7 @@ const getEdgesByRelationType = (edges: PubEdge[]): Record<string, PubEdge[]> => 
 	return res;
 };
 
-const renderEdgeLink = (edge: PubEdge, renderTitle: Boolean = false) => {
+const renderEdgeLink = (edge: PubEdge, renderTitle = false) => {
 	const { pubIsParent, targetPub, pub, externalPublication } = edge;
 	if (externalPublication) {
 		const { contributors = [], title, url } = externalPublication;

--- a/client/components/PubPreview/PubPreviewEdges.tsx
+++ b/client/components/PubPreview/PubPreviewEdges.tsx
@@ -28,7 +28,9 @@ const getChildEdges = (pubData: Pub) => {
 			}
 			return false;
 		}),
-		...outboundEdges.filter((edge) => edge.pubIsParent && edge.targetPub),
+		...outboundEdges.filter(
+			(edge) => edge.pubIsParent && (edge.targetPub || edge.externalPublication),
+		),
 	];
 };
 

--- a/client/components/WithinCommunityByline/WithinCommunityByline.tsx
+++ b/client/components/WithinCommunityByline/WithinCommunityByline.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import Byline, { BylineProps } from 'components/Byline/Byline';
+import { AttributionWithUser } from 'types';
+import { usePageContext } from 'utils/hooks';
+import { Tooltip, Icon } from '@blueprintjs/core';
+
+// I bet there's a better way to do this?
+type OwnProps = Omit<BylineProps, 'contributors'> & {
+	contributors: AttributionWithUser[];
+};
+
+const WithinCommunityByline = (props: OwnProps) => {
+	const { communityData } = usePageContext();
+	const { contributors } = props;
+	let { bylinePrefix } = props;
+	// TODO: Add function to get the sort option from community settings, and add other sort options
+	if (communityData.id === '1a71ef4d-f6fe-40d3-8379-42fa2141db58') {
+		contributors.sort((last, next) => {
+			if (last.user.lastName > next.user.lastName) {
+				return -1;
+			}
+			return 1;
+		});
+		bylinePrefix = (
+			<Tooltip
+				content="Contributors (A-Z)"
+				children={<Icon iconSize={14} icon="sort-alphabetical" className="byline-icon" />}
+			/>
+		);
+	}
+	return <Byline {...props} bylinePrefix={bylinePrefix} contributors={contributors} />;
+};
+export default WithinCommunityByline;

--- a/client/components/WithinCommunityByline/WithinCommunityByline.tsx
+++ b/client/components/WithinCommunityByline/WithinCommunityByline.tsx
@@ -5,7 +5,7 @@ import { AttributionWithUser } from 'types';
 import { usePageContext } from 'utils/hooks';
 import { Tooltip, Icon } from '@blueprintjs/core';
 
-// I bet there's a better way to do this?
+// Review Note; I bet there's a better way to do this?
 type OwnProps = Omit<BylineProps, 'contributors'> & {
 	contributors: AttributionWithUser[];
 };
@@ -25,7 +25,7 @@ const WithinCommunityByline = (props: OwnProps) => {
 		bylinePrefix = (
 			<Tooltip
 				content="Contributors (A-Z)"
-				children={<Icon iconSize={14} icon="sort-alphabetical" className="byline-icon" />}
+				children={<Icon iconSize={12} icon="sort-alphabetical" className="byline-icon" />}
 			/>
 		);
 	}

--- a/client/components/WithinCommunityByline/WithinCommunityByline.tsx
+++ b/client/components/WithinCommunityByline/WithinCommunityByline.tsx
@@ -10,25 +10,38 @@ type Props = Omit<BylineProps, 'contributors'> & {
 	contributors: AttributionWithUser[];
 };
 
+const sortContributorsByLastName = (contributors) => {
+	return contributors.sort((last, next) => {
+		if (last.user.lastName === next.user.lastName) {
+			return last.user.firstName - next.user.firstName;
+		}
+		if (last.user.lastName > next.user.lastName) {
+			return 1;
+		}
+		return -1;
+	});
+};
+
 const WithinCommunityByline = (props: Props) => {
 	const { communityData } = usePageContext();
 	const { contributors } = props;
 	let { bylinePrefix } = props;
 	// TODO: Add function to get the sort option from community settings, and add other sort options
-	if (communityData.id === '1a71ef4d-f6fe-40d3-8379-42fa2141db58') {
-		contributors.sort((last, next) => {
-			if (last.user.lastName > next.user.lastName) {
-				return -1;
-			}
-			return 1;
-		});
-		bylinePrefix = (
-			<Tooltip
-				content="Contributors (A-Z)"
-				children={<Icon iconSize={12} icon="sort-alphabetical" className="byline-icon" />}
-			/>
-		);
-	}
-	return <Byline {...props} bylinePrefix={bylinePrefix} contributors={contributors} />;
+	const sortedContributors =
+		communityData.id === '1a71ef4d-f6fe-40d3-8379-42fa2141db58'
+			? sortContributorsByLastName(contributors)
+			: contributors;
+	bylinePrefix =
+		communityData.id === '1a71ef4d-f6fe-40d3-8379-42fa2141db58'
+			? (bylinePrefix = (
+					<Tooltip
+						content="Contributors (A-Z)"
+						children={
+							<Icon iconSize={12} icon="sort-alphabetical" className="byline-icon" />
+						}
+					/>
+			  ))
+			: bylinePrefix;
+	return <Byline {...props} bylinePrefix={bylinePrefix} contributors={sortedContributors} />;
 };
 export default WithinCommunityByline;

--- a/client/components/WithinCommunityByline/WithinCommunityByline.tsx
+++ b/client/components/WithinCommunityByline/WithinCommunityByline.tsx
@@ -6,11 +6,11 @@ import { usePageContext } from 'utils/hooks';
 import { Tooltip, Icon } from '@blueprintjs/core';
 
 // Review Note; I bet there's a better way to do this?
-type OwnProps = Omit<BylineProps, 'contributors'> & {
+type Props = Omit<BylineProps, 'contributors'> & {
 	contributors: AttributionWithUser[];
 };
 
-const WithinCommunityByline = (props: OwnProps) => {
+const WithinCommunityByline = (props: Props) => {
 	const { communityData } = usePageContext();
 	const { contributors } = props;
 	let { bylinePrefix } = props;

--- a/client/containers/DashboardOverview/overviewRows/overviewRowSkeleton.scss
+++ b/client/containers/DashboardOverview/overviewRows/overviewRowSkeleton.scss
@@ -67,11 +67,9 @@ $mobile-viewport-cutoff: 750px;
 		}
 		.byline {
 			font-style: italic;
-			.byline-icon {
-				svg {
-					width: 11px;
-					height: auto;
-				}
+			.byline-icon svg {
+				width: 11px;
+				height: auto;
 			}
 		}
 		.byline,

--- a/client/containers/DashboardOverview/overviewRows/overviewRowSkeleton.scss
+++ b/client/containers/DashboardOverview/overviewRows/overviewRowSkeleton.scss
@@ -67,6 +67,12 @@ $mobile-viewport-cutoff: 750px;
 		}
 		.byline {
 			font-style: italic;
+			.byline-icon {
+				svg {
+					width: 11px;
+					height: auto;
+				}
+			}
 		}
 		.byline,
 		.summary-icons {

--- a/client/containers/Pub/PubHeader/pubHeader.scss
+++ b/client/containers/Pub/PubHeader/pubHeader.scss
@@ -109,6 +109,10 @@ $mobile-bottom-buttons-spacing: 10px;
 		font-weight: normal;
 		font-family: $header-font;
 		letter-spacing: 0.5px;
+		.byline-icon svg {
+			width: 14px;
+			height: auto;
+		}
 	}
 
 	@include mobile {


### PR DESCRIPTION
New and improved refactoring!

When Arcadia's community is loaded: 

1. Overrides the byline with an alphabetically sorted list and an `Az` icon with a tooltip. Not implemented in exports (lower priority since it doesn't have the word by, and needs a more major refactor), search (we send algolia a string containing the word 'by'. Will need more of a refactor), or `PubMenuItems` (really tough to enforce type, will take suggestions if you have them).
2. Per request, uses the title of connections instead of authors to display all connections (since they care less about authorship).
3. Fixes #1999 (a bug I'm pretty sure, because there's code for it that was never being accessed) that made it so external child connections were never displayed in pub blocks, also requested by Arcadia.

One todo I'd like your help with: proper type guarding in https://github.com/pubpub/pubpub/pull/2010/files#diff-5bcb9ab7ea16fa0f1d43c3da38cb07845081ba970557f079c5e0f223ddcc9939R103

<img width="623" alt="Screen Shot 2022-05-11 at 11 38 02" src="https://user-images.githubusercontent.com/639110/167890396-f2bcb47e-190c-4904-9433-39a260919b6d.png">

_To test_
- Load the `arcadia-research` community locally
- Verify that the new tooltip appears in: pub header, pub previews, overview dashboards, internal pub connections
- Verify that it does not appear in external pub connections
- Load a different community, make sure by still appears.