### PR TITLE
Bump pandoc and support JATS footnotes and Word citations from Mendeley, Endnote, Zotero

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,12 +1,16 @@
 # Pandoc is central to the Pub import and export features
-https://github.com/jgm/pandoc/releases/download/2.14.2/pandoc-2.14.2-1-amd64.deb
+
+https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-1-amd64.deb
 
 # xsltproc is ued to extract bibliographies from XML (JATS) files on import
+
 xsltproc
 
 # poppler-utils contains pdftoppm, which we use to import PDF graphics as web-friendy images
+
 :repo:deb http://cz.archive.ubuntu.com/ubuntu bionic main universe
 poppler-utils
 
 # imagemagick is used to convert other images to web-friendly formats
+
 imagemagick

--- a/client/components/PubPreview/PubPreview.tsx
+++ b/client/components/PubPreview/PubPreview.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
 import classNames from 'classnames';
-import dateFormat from 'dateformat';
 
 import { Pub, Community } from 'types';
 import { getResizedUrl } from 'utils/images';

--- a/utils/import/formats.js
+++ b/utils/import/formats.js
@@ -1,5 +1,5 @@
 export const extensionToPandocFormat = {
-	docx: 'docx',
+	docx: 'docx+citations',
 	epub: 'epub',
 	html: 'html',
 	md: 'markdown',

--- a/workers/tasks/import/bibliography.ts
+++ b/workers/tasks/import/bibliography.ts
@@ -23,8 +23,12 @@ export const extractRefBlocks = (pandocAst) => {
 	return { pandocAst, refBlocks: null };
 };
 
-const extractCitationsUsingPandoc = (bibliographyTmpPath) => {
-	const proc = spawnSync('pandoc', [bibliographyTmpPath, '-t', 'csljson']);
+const extractCitationsUsingPandoc = (bibliographyTmpPath, docx = false) => {
+	const pandocOptions = [bibliographyTmpPath, '-t', 'csljson'];
+	if (docx) {
+		pandocOptions.push('-f', 'docx+citations');
+	}
+	const proc = spawnSync('pandoc', pandocOptions);
 	const output = proc.stdout.toString();
 	const cslJson = JSON.parse(output);
 	// @ts-expect-error ts-migrate(2339) FIXME: Property 'fromEntries' does not exist on type 'Obj... Remove this comment to see the full error message
@@ -49,6 +53,9 @@ export const extractBibliographyItems = async ({ bibliography, document, extract
 	if (document && extensionFor(document.tmpPath) === 'xml' && extractBibFromJats) {
 		const generatedBibPath = await getBibPathFromXslTransform(document.tmpPath);
 		return extractCitationsUsingPandoc(generatedBibPath);
+	}
+	if (document && extensionFor(document.tmpPath) === 'docx') {
+		return extractCitationsUsingPandoc(document.tmpPath, true);
 	}
 	return {};
 };

--- a/workers/tasks/import/images.ts
+++ b/workers/tasks/import/images.ts
@@ -22,8 +22,8 @@ export const convertFileTypeIfNecessary = async (tmpFilePath) => {
 		return pngPath;
 	}
 	if (extension === 'tiff' || extension === 'tif') {
-		const { path: pngPath } = await tmp.file({ postfix: '.png' });
-		await spawn('convert', [tmpFilePath, pngPath, '-quiet']);
+		const pngPath = await tmp.tmpName({ postfix: '.png' });
+		await spawn('convert', ['-quiet', tmpFilePath, pngPath]);
 		return pngPath;
 	}
 	return tmpFilePath;

--- a/workers/tasks/import/images.ts
+++ b/workers/tasks/import/images.ts
@@ -23,7 +23,7 @@ export const convertFileTypeIfNecessary = async (tmpFilePath) => {
 	}
 	if (extension === 'tiff' || extension === 'tif') {
 		const { path: pngPath } = await tmp.file({ postfix: '.png' });
-		await spawn('convert', [tmpFilePath, pngPath]);
+		await spawn('convert', [tmpFilePath, pngPath, '-quiet']);
 		return pngPath;
 	}
 	return tmpFilePath;

--- a/workers/tasks/import/import.ts
+++ b/workers/tasks/import/import.ts
@@ -20,7 +20,7 @@ setPandocApiVersion([1, 22]);
 const dataRoot = process.env.NODE_ENV === 'production' ? '/app/.apt/usr/share/pandoc/data ' : '';
 
 const createPandocArgs = (pandocFormat, tmpDirPath, metadataPath) => {
-	const shouldExtractMedia = ['odt', 'docx', 'epub'].includes(pandocFormat);
+	const shouldExtractMedia = ['odt', 'docx+citations', 'epub'].includes(pandocFormat);
 	return [
 		dataRoot && [`--data-dir=${dataRoot}`],
 		['-f', pandocFormat],
@@ -28,6 +28,7 @@ const createPandocArgs = (pandocFormat, tmpDirPath, metadataPath) => {
 		metadataPath && [`--metadata-file=${metadataPath}`],
 		shouldExtractMedia && [`--extract-media=${path.join(tmpDirPath, 'media')}`],
 		pandocFormat === 'latex' && ['--verbose'],
+		pandocFormat === 'docx+citations' && ['--citeproc', '-M', 'suppress-bibliography:true'],
 	]
 		.filter((x): x is string[] => !!x)
 		.reduce((acc, next) => [...acc, ...next], []);


### PR DESCRIPTION
Bumps pandoc to 2.18 and fixes a tif-to-png conversion bug.

This gets us:
-  Importing Word citations from Mendeley, Endnote, and Zotero (uses the code we built for processing jats-extracted references to do the same for Word docs). There's probably a universe where we handle that in pandoc-prosemirror instead, but doesn't seem worth it for now.
- Importing JATS footnotes!!!
- Importing LaTeX footnotes!!
- Some other cool stuff I'm sure...

_Test plan_
I tested import and export of complex docs heavily, using [this collection](http://localhost:9876/pandoc-importexport-tests), but you should also take it for a spin. The easiest way to do this is locally, making sure you have pandoc 2.18 installed via brew.

We should also do some group smoke testing on dev before release, particularly of the png-to-tif conversion stuff.