### PR TITLE
fix: include authors with non-editor/illustrator/translator/chair roles in citation

### DIFF
--- a/utils/contributors.ts
+++ b/utils/contributors.ts
@@ -16,6 +16,8 @@ const orderedContributors = (maybeContributors: Attribution[] | undefined | null
 
 const editorRoles = ['Editor', 'Writing – Review & Editing'];
 const illustratorRoles = ['Illustrator', 'Visualization'];
+const otherKnownRoles = ['Translator', 'Series Editor', 'Chair'];
+
 const getPrimaryRole = (contributor: AttributionWithUser) =>
 	contributor.roles ? contributor.roles[0] : '';
 
@@ -66,8 +68,9 @@ export const getAllPubContributors = (
 		const contributorsWithRoles = contributors.filter((contributor) => {
 			return (
 				!contributor.roles ||
-				(!editorRoles.includes(getPrimaryRole(contributor)) &&
-					!illustratorRoles.includes(getPrimaryRole(contributor)))
+				!editorRoles
+					.concat(illustratorRoles, otherKnownRoles)
+					.includes(getPrimaryRole(contributor))
 			);
 		});
 		return resolveContributors(contributorsWithRoles, hideAuthors, hideNonAuthors);

--- a/utils/contributors.ts
+++ b/utils/contributors.ts
@@ -64,7 +64,11 @@ export const getAllPubContributors = (
 
 	if (role === 'author') {
 		const contributorsWithRoles = contributors.filter((contributor) => {
-			return !contributor.roles;
+			return (
+				!contributor.roles ||
+				(!editorRoles.includes(getPrimaryRole(contributor)) &&
+					!illustratorRoles.includes(getPrimaryRole(contributor)))
+			);
 		});
 		return resolveContributors(contributorsWithRoles, hideAuthors, hideNonAuthors);
 	}


### PR DESCRIPTION
Our citation improvements introduced a bug where a byline contributor with a role that was not one of our known ones would not show up as an author in the pub citation. This fixes that by checking the contributor against known roles and, if they don't have one as their primary role, adds them as an author.

It also makes a slight change to behavior with collection-level non-byline editors and chairs by always adding them to citations. This was a regression from prior behavior, but is what we want, as it allows people to credit editors on collections without forcing them to be in the byline.

_To test_
1. Create a pub with two byline authors, one with a custom role; one pub-level editor with byline; one illustrator with byline; one collection-level editor with byline; one collection-level editor without byline.
2. Verify:
Byline includes: two byline authors, pub-level editor with byline, illustrator with byline, collection-level editor with byline
Citation includes:
- Authors: two byline authors only
- Editors (some styles): pub-level editor, collection-level editor with byline, collection-level editor without byline
- Illustrators (some styles): illustrator with byline

e.g.: http://localhost:9876/pub/zo3qc6kw/draft