### PR TITLE
fix: export detached references

### DIFF
--- a/workers/tasks/import/rules.ts
+++ b/workers/tasks/import/rules.ts
@@ -381,7 +381,7 @@ rules.fromProsemirrorNode('reference', (node) => {
 	return {
 		type: 'Link',
 		attr: createAttr(),
-		content: textToStrSpace(node.attrs.label),
+		content: textToStrSpace(node.attrs.label ?? ''),
 		target: {
 			url: `#${node.attrs.targetId}`,
 			title: '',


### PR DESCRIPTION
This PR fixes an issue where detached references (references whose referenced nodes have been deleted, appearing as `(ref?)`) cause exports to fail.

_Test Plan_
1. Create a Pub.
2. Enable node labels (hover the `@` in the editor toolbar for instructions).
3. Create a referenceable node, like an image/table/equation.
4. Create a reference to the node (you can use the `@` keyboard shortcut in the Pub body)
5. Delete the referenced node. The reference should now show appear as `(ref?)`.
6. Export the document. It shouldn't break!