### PR TITLE
chore: bump prosemirror-pandoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@google-cloud/storage": "^5.8.1",
 		"@monaco-editor/react": "^4.1.1",
 		"@popperjs/core": "^2.11.5",
-		"@pubpub/prosemirror-pandoc": "^1.1.1",
+		"@pubpub/prosemirror-pandoc": "^1.1.2",
 		"@pubpub/prosemirror-reactive": "^0.2.0",
 		"@sentry/browser": "^5.5.0",
 		"@sentry/node": "^5.5.0",


### PR DESCRIPTION
Fixes an small issue with a specific Pub not being exportable due to empty `<tr>` elements.