### PR TITLE
Update citation.js, fix Harvard, add Arcadia csl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3691,20 +3691,36 @@
 			}
 		},
 		"@citation-js/core": {
-			"version": "0.5.0-alpha.5",
-			"resolved": "https://registry.npmjs.org/@citation-js/core/-/core-0.5.0-alpha.5.tgz",
-			"integrity": "sha512-2yG1G02sz9lnsJ25mx8aAn5FPFQR2l46kYMzibQajJaV6+P0swqf6xzUBPxQ4i06+FW9wS7jsekOYbvcAthAdA==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@citation-js/core/-/core-0.5.7.tgz",
+			"integrity": "sha512-ywKqOCQfLbm59VjiQCnM7vtx9wlLjDdxU2G27V9gQASKWCAVRIgTLrT8T2PFJMmur6plMZkrsaXR5Ajfpasfug==",
 			"requires": {
-				"@citation-js/date": "^0.4.4",
+				"@citation-js/date": "^0.5.0",
 				"@citation-js/name": "^0.4.2",
-				"isomorphic-fetch": "^2.2.1",
-				"sync-fetch": "^0.1.0"
+				"isomorphic-fetch": "^3.0.0",
+				"sync-fetch": "^0.3.0"
+			},
+			"dependencies": {
+				"isomorphic-fetch": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+					"integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+					"requires": {
+						"node-fetch": "^2.6.1",
+						"whatwg-fetch": "^3.4.1"
+					}
+				},
+				"whatwg-fetch": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+					"integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+				}
 			}
 		},
 		"@citation-js/date": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/@citation-js/date/-/date-0.4.4.tgz",
-			"integrity": "sha512-wD195pZPwCCN8idhxz4HYZbf5mMnPZMRhOipcU8v1orZWqZp6YDRjOplNKo6yX7tf6fB4ZO8QLuNaNjuic5AWQ=="
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/@citation-js/date/-/date-0.5.1.tgz",
+			"integrity": "sha512-1iDKAZ4ie48PVhovsOXQ+C6o55dWJloXqtznnnKy6CltJBQLIuLLuUqa8zlIvma0ZigjVjgDUhnVaNU1MErtZw=="
 		},
 		"@citation-js/name": {
 			"version": "0.4.2",
@@ -3712,52 +3728,56 @@
 			"integrity": "sha512-brSPsjs2fOVzSnARLKu0qncn6suWjHVQtrqSUrnqyaRH95r/Ad4wPF5EsoWr+Dx8HzkCGb/ogmoAzfCsqlTwTQ=="
 		},
 		"@citation-js/plugin-bibjson": {
-			"version": "0.5.0-alpha.5",
-			"resolved": "https://registry.npmjs.org/@citation-js/plugin-bibjson/-/plugin-bibjson-0.5.0-alpha.5.tgz",
-			"integrity": "sha512-yPZ5YukiCj38xzhkcJzou8MLsSiRRlqflHyVme/zOxZlqh9twO8XcZRJlzyppMzbyZThxxnMzbFix8uxpRb/Gg==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@citation-js/plugin-bibjson/-/plugin-bibjson-0.5.7.tgz",
+			"integrity": "sha512-aRPMZ5hLsb9rLH5JxWP374Q+KKAiPF5ejgY3e8ftyNvvhCCNXwBIvrJk8hdACpIF3x7SKWgZVkz/4i5vHJiavw==",
 			"requires": {
-				"@citation-js/date": "^0.4.4",
+				"@citation-js/date": "^0.5.0",
 				"@citation-js/name": "^0.4.2"
 			}
 		},
 		"@citation-js/plugin-bibtex": {
-			"version": "0.5.0-alpha.5",
-			"resolved": "https://registry.npmjs.org/@citation-js/plugin-bibtex/-/plugin-bibtex-0.5.0-alpha.5.tgz",
-			"integrity": "sha512-whickBbWIUrAt8iR9BewjuT2Cxz/YsWEYHhOZohOBrx9b3rn3+hIpfsZZKV60hr03SjBqIlOOhlqqogiQxGWsw==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@citation-js/plugin-bibtex/-/plugin-bibtex-0.5.7.tgz",
+			"integrity": "sha512-g/4hA0N+/uYFDb7SUWEaIZm1hLK5AYNdmR+mB8T5kCoQ0vZS63Z0NaZMrZY8btPvX2cCHpPv8r2rmhOjnZKuvA==",
 			"requires": {
-				"@citation-js/date": "^0.4.4",
+				"@citation-js/date": "^0.5.0",
 				"@citation-js/name": "^0.4.2",
 				"moo": "^0.5.1"
 			}
 		},
 		"@citation-js/plugin-csl": {
-			"version": "0.5.0-alpha.5",
-			"resolved": "https://registry.npmjs.org/@citation-js/plugin-csl/-/plugin-csl-0.5.0-alpha.5.tgz",
-			"integrity": "sha512-7fzeSadwNeVlOGUgmSgKcCpT89NCNgGECqlaT71RIlF1gp3+BFy80g2WrSaw0Ir0HEoZDmL3mvBkx4gF3VsK3Q==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@citation-js/plugin-csl/-/plugin-csl-0.5.7.tgz",
+			"integrity": "sha512-RuFIBi9KhmNmzOJZs24UBM5olvY71hJZ+qNnY89YIfszoMJHdotYc/NRmHlM/dSMy9A3BbnDC6WzDIpYZGuU6w==",
 			"requires": {
-				"citeproc": "^2.2.27"
+				"@citation-js/date": "^0.5.0",
+				"citeproc": "^2.4.6"
 			}
 		},
 		"@citation-js/plugin-doi": {
-			"version": "0.5.0-alpha.5",
-			"resolved": "https://registry.npmjs.org/@citation-js/plugin-doi/-/plugin-doi-0.5.0-alpha.5.tgz",
-			"integrity": "sha512-h5OIGCr7RBC6HaIbmyOhfbFQp145qNtfZZhMarI7yw1nY86KcsAJc9F6LOnuflMntnvlD7vK5umHuBCfFYP5lg=="
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@citation-js/plugin-doi/-/plugin-doi-0.5.7.tgz",
+			"integrity": "sha512-22LJ93q8nevNv83OB5G7pKcjgueepjNyj14EKBzL5IJaXVP8WraPD9PoRBC71SJlbBS7FYby7yTQq44LVGi5Ag==",
+			"requires": {
+				"@citation-js/date": "^0.5.0"
+			}
 		},
 		"@citation-js/plugin-ris": {
-			"version": "0.5.0-alpha.5",
-			"resolved": "https://registry.npmjs.org/@citation-js/plugin-ris/-/plugin-ris-0.5.0-alpha.5.tgz",
-			"integrity": "sha512-dF6bzOk8QJjsv/ce65zYjVAPZb6BYTF6x6IsO2ixf0H2nWQ6sOaWiBOtHSO45EWNyHlq7drrl6BL8IdI2YvY6w==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@citation-js/plugin-ris/-/plugin-ris-0.5.7.tgz",
+			"integrity": "sha512-MAI9/ckfbBlQ7h8oT/VnaKmsS3nG7dci85so/GQhkr4Er5IsFMHGuk56tu5iChFvxWcOtt/SEol0h/0GaNH+Jw==",
 			"requires": {
-				"@citation-js/date": "^0.4.4",
+				"@citation-js/date": "^0.5.0",
 				"@citation-js/name": "^0.4.2"
 			}
 		},
 		"@citation-js/plugin-wikidata": {
-			"version": "0.5.0-alpha.5",
-			"resolved": "https://registry.npmjs.org/@citation-js/plugin-wikidata/-/plugin-wikidata-0.5.0-alpha.5.tgz",
-			"integrity": "sha512-vS/JLD+OVEh9cG1cJpIy10z7x6ZskId+k4KTeB5dhxWk7gjWHsubSoVi7uZ29zdTIDRDsTfTzymC2lngOLRC5g==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/@citation-js/plugin-wikidata/-/plugin-wikidata-0.5.7.tgz",
+			"integrity": "sha512-TPqrcFzpAk2OVd796obHRHOq/4ys5Zm/83VMf44zorjZfOdV1Gwwwds7LpArD0TkZ0cC5xtyiOZrsBcjer2Nyg==",
 			"requires": {
-				"@citation-js/date": "^0.4.4",
+				"@citation-js/date": "^0.5.0",
 				"@citation-js/name": "^0.4.2",
 				"wikidata-sdk": "7"
 			}
@@ -17558,49 +17578,44 @@
 			}
 		},
 		"citation-js": {
-			"version": "0.5.0-alpha.5",
-			"resolved": "https://registry.npmjs.org/citation-js/-/citation-js-0.5.0-alpha.5.tgz",
-			"integrity": "sha512-JjJQSnwvtupaR9FLU7ANAfihycMwtzvDGIbJxHEmV8RRIfy/Swq+UAZY0gMNit885zuu6HEqZZuILOS9y0vKsQ==",
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/citation-js/-/citation-js-0.5.7.tgz",
+			"integrity": "sha512-goKbDIZnE3qsicsEn0sNuE5QFBe5WxVbQv1oEDH7VaDBoxXQniCvK3Wzn1FamdUcwKodGb7L/FpUyNNLAHYcyQ==",
 			"requires": {
-				"@citation-js/cli": "0.5.0-alpha.5",
-				"@citation-js/core": "0.5.0-alpha.5",
-				"@citation-js/date": "0.4.4",
+				"@citation-js/cli": "0.5.7",
+				"@citation-js/core": "0.5.7",
+				"@citation-js/date": "0.5.1",
 				"@citation-js/name": "0.4.2",
-				"@citation-js/plugin-bibjson": "0.5.0-alpha.5",
-				"@citation-js/plugin-bibtex": "0.5.0-alpha.5",
-				"@citation-js/plugin-csl": "0.5.0-alpha.5",
-				"@citation-js/plugin-doi": "0.5.0-alpha.5",
-				"@citation-js/plugin-ris": "0.5.0-alpha.5",
-				"@citation-js/plugin-wikidata": "0.5.0-alpha.5",
-				"citeproc": "^2.2.27"
+				"@citation-js/plugin-bibjson": "0.5.7",
+				"@citation-js/plugin-bibtex": "0.5.7",
+				"@citation-js/plugin-csl": "0.5.7",
+				"@citation-js/plugin-doi": "0.5.7",
+				"@citation-js/plugin-ris": "0.5.7",
+				"@citation-js/plugin-wikidata": "0.5.7",
+				"citeproc": "^2.4.59"
 			},
 			"dependencies": {
 				"@citation-js/cli": {
-					"version": "0.5.0-alpha.5",
-					"resolved": "https://registry.npmjs.org/@citation-js/cli/-/cli-0.5.0-alpha.5.tgz",
-					"integrity": "sha512-ktZBiKTTG/6o66GMTlnfALErQDblstOF1N3xP3iqdGJkBexduMn197ty/PwuFk4FJLQYsWl/6IovLbRbMUPtBA==",
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/@citation-js/cli/-/cli-0.5.7.tgz",
+					"integrity": "sha512-bU9Z8zyMZEU5PpoD3y+5YYCqH4GHoGsH+dKTmLH1eX+HMYRVstM+jttJymTf0lJA9w6T+weUrRv/S5By0qcMbg==",
 					"requires": {
-						"@citation-js/core": "^0.5.0-alpha.5",
-						"@citation-js/plugin-bibjson": "^0.5.0-alpha.5",
-						"@citation-js/plugin-bibtex": "^0.5.0-alpha.5",
-						"@citation-js/plugin-csl": "^0.5.0-alpha.5",
-						"@citation-js/plugin-doi": "^0.5.0-alpha.5",
-						"@citation-js/plugin-ris": "^0.5.0-alpha.5",
-						"@citation-js/plugin-wikidata": "^0.5.0-alpha.5",
-						"commander": "^2.20.0"
+						"@citation-js/core": "^0.5.7",
+						"@citation-js/plugin-bibjson": "^0.5.7",
+						"@citation-js/plugin-bibtex": "^0.5.7",
+						"@citation-js/plugin-csl": "^0.5.7",
+						"@citation-js/plugin-doi": "^0.5.7",
+						"@citation-js/plugin-ris": "^0.5.7",
+						"@citation-js/plugin-wikidata": "^0.5.7",
+						"commander": "^5.1.0"
 					}
-				},
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 				}
 			}
 		},
 		"citeproc": {
-			"version": "2.2.36",
-			"resolved": "https://registry.npmjs.org/citeproc/-/citeproc-2.2.36.tgz",
-			"integrity": "sha512-tLY8v3DVtULnkwH234Zjeljwu8QZen17GmQW6tl6PmMSawV7ZnTHFcxwFqOD85LsVygS9w//DiUBdg9JzY4DEw=="
+			"version": "2.4.62",
+			"resolved": "https://registry.npmjs.org/citeproc/-/citeproc-2.4.62.tgz",
+			"integrity": "sha512-l3uFfSEwNZp/jlz/TpgyBs85kOww6VlQHbAth0cpbgOn6iulZd+QlFY43LrRelzcYt3FZHTZ3soDyd8lNmkqdw=="
 		},
 		"cjs-module-lexer": {
 			"version": "0.6.0",
@@ -18006,8 +18021,7 @@
 		"commander": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-			"dev": true
+			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -22016,22 +22030,22 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 				},
 				"are-we-there-yet": {
 					"version": "1.1.5",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 					"requires": {
 						"delegates": "^1.0.0",
@@ -22040,12 +22054,12 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -22054,32 +22068,32 @@
 				},
 				"chownr": {
 					"version": "1.1.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
 					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 				},
 				"debug": {
 					"version": "3.2.6",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"requires": {
 						"ms": "^2.1.1"
@@ -22087,32 +22101,32 @@
 				},
 				"deep-extend": {
 					"version": "0.6.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
 					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 				},
 				"fs-minipass": {
 					"version": "1.2.7",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
 					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA=="
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"requires": {
 						"aproba": "^1.0.3",
@@ -22127,7 +22141,7 @@
 				},
 				"glob": {
 					"version": "7.1.6",
-					"resolved": false,
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -38013,48 +38027,21 @@
 			}
 		},
 		"sync-fetch": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.1.1.tgz",
-			"integrity": "sha512-8AkbqoxM0d/b8NKm5HuIJiFas/BkDTvKGDXIvZ8phT+gdyaVxKbzfae4bvgKUXwOvYWGdWjMQxJFkJxC+9Ee9A==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/sync-fetch/-/sync-fetch-0.3.1.tgz",
+			"integrity": "sha512-xj5qiCDap/03kpci5a+qc5wSJjc8ZSixgG2EUmH1B8Ea2sfWclQA7eH40hiHPCtkCn6MCk4Wb+dqcXdCy2PP3g==",
 			"requires": {
-				"buffer": "^5.4.2",
-				"node-fetch": "^2.6.0"
+				"buffer": "^5.7.0",
+				"node-fetch": "^2.6.1"
 			},
 			"dependencies": {
 				"buffer": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
 					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				},
-				"node-fetch": {
-					"version": "2.6.7",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-					"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-					"requires": {
-						"whatwg-url": "^5.0.0"
-					}
-				},
-				"tr46": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-				},
-				"webidl-conversions": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-				},
-				"whatwg-url": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-					"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-					"requires": {
-						"tr46": "~0.0.3",
-						"webidl-conversions": "^3.0.0"
+						"base64-js": "^1.3.1",
+						"ieee754": "^1.1.13"
 					}
 				}
 			}
@@ -40605,16 +40592,16 @@
 			}
 		},
 		"wikibase-sdk": {
-			"version": "7.4.1",
-			"resolved": "https://registry.npmjs.org/wikibase-sdk/-/wikibase-sdk-7.4.1.tgz",
-			"integrity": "sha512-6noMz3puMJGO1mP1Orq5n+jobaMH/9NIYaSZIxNBR+tFfDG9zNDST8ZqBwGwka4X4QQV65gLoEk4r1TXNSSB7A=="
+			"version": "7.15.0",
+			"resolved": "https://registry.npmjs.org/wikibase-sdk/-/wikibase-sdk-7.15.0.tgz",
+			"integrity": "sha512-EZvOVz2Ezx1IsiSTlJ5XF1SLLudzWvtm7CV5DYKhO7CIX4EkB0Pc8seb8h6ZNEPRgYqnmrTx5aLsaIQW7GBe2w=="
 		},
 		"wikidata-sdk": {
-			"version": "7.4.1",
-			"resolved": "https://registry.npmjs.org/wikidata-sdk/-/wikidata-sdk-7.4.1.tgz",
-			"integrity": "sha512-CAgBrN3BGIMxCcMv4omcTmuaO1yy0ErQbOHuyUeeFnkBW5kI7h8DUsGVWyARrWcYAgkfbmGMMzo07kYbAzavDg==",
+			"version": "7.14.4",
+			"resolved": "https://registry.npmjs.org/wikidata-sdk/-/wikidata-sdk-7.14.4.tgz",
+			"integrity": "sha512-UAFBXWLxEWvB0Pn/c+ekc1voU8o0zR7T3kRt9xHLyfy2OiV7W1htk2iErwJdfisBPDb2a35HUgf2x1+ZAdrM8A==",
 			"requires": {
-				"wikibase-sdk": "^7.4.1"
+				"wikibase-sdk": "^7.14.4"
 			}
 		},
 		"winston": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"camelcase-css": "^2.0.1",
 		"cheerio": "^1.0.0-rc.3",
 		"chunk-text": "^2.0.1",
-		"citation-js": "^0.5.0-alpha.2",
+		"citation-js": "^0.5.7",
 		"classnames": "^2.2.6",
 		"color": "^3.1.1",
 		"compression": "^1.7.4",

--- a/server/utils/citations/citeStyles/arcadia-science.csl
+++ b/server/utils/citations/citeStyles/arcadia-science.csl
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Arcadia Science</title>
+    <id>http://www.zotero.org/styles/arcadia-science</id>
+    <link rel="self" href="http://www.zotero.org/styles/arcadia-science"/>
+    <author>
+      <name>Feridun Mert Celebi</name>
+      <email>mert.celebi@arcadiascience.com</email>
+    </author>
+    <author>
+      <name>Megan Hochstrasser</name>
+      <email>megan.hochstrasser@arcadiascience.com </email>
+    </author>
+    <issn/>
+    <updated>2022-05-18T15:24:16+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="author">
+    <names variable="author">
+      <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <label prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else-if type="webpage">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="report thesis" match="any">
+        <text variable="title"/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="genre"/>
+          <text variable="number" prefix="No. "/>
+        </group>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song speech" match="any">
+        <text variable="title"/>
+        <text macro="edition" prefix=", "/>
+      </else-if>
+      <else-if type="webpage">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="edition">
+          <number variable="edition" form="ordinal"/>
+        </if>
+        <else>
+          <text variable="edition" suffix="."/>
+        </else>
+      </choose>
+      <text value="ed"/>
+    </group>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year" cite-group-delimiter=", ">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued" sort="descending"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued"/>
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" entry-spacing="0" line-spacing="1">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued" sort="descending"/>
+    </sort>
+    <layout>
+      <group>
+        <text macro="author" suffix="."/>
+        <text macro="issued" strip-periods="false" prefix=" (" suffix=")"/>
+        <group prefix=". ">
+          <text macro="title"/>
+        </group>
+      </group>
+      <text macro="access" prefix=". "/>
+    </layout>
+  </bibliography>
+</style>

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -108,28 +108,22 @@ export const generateCitationHtml = async (
 	return {
 		pub: {
 			default: pubCiteObject
-				.get({
-					format: 'string',
-					type: 'html',
-					style: `citation-${pubData.citationStyle}`,
+				.format('bibliography', {
+					format: 'html',
+					template: pubData.citationStyle,
 					lang: 'en-US',
 				})
 				.replace(/\n/gi, ''),
 			apa: pubCiteObject
-				.get({ format: 'string', type: 'html', style: 'citation-apa', lang: 'en-US' })
+				.format('bibliography', { format: 'html', template: 'apa', lang: 'en-US' })
 				.replace(/\n/gi, ''),
 			harvard: pubCiteObject
-				.get({ format: 'string', type: 'html', style: 'citation-harvard', lang: 'en-US' })
+				.format('bibliography', { format: 'html', template: 'harvard1', lang: 'en-US' })
 				.replace(/\n/gi, ''),
 			vancouver: pubCiteObject
-				.get({ format: 'string', type: 'html', style: 'citation-vancouver', lang: 'en-US' })
+				.format('bibliography', { format: 'html', template: 'vancouver', lang: 'en-US' })
 				.replace(/\n/gi, ''),
-			bibtex: pubCiteObject.get({
-				format: 'string',
-				type: 'html',
-				style: 'bibtex',
-				lang: 'en-US',
-			}),
+			bibtex: pubCiteObject.format('bibtex'),
 		},
 	};
 };

--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -110,7 +110,8 @@ export const generateCitationHtml = async (
 			default: pubCiteObject
 				.format('bibliography', {
 					format: 'html',
-					template: pubData.citationStyle,
+					template:
+						pubData.citationStyle === 'harvard' ? 'harvard1' : pubData.citationStyle,
 					lang: 'en-US',
 				})
 				.replace(/\n/gi, ''),

--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -77,7 +77,7 @@ const getSingleStructuredCitation = async (
 		if (citationData) {
 			const citationJson = citationData.format('data', { format: 'object' });
 			const citationHtml = citationData.format('bibliography', {
-				template: citationStyle,
+				template: citationStyle === 'harvard' ? 'harvard1' : citationStyle,
 				format: 'html',
 			});
 			const citationApa = citationData.format('citation', {

--- a/utils/citations.ts
+++ b/utils/citations.ts
@@ -3,6 +3,7 @@ export type CitationStyleKind =
 	| 'american-anthro'
 	| 'apa'
 	| 'apa-7'
+	| 'arcadia-science'
 	| 'cell'
 	| 'chicago'
 	| 'harvard'
@@ -39,6 +40,7 @@ export const citationStyles: CitationStyle[] = [
 		name: 'APA 7th Edition',
 		path: './citeStyles/apa-7.csl',
 	},
+	{ key: 'arcadia-science', name: 'Arcadia Science', path: './citeStyles/arcadia-science.csl' },
 	{ key: 'cell', name: 'Cell', path: './citeStyles/cell.csl' },
 	{ key: 'chicago', name: 'Chicago', path: './citeStyles/chicago-author-date.csl' },
 	{ key: 'harvard', name: 'Harvard' },


### PR DESCRIPTION
1. Updates citation.js to `0.5.7`. We had been using `0.5.0-alpha2`. No breaking API changes, but a lot of bug fixes since then.
2. As of citation.js 5, the built-in Harvard style had switched from a key of `harvard` to `harvard1`. So we haven't actually supported Harvard styles for some time. We're using `harvard` as our key in the db, so I aliased `harvard` to `harvard1` in the two callsites for `Cite.format`. Eventually we'll probably want to update in the db.
3. Switches citation generation in `generateCitationHtml` from `Cite.get`, which was deprecated in `0.5.x`, to `Cite.format`. This was causing an issue loading newer CSL files, which were defaulting to APA. We are already using `Cite.format` to generate Cites in the editor, and they're both sync functions, so this seems completely safe.
4. Adds Arcadia's style file.

_To test_
1. Create a pub, add a cite or two.
2. In the expanded Cite modal, verify that all normal citation styles work correctly.
3. Verify that the cite you added to the body works correctly in the expected style.
4. Switch citation style to Harvard and make sure cites load as expected, not defaulting to APA (date will note have parens around it).
5. Visit the Pub overview and make sure Cite styles load correctly.
6. Switch to Arcadia and make sure their style loads correctly in both the Cite menu and inline cites. Should have no title at all.
7. Export a JATS pub from Harvard and Arcadia and make sure cites load as expected (no real changes here, as it was already using cite.format and bibtex not specific styles, but just to be sure).