### PR TITLE
fix: break-word for <ol> in tables

### DIFF
--- a/client/containers/Pub/PubDocument/pubBody.scss
+++ b/client/containers/Pub/PubDocument/pubBody.scss
@@ -114,7 +114,7 @@ $pub-body-font-size: if-is-export(14px, 20px);
 		padding-left: 0;
 		list-style-position: inside;
 		li p {
-			word-break: break-all;
+			word-break: break-word;
 			&:first-child {
 				display: inline;
 			}


### PR DESCRIPTION
The final word.

swap in `break-word` for `break-all`