### PR TITLE
fix: copy text title to html title when updating from dashboard

### DIFF
--- a/server/pub/queries.ts
+++ b/server/pub/queries.ts
@@ -99,6 +99,8 @@ export const updatePub = (inputValues, updatePermissions, actorId) => {
 	}
 	if (filteredValues.htmlTitle) {
 		filteredValues.title = striptags(filteredValues.htmlTitle).replace(/&nbsp;/gi, ' ');
+	} else if (filteredValues.title) {
+		filteredValues.htmlTitle = filteredValues.title;
 	}
 
 	return Pub.update(filteredValues, {


### PR DESCRIPTION
*Test Plan*
* Change a Pub's title via the Pub header
* Change a Pub's title via the Pub dashboard page
* Go back to the draft/release view. The Pub's title should be updated with the value entered via the Pub dashboard page.