### PR TITLE
fix: correctly save changes to Pub connections

### DIFF
--- a/server/pubEdge/queries.ts
+++ b/server/pubEdge/queries.ts
@@ -53,6 +53,9 @@ export const updatePubEdge = async ({ pubEdgeId, ...update }) => {
 		where: { id: pubEdgeId },
 		include: getPubEdgeIncludes({ includeTargetPub: true }),
 	});
+	if (edge.externalPublication && update.externalPublication) {
+		await edge.externalPublication.update(update.externalPublication);
+	}
 	await edge.update(update);
 	return edge;
 };


### PR DESCRIPTION
Resolves #2019

_Test Plan_
* Add a connection to an external publication to a Pub (for example, use a URL like https://www.nature.com/articles/s41586-022-04645-w)
* Save the connection.
* Edit the connection description, title, and contributors list.
* Save the connection.
* Refresh the page. The edits you made should have persisted.