### PR TITLE
Enhancement: PDF and HTML links

### DIFF
--- a/utils/pubEdge/helpers.ts
+++ b/utils/pubEdge/helpers.ts
@@ -13,7 +13,7 @@ export const getHostnameForUrl = (url: string) => {
 	}
 };
 
-const getUrlForPub = (pubData: Pub, communityData: Community) => {
+export const getUrlForPub = (pubData: Pub, communityData: Community) => {
 	if (communityData.id === pubData.communityId) {
 		return pubUrl(communityData, pubData);
 	}

--- a/workers/tasks/export/html.tsx
+++ b/workers/tasks/export/html.tsx
@@ -143,7 +143,7 @@ const blankIframes = (nodes) =>
 		nodes,
 	);
 
-const renderDetails = ({ updatedDateString, publishedDateString, doi, license }) => {
+const renderDetails = ({ updatedDateString, publishedDateString, doi, license, pubUrl }) => {
 	const showUpdatedDate = updatedDateString && updatedDateString !== publishedDateString;
 	return (
 		<>
@@ -152,9 +152,15 @@ const renderDetails = ({ updatedDateString, publishedDateString, doi, license })
 					<strong>Updated on:</strong> {updatedDateString}
 				</div>
 			)}
-			{doi && (
+			{doi ? (
 				<div>
-					<strong>DOI:</strong> {doi}
+					<strong>DOI: </strong>
+					<a href={`https://dx.doi.org/${doi}`}>{doi}</a>
+				</div>
+			) : (
+				<div>
+					<strong>URL: </strong>
+					<a href={pubUrl}>{pubUrl}</a>
 				</div>
 			)}
 			{license && (
@@ -176,6 +182,7 @@ const renderFrontMatter = ({
 	primaryCollectionMetadata,
 	doi,
 	title,
+	pubUrl,
 	communityTitle,
 	accentColor,
 	attributions,
@@ -245,6 +252,7 @@ const renderFrontMatter = ({
 					updatedDateString,
 					publishedDateString,
 					doi,
+					pubUrl,
 					license,
 				})}
 			</div>

--- a/workers/tasks/export/metadata.ts
+++ b/workers/tasks/export/metadata.ts
@@ -4,6 +4,7 @@ import * as types from 'types';
 import { getPubPublishedDate, getPubUpdatedDate } from 'utils/pub/pubDates';
 import { getPrimaryCollection } from 'utils/collections/primary';
 import { renderJournalCitation } from 'utils/citations';
+import { getUrlForPub } from 'utils/pubEdge';
 import {
 	Collection,
 	CollectionPub,
@@ -61,6 +62,7 @@ export const getPubMetadata = async (pubId: string): Promise<PubMetadata> => {
 			},
 		],
 	});
+	const pubUrl = getUrlForPub(pubData, pubData.community);
 	const publishedDate = getPubPublishedDate(pubData);
 	const license = getLicenseForPub(pubData, pubData.community);
 	const updatedDate = getPubUpdatedDate({ pub: pubData });
@@ -71,6 +73,7 @@ export const getPubMetadata = async (pubId: string): Promise<PubMetadata> => {
 	return {
 		title: pubData.title,
 		slug: pubData.slug,
+		pubUrl,
 		doi: pubData.doi,
 		publishedDateString,
 		updatedDateString,

--- a/workers/tasks/export/types.ts
+++ b/workers/tasks/export/types.ts
@@ -7,6 +7,7 @@ import { RenderedStructuredValue } from 'utils/notesCore';
 export type PubMetadata = {
 	title: string;
 	slug: string;
+	pubUrl: string;
 	doi: null | string;
 	publishedDateString: Maybe<string>;
 	updatedDateString: Maybe<string>;


### PR DESCRIPTION
In PDF and HTML exports: if no DOI is issued, adds a URL field to the export's cover page. If DOI issued, adds a link to the DOI. 

Resolves part of #1633 

<img width="774" alt="Screen Shot 2022-06-06 at 15 47 18" src="https://user-images.githubusercontent.com/639110/172236401-d40a67f2-1799-4240-8eeb-9d0bf3a91fea.png">

<img width="776" alt="Screen Shot 2022-06-06 at 15 47 30" src="https://user-images.githubusercontent.com/639110/172236427-7dea8297-8e38-49d1-bb4c-86a010baad73.png">

_Test Plan_
1. Export PDF of pub without DOI.
2. Make sure link to Pub is in PDF cover page
3. Mint test DOI for pub
4. Make sure URL is replaced with DOI, with proper link (https://doi.org...)