### PR TITLE
enhancement: Add RTL to Additional Editor Fields

### DIFF
--- a/client/components/Editor/views/notePopover.scss
+++ b/client/components/Editor/views/notePopover.scss
@@ -8,8 +8,8 @@
 	p:last-child {
 		margin-bottom: 0;
 	}
-}
 
-[data-rtl='true'] {
-	direction: rtl;
+	[data-rtl='true'] {
+		direction: rtl;
+	}
 }

--- a/client/components/Editor/views/notePopover.scss
+++ b/client/components/Editor/views/notePopover.scss
@@ -9,3 +9,7 @@
 		margin-bottom: 0;
 	}
 }
+
+[data-rtl='true'] {
+	direction: rtl;
+}

--- a/client/components/FormattingBar/buttons.ts
+++ b/client/components/FormattingBar/buttons.ts
@@ -301,14 +301,19 @@ export const simpleMedia: FormattingBarButtonData = {
 	isMedia: true,
 };
 
-export const minimalButtonSet = [[strong, em, link, block_or_inline_equation]];
-export const abstractButtonSet = [[strong, em, link, inline_equation]];
-export const discussionButtonSet = [[strong, em, link], [simpleMedia]];
+export const minimalButtonSet = [[strong, em, link, rightToLeft, block_or_inline_equation]];
+export const abstractButtonSet = [[strong, em, link, rightToLeft, inline_equation]];
+export const discussionButtonSet = [[strong, em, link], [rightToLeft], [simpleMedia]];
 export const inlineMenuButtonSet = [[heading1, heading2, strong, em, link]];
-export const workflowButtonSet = [[heading1, heading2, strong, em, link], [simpleMedia]];
+export const workflowButtonSet = [
+	[heading1, heading2, strong, em, link],
+	[rightToLeft],
+	[simpleMedia],
+];
 
 export const fullButtonSet = [
-	[alignLeft, alignCenter, alignRight, rightToLeft],
+	[alignLeft, alignCenter, alignRight],
+	[rightToLeft],
 	[
 		strong,
 		em,
@@ -332,6 +337,7 @@ export const fullButtonSet = [
 
 export const layoutEditorButtonSet = [
 	[alignLeft, alignCenter, alignRight],
+	[rightToLeft],
 	[
 		strong,
 		em,

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
@@ -68,22 +68,18 @@ const ThreadComment = (props: Props) => {
 	};
 
 	const isAuthor = loginData.id === threadCommentData.userId;
-	const handleChangeEditorObject = (editorChangeObject: EditorChangeObject) => {
-		if (isEditing) {
-			setChangeObject(editorChangeObject);
-		}
-	};
-	const renderText = (
-		key: string, // key={`${isEditing}-${threadCommentData.text}`}
-		isReadOnly: boolean, // isReadOnly={!isEditing}
-		onChange?: any,
-	) => {
+
+	const renderText = () => {
 		return (
 			<Editor
-				key={key}
-				isReadOnly={isReadOnly}
+				key={`${isEditing}-${threadCommentData.text}`}
+				isReadOnly={!isEditing}
 				initialContent={threadCommentData.content}
-				onChange={onChange}
+				onChange={(editorChangeObject) => {
+					if (isEditing) {
+						setChangeObject(editorChangeObject);
+					}
+				}}
 			/>
 		);
 	};
@@ -153,11 +149,7 @@ const ThreadComment = (props: Props) => {
 								isSmall
 							/>
 						)}
-						{renderText(
-							`${isEditing}-${threadCommentData.text}`,
-							!isEditing,
-							handleChangeEditorObject(),
-						)}
+						{renderText()}
 					</div>
 				)}
 				{isEditing && (

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
@@ -68,17 +68,22 @@ const ThreadComment = (props: Props) => {
 	};
 
 	const isAuthor = loginData.id === threadCommentData.userId;
-	const renderText = () => {
+	const handleChangeEditorObject = (editorChangeObject: EditorChangeObject) => {
+		if (isEditing) {
+			setChangeObject(editorChangeObject);
+		}
+	};
+	const renderText = (
+		key: string, // key={`${isEditing}-${threadCommentData.text}`}
+		isReadOnly: boolean, // isReadOnly={!isEditing}
+		onChange?: any,
+	) => {
 		return (
 			<Editor
-				key={`${isEditing}-${threadCommentData.text}`}
-				isReadOnly={!isEditing}
+				key={key}
+				isReadOnly={isReadOnly}
 				initialContent={threadCommentData.content}
-				onChange={(editorChangeObject) => {
-					if (isEditing) {
-						setChangeObject(editorChangeObject);
-					}
-				}}
+				onChange={onChange}
 			/>
 		);
 	};
@@ -148,7 +153,11 @@ const ThreadComment = (props: Props) => {
 								isSmall
 							/>
 						)}
-						{renderText()}
+						{renderText(
+							`${isEditing}-${threadCommentData.text}`,
+							!isEditing,
+							handleChangeEditorObject(),
+						)}
 					</div>
 				)}
 				{isEditing && (

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
@@ -156,7 +156,7 @@ const ThreadComment = (props: Props) => {
 						)}
 						{renderText(
 							`${isEditing}-${threadCommentData.text}`,
-							true,
+							!isEditing,
 							(editorChangeObject: EditorChangeObject) => {
 								if (isEditing) {
 									setChangeObject(editorChangeObject);

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
@@ -99,7 +99,7 @@ const ThreadComment = (props: Props) => {
 						{isPreview ? ': ' : ''}
 					</span>
 
-					{isPreview && renderText()}
+					{isPreview && <span className="preview-text">{renderText()}</span>}
 					{!isPreview && (
 						<span className="time">
 							{!isEditing && (

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
@@ -8,6 +8,7 @@ import { FormattingBar, buttons } from 'components/FormattingBar';
 import { Avatar, Icon } from 'components';
 import { usePageContext } from 'utils/hooks';
 import { apiFetch } from 'client/utils/apiFetch';
+import { Callback } from 'types';
 
 require('./threadComment.scss');
 
@@ -68,7 +69,11 @@ const ThreadComment = (props: Props) => {
 	};
 
 	const isAuthor = loginData.id === threadCommentData.userId;
-	const renderText = (key: string, isReadOnly: boolean, onChange?: any) => {
+	const renderText = (
+		key: string,
+		isReadOnly: boolean,
+		onChange?: Callback<EditorChangeObject>,
+	) => {
 		return (
 			<Editor
 				key={key}

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
@@ -68,6 +68,20 @@ const ThreadComment = (props: Props) => {
 	};
 
 	const isAuthor = loginData.id === threadCommentData.userId;
+	const renderText = () => {
+		return (
+			<Editor
+				key={`${isEditing}-${threadCommentData.text}`}
+				isReadOnly={!isEditing}
+				initialContent={threadCommentData.content}
+				onChange={(editorChangeObject) => {
+					if (isEditing) {
+						setChangeObject(editorChangeObject);
+					}
+				}}
+			/>
+		);
+	};
 	return (
 		<div className={classNames('thread-comment-component', isPreview && 'is-preview')}>
 			<div className="avatar-wrapper">
@@ -84,7 +98,7 @@ const ThreadComment = (props: Props) => {
 						{isPreview ? ': ' : ''}
 					</span>
 
-					{isPreview && <span className="preview-text">{threadCommentData.text}</span>}
+					{isPreview && renderText()}
 					{!isPreview && (
 						<span className="time">
 							{!isEditing && (
@@ -134,16 +148,7 @@ const ThreadComment = (props: Props) => {
 								isSmall
 							/>
 						)}
-						<Editor
-							key={`${isEditing}-${threadCommentData.text}`}
-							isReadOnly={!isEditing}
-							initialContent={threadCommentData.content}
-							onChange={(editorChangeObject) => {
-								if (isEditing) {
-									setChangeObject(editorChangeObject);
-								}
-							}}
-						/>
+						{renderText()}
 					</div>
 				)}
 				{isEditing && (

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ThreadComment.tsx
@@ -68,21 +68,17 @@ const ThreadComment = (props: Props) => {
 	};
 
 	const isAuthor = loginData.id === threadCommentData.userId;
-
-	const renderText = () => {
+	const renderText = (key: string, isReadOnly: boolean, onChange?: any) => {
 		return (
 			<Editor
-				key={`${isEditing}-${threadCommentData.text}`}
-				isReadOnly={!isEditing}
+				key={key}
+				isReadOnly={isReadOnly}
 				initialContent={threadCommentData.content}
-				onChange={(editorChangeObject) => {
-					if (isEditing) {
-						setChangeObject(editorChangeObject);
-					}
-				}}
+				onChange={onChange}
 			/>
 		);
 	};
+
 	return (
 		<div className={classNames('thread-comment-component', isPreview && 'is-preview')}>
 			<div className="avatar-wrapper">
@@ -99,7 +95,11 @@ const ThreadComment = (props: Props) => {
 						{isPreview ? ': ' : ''}
 					</span>
 
-					{isPreview && <span className="preview-text">{renderText()}</span>}
+					{isPreview && (
+						<span className="preview-text">
+							{renderText(`preview-${threadCommentData.text}`, true)}
+						</span>
+					)}
 					{!isPreview && (
 						<span className="time">
 							{!isEditing && (
@@ -149,7 +149,15 @@ const ThreadComment = (props: Props) => {
 								isSmall
 							/>
 						)}
-						{renderText()}
+						{renderText(
+							`${isEditing}-${threadCommentData.text}`,
+							true,
+							(editorChangeObject: EditorChangeObject) => {
+								if (isEditing) {
+									setChangeObject(editorChangeObject);
+								}
+							},
+						)}
 					</div>
 				)}
 				{isEditing && (

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/discussion.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/discussion.scss
@@ -31,7 +31,7 @@
 	}
 	.item-header {
 		display: flex;
-		align-items: center;
+		align-items: flex-start;
 		line-height: 1em;
 		margin-bottom: 0.25em;
 		font-size: 13px;

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/discussion.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/discussion.scss
@@ -16,6 +16,7 @@
 	}
 	.manage-tools-component {
 		margin-bottom: 1em;
+		direction: ltr;
 	}
 	.anchor-text {
 		padding: 0.25em;
@@ -34,6 +35,8 @@
 		line-height: 1em;
 		margin-bottom: 0.25em;
 		font-size: 13px;
+		direction: ltr;
+
 		.name {
 			font-weight: 600;
 			margin-right: 1em;

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/threadComment.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/threadComment.scss
@@ -24,11 +24,14 @@
 	.preview-text {
 		white-space: nowrap;
 		overflow: hidden;
-		text-overflow: ellipsis;
+		max-height: 19px;
 		font-style: 14px;
 		> .editor.ProseMirror {
 			min-height: 0px;
 			p {
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
 				margin-bottom: 0px;
 			}
 		}

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/threadComment.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/threadComment.scss
@@ -24,6 +24,12 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		font-style: 14px;
+		> .editor.ProseMirror {
+			min-height: 0px;
+			p {
+				margin-bottom: 0px;
+			}
+		}
 	}
 	.discussion-body-wrapper {
 		> .editor.ProseMirror {

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/threadComment.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/threadComment.scss
@@ -2,6 +2,8 @@
 
 .thread-comment-component {
 	display: flex;
+	direction: ltr;
+
 	&:not(:last-child):not(.input) {
 		margin-bottom: 1em;
 		border-bottom: 1px solid #f0f0f7;

--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionGroup/discussionNav.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionGroup/discussionNav.scss
@@ -3,6 +3,7 @@
 	align-items: center;
 	height: 1.7em;
 	margin-left: 3px;
+	direction: ltr;
 	.caret-button {
 		min-width: 14px;
 	}
@@ -17,5 +18,4 @@
 		padding-top: 3px;
 	}
 
-	direction: ltr;
 }

--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionGroup/discussionNav.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionGroup/discussionNav.scss
@@ -16,4 +16,6 @@
 	.overflow-icon {
 		padding-top: 3px;
 	}
+
+	direction: ltr;
 }

--- a/client/containers/Pub/PubDocument/PubDiscussions/DiscussionGroup/discussionNav.scss
+++ b/client/containers/Pub/PubDocument/PubDiscussions/DiscussionGroup/discussionNav.scss
@@ -17,5 +17,4 @@
 	.overflow-icon {
 		padding-top: 3px;
 	}
-
 }


### PR DESCRIPTION
addresses issue #2058

We recently added RTL to the main editor. This adds RTL directionality to other editors. 

test:
Create text in the layout editor, submission workflow, submission abstract, discussion, citation, and footnotes. Observe RTL persist when rendered

*also fixes some padding added to comments to the right caused by being a child of a prosemirror node