### PR TITLE
Update: add helper body css class for user status

### DIFF
--- a/server/Html.tsx
+++ b/server/Html.tsx
@@ -49,6 +49,16 @@ const getActiveSlugClassName = (initialData: InitialData, viewData?: any) => {
 	return '';
 };
 
+const getUserClassName = (initialData: InitialData) => {
+	if (initialData.scopeData.activePermissions.activePermission) {
+		return 'user-member';
+	}
+	if (initialData.loginData.id) {
+		return 'user-logged-in';
+	}
+	return 'user-anonymous';
+};
+
 const Html = (props: Props) => {
 	const { customScripts } = props;
 	const getPath = (chunkName, extension) => {
@@ -88,6 +98,7 @@ const Html = (props: Props) => {
 				className={classNames(
 					props.bodyClassPrefix && `${props.bodyClassPrefix}-body-wrapper`,
 					getActiveSlugClassName(props.initialData, props.viewData),
+					getUserClassName(props.initialData),
 				)}
 			>
 				{/* This script tag is here to prevent FOUC in Firefox: https://stackoverflow.com/questions/21147149/flash-of-unstyled-content-fouc-in-firefox-only-is-ff-slow-renderer */}

--- a/server/Html.tsx
+++ b/server/Html.tsx
@@ -49,14 +49,16 @@ const getActiveSlugClassName = (initialData: InitialData, viewData?: any) => {
 	return '';
 };
 
-const getUserClassName = (initialData: InitialData) => {
-	if (initialData.scopeData.activePermissions.activePermission) {
-		return 'user-member';
-	}
+const getUserClassName = (initialData: InitialData): String[] => {
+	const classes: String[] = [];
 	if (initialData.loginData.id) {
-		return 'user-logged-in';
+		classes.push('user-logged-in');
 	}
-	return 'user-anonymous';
+	if (initialData.scopeData.activePermissions.activePermission) {
+		classes.push('user-member');
+		classes.push(`user-permission-${initialData.scopeData.activePermissions.activePermission}`);
+	}
+	return classes;
 };
 
 const Html = (props: Props) => {


### PR DESCRIPTION
resolves #2062

Adds classes to the site body based on the user, to help people target custom CSS changes to different types of users.

If logged out: no `user-*` classes, can target with :not()
If logged in but not a member at a given scope: `user-logged-in`
If a member at a given scope: `user-logged-in` and `user-member` and `user-permission-[permission]`

_To test_
1. Logout and visit. Should see no `user-*` body classes.
2. Login as a member and visit. Should see `user-member` and `user-permission-[permission]` as a body class.
3. Login as a non-member and visit. Should see `user-logged-in` as a body class.
4. Add user as a member to a non-community-wide scope.
6. Visit that scope.
7. Should see `user-member` and `user-permission-[permission]` as a body class.
8. Visit another scope they're not a member of.
9. Should see `user-logged-in` as a body class.