### PR TITLE
Update: deposit ORCID IDs to crossref

### DIFF
--- a/utils/crossref/schema/contributors.js
+++ b/utils/crossref/schema/contributors.js
@@ -29,13 +29,16 @@ export default (attributions) => {
 						? attribution.user.lastName
 						: attribution.user.firstName,
 					affiliation: attribution.affiliation,
-					ORCID: attribution.user.orcid && `https://orcid.org/${attribution.user.orcid}`,
+					ORCID: `https://orcid.org/${attribution.user.orcid}`,
 				};
 				if (!personNameOutput.affiliation) {
 					delete personNameOutput.affiliation;
 				}
 				if (!personNameOutput.given_name) {
 					delete personNameOutput.given_name;
+				}
+				if (!attribution.user.orcid) {
+					delete personNameOutput.ORCID;
 				}
 				return personNameOutput;
 			}),

--- a/utils/crossref/schema/contributors.js
+++ b/utils/crossref/schema/contributors.js
@@ -29,6 +29,7 @@ export default (attributions) => {
 						? attribution.user.lastName
 						: attribution.user.firstName,
 					affiliation: attribution.affiliation,
+					ORCID: attribution.user.orcid && `https://orcid.org/${attribution.user.orcid}`,
 				};
 				if (!personNameOutput.affiliation) {
 					delete personNameOutput.affiliation;


### PR DESCRIPTION
Very simple enhancement that will help a lot with Crossref support. Crossref will now automatically ask authors permission to add pubpub-deposited documents to their profiles.

_To test_
1. Create a pub with four users: a registered user with an ORCID in their profile, a registered user without one, a shadow author without an ORCID, and a shadow author with an ORCID.
2. Release & generate a deposit for the pub
3. Check the XML for the deposit: registered user with ORCID and shadow user with ORCID should have `<ORCID>https://orcid.org/ORCID-ID-NUMBER</ORCID>` as an attribute in the `<person>` record, per [Crossref](https://www.crossref.org/documentation/content-registration/descriptive-metadata/contributors/) docs. The users without ORCID should not have an `<ORCID>` attribute, as an empty one will cause a Crossref error.
4. Deposit to crossref test and login to https://test.crossref.org to verify it works.

Note that Crossref will error if the ORCID ID is not valid. This is expected.