### PR TITLE
fix: Patch up logic for what's shown above title in PDF exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ dist
 .vscode
 workers/tasks/export/styles/printDocument.css
 pubpub-postgres-test/
+pubpub-localdb/
 .pubpub_repl_history*

--- a/utils/arrays.ts
+++ b/utils/arrays.ts
@@ -28,7 +28,12 @@ export const indexByProperty = <T extends { [key: string]: any }>(
 
 export const indexById = <T extends WithId>(items: T[]): IdIndex<T> => indexByProperty(items, 'id');
 
-export const unique = <T, Q>(array: T[], fn: (t: T, s: Symbol) => Q | Symbol) => {
+const uniqueByIdentity = (x) => x;
+
+export const unique = <T, Q>(
+	array: T[],
+	fn: (t: T, s: Symbol) => Q | Symbol = uniqueByIdentity,
+) => {
 	const uniqueSymbol = Symbol('unique');
 	const res: T[] = [];
 	const seenValues = new Set<Q | Symbol>();

--- a/workers/tasks/export/html.tsx
+++ b/workers/tasks/export/html.tsx
@@ -176,9 +176,7 @@ const renderDetails = ({ updatedDateString, publishedDateString, doi, license, p
 };
 
 const getHeadingItems = (metadata: PubMetadata) => {
-	const { primaryCollectionMetadata, primaryCollectionTitle, publisher, communityTitle } =
-		metadata;
-	const primaryCollectionKind = primaryCollectionMetadata?.kind;
+	const { primaryCollectionKind, primaryCollectionTitle, publisher, communityTitle } = metadata;
 	if (primaryCollectionKind === 'book' || primaryCollectionKind === 'conference') {
 		// For books and conferences, prefer showing the publisher string to the Community title
 		return [publisher || communityTitle, primaryCollectionTitle];

--- a/workers/tasks/export/metadata.ts
+++ b/workers/tasks/export/metadata.ts
@@ -87,7 +87,7 @@ export const getPubMetadata = async (pubId: string): Promise<PubMetadata> => {
 		citationStyle: pubData.citationStyle,
 		citationInlineStyle: pubData.citationInlineStyle,
 		nodeLabels: pubData.nodeLabels,
-		publisher: pubData.community.publishAs || pubData.communityTitle,
+		publisher: pubData.community.publishAs,
 		...getPrimaryCollectionMetadata(pubData.collectionPubs),
 		license,
 	};

--- a/workers/tasks/export/metadata.ts
+++ b/workers/tasks/export/metadata.ts
@@ -23,8 +23,12 @@ import { PubMetadata } from './types';
 const getPrimaryCollectionMetadata = (collectionPubs: types.CollectionPub[]) => {
 	const primaryCollection = getPrimaryCollection(collectionPubs);
 	if (primaryCollection) {
-		const { metadata, title } = primaryCollection;
-		return { primaryCollectionMetadata: metadata, primaryCollectionTitle: title };
+		const { metadata, title, kind } = primaryCollection;
+		return {
+			primaryCollectionMetadata: metadata,
+			primaryCollectionTitle: title,
+			primaryCollectionKind: kind,
+		};
 	}
 	return null;
 };

--- a/workers/tasks/export/styles/printDocument.scss
+++ b/workers/tasks/export/styles/printDocument.scss
@@ -108,7 +108,7 @@ section.cover {
 			color: #666;
 			font-size: 10px;
 			font-family: $header-font;
-			content: string(community-and-collection);
+			content: string(top-heading-items);
 		}
 		@top-right {
 			color: #666;
@@ -218,8 +218,8 @@ section.cover {
 		}
 	}
 
-	.community-and-collection {
-		string-set: community-and-collection content();
+	.top-heading-items {
+		string-set: top-heading-items content();
 	}
 
 	.title {

--- a/workers/tasks/export/types.ts
+++ b/workers/tasks/export/types.ts
@@ -1,4 +1,4 @@
-import { AttributionWithUser, Maybe, RenderedLicense } from 'types';
+import { AttributionWithUser, Collection, Maybe, RenderedLicense } from 'types';
 import { NodeLabelMap, Note } from 'components/Editor';
 import { NoteManager } from 'client/utils/notes';
 import { CitationInlineStyleKind, CitationStyleKind } from 'utils/citations';
@@ -18,6 +18,7 @@ export type PubMetadata = {
 	citationInlineStyle: CitationInlineStyleKind;
 	nodeLabels: NodeLabelMap;
 	publisher?: string;
+	primaryCollectionKind?: Collection['kind'];
 	primaryCollectionTitle?: string;
 	primaryCollectionMetadata?: Record<string, any>;
 	license: RenderedLicense;


### PR DESCRIPTION
This is a bit of a patch job while we figure out what to actually do here

- Don't pass `communityData.title` in as fallback to `communityData.publishAs`
- Don't show the same string twice in the header (thanks @qweliant)
- Actually pass in a `primaryCollectionKind` value...previously was undefined