### PR TITLE
fix: Memoize `usePubContext()` contents while typing

### DIFF
--- a/client/containers/Pub/Pub.tsx
+++ b/client/containers/Pub/Pub.tsx
@@ -7,7 +7,7 @@ import SpubHeader from './SpubHeader';
 import PubDocument from './PubDocument';
 import { usePubContext } from './pubHooks';
 import { PubContextProvider } from './PubContextProvider';
-import { PubSuspendWhileTypingProvider, PubSuspendWhileTyping } from './PubSuspendWhileTyping';
+import { PubSuspendWhileTypingProvider } from './PubSuspendWhileTyping';
 
 require('./pub.scss');
 
@@ -19,20 +19,19 @@ const SomePubHeader = () => {
 	const pubContext = usePubContext();
 	const { submissionState } = pubContext;
 	const HeaderComponent = submissionState ? SpubHeader : PubHeader;
-	return <PubSuspendWhileTyping delay={1000}>{() => <HeaderComponent />}</PubSuspendWhileTyping>;
+	return <HeaderComponent />;
 };
 
 const Pub = (props: Props) => {
 	const { pubData } = props;
-
 	return (
 		<div id="pub-container">
-			<PubContextProvider pubData={pubData}>
-				<PubSuspendWhileTypingProvider>
+			<PubSuspendWhileTypingProvider>
+				<PubContextProvider pubData={pubData}>
 					<SomePubHeader />
 					<PubDocument />
-				</PubSuspendWhileTypingProvider>
-			</PubContextProvider>
+				</PubContextProvider>
+			</PubSuspendWhileTypingProvider>
 		</div>
 	);
 };

--- a/client/containers/Pub/PubContextProvider.tsx
+++ b/client/containers/Pub/PubContextProvider.tsx
@@ -15,6 +15,7 @@ import { usePubCollabState, PubCollabState } from './usePubCollabState';
 import { usePubHistoryState } from './usePubHistoryState';
 import { IdlePatchFn, useIdlyUpdatedState } from './useIdlyUpdatedState';
 import { PubBodyState, usePubBodyState } from './usePubBodyState';
+import { usePubSuspendWhileTyping } from './PubSuspendWhileTyping';
 
 type Props = {
 	children: React.ReactNode;
@@ -55,7 +56,8 @@ const shimPubContextProps = {
 	noteManager: new NoteManager('apa', 'count', {}),
 } as any;
 
-export const PubContext = React.createContext<PubContextType>(shimPubContextProps);
+export const SuspendedPubContext = React.createContext<PubContextType>(shimPubContextProps);
+export const ImmediatePubContext = React.createContext<PubContextType>(shimPubContextProps);
 
 export const PubContextProvider = (props: Props) => {
 	const { children, pubData: initialPubData } = props;
@@ -113,6 +115,13 @@ export const PubContextProvider = (props: Props) => {
 		updateLocalData,
 		pubHeadings,
 	};
+	const suspendedPubContext: PubContextType = usePubSuspendWhileTyping(pubContext);
 
-	return <PubContext.Provider value={pubContext}>{children}</PubContext.Provider>;
+	return (
+		<SuspendedPubContext.Provider value={suspendedPubContext}>
+			<ImmediatePubContext.Provider value={pubContext}>
+				{children}
+			</ImmediatePubContext.Provider>
+		</SuspendedPubContext.Provider>
+	);
 };

--- a/client/containers/Pub/PubDocument/PubDocument.tsx
+++ b/client/containers/Pub/PubDocument/PubDocument.tsx
@@ -11,7 +11,6 @@ import {
 import { usePubContext } from '../pubHooks';
 import { usePermalinkOnMount } from '../usePermalinkOnMount';
 import { usePubHrefs } from '../usePubHrefs';
-import { PubSuspendWhileTyping } from '../PubSuspendWhileTyping';
 import PubBody from './PubBody';
 import PubBottom from './PubBottom/PubBottom';
 import PubFileImport from './PubFileImport';
@@ -52,7 +51,6 @@ const PubDocument = () => {
 		<div className="pub-document-component">
 			{(!isReadOnly || isViewingHistory) && (
 				<PubHeaderFormatting
-					collabData={collabData}
 					disabled={isViewingHistory}
 					editorWrapperRef={editorWrapperRef}
 				/>
@@ -99,16 +97,12 @@ const PubDocument = () => {
 					)}
 				</div>
 			</div>
-			<PubSuspendWhileTyping delay={1000}>
-				{() => (
-					<PubBottom
-						pubData={pubData}
-						updateLocalData={updateLocalData}
-						sideContentRef={sideContentRef}
-						mainContentRef={mainContentRef}
-					/>
-				)}
-			</PubSuspendWhileTyping>
+			<PubBottom
+				pubData={pubData}
+				updateLocalData={updateLocalData}
+				sideContentRef={sideContentRef}
+				mainContentRef={mainContentRef}
+			/>
 			<PubLinkController mainContentRef={mainContentRef} />
 		</div>
 	);

--- a/client/containers/Pub/PubDocument/PubHeaderCollaborators.tsx
+++ b/client/containers/Pub/PubDocument/PubHeaderCollaborators.tsx
@@ -2,21 +2,10 @@ import React from 'react';
 import { Tooltip } from '@blueprintjs/core';
 
 import { Avatar } from 'components';
-
-type Collaborator = {
-	cursorColor?: string;
-	id?: string;
-	image?: string;
-	initials?: string;
-	name?: string;
-};
+import { PubCollabState } from '../usePubCollabState';
 
 type Props = {
-	collabData: {
-		localCollabUser?: Collaborator;
-		collaborators?: Collaborator[];
-		remoteCollabUsers?: any[];
-	};
+	collabData: PubCollabState;
 };
 
 const getUniqueCollaborators = (collaborators, isAnonymous) => {
@@ -48,7 +37,6 @@ const getUniqueCollaborators = (collaborators, isAnonymous) => {
 
 const PubHeaderCollaborators = (props: Props) => {
 	const { remoteCollabUsers, localCollabUser } = props.collabData;
-	// @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
 	const uniqueCollaborators = getUniqueCollaborators(remoteCollabUsers, !localCollabUser.id);
 	return (
 		<div>
@@ -76,4 +64,5 @@ const PubHeaderCollaborators = (props: Props) => {
 		</div>
 	);
 };
+
 export default PubHeaderCollaborators;

--- a/client/containers/Pub/PubDocument/PubHeaderFormatting.tsx
+++ b/client/containers/Pub/PubDocument/PubHeaderFormatting.tsx
@@ -13,7 +13,6 @@ import PubWordCountButton from './PubWordCountButton';
 require('./pubHeaderFormatting.scss');
 
 type Props = {
-	collabData: any;
 	disabled: boolean;
 	editorWrapperRef: React.RefObject<HTMLDivElement>;
 };
@@ -24,7 +23,9 @@ const PubHeaderFormatting = (props: Props) => {
 	const { canEdit, canEditDraft } = scopeData.activePermissions;
 	const {
 		pubBodyState: { isReadOnly },
-	} = usePubContext();
+		collabData,
+	} = usePubContext({ immediate: true });
+	const { editorChangeObject } = collabData;
 
 	useSticky({
 		target: '.pub-draft-header-component',
@@ -36,13 +37,13 @@ const PubHeaderFormatting = (props: Props) => {
 		return null;
 	}
 
-	const state = props.collabData.editorChangeObject.view?.state;
+	const state = editorChangeObject?.view?.state;
 
 	return (
 		<div className={classNames('pub-draft-header-component', disabled && 'disabled')}>
 			<FormattingBar
 				buttons={buttons.fullButtonSet}
-				editorChangeObject={props.collabData.editorChangeObject || {}}
+				editorChangeObject={editorChangeObject || ({} as any)}
 				controlsConfiguration={{
 					container: editorWrapperRef.current!,
 					isAbsolutelyPositioned: true,
@@ -51,7 +52,7 @@ const PubHeaderFormatting = (props: Props) => {
 			/>
 			<div className="right-content">
 				{state && <PubWordCountButton doc={state.doc} />}
-				<PubHeaderCollaborators collabData={props.collabData} />
+				<PubHeaderCollaborators collabData={collabData} />
 				<PubConnectionStatusIndicator />
 			</div>
 		</div>

--- a/client/containers/Pub/PubHeader/PubHeader.tsx
+++ b/client/containers/Pub/PubHeader/PubHeader.tsx
@@ -40,7 +40,7 @@ const ToggleDetailsButton = (props: ToggleDetailsProps) => {
 
 const PubHeader = (props: Props) => {
 	const headerRef = useRef<HTMLDivElement>(null);
-	const { pubData, updateLocalData, pubHeadings } = usePubContext();
+	const { pubData, updateLocalData } = usePubContext();
 	const { sticky = true } = props;
 	const { communityData } = usePageContext();
 	const [showingDetails, setShowingDetails] = useState(false);
@@ -89,7 +89,6 @@ const PubHeader = (props: Props) => {
 					<PubHeaderContent
 						pubData={pubData}
 						updateLocalData={updateLocalData}
-						pubHeadings={pubHeadings}
 						onShowHeaderDetails={toggleDetails}
 					/>
 				)}

--- a/client/containers/Pub/PubHeader/PubHeaderContent.tsx
+++ b/client/containers/Pub/PubHeader/PubHeaderContent.tsx
@@ -15,12 +15,11 @@ import UtilityButtons from './UtilityButtons';
 type Props = {
 	onShowHeaderDetails: (...args: any[]) => any;
 	pubData: PubPageData;
-	pubHeadings: any[];
 	updateLocalData: (...args: any[]) => any;
 };
 
 const PubHeaderContent = (props: Props) => {
-	const { onShowHeaderDetails, pubData, pubHeadings, updateLocalData } = props;
+	const { onShowHeaderDetails, pubData, updateLocalData } = props;
 	const { doi, isInMaintenanceMode } = pubData;
 	const { communityData } = usePageContext();
 	const { submissionState, historyData } = usePubContext();
@@ -84,12 +83,7 @@ const PubHeaderContent = (props: Props) => {
 		<div className="pub-header-content-component">
 			{renderTop()}
 			<TitleGroup pubData={pubData} updatePubData={updateAndSavePubData} />
-			<UtilityButtons
-				pubData={pubData}
-				updatePubData={updateAndSavePubData}
-				pubHeadings={pubHeadings}
-				onShowHeaderDetails={onShowHeaderDetails}
-			/>
+			<UtilityButtons onShowHeaderDetails={onShowHeaderDetails} />
 			{!isInMaintenanceMode && (
 				<DraftReleaseButtons
 					pubData={pubData}

--- a/client/containers/Pub/PubHeader/PubHeaderSticky.tsx
+++ b/client/containers/Pub/PubHeader/PubHeaderSticky.tsx
@@ -9,23 +9,26 @@ import { usePubContext } from '../pubHooks';
 require('./pubHeaderSticky.scss');
 
 const PubHeaderSticky = () => {
-	const { pubData, pubHeadings } = usePubContext();
+	const { pubData } = usePubContext({ immediate: true });
 	return (
 		<div className="pub-header-sticky-component">
 			<div className="sticky-title">{pubData.title}</div>
 			<div className="sticky-buttons">
-				{pubHeadings.length > 0 && (
-					<React.Fragment>
-						<PubToc headings={pubHeadings} limitHeight>
-							{({ ref, ...disclosureProps }) => (
-								<Button minimal={true} {...disclosureProps} elementRef={ref as any}>
-									Contents
-								</Button>
-							)}
-						</PubToc>
-						<span className="dot">·</span>
-					</React.Fragment>
-				)}
+				<PubToc limitHeight>
+					{({ ref, ...disclosureProps }) => (
+						<>
+							<Button
+								minimal={true}
+								{...disclosureProps}
+								elementRef={ref as any}
+								className="contents-button"
+							>
+								Contents
+							</Button>
+							<span className="dot">·</span>
+						</>
+					)}
+				</PubToc>
 				<Button
 					minimal={true}
 					onClick={() => window.scrollTo({ left: 0, top: 0, behavior: 'auto' })}

--- a/client/containers/Pub/PubHeader/PubToc.tsx
+++ b/client/containers/Pub/PubHeader/PubToc.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import { Menu, MenuItem } from 'components/Menu';
 import { usePageContext } from 'utils/hooks';
-import { PubHeading } from './headerUtils';
+import { usePubContext } from '../pubHooks';
 
 require('./pubToc.scss');
 
@@ -12,16 +12,21 @@ type MenuType = React.ComponentProps<typeof Menu>;
 
 type Props = {
 	children: MenuType['disclosure'];
-	headings: PubHeading[];
 	onSelect?: (...args: any[]) => any;
 	placement?: MenuType['placement'];
 	limitHeight?: boolean;
 };
 
 const PubToc = (props: Props) => {
-	const { headings, children, limitHeight, onSelect = null, placement = 'bottom-end' } = props;
+	const { children, limitHeight, onSelect = null, placement = 'bottom-end' } = props;
 	const { scopeData } = usePageContext();
+	const { pubHeadings } = usePubContext({ immediate: true });
 	const { canEdit, canEditDraft } = scopeData.activePermissions;
+
+	if (pubHeadings.length === 0) {
+		return null;
+	}
+
 	return (
 		<Menu
 			aria-label="Table of contents"
@@ -29,7 +34,7 @@ const PubToc = (props: Props) => {
 			disclosure={children}
 			placement={placement}
 		>
-			{headings.map((heading) => {
+			{pubHeadings.map((heading) => {
 				return (
 					<MenuItem
 						key={heading.index}

--- a/client/containers/Pub/PubHeader/UtilityButtons.tsx
+++ b/client/containers/Pub/PubHeader/UtilityButtons.tsx
@@ -9,23 +9,17 @@ import Download from './Download';
 import PubToc from './PubToc';
 import SmallHeaderButton from './SmallHeaderButton';
 import Social from './Social';
-import { PubHeading } from './headerUtils';
+import { usePubContext } from '../pubHooks';
 
 type Props = {
 	onShowHeaderDetails: (...args: any[]) => any;
-	pubData: {
-		membersData?: {};
-		slug?: string;
-		isRelease?: boolean;
-	};
-	pubHeadings: PubHeading[];
-	updatePubData: (...args: any[]) => any;
 };
 
 const UtilityButtons = (props: Props) => {
-	const { onShowHeaderDetails, pubData, pubHeadings, updatePubData } = props;
-	const { membersData, isRelease } = pubData;
+	const { onShowHeaderDetails } = props;
+	const { pubData, updatePubData } = usePubContext();
 	const { communityData, scopeData } = usePageContext();
+	const { isRelease, membersData } = pubData;
 	const { canManage } = scopeData.activePermissions;
 	return (
 		<div className="utility-buttons-component">
@@ -93,11 +87,9 @@ const UtilityButtons = (props: Props) => {
 			<Download pubData={pubData}>
 				<SmallHeaderButton label="Download" labelPosition="left" icon="download2" />
 			</Download>
-			{pubHeadings.length > 0 && (
-				<PubToc headings={pubHeadings}>
-					<SmallHeaderButton label="Contents" labelPosition="left" icon="toc" />
-				</PubToc>
-			)}
+			<PubToc>
+				<SmallHeaderButton label="Contents" labelPosition="left" icon="toc" />
+			</PubToc>
 		</div>
 	);
 };

--- a/client/containers/Pub/PubHeader/pubHeaderStories.tsx
+++ b/client/containers/Pub/PubHeader/pubHeaderStories.tsx
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react';
 
 import PubHeader from 'containers/Pub/PubHeader';
 import { pubData, communityData, attributionsData } from 'utils/storybook/data';
-import { PubContext } from '../PubContextProvider';
+import { ImmediatePubContext } from '../PubContextProvider';
 
 const altPubData = {
 	...pubData,
@@ -71,9 +71,9 @@ const PubHeaderWrapper = (props) => {
 	};
 
 	return (
-		<PubContext.Provider value={{ ...localData, updateLocalData } as any}>
+		<ImmediatePubContext.Provider value={{ ...localData, updateLocalData } as any}>
 			<PubHeader sticky={false} />
-		</PubContext.Provider>
+		</ImmediatePubContext.Provider>
 	);
 };
 

--- a/client/containers/Pub/pubHooks.ts
+++ b/client/containers/Pub/pubHooks.ts
@@ -1,22 +1,23 @@
 import { useContext } from 'react';
 
-import { PubContext } from './PubContextProvider';
+import { ImmediatePubContext, SuspendedPubContext } from './PubContextProvider';
 
-export const usePubContext = () => {
-	return useContext(PubContext);
+export const usePubContext = (options?: { immediate: boolean }) => {
+	const { immediate = false } = options ?? {};
+	return useContext(immediate ? ImmediatePubContext : SuspendedPubContext);
 };
 
 export const useCollab = () => {
-	const { collabData } = useContext(PubContext);
+	const { collabData } = usePubContext();
 	return collabData;
 };
 
 export const usePubHistory = () => {
-	const { historyData } = useContext(PubContext);
+	const { historyData } = usePubContext();
 	return historyData;
 };
 
 export const usePubData = () => {
-	const { pubData } = useContext(PubContext);
+	const { pubData } = usePubContext();
 	return pubData;
 };

--- a/types/pub.ts
+++ b/types/pub.ts
@@ -126,6 +126,9 @@ export type PubPageDiscussion = DefinitelyHas<Discussion, 'anchors'> & {
 
 export type PubPageData = DefinitelyHas<Omit<Pub, 'discussions'>, 'collectionPubs'> &
 	PubDocInfo & {
+		membersData?: {
+			members: Member[];
+		};
 		collectionPubs: DefinitelyHas<CollectionPub, 'collection'>[];
 		discussions: PubPageDiscussion[];
 		viewHash: Maybe<string>;


### PR DESCRIPTION
Recall two quick facts about state management on the Pub page:

- We use the `PubSuspendWhileTyping` component to prevent major re-renders while the Pub receives text input
- We (increasingly) use the `usePubContext()` hook to access Pub state deep in the render tree

The problem is that `usePubContext()` basically makes `PubSuspendWhileTyping` because React re-renders whenever a Context value changes. So I've made these changes:

- Replace the `PubSuspendWhileTyping` wrapper component with a `usePubSuspendWhileTyping()` hook that memoizes a value it receives.
- Call `usePubSuspendWhileTyping()` from `usePubContext()` so that, by default, it passes a memoized value while the Pub is receiving input. This prevents a lot of unnecessary re-renders.

Since we do sometimes want to immediately receive the latest state, I added a second context provider that stores the most recent pub state, rather than the memoized one. You can access it by calling `usePubContext({ immediate: true })`. We do this in two places where immediate visual feedback from the editor is important:

- The Pub formatting bar
- The Pub table of contents

As a result of these changes, a typical render that occurs after a keypress now takes about half as long in my testing:

_Before:_
<img width="396" alt="image" src="https://user-images.githubusercontent.com/2208769/174893974-82f93d15-8632-426f-8f4e-bbed655a640b.png">


_After:_
<img width="455" alt="image" src="https://user-images.githubusercontent.com/2208769/174893928-5ac8aec7-9916-440f-a315-3e58af298625.png">

_Test plan:_
Visit a Pub and make sure that:
- Broadly speaking, text input still works
- The `PubHeaderFormatting` immediately receives changes from the editor (try using Cmd+B to switch to bold text quickly as you type and verify that the Bold button in the toolbar is highlighted)
- The `PubToc` also receives changes immediately (try using the `#` shortcut to create a heading and verify that the Contents menu in the Pub header immediately appears)