### PR TITLE
fix: Alphabetize citations in HTML/PDF exports, where appropriate

### DIFF
--- a/client/components/Editor/utils/notes.ts
+++ b/client/components/Editor/utils/notes.ts
@@ -1,13 +1,9 @@
 import { Node } from 'prosemirror-model';
 import striptags from 'striptags';
 
-export type CitationFingerprintFunction = (node: Node) => string;
+import { Note } from 'utils/notes';
 
-export type Note = {
-	id: string;
-	structuredValue: string;
-	unstructuredValue: string;
-};
+export type CitationFingerprintFunction = (node: Node) => string;
 
 export const citationFingerprintStripTags = (node: Node) => {
 	const { unstructuredValue, value } = node.attrs;

--- a/client/containers/Pub/PubDocument/PubBottom/Notes.tsx
+++ b/client/containers/Pub/PubDocument/PubBottom/Notes.tsx
@@ -2,23 +2,10 @@ import React, { useState, useRef, useLayoutEffect } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 
-import { RenderedStructuredValue } from 'utils/notesCore';
 import { Icon, PubNoteContent } from 'components';
+import { RenderedNote } from 'utils/notes';
 
 require('./notes.scss');
-
-export type NotePropType = {
-	structuredValue?: string;
-	unstructuredValue?: string;
-	renderedStructuredValue?: RenderedStructuredValue;
-	number?: number;
-	id?: string;
-};
-
-type NotesProps = {
-	accentColor: string;
-	notes: NotePropType[];
-};
 
 const scrollToNode = (node) => {
 	if (node) {
@@ -45,7 +32,7 @@ const findLastElementChild = (node) => {
 
 type NoteProps = {
 	accentColor: string;
-	note: NotePropType;
+	note: RenderedNote;
 };
 
 const Note = (props: NoteProps) => {
@@ -78,10 +65,8 @@ const Note = (props: NoteProps) => {
 						<span
 							role="button"
 							aria-label="Jump back to source"
-							// @ts-expect-error ts-migrate(2322) FIXME: Type 'string' is not assignable to type 'number | ... Remove this comment to see the full error message
-							tabIndex="0"
+							tabIndex={0}
 							style={{ cursor: 'pointer' }}
-							// @ts-expect-error ts-migrate(2339) FIXME: Property 'id' does not exist on type 'notePropType... Remove this comment to see the full error message
 							onClick={() => scrollToNode(document.getElementById(note.id))}
 						>
 							<Icon
@@ -98,6 +83,11 @@ const Note = (props: NoteProps) => {
 	);
 };
 
+type NotesProps = {
+	accentColor: string;
+	notes: RenderedNote[];
+};
+
 const Notes = (props: NotesProps) => {
 	const { notes, ...restProps } = props;
 	const hasNumbering = notes.some(({ number }) => !!number);
@@ -109,4 +99,5 @@ const Notes = (props: NotesProps) => {
 		</ul>
 	);
 };
+
 export default Notes;

--- a/client/containers/Pub/PubDocument/PubBottom/SearchableNoteSection.tsx
+++ b/client/containers/Pub/PubDocument/PubBottom/SearchableNoteSection.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
 import { usePageContext } from 'utils/hooks';
+import { RenderedNote } from 'utils/notes';
 
-import Notes, { NotePropType } from './Notes';
+import Notes from './Notes';
 import PubBottomSection, { SectionBullets } from './PubBottomSection';
 
 type Props = {
-	notes: NotePropType[];
+	notes: RenderedNote[];
 } & React.ComponentProps<typeof PubBottomSection>;
 
 const checkContains = (searchTerm) => (note) =>

--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -6,7 +6,7 @@ import Cite from 'citation-js';
 import { DocJson, Pub } from 'types';
 import { citationFingerprintStripTags, getNotes, jsonToNode } from 'components/Editor';
 import { citationStyles, CitationStyleKind, CitationInlineStyleKind } from 'utils/citations';
-import { StructuredValue, RenderedStructuredValue } from 'utils/notesCore';
+import { StructuredValue, RenderedStructuredValue } from 'utils/notes';
 import { expiringPromise } from 'utils/promises';
 
 /* Different styles available here: */

--- a/utils/notes.ts
+++ b/utils/notes.ts
@@ -1,0 +1,88 @@
+import { CitationInlineStyleKind } from './citations';
+
+export type Note = {
+	id: string;
+	structuredValue: string;
+	unstructuredValue: string;
+};
+
+export type RenderedNote = Note & {
+	renderedStructuredValue?: RenderedStructuredValue;
+	number?: number;
+};
+
+export type StructuredValue = string;
+
+export type RenderedStructuredValue = {
+	html: string;
+	inline: string;
+	error?: boolean;
+	json: any;
+};
+
+export type RenderedStructuredValues = Record<StructuredValue, RenderedStructuredValue>;
+
+export type ByNoteKind<T> = {
+	footnotes: T;
+	citations: T;
+};
+
+const getAlphabetizableValue = (note: RenderedNote) => {
+	const hasRenderedStructuredValue = note.renderedStructuredValue?.json?.length;
+	const sortableString = hasRenderedStructuredValue
+		? note.renderedStructuredValue?.html
+		: note.unstructuredValue;
+	return (sortableString || '')
+		.replace(/(<([^>]+)>)/gi, '')
+		.toLowerCase()
+		.trim();
+};
+
+const getRenderedNotes = (
+	notes: Note[],
+	renderedStructuredValues: RenderedStructuredValues,
+	includeNumbers: boolean,
+): RenderedNote[] => {
+	return notes.map((note, index) => {
+		return {
+			...note,
+			...(includeNumbers && { number: index + 1 }),
+			renderedStructuredValue: renderedStructuredValues[note.structuredValue],
+		};
+	});
+};
+
+const alphabetizeCitations = (citations: RenderedNote[]) => {
+	return citations
+		.map((citation) => {
+			return {
+				...citation,
+				sortOn: getAlphabetizableValue(citation),
+			};
+		})
+		.sort((a, b) => a.sortOn.localeCompare(b.sortOn));
+};
+
+type RenderAndSortOptions = {
+	citations: Note[];
+	footnotes: Note[];
+	citationInlineStyle: CitationInlineStyleKind;
+	renderedStructuredValues: RenderedStructuredValues;
+};
+
+export const renderAndSortNotes = (options: RenderAndSortOptions): ByNoteKind<RenderedNote[]> => {
+	const { citations, footnotes, citationInlineStyle, renderedStructuredValues } = options;
+	const shouldAlphabetizeCitations = citationInlineStyle !== 'count';
+	const renderedFootnotes = getRenderedNotes(footnotes, renderedStructuredValues, true);
+	const renderedCitations = getRenderedNotes(
+		citations,
+		renderedStructuredValues,
+		!shouldAlphabetizeCitations,
+	);
+	return {
+		footnotes: renderedFootnotes,
+		citations: shouldAlphabetizeCitations
+			? alphabetizeCitations(renderedCitations)
+			: renderedCitations,
+	};
+};

--- a/utils/notesCore.ts
+++ b/utils/notesCore.ts
@@ -1,15 +1,5 @@
 import { CitationStyleKind, CitationInlineStyleKind } from 'utils/citations';
-
-export type StructuredValue = string;
-
-export type RenderedStructuredValue = {
-	html: string;
-	inline: string;
-	error?: boolean;
-	json: any;
-};
-
-export type RenderedStructuredValues = Record<string, RenderedStructuredValue>;
+import { StructuredValue, RenderedStructuredValue } from 'utils/notes';
 
 type Notes = Record<StructuredValue, RenderedStructuredValue>;
 

--- a/workers/tasks/export/SimpleNotesList.tsx
+++ b/workers/tasks/export/SimpleNotesList.tsx
@@ -4,12 +4,10 @@
 import React from 'react';
 
 import { PubNoteContent } from 'components';
+import { RenderedNote } from 'utils/notes';
 
 type Props = {
-	notes: {
-		structuredHtml?: string;
-		unstructuredValue?: string;
-	}[];
+	notes: RenderedNote[];
 	getLinkage: (...args: any[]) => any;
 	title: string;
 };
@@ -19,16 +17,18 @@ const SimpleNotesList = (props: Props) => {
 	if (notes.length === 0) {
 		return null;
 	}
+	const isNumberedList = notes.some((note) => typeof note.number === 'number');
+	const ListWrapper = isNumberedList ? 'ol' : 'ul';
 	return (
 		<React.Fragment>
 			<h1>{title}</h1>
-			<ol>
+			<ListWrapper>
 				{notes.map((note, index) => {
 					const { bottomElementId, inlineElementId } = getLinkage(note, index);
 					return (
 						<li key={bottomElementId} id={bottomElementId}>
 							<PubNoteContent
-								structured={note.structuredHtml}
+								structured={note.renderedStructuredValue?.html}
 								unstructured={note.unstructuredValue}
 							/>{' '}
 							<a href={`#${inlineElementId}`} className="return-link">
@@ -37,7 +37,7 @@ const SimpleNotesList = (props: Props) => {
 						</li>
 					);
 				})}
-			</ol>
+			</ListWrapper>
 		</React.Fragment>
 	);
 };

--- a/workers/tasks/export/types.ts
+++ b/workers/tasks/export/types.ts
@@ -1,8 +1,8 @@
 import { AttributionWithUser, Collection, Maybe, RenderedLicense } from 'types';
-import { NodeLabelMap, Note } from 'components/Editor';
+import { NodeLabelMap } from 'components/Editor';
 import { NoteManager } from 'client/utils/notes';
 import { CitationInlineStyleKind, CitationStyleKind } from 'utils/citations';
-import { RenderedStructuredValue } from 'utils/notesCore';
+import { RenderedNote } from 'utils/notes';
 
 export type PubMetadata = {
 	title: string;
@@ -24,13 +24,10 @@ export type PubMetadata = {
 	license: RenderedLicense;
 };
 
-export type NoteWithStructuredHtml = Note & { structuredHtml?: string };
-
 export type NotesData = {
-	renderedStructuredValues: Record<string, RenderedStructuredValue>;
 	noteManager: NoteManager;
-	citations: NoteWithStructuredHtml[];
-	footnotes: NoteWithStructuredHtml[];
+	citations: RenderedNote[];
+	footnotes: RenderedNote[];
 };
 
 export type PandocFlag = {


### PR DESCRIPTION
Resolves #2082

Pubs have an "inline citation style" that dictates how in-text citation nodes should be displayed. Two common values are `count`, which looks like `[4]` and `author-year`, which looks like `(Deng et al., 2031)`. For styles besides `count`, readers expect to see citations in alphabetical order rather than by order of appearance. We implemented this behavior in #1349, but never added it to the separate codepaths that render citations for HTML/PDF exports. Until now!

Some notes-to-future-self: This PR is reminding me how much complexity there is around citation rendering in PubPub, and how much it needs to be streamlined. Basically there are four steps that happen in places all over the codebase:

1. Grabbing a set of `Note` objects with structured values (like a DOI) from somewhere, probably the Pub body with `getNotes()`.
2. Feeding those into citation-js to get `RenderedStructuredValues`, which maps these e.g. DOIs to rendered citations in HTML, CSL-JSON, etc. This must be done on the server. On the client, we have `NotesManager` to help manage the round-trip.
3. Merging the unstructured `Note[]` with `RenderedStructuredValues` to get `RenderedNote[]`.
4. De-duping, sorting, and numbering these rendered notes as appropriate.

For now I've introduced a new function called `renderAndSortNotes()` that handles these last two. But it's becoming clearer to me that we should probably have a helper class of some kind that manages this whole process. I think it could compose `NoteManager` (which should be renamed, ahem, `RenderedStructuredValuesManager`) and also manage steps 1, 3, and 4.

 _Test plan:_
Add two citations to a new Pub in reverse-alphabetical order by first author's surname. You can use [this one](https://doi.org/10.1073/pnas.2102466119) and [that one](https://doi.org/10.1016/j.cstp.2017.08.007)

- They should appear in the Pub-bottom Citations section in that order, with numbering.
- The backlinks on the citations should work.
- Add a _footnote_ with structured data. It should appear in the footnotes section.
- Adding unstructured (rich text) data to citations and footnotes should work.
- Refreshing the page should not crash the Pub.

Now visit Pub Settings and change the inline citation style to `author-year`.

- The citations should now be rendered in author-year form.
- The Pub-bottom Citations section should list them alphabetically.
- They should not be numbered.

Now create a JATS XML export of the Pub.

- Verify that we're still linking citations correctly. Each inline citation should create an `xref` element with an ID that corresponds to a richly-populated `ref` element in `ref-list`.

Now create a PDF (or, hell, HTML) export of the Pub.

- Check that the citations at the bottom appear in a bullet list, in alphabetical order.
- Restore the `Count` inline citation style. Check that they appear in an ordered list, as usual.

_Cool, huh:_

<img src="https://user-images.githubusercontent.com/2208769/175368379-bc775f87-a978-4508-a662-c298d71f7787.png" width="500">
