### PR TITLE
fix: prevent double doi field in Layout header

### DIFF
--- a/client/components/Layout/LayoutCollectionHeader.tsx
+++ b/client/components/Layout/LayoutCollectionHeader.tsx
@@ -33,7 +33,8 @@ const MetadataDetails = (props: Props) => {
 		return null;
 	}
 
-	const fields = getOrderedCollectionMetadataFields(collection).filter((x) => x.name !== 'url');
+	const excludedMetadataFields = ['doi', 'url'];
+	const fields = getOrderedCollectionMetadataFields(collection).filter((x) => !excludedMetadataFields.includes[x.name]);
 
 	return (
 		<>


### PR DESCRIPTION
The DOI field gets printed twice in the LayoutCollectionHeader, this PR filters out the DOI in the second printing.

There's probably better ways to do this, but I'll leave that up to your discretion!


![image](https://user-images.githubusercontent.com/21983833/176896444-9a3733e2-79de-4cea-99f7-c900fa4c2cd4.png)

This is related to https://github.com/pubpub/pubpub/discussions/1565#discussioncomment-3063822