### PR TITLE
fix: sync package-lock with npm/node versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60635,17 +60635,6 @@
 				"mime-types": "^2.1.12"
 			}
 		},
-		"form-data": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			}
-		},
 		"format": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
@@ -62100,6 +62089,35 @@
 					"optional": true,
 					"requires": {
 						"whatwg-url": "^5.0.0"
+					}
+				},
+				"protobufjs": {
+					"version": "6.10.2",
+					"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
+					"integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+					"optional": true,
+					"requires": {
+						"@protobufjs/aspromise": "^1.1.2",
+						"@protobufjs/base64": "^1.1.2",
+						"@protobufjs/codegen": "^2.0.4",
+						"@protobufjs/eventemitter": "^1.1.0",
+						"@protobufjs/fetch": "^1.1.0",
+						"@protobufjs/float": "^1.0.2",
+						"@protobufjs/inquire": "^1.1.0",
+						"@protobufjs/path": "^1.1.2",
+						"@protobufjs/pool": "^1.1.0",
+						"@protobufjs/utf8": "^1.1.0",
+						"@types/long": "^4.0.1",
+						"@types/node": "^13.7.0",
+						"long": "^4.0.0"
+					},
+					"dependencies": {
+						"@types/node": {
+							"version": "13.13.39",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.39.tgz",
+							"integrity": "sha512-wct+WgRTTkBm2R3vbrFOqyZM5w0g+D8KnhstG9463CJBVC3UVZHMToge7iMBR1vDl/I+NWFHUeK9X+JcF0rWKw==",
+							"optional": true
+						}
 					}
 				},
 				"readable-stream": {
@@ -63607,6 +63625,12 @@
 			"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
 			"dev": true
 		},
+		"ip-regex": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+			"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+			"dev": true
+		},
 		"ipaddr.js": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -63917,6 +63941,12 @@
 			"requires": {
 				"isobject": "^3.0.1"
 			}
+		},
+		"is-potential-custom-element-name": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+			"integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+			"dev": true
 		},
 		"is-redirect": {
 			"version": "1.0.0",
@@ -68881,132 +68911,60 @@
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"jsdom": {
-			"version": "16.7.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
-			"integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
+			"version": "16.4.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
+			"integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.5",
-				"acorn": "^8.2.4",
+				"abab": "^2.0.3",
+				"acorn": "^7.1.1",
 				"acorn-globals": "^6.0.0",
 				"cssom": "^0.4.4",
-				"cssstyle": "^2.3.0",
+				"cssstyle": "^2.2.0",
 				"data-urls": "^2.0.0",
-				"decimal.js": "^10.2.1",
+				"decimal.js": "^10.2.0",
 				"domexception": "^2.0.1",
-				"escodegen": "^2.0.0",
-				"form-data": "^3.0.0",
+				"escodegen": "^1.14.1",
 				"html-encoding-sniffer": "^2.0.1",
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"is-potential-custom-element-name": "^1.0.1",
+				"is-potential-custom-element-name": "^1.0.0",
 				"nwsapi": "^2.2.0",
-				"parse5": "6.0.1",
-				"saxes": "^5.0.1",
+				"parse5": "5.1.1",
+				"request": "^2.88.2",
+				"request-promise-native": "^1.0.8",
+				"saxes": "^5.0.0",
 				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^4.0.0",
+				"tough-cookie": "^3.0.1",
 				"w3c-hr-time": "^1.0.2",
 				"w3c-xmlserializer": "^2.0.0",
 				"webidl-conversions": "^6.1.0",
 				"whatwg-encoding": "^1.0.5",
 				"whatwg-mimetype": "^2.3.0",
-				"whatwg-url": "^8.5.0",
-				"ws": "^7.4.6",
+				"whatwg-url": "^8.0.0",
+				"ws": "^7.2.3",
 				"xml-name-validator": "^3.0.0"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "8.7.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-					"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
-					"dev": true
-				},
-				"agent-base": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-					"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-					"dev": true,
-					"requires": {
-						"debug": "4"
-					}
-				},
-				"escodegen": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-					"integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-					"dev": true,
-					"requires": {
-						"esprima": "^4.0.1",
-						"estraverse": "^5.2.0",
-						"esutils": "^2.0.2",
-						"optionator": "^0.8.1",
-						"source-map": "~0.6.1"
-					}
-				},
-				"estraverse": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-					"dev": true
-				},
-				"https-proxy-agent": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-					"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-					"dev": true,
-					"requires": {
-						"agent-base": "6",
-						"debug": "4"
-					}
-				},
-				"is-potential-custom-element-name": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-					"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
 					"dev": true
 				},
 				"parse5": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-					"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+					"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
 					"dev": true
 				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
-					"optional": true
-				},
 				"tough-cookie": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-					"integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+					"integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
 					"dev": true,
 					"requires": {
-						"psl": "^1.1.33",
-						"punycode": "^2.1.1",
-						"universalify": "^0.1.2"
-					}
-				},
-				"tr46": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
-					"integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
-					"dev": true,
-					"requires": {
+						"ip-regex": "^2.1.0",
+						"psl": "^1.1.28",
 						"punycode": "^2.1.1"
-					}
-				},
-				"whatwg-url": {
-					"version": "8.7.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
-					"integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
-					"dev": true,
-					"requires": {
-						"lodash": "^4.7.0",
-						"tr46": "^2.1.0",
-						"webidl-conversions": "^6.1.0"
 					}
 				}
 			}
@@ -72885,9 +72843,9 @@
 			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
 		},
 		"protobufjs": {
-			"version": "6.11.3",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-			"integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
+			"integrity": "sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==",
 			"requires": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
@@ -72900,7 +72858,7 @@
 				"@protobufjs/pool": "^1.1.0",
 				"@protobufjs/utf8": "^1.1.0",
 				"@types/long": "^4.0.1",
-				"@types/node": ">=13.7.0",
+				"@types/node": "^13.7.0",
 				"long": "^4.0.0"
 			}
 		},


### PR DESCRIPTION
Bring `package-lock.json` into alignment with `npm i` w/ npm version 8.9.0 and node version 18.2.0