### PR TITLE
fix: forcibly unset font size on math nodes

### DIFF
--- a/workers/tasks/export/styles/printDocument.scss
+++ b/workers/tasks/export/styles/printDocument.scss
@@ -199,6 +199,7 @@ section.cover {
 	}
 
 	[data-node-type='math-block'] {
+		font-size: unset;
 		break-inside: avoid;
 	}
 


### PR DESCRIPTION
addresses #2100

_test plan_

1. export a pub with a block equation to PDF or HTML
2. check size of rendered block equation, shouldn't have jumped up to 20px