### PR TITLE
fix: typo column row -> header column

### DIFF
--- a/client/components/FormattingBar/controlComponents/ControlsTable.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsTable.tsx
@@ -68,7 +68,7 @@ const columnCommands = [
 	},
 	{
 		key: 'table-toggle-header-column',
-		title: 'Toggle column row',
+		title: 'Toggle header column',
 		icon: 'page-layout',
 		command: tableToggleHeaderColumn,
 	},


### PR DESCRIPTION
Fix a small typo, i don't think a column row is what was meant here