### PR TITLE
fix: unbreak pandox math node handling, bump prosemirror-pandoc

### DIFF
--- a/client/components/Editor/schemas/math.tsx
+++ b/client/components/Editor/schemas/math.tsx
@@ -48,7 +48,7 @@ const renderStaticMath = (mathNode: Node, tagName: string, displayMode: boolean)
 export default {
 	math_inline: {
 		...inlineMathSchema,
-		group: 'inline math',
+		group: 'inline',
 		toDOM: (node: Node, { isReact } = { isReact: false }) => {
 			if (isReact) {
 				return renderStaticMath(node, 'math-inline', false);
@@ -59,7 +59,7 @@ export default {
 	math_display: {
 		...mathDisplaySchema,
 		reactive: true,
-		group: 'block math',
+		group: 'block',
 		attrs: {
 			id: { default: null },
 			hideLabel: { default: false },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@google-cloud/storage": "^5.8.1",
 				"@monaco-editor/react": "^4.1.1",
 				"@popperjs/core": "^2.11.5",
-				"@pubpub/prosemirror-pandoc": "^1.1.3",
+				"@pubpub/prosemirror-pandoc": "^1.1.5",
 				"@pubpub/prosemirror-reactive": "^0.2.0",
 				"@sentry/browser": "^5.5.0",
 				"@sentry/node": "^5.5.0",
@@ -6624,9 +6624,9 @@
 			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
 		},
 		"node_modules/@pubpub/prosemirror-pandoc": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@pubpub/prosemirror-pandoc/-/prosemirror-pandoc-1.1.3.tgz",
-			"integrity": "sha512-Z/Jn5HnAulymMGtq+V0yHG/HwdzP0u7e8ADWs+JLUmdtKFtYmjfOIxWCKKNhWlml/lG3S1+x4trNv7ZTLg3TyQ=="
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@pubpub/prosemirror-pandoc/-/prosemirror-pandoc-1.1.5.tgz",
+			"integrity": "sha512-Mek9o0LVbV/GRxcYPmLBJ3N+b5AMoD937P2HXCvwkzm+g3grXZPweD30VyZqfFc6icdmjXrj/AfuoaHfisEqDw=="
 		},
 		"node_modules/@pubpub/prosemirror-reactive": {
 			"version": "0.2.0",
@@ -48971,9 +48971,9 @@
 			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
 		},
 		"@pubpub/prosemirror-pandoc": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@pubpub/prosemirror-pandoc/-/prosemirror-pandoc-1.1.3.tgz",
-			"integrity": "sha512-Z/Jn5HnAulymMGtq+V0yHG/HwdzP0u7e8ADWs+JLUmdtKFtYmjfOIxWCKKNhWlml/lG3S1+x4trNv7ZTLg3TyQ=="
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@pubpub/prosemirror-pandoc/-/prosemirror-pandoc-1.1.5.tgz",
+			"integrity": "sha512-Mek9o0LVbV/GRxcYPmLBJ3N+b5AMoD937P2HXCvwkzm+g3grXZPweD30VyZqfFc6icdmjXrj/AfuoaHfisEqDw=="
 		},
 		"@pubpub/prosemirror-reactive": {
 			"version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"@google-cloud/storage": "^5.8.1",
 		"@monaco-editor/react": "^4.1.1",
 		"@popperjs/core": "^2.11.5",
-		"@pubpub/prosemirror-pandoc": "^1.1.3",
+		"@pubpub/prosemirror-pandoc": "^1.1.5",
 		"@pubpub/prosemirror-reactive": "^0.2.0",
 		"@sentry/browser": "^5.5.0",
 		"@sentry/node": "^5.5.0",

--- a/utils/import/formats.js
+++ b/utils/import/formats.js
@@ -2,7 +2,7 @@ export const extensionToPandocFormat = {
 	docx: 'docx+citations',
 	epub: 'epub',
 	html: 'html',
-	md: 'markdown',
+	md: 'markdown+tex_math_dollars',
 	odt: 'odt',
 	txt: 'markdown_strict',
 	xml: 'jats',

--- a/workers/tasks/import/rules.ts
+++ b/workers/tasks/import/rules.ts
@@ -343,7 +343,7 @@ rules.toProsemirrorNode('Math', (node) => {
 	const prosemirrorType = isDisplay ? 'math_display' : 'math_inline';
 	return {
 		type: prosemirrorType,
-		content,
+		content: [{ type: 'text', text: content }],
 	};
 });
 
@@ -368,13 +368,17 @@ rules.fromProsemirrorNode('block_equation', (node) => {
 	};
 });
 
-rules.fromProsemirrorNode('math_inline', ({ content }) => ({
-	type: 'Math',
-	mathType: 'InlineMath',
-	content,
-}));
+rules.fromProsemirrorNode('math_inline', (node) => {
+	const content = node.content.reduce((memo, textNode) => memo + textNode.text, '');
+	return {
+		type: 'Math',
+		mathType: 'InlineMath',
+		content,
+	};
+});
 
-rules.fromProsemirrorNode('math_display', ({ content }) => {
+rules.fromProsemirrorNode('math_display', (node) => {
+	const content = node.content.reduce((memo, textNode) => memo + textNode.text, '');
 	return {
 		type: 'Plain',
 		content: [


### PR DESCRIPTION
Fixes bug [pointed out here](https://github.com/pubpub/pubpub/discussions/1869#discussioncomment-3186517) where importing from markdown wasn't working so well.

_test plan_

+ write a pub with both inline and display math nodes
+ export that pub to md
+ import the md
+ check for consistency
+ repeat above steps for LaTeX filetype