### PR TITLE
feat: add sitemap.xml endpoint

### DIFF
--- a/server/routes/sitemap.ts
+++ b/server/routes/sitemap.ts
@@ -128,6 +128,23 @@ const getSitemapIndex = async (community, targetFilename) => {
 };
 
 app.get(
+	'/sitemap.xml',
+	wrap(async (req, res, next) => {
+		if (!hostIsValid(req, 'community')) {
+			return next();
+		}
+
+		const { communityData } = await getInitialData(req, true);
+		const sitemapFileStream = await getSitemapIndex(communityData, 'sitemap-index.xml');
+
+		res.header('Content-Encoding', 'gzip');
+		res.header('Content-Type', 'application/xml');
+
+		return sitemapFileStream.pipe(res);
+	}),
+);
+
+app.get(
 	'/sitemap*',
 	wrap(async (req, res, next) => {
 		if (!hostIsValid(req, 'community')) {


### PR DESCRIPTION
Resolves #2130 

This PR adds a `sitemap.xml` file to the root of communities that serves as a simple alias to `sitemap-index.xml`.

_Test plan_

- Navigate to the `/sitemap.xml` path of any community. It's response should match `/sitemap-index.xml`