### PR TITLE
update: Add HTML title editor to Pub Settings

### DIFF
--- a/client/components/TitleEditor/TitleEditor.tsx
+++ b/client/components/TitleEditor/TitleEditor.tsx
@@ -10,6 +10,7 @@ type Props = {
 	isReadOnly?: boolean;
 	initialValue?: string;
 	onChange?: (html: string, text: string) => void;
+	onInput?: (html: string, text: string) => void;
 	className?: string;
 	placeholder?: string;
 };
@@ -71,7 +72,7 @@ const commonProps = {
 };
 
 export default function TitleEditor(props: Props) {
-	const { initialValue = '', onChange, isReadOnly = false, ...restProps } = props;
+	const { initialValue = '', onChange, onInput, isReadOnly = false, ...restProps } = props;
 	const node = useRef<HTMLDivElement>(null);
 	const init = useRef(false);
 	const [focused, setFocused] = useState(false);
@@ -82,7 +83,7 @@ export default function TitleEditor(props: Props) {
 		'data-placeholder': restProps.placeholder,
 	};
 
-	const onPaste = useCallback(
+	const handlePaste = useCallback(
 		(event: ClipboardEvent) => {
 			event.preventDefault();
 			const editor = node.current;
@@ -115,7 +116,7 @@ export default function TitleEditor(props: Props) {
 		[node],
 	);
 
-	const onKeyDown = useCallback((event) => {
+	const handleKeyDown = useCallback((event) => {
 		if (event.key === 'Enter') {
 			event.preventDefault();
 		} else if (event.key.toLowerCase() === 'u' && event.metaKey) {
@@ -131,17 +132,22 @@ export default function TitleEditor(props: Props) {
 
 	// contenteditable inserts a <br> when it contains an element (e.g. <b>,
 	// <em>, etc.) and its contents are cleared.
-	const onInput = useCallback(() => {
+	const handleInput = useCallback(() => {
 		if (node.current?.textContent === '') {
 			node.current.innerHTML = '';
 		}
-	}, [node]);
+		if (onInput) {
+			const html = node.current?.innerHTML ?? '';
+			const text = node.current?.innerText ?? '';
+			onInput(html, text);
+		}
+	}, [node, onInput]);
 
-	const onFocus = useCallback(() => {
+	const handleFocus = useCallback(() => {
 		setFocused(true);
 	}, []);
 
-	const onBlur = useCallback(() => {
+	const handleBlur = useCallback(() => {
 		const html = node.current?.innerHTML ?? '';
 		const text = node.current?.innerText ?? '';
 		onChange?.(html, text);
@@ -181,11 +187,11 @@ export default function TitleEditor(props: Props) {
 				{...sharedProps}
 				contentEditable={true}
 				ref={node}
-				onKeyDown={onKeyDown}
-				onPaste={onPaste}
-				onInput={onInput}
-				onFocus={onFocus}
-				onBlur={onBlur}
+				onKeyDown={handleKeyDown}
+				onPaste={handlePaste}
+				onInput={handleInput}
+				onFocus={handleFocus}
+				onBlur={handleBlur}
 			/>
 		</ClientOnly>
 	);

--- a/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
+++ b/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
@@ -14,6 +14,7 @@ import {
 	PubAttributionEditor,
 	PubThemePicker,
 	PubCollectionsListing,
+	TitleEditor,
 } from 'components';
 import { apiFetch } from 'client/utils/apiFetch';
 import { slugifyString } from 'utils/strings';
@@ -108,12 +109,15 @@ const PubSettings = (props: Props) => {
 		return (
 			<React.Fragment>
 				<SettingsSection title="Details">
-					<InputField
-						label="Title"
-						value={pubData.title}
-						onChange={(evt) => updatePubData({ title: evt.target.value })}
-						error={!pubData.title ? 'Required' : null}
-					/>
+					<InputField label="Title" error={!pubData.title ? 'Required' : null}>
+						<TitleEditor
+							className="bp3-input"
+							initialValue={pubData.htmlTitle}
+							onInput={(nextHtmlTitle, nextTitle) =>
+								updatePubData({ htmlTitle: nextHtmlTitle, title: nextTitle })
+							}
+						/>
+					</InputField>
 					<InputField
 						label="Link"
 						helperText={`Pub will be available at ${pubUrl(communityData, pubData)}`}

--- a/server/pub/queries.ts
+++ b/server/pub/queries.ts
@@ -1,3 +1,5 @@
+import striptags from 'striptags';
+
 import { Collection, Community, Pub, PubAttribution, Member } from 'server/models';
 import { setPubSearchData, deletePubSearchData } from 'server/utils/search';
 import { createCollectionPub } from 'server/collectionPub/queries';
@@ -97,6 +99,9 @@ export const updatePub = (inputValues, updatePermissions, actorId) => {
 	}
 	if (filteredValues.title && !filteredValues.htmlTitle) {
 		filteredValues.htmlTitle = filteredValues.title;
+	}
+	if (filteredValues.htmlTitle) {
+		filteredValues.title = striptags(filteredValues.htmlTitle);
 	}
 
 	return Pub.update(filteredValues, {


### PR DESCRIPTION
In order to launch rich text titles for all of PubPub, we need to add this capability to Pub Settings. This turns out to be pretty easy! Adding the `.bp3-input` class to the `TitleEditor` component's rendered div styles it perfectly. The only other substantial change I made was to add an `onInput` callback to the `TitleEditor` so we can get changes on keypress instead of blur, and a new check in the Pub PUT handler to convert `htmlTitle` to `title` by stripping tags.

_Test plan:_
- Visit Pub Settings for a Pub and verify that you can use bold and italics in the title, and persist those changes. The title at the top of the dashboard won't change, but that's an existing issue.
- Also make sure the `TitleEditor` in the Pub header continues to work.