### PR TITLE
fix: use right key for issn meta display

### DIFF
--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -137,9 +137,9 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 				<meta
 					key="c4"
 					name="citation_issn"
-					content={collection.metadata?.electronic_issn}
+					content={collection.metadata?.electronicIssn}
 				/>,
-				<meta key="c5" name="citation_issn" content={collection.metadata?.print_issn} />,
+				<meta key="c5" name="citation_issn" content={collection.metadata?.printIssn} />,
 			];
 		}
 		if (collection.kind === 'book') {


### PR DESCRIPTION
Fixes metadata for things that have ISSNs so it actually shows up.

_To test_
1. Visit a pub that's in a journal issue collection that has an ISSN (electronic or print) entered in the settings.
2. Open the inspector and make sure the `<meta name="citation_issn" content="XXXX-XXXX" />` tag displays properly, with the ISSN you entered in step 1.