### PR TITLE
fix: De-dupe notes in `renderNotesForListing()` instead of `getNotesByKind()`

### DIFF
--- a/client/components/Editor/utils/notes.ts
+++ b/client/components/Editor/utils/notes.ts
@@ -5,41 +5,34 @@ import { Note } from 'utils/notes';
 
 export type CitationFingerprintFunction = (node: Node) => string;
 
-const citationFingerprintStripTags = (node: Node) => {
+const fingerprintNote = (node: Node) => {
 	const { unstructuredValue, value } = node.attrs;
 	const strippedUnstructuredValue = unstructuredValue ? striptags(unstructuredValue) : '';
 	return `${value}-${strippedUnstructuredValue}`;
 };
 
-export const getNotes = (
-	doc: Node,
-	citationFingerprintFn: CitationFingerprintFunction = citationFingerprintStripTags,
-) => {
-	const citationFingerprints = new Set<unknown>();
+export const getNotesByKindFromDoc = (doc: Node) => {
 	const footnoteItems: Note[] = [];
 	const citationItems: Note[] = [];
 
 	doc.nodesBetween(0, doc.nodeSize - 2, (node) => {
+		const fingerprint = fingerprintNote(node);
 		if (node.type.name === 'footnote') {
+			const { value, structuredValue } = node.attrs;
 			footnoteItems.push({
 				id: node.attrs.id,
-				structuredValue: node.attrs.structuredValue,
-				unstructuredValue: node.attrs.value,
+				unstructuredValue: value,
+				structuredValue,
+				fingerprint,
 			});
 		}
 		if (node.type.name === 'citation') {
 			const { unstructuredValue, value } = node.attrs;
-			if (citationFingerprintFn) {
-				const citationFingerprint = citationFingerprintFn(node);
-				if (citationFingerprints.has(citationFingerprint)) {
-					return true;
-				}
-				citationFingerprints.add(citationFingerprint);
-			}
 			citationItems.push({
 				id: node.attrs.id,
 				structuredValue: value,
 				unstructuredValue,
+				fingerprint,
 			});
 		}
 		return true;

--- a/client/containers/Pub/usePubNotes.ts
+++ b/client/containers/Pub/usePubNotes.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 
-import { getNotes } from 'components/Editor/utils';
-import { renderAndSortNotes } from '../../../utils/notes';
+import { getNotesByKindFromDoc } from 'components/Editor/utils';
+import { renderNotesForListing } from '../../../utils/notes';
 
 import { usePubContext } from './pubHooks';
 
@@ -14,11 +14,11 @@ export const usePubNotes = () => {
 	const { citationInlineStyleKind: citationInlineStyle } = noteManager;
 	const view = editorChangeObject!.view;
 
-	const { citations = [], footnotes = [] } = view ? getNotes(view.state.doc) : {};
+	const { citations = [], footnotes = [] } = view ? getNotesByKindFromDoc(view.state.doc) : {};
 
 	const renderedNotes = useMemo(
 		() =>
-			renderAndSortNotes({
+			renderNotesForListing({
 				citations,
 				footnotes,
 				citationInlineStyle,

--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -4,7 +4,7 @@ import crypto from 'crypto';
 import Cite from 'citation-js';
 
 import { DocJson, Pub } from 'types';
-import { getNotes, jsonToNode } from 'components/Editor';
+import { getNotesByKindFromDoc, jsonToNode } from 'components/Editor';
 import { citationStyles, CitationStyleKind, CitationInlineStyleKind } from 'utils/citations';
 import { StructuredValue, RenderedStructuredValue } from 'utils/notes';
 import { expiringPromise } from 'utils/promises';
@@ -125,7 +125,7 @@ export const getStructuredCitations = async (
 export const getStructuredCitationsForPub = (pubData: Pub, pubDoc: DocJson) => {
 	const pubDocNode = jsonToNode(pubDoc);
 	const { citationStyle = 'apa-7', citationInlineStyle = 'count' } = pubData;
-	const { footnotes, citations } = getNotes(pubDocNode);
+	const { footnotes, citations } = getNotesByKindFromDoc(pubDocNode);
 	const structuredValuesInDoc = [
 		...new Set([...footnotes, ...citations].map((note) => note.structuredValue)),
 	];

--- a/utils/notes.ts
+++ b/utils/notes.ts
@@ -1,9 +1,11 @@
+import { unique } from './arrays';
 import { CitationInlineStyleKind } from './citations';
 
 export type Note = {
 	id: string;
 	structuredValue: string;
 	unstructuredValue: string;
+	fingerprint: string;
 };
 
 export type RenderedNote = Note & {
@@ -43,7 +45,7 @@ const getRenderedNotes = (
 	renderedStructuredValues: RenderedStructuredValues,
 	includeNumbers: boolean,
 ): RenderedNote[] => {
-	return notes.map((note, index) => {
+	return unique(notes, (note) => note.fingerprint).map((note, index) => {
 		return {
 			...note,
 			...(includeNumbers && { number: index + 1 }),
@@ -63,14 +65,16 @@ const alphabetizeCitations = (citations: RenderedNote[]) => {
 		.sort((a, b) => a.sortOn.localeCompare(b.sortOn));
 };
 
-type RenderAndSortOptions = {
+type RenderForListingOptions = {
 	citations: Note[];
 	footnotes: Note[];
 	citationInlineStyle: CitationInlineStyleKind;
 	renderedStructuredValues: RenderedStructuredValues;
 };
 
-export const renderAndSortNotes = (options: RenderAndSortOptions): ByNoteKind<RenderedNote[]> => {
+export const renderNotesForListing = (
+	options: RenderForListingOptions,
+): ByNoteKind<RenderedNote[]> => {
 	const { citations, footnotes, citationInlineStyle, renderedStructuredValues } = options;
 	const shouldAlphabetizeCitations = citationInlineStyle !== 'count';
 	const renderedFootnotes = getRenderedNotes(footnotes, renderedStructuredValues, true);

--- a/workers/tasks/export/html.tsx
+++ b/workers/tasks/export/html.tsx
@@ -6,8 +6,9 @@ import ReactDOMServer from 'react-dom/server';
 
 import { AttributionWithUser, DocJson } from 'types';
 import { renderStatic, editorSchema } from 'components/Editor';
-
 import { intersperse, unique } from 'utils/arrays';
+import { renderNotesForListing } from '../../../utils/notes';
+
 import { NotesData, PubMetadata } from './types';
 import { digestCitation } from './util';
 import SimpleNotesList from './SimpleNotesList';
@@ -290,8 +291,16 @@ type RenderStaticHtmlOptions = {
 
 export const renderStaticHtml = async (options: RenderStaticHtmlOptions) => {
 	const { pubDoc, pubMetadata, notesData } = options;
-	const { title, nodeLabels } = pubMetadata;
-	const { footnotes, citations, noteManager } = notesData;
+	const { title, nodeLabels, citationInlineStyle } = pubMetadata;
+	const { footnotes, citations, noteManager, renderedStructuredValues } = notesData;
+
+	const renderedNotes = renderNotesForListing({
+		footnotes,
+		citations,
+		citationInlineStyle,
+		renderedStructuredValues,
+	});
+
 	const renderableNodes = [filterNonExportableNodes, addHrefsToNotes, blankIframes]
 		.filter((x): x is (nodes: any) => any => !!x)
 		.reduce((nodes, fn) => fn(nodes), pubDoc.content);
@@ -321,12 +330,12 @@ export const renderStaticHtml = async (options: RenderStaticHtmlOptions) => {
 						<div className="pub-notes">
 							<SimpleNotesList
 								title="Footnotes"
-								notes={footnotes}
+								notes={renderedNotes.footnotes}
 								getLinkage={(_, index) => getFootnoteLinkage(index)}
 							/>
 							<SimpleNotesList
 								title="References"
-								notes={citations}
+								notes={renderedNotes.citations}
 								getLinkage={(note) =>
 									getCitationLinkage(note.unstructuredValue, note.structuredValue)
 								}

--- a/workers/tasks/export/pandoc.ts
+++ b/workers/tasks/export/pandoc.ts
@@ -16,8 +16,7 @@ import { getTmpFileForExtension } from './util';
 import { NotesData, PubMetadata, PandocFlag } from './types';
 import { runTransforms } from './transforms';
 import {
-	getPandocNotesByHash,
-	getCslJsonForPandocNotes,
+	getPandocNotesById,
 	PandocNotes,
 	modifyJatsContentToIncludeUnstructuredNotes,
 } from './notes';
@@ -55,8 +54,8 @@ const createPandocArgs = (
 		.reduce((acc, next) => [...acc, ...next], []);
 };
 
-const createCslJsonBibliographyFile = async (pandocNotes: PandocNotes) => {
-	const cslJson = getCslJsonForPandocNotes(pandocNotes);
+const createCslJsonBibliographyFile = async (notes: PandocNotes) => {
+	const cslJson = Object.values(notes).map((note) => note.cslJson);
 	const file = await getTmpFileForExtension('json');
 	fs.writeFileSync(file.path, JSON.stringify(cslJson));
 	return file.path;
@@ -177,7 +176,7 @@ type ExportWithPandocOptions = {
 
 export const exportWithPandoc = async (options: ExportWithPandocOptions) => {
 	const { pandocTarget, pubMetadata, tmpFile, notesData } = options;
-	const pandocNotes = getPandocNotesByHash(notesData);
+	const pandocNotes = getPandocNotesById(notesData);
 	const pubDoc = reactPubDoc(options);
 	const metadataFile = await createYamlMetadataFile(pubMetadata, pandocTarget);
 	const bibliographyFile = await createCslJsonBibliographyFile(pandocNotes);

--- a/workers/tasks/export/types.ts
+++ b/workers/tasks/export/types.ts
@@ -2,7 +2,7 @@ import { AttributionWithUser, Collection, Maybe, RenderedLicense } from 'types';
 import { NodeLabelMap } from 'components/Editor';
 import { NoteManager } from 'client/utils/notes';
 import { CitationInlineStyleKind, CitationStyleKind } from 'utils/citations';
-import { RenderedNote } from 'utils/notes';
+import { Note, RenderedStructuredValues } from 'utils/notes';
 
 export type PubMetadata = {
 	title: string;
@@ -26,8 +26,9 @@ export type PubMetadata = {
 
 export type NotesData = {
 	noteManager: NoteManager;
-	citations: RenderedNote[];
-	footnotes: RenderedNote[];
+	citations: Note[];
+	footnotes: Note[];
+	renderedStructuredValues: RenderedStructuredValues;
 };
 
 export type PandocFlag = {

--- a/workers/tasks/import/rules.ts
+++ b/workers/tasks/import/rules.ts
@@ -323,9 +323,9 @@ rules.transform('Note', 'footnote', {
 	},
 	fromProsemirrorNode: (node, { resources }) => {
 		const { value: unstructuredValue } = node.attrs;
-		const { html } = resources.note(node.attrs.id);
+		const { unstructuredHtml } = resources.note(node.attrs.id);
 		const unstructuredBlocks = unstructuredValue && htmlStringToPandocBlocks(unstructuredValue);
-		const structuredBlocks = html && htmlStringToPandocBlocks(html);
+		const structuredBlocks = unstructuredHtml && htmlStringToPandocBlocks(unstructuredHtml);
 		const content = [structuredBlocks, unstructuredBlocks].reduce(
 			(acc, next) => [...acc, ...(next || [])],
 			[],


### PR DESCRIPTION
Resolves #2146

This fixes a problem where identical `citation` nodes in a Pub document are de-duped "too early" in `getNotesByKind()`, which prevents them from being processed by `getPandocNotesById()`. We want to de-dupe a list of notes only shortly before displaying it to users, so I've moved that functionality into `renderNotesForListing()`.

_Test plan:_
- Create a Pub with several identical citation nodes (feel free to copy [this one](https://openpresstiu.pubpub.org/pub/kritisch-wetenschappelijk-4/release/1?readingCollection=19a3c21e) from the linked bug report)
- Make sure that both Pandoc (JATS, Markdown, ...) and non-Pandoc (HTML) exports work propertly
- Verify that identical citations are de-duped properly in both the Pub footer and HTML exports (easiest to see when they are alphabetized by turning on Author-Year citations style)
