### PR TITLE
dev: Community switcher for dev environment

### DIFF
--- a/client/components/DevCommunitySwitcherMenu/DevCommunitySwitcherMenu.tsx
+++ b/client/components/DevCommunitySwitcherMenu/DevCommunitySwitcherMenu.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { Menu } from 'components/Menu';
+
+import DevCommunitySwitcherMenuItems from './DevCommunitySwitcherMenuItems';
+
+type Props = Omit<React.ComponentProps<typeof Menu>, 'children'>;
+
+const DevCommunitySwitcherMenu = (props: Props) => {
+	return (
+		<Menu {...props}>
+			<DevCommunitySwitcherMenuItems />
+		</Menu>
+	);
+};
+
+export default DevCommunitySwitcherMenu;

--- a/client/components/DevCommunitySwitcherMenu/DevCommunitySwitcherMenu.tsx
+++ b/client/components/DevCommunitySwitcherMenu/DevCommunitySwitcherMenu.tsx
@@ -4,11 +4,11 @@ import { Menu } from 'components/Menu';
 
 import DevCommunitySwitcherMenuItems from './DevCommunitySwitcherMenuItems';
 
-type Props = Omit<React.ComponentProps<typeof Menu>, 'children'>;
+type Props = Omit<React.ComponentProps<typeof Menu>, 'children' | 'aria-label'>;
 
 const DevCommunitySwitcherMenu = (props: Props) => {
 	return (
-		<Menu {...props}>
+		<Menu {...props} aria-label="Switch Community">
 			<DevCommunitySwitcherMenuItems />
 		</Menu>
 	);

--- a/client/components/DevCommunitySwitcherMenu/DevCommunitySwitcherMenuItems.tsx
+++ b/client/components/DevCommunitySwitcherMenu/DevCommunitySwitcherMenuItems.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback } from 'react';
+
+import { MenuItem, MenuItemDivider } from 'components/Menu';
+import { apiFetch } from 'client/utils/apiFetch';
+
+import { communities } from './communities';
+
+const setDevSubdomain = async (subdomain: null | string) => {
+	await apiFetch.post('/api/dev', { subdomain });
+	window.location.href = '/';
+};
+
+const DevCommunitySwitcherMenuItems = () => {
+	const selectDevSubdomain = useCallback(() => {
+		// eslint-disable-next-line no-alert
+		const subdomain = prompt('Enter a Community subdomain');
+		setDevSubdomain(subdomain);
+	}, []);
+
+	return (
+		<>
+			<MenuItem text="Base PubPub" icon="home" onClick={() => setDevSubdomain(null)} />
+			<MenuItem
+				text="Choose a Community..."
+				icon="text-highlight"
+				onClick={selectDevSubdomain}
+			/>
+			<MenuItemDivider />
+			{communities.map(({ title, subdomain, icon }) => (
+				<MenuItem
+					key={subdomain}
+					text={title}
+					icon={icon}
+					onClick={() => setDevSubdomain(subdomain)}
+				/>
+			))}
+		</>
+	);
+};
+
+export default DevCommunitySwitcherMenuItems;

--- a/client/components/DevCommunitySwitcherMenu/communities.ts
+++ b/client/components/DevCommunitySwitcherMenu/communities.ts
@@ -1,0 +1,23 @@
+import { IconName } from '../Icon/Icon';
+
+type CommunityOption = {
+	title: string;
+	subdomain: string;
+	icon?: IconName;
+};
+
+// eslint-disable-next-line import/no-mutable-exports
+let communities: CommunityOption[] = [];
+
+if (process.env.NODE_ENV !== 'production') {
+	communities = [
+		{ title: 'PubPub Demo Site', subdomain: 'demo', icon: 'build' },
+		{ title: 'DesignSpace', subdomain: 'designspace', icon: 'clean' },
+		{ title: 'KFG Notes', subdomain: 'kfg-notes', icon: 'document' },
+		{ title: 'HDSR', subdomain: 'hdsr', icon: 'regression-chart' },
+		{ title: 'BAAS', subdomain: 'baas', icon: 'moon' },
+		{ title: 'Cursor', subdomain: 'cursor', icon: 'book' },
+	];
+}
+
+export { communities };

--- a/client/components/DevCommunitySwitcherMenu/index.ts
+++ b/client/components/DevCommunitySwitcherMenu/index.ts
@@ -1,0 +1,2 @@
+export { default as DevCommunitySwitcherMenu } from './DevCommunitySwitcherMenu';
+export { default as DevCommunitySwitcherMenuItems } from './DevCommunitySwitcherMenuItems';

--- a/client/components/GlobalControls/GlobalControls.tsx
+++ b/client/components/GlobalControls/GlobalControls.tsx
@@ -97,18 +97,6 @@ const GlobalControls = (props: Props) => {
 		if (isBasePubPub) {
 			return (
 				<>
-					{isDevelopment() && (
-						<DevCommunitySwitcherMenu
-							disclosure={
-								<GlobalControlsButton
-									mobileOrDesktop={{
-										icon: pubPubIcons.community,
-										rightIcon: 'chevron-down',
-									}}
-								/>
-							}
-						/>
-					)}
 					<GlobalControlsButton href="/explore" mobileOrDesktop={{ text: 'Explore' }} />
 					<GlobalControlsButton href="/pricing" mobileOrDesktop={{ text: 'Pricing' }} />
 					<GlobalControlsButton href="/about" mobileOrDesktop={{ text: 'About' }} />
@@ -128,6 +116,18 @@ const GlobalControls = (props: Props) => {
 
 	return (
 		<div className="global-controls-component">
+			{isDevelopment() && (
+				<DevCommunitySwitcherMenu
+					disclosure={
+						<GlobalControlsButton
+							mobileOrDesktop={{
+								icon: pubPubIcons.community,
+								rightIcon: 'caret-down',
+							}}
+						/>
+					}
+				/>
+			)}
 			{renderItemsVisibleFromCommunity()}
 			{renderBasePubPubLinks()}
 			{renderUserMenuOrLogin()}

--- a/client/components/GlobalControls/GlobalControls.tsx
+++ b/client/components/GlobalControls/GlobalControls.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 
-import { ScopeDropdown, Menu, UserNotificationsPopover } from 'components';
+import {
+	ScopeDropdown,
+	Menu,
+	UserNotificationsPopover,
+	DevCommunitySwitcherMenu,
+} from 'components';
 import { usePageContext } from 'utils/hooks';
+import { isDevelopment } from 'utils/environment';
+import { pubPubIcons } from 'client/utils/icons';
 
 import UserMenu from './UserMenu';
 import LoginButton from './LoginButton';
@@ -90,6 +97,18 @@ const GlobalControls = (props: Props) => {
 		if (isBasePubPub) {
 			return (
 				<>
+					{isDevelopment() && (
+						<DevCommunitySwitcherMenu
+							disclosure={
+								<GlobalControlsButton
+									mobileOrDesktop={{
+										icon: pubPubIcons.community,
+										rightIcon: 'chevron-down',
+									}}
+								/>
+							}
+						/>
+					)}
 					<GlobalControlsButton href="/explore" mobileOrDesktop={{ text: 'Explore' }} />
 					<GlobalControlsButton href="/pricing" mobileOrDesktop={{ text: 'Pricing' }} />
 					<GlobalControlsButton href="/about" mobileOrDesktop={{ text: 'About' }} />

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -3,11 +3,7 @@ import classNames from 'classnames';
 
 import { getDashUrl } from 'utils/dashboard';
 import { usePageContext } from 'utils/hooks';
-import { isDevelopment } from 'utils/environment';
-import { pubPubIcons } from 'client/utils/icons';
-import { Avatar, Icon, IconName, MenuItem, DevCommunitySwitcherMenuItems } from 'components';
-
-import { MenuItemDivider } from '../Menu';
+import { Avatar, Icon, IconName, MenuItem } from 'components';
 
 require('./scopeDropdown.scss');
 
@@ -78,14 +74,6 @@ const ScopeDropdown = (props: Props) => {
 		<div className={classNames('scope-dropdown-component', isDashboard && 'in-dashboard')}>
 			{isDashboard && <div className="intro">Select Scope:</div>}
 			<div className="scopes">
-				{isDevelopment() && (
-					<>
-						<MenuItem text="Switch Community..." icon={pubPubIcons.community}>
-							<DevCommunitySwitcherMenuItems />
-						</MenuItem>
-						<MenuItemDivider />
-					</>
-				)}
 				{scopes.map((scope, index) => {
 					return (
 						<MenuItem

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -3,7 +3,11 @@ import classNames from 'classnames';
 
 import { getDashUrl } from 'utils/dashboard';
 import { usePageContext } from 'utils/hooks';
-import { Avatar, Icon, IconName, MenuItem } from 'components';
+import { isDevelopment } from 'utils/environment';
+import { pubPubIcons } from 'client/utils/icons';
+import { Avatar, Icon, IconName, MenuItem, DevCommunitySwitcherMenuItems } from 'components';
+
+import { MenuItemDivider } from '../Menu';
 
 require('./scopeDropdown.scss');
 
@@ -74,6 +78,14 @@ const ScopeDropdown = (props: Props) => {
 		<div className={classNames('scope-dropdown-component', isDashboard && 'in-dashboard')}>
 			{isDashboard && <div className="intro">Select Scope:</div>}
 			<div className="scopes">
+				{isDevelopment() && (
+					<>
+						<MenuItem text="Switch Community..." icon={pubPubIcons.community}>
+							<DevCommunitySwitcherMenuItems />
+						</MenuItem>
+						<MenuItemDivider />
+					</>
+				)}
 				{scopes.map((scope, index) => {
 					return (
 						<MenuItem

--- a/client/components/index.ts
+++ b/client/components/index.ts
@@ -17,6 +17,10 @@ export { default as DashboardFrame } from './DashboardFrame/DashboardFrame';
 export { default as DashboardRow } from './DashboardRow/DashboardRow';
 export { default as DashboardRowListing } from './DashboardRow/DashboardRowListing';
 export { default as DatePicker } from './DatePicker/DatePicker';
+export {
+	DevCommunitySwitcherMenu,
+	DevCommunitySwitcherMenuItems,
+} from './DevCommunitySwitcherMenu';
 export { default as DialogLauncher } from './DialogLauncher/DialogLauncher';
 export { default as DownloadChooser } from './DownloadChooser/DownloadChooser';
 export { DragDropListing, DragDropOrdering, DragHandle } from './DragDropListing';

--- a/client/containers/App/SideMenu/ScopePicker.tsx
+++ b/client/containers/App/SideMenu/ScopePicker.tsx
@@ -1,17 +1,8 @@
 import React from 'react';
-import { getDashUrl } from 'utils/dashboard';
 import { usePageContext } from 'utils/hooks';
 import { Icon, IconName, MenuButton, ScopeDropdown } from 'components';
 
 require('./scopePicker.scss');
-
-type Scope = {
-	type: 'Community' | 'Collection' | 'Pub';
-	icon: IconName;
-	title: string;
-	avatar?: string;
-	href: string;
-};
 
 type Props = {
 	isMobile?: boolean;
@@ -19,11 +10,8 @@ type Props = {
 
 const ScopePicker = (props: Props) => {
 	const { isMobile } = props;
-	const { locationData, communityData, scopeData } = usePageContext();
+	const { scopeData } = usePageContext();
 	const { activeCollection, activePub } = scopeData.elements;
-
-	const collectionSlug = locationData.params.collectionSlug || locationData.query.collectionSlug;
-	const pubSlug = locationData.params.pubSlug;
 
 	let currentScopeTitle = 'Community';
 	let icon: IconName = 'office';
@@ -34,38 +22,6 @@ const ScopePicker = (props: Props) => {
 	if (activePub) {
 		currentScopeTitle = 'Pub';
 		icon = 'pubDoc';
-	}
-
-	const scopes: Scope[] = [];
-	scopes.push({
-		type: 'Community',
-		icon: 'office',
-		title: communityData.title,
-		avatar: communityData.avatar,
-		href: getDashUrl({}),
-	});
-	if (activeCollection) {
-		scopes.push({
-			type: 'Collection',
-			icon: 'collection',
-			title: activeCollection.title,
-			avatar: activeCollection.avatar,
-			href: getDashUrl({
-				collectionSlug,
-			}),
-		});
-	}
-	if (activePub) {
-		scopes.push({
-			type: 'Pub',
-			icon: 'pubDoc',
-			title: activePub.title,
-			avatar: activePub.avatar,
-			href: getDashUrl({
-				collectionSlug,
-				pubSlug,
-			}),
-		});
 	}
 
 	return (

--- a/server/apiRoutes.ts
+++ b/server/apiRoutes.ts
@@ -5,7 +5,6 @@ require('./collectionPub/api');
 require('./community/api');
 require('./communityServices/api');
 require('./customScript/api');
-require('./dev/api');
 require('./discussion/api');
 require('./doi/api');
 require('./editor/api');
@@ -40,3 +39,8 @@ require('./userNotification/api');
 require('./userNotificationPreferences/api');
 require('./userSubscription/api');
 require('./workerTask/api');
+
+if (process.env.NODE_ENV === 'development') {
+	// eslint-disable-next-line global-require
+	require('./dev/api');
+}

--- a/server/apiRoutes.ts
+++ b/server/apiRoutes.ts
@@ -5,6 +5,7 @@ require('./collectionPub/api');
 require('./community/api');
 require('./communityServices/api');
 require('./customScript/api');
+require('./dev/api');
 require('./discussion/api');
 require('./doi/api');
 require('./editor/api');

--- a/server/dev/api.ts
+++ b/server/dev/api.ts
@@ -1,0 +1,29 @@
+import app, { wrap } from 'server/server';
+import { Community } from 'server/models';
+import { ForbiddenError, NotFoundError } from 'server/utils/errors';
+import { isDevelopment } from 'utils/environment';
+
+const setSubdomain = async (subdomain: string | null) => {
+	process.env.FORCE_BASE_PUBPUB = subdomain === null ? 'true' : '';
+	if (subdomain) {
+		const exists = await Community.findOne({ where: { subdomain } });
+		if (!exists) {
+			throw new NotFoundError();
+		}
+		process.env.PUBPUB_LOCAL_COMMUNITY = subdomain;
+	}
+};
+
+app.post(
+	'/api/dev',
+	wrap(async (req, res) => {
+		if (!isDevelopment()) {
+			throw new ForbiddenError();
+		}
+		const { subdomain } = req.body;
+		if (subdomain || subdomain === null) {
+			await setSubdomain(subdomain);
+		}
+		return res.status(200).json({});
+	}),
+);

--- a/server/utils/initData.ts
+++ b/server/utils/initData.ts
@@ -1,7 +1,7 @@
 import queryString from 'query-string';
 
 import * as types from 'types';
-import { isProd, isDuqDuq, isQubQub, getAppCommit } from 'utils/environment';
+import { isProd, isDuqDuq, isQubQub, getAppCommit, isDevelopment } from 'utils/environment';
 import { getFeatureFlagsForUserAndCommunity } from 'server/featureFlag/queries';
 import { UserNotification } from 'server/models';
 
@@ -40,6 +40,8 @@ export const getInitialData = async (req, isDashboard = false): Promise<types.In
 		gdprConsent: user.gdprConsent,
 	};
 
+	const shouldForceBasePubPub = !!(isDevelopment() && process.env.FORCE_BASE_PUBPUB);
+
 	/* Gather location data */
 	const locationData = {
 		hostname: req.hostname,
@@ -48,7 +50,7 @@ export const getInitialData = async (req, isDashboard = false): Promise<types.In
 		query: req.query,
 		queryString: req.query ? `?${queryString.stringify(req.query)}` : '',
 		isDashboard,
-		isBasePubPub: hostname === 'www.pubpub.org',
+		isBasePubPub: shouldForceBasePubPub || hostname === 'www.pubpub.org',
 		isProd: isProd(),
 		isDuqDuq: isDuqDuq(),
 		isQubQub: isQubQub(),

--- a/server/utils/routes.ts
+++ b/server/utils/routes.ts
@@ -1,5 +1,9 @@
+import { isDevelopment } from 'utils/environment';
+
 export const hostIsValid = (req, access) => {
-	const isBasePubPub = req.hostname === 'www.pubpub.org';
+	// This should be merged with the check in getInitialData
+	const shouldForceBasePubPub = !!(isDevelopment() && process.env.FORCE_BASE_PUBPUB);
+	const isBasePubPub = shouldForceBasePubPub || req.hostname === 'www.pubpub.org';
 	if (!isBasePubPub && access !== 'community') {
 		return false;
 	}


### PR DESCRIPTION
We need an easy way to examine "base PubPub" on dev. We desperately need a way to switch the Community we're looking at on dev without updating the `PUBPUB_LOCAL_COMMUNITY` env var and restarting the dev server. 

So I made one! You can access it from two places:

From the `ScopeDropdown` inside a Community...

![Screen Shot 2022-08-04 at 11 32 38 AM](https://user-images.githubusercontent.com/2208769/182887964-9c86ac89-e3e6-4717-bfb5-6aa50380be86.png)

Or from a new menu on "base PubPub"...

![Screen Shot 2022-08-04 at 11 33 01 AM](https://user-images.githubusercontent.com/2208769/182887965-e0c3a760-db79-4665-ab3d-728a533cdf5c.png)

_Test plan:_

Check that:
- The switcher works (preset Communities and custom input) from a Community
- It also takes you to base PubPub
- It takes you back to a Community from base PubPub
- If you enter an invalid Community subdomain, it will not accept it
- (On prod) This whole thing does not appear and the `/api/dev` route errors out.