### PR TITLE
hack: Add extra error handling (and patched prosemirror-math) to recover from bad chars in KaTeX

### DIFF
--- a/client/components/Editor/schemas/math.tsx
+++ b/client/components/Editor/schemas/math.tsx
@@ -1,5 +1,6 @@
 import { DOMOutputSpec, Node } from 'prosemirror-model';
-import katex from 'katex';
+
+import { renderToKatexString } from 'utils/katex';
 
 import { counter } from './reactive/counter';
 
@@ -36,7 +37,7 @@ const renderStaticMath = (mathNode: Node, tagName: string, displayMode: boolean)
 	const { attrs, textContent } = mathNode;
 	const count = attrs?.count;
 	const textContentWithCount = count ? `${textContent} \\tag{${count}}` : textContent;
-	const renderedKatex = katex.renderToString(textContentWithCount, {
+	const renderedKatex = renderToKatexString(textContentWithCount, {
 		displayMode,
 		throwOnError: false,
 		globalGroup: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"hasInstallScript": true,
 			"license": "GPL-2.0+",
 			"dependencies": {
-				"@benrbray/prosemirror-math": "0.2.2",
+				"@benrbray/prosemirror-math": "git+https://github.com/pubpub/prosemirror-math#a053679075243838cf3aeef2196d3bb497d33807",
 				"@blueprintjs/core": "^3.24.0",
 				"@blueprintjs/icons": "^3.14.0",
 				"@blueprintjs/select": "^3.12.0",
@@ -164,6 +164,7 @@
 				"@storybook/addon-viewport": "^6.4.0",
 				"@storybook/react": "^6.4.0",
 				"@types/jest": "^26.0.16",
+				"@types/katex": "^0.14.0",
 				"@types/prosemirror-model": "^1.13.2",
 				"@types/prosemirror-state": "^1.2.7",
 				"@types/prosemirror-view": "^1.19.1",
@@ -2275,8 +2276,9 @@
 		},
 		"node_modules/@benrbray/prosemirror-math": {
 			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@benrbray/prosemirror-math/-/prosemirror-math-0.2.2.tgz",
-			"integrity": "sha512-n+V8MNKaQ9HtA1IASzoBFwthFY55kpu2I+0aF103AbqUw5eM8YlxHeltnLqjnYRVY4/a6A9t9YlBMBQOli5jgw==",
+			"resolved": "git+ssh://git@github.com/pubpub/prosemirror-math.git#a053679075243838cf3aeef2196d3bb497d33807",
+			"integrity": "sha512-ZR66hoJGK/FBZulgwWQjFkFuv/77RMg2gOXnFTdla2svf3cyA9cUYxnVca+X4HS8Lw5fsBOj0gRNVCMmbvN39Q==",
+			"license": "MIT",
 			"peerDependencies": {
 				"katex": "^0.13.0",
 				"prosemirror-commands": "^1.1.7",
@@ -9195,6 +9197,12 @@
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+			"dev": true
+		},
+		"node_modules/@types/katex": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.14.0.tgz",
+			"integrity": "sha512-+2FW2CcT0K3P+JMR8YG846bmDwplKUTsWgT2ENwdQ1UdVfRk3GQrh6Mi4sTopy30gI8Uau5CEqHTDZ6YvWIUPA==",
 			"dev": true
 		},
 		"node_modules/@types/lodash": {
@@ -39421,9 +39429,9 @@
 			"dev": true
 		},
 		"@benrbray/prosemirror-math": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@benrbray/prosemirror-math/-/prosemirror-math-0.2.2.tgz",
-			"integrity": "sha512-n+V8MNKaQ9HtA1IASzoBFwthFY55kpu2I+0aF103AbqUw5eM8YlxHeltnLqjnYRVY4/a6A9t9YlBMBQOli5jgw==",
+			"version": "git+ssh://git@github.com/pubpub/prosemirror-math.git#a053679075243838cf3aeef2196d3bb497d33807",
+			"integrity": "sha512-ZR66hoJGK/FBZulgwWQjFkFuv/77RMg2gOXnFTdla2svf3cyA9cUYxnVca+X4HS8Lw5fsBOj0gRNVCMmbvN39Q==",
+			"from": "@benrbray/prosemirror-math@git+https://github.com/pubpub/prosemirror-math#a053679075243838cf3aeef2196d3bb497d33807",
 			"requires": {}
 		},
 		"@blueprintjs/core": {
@@ -44568,6 +44576,12 @@
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+			"dev": true
+		},
+		"@types/katex": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.14.0.tgz",
+			"integrity": "sha512-+2FW2CcT0K3P+JMR8YG846bmDwplKUTsWgT2ENwdQ1UdVfRk3GQrh6Mi4sTopy30gI8Uau5CEqHTDZ6YvWIUPA==",
 			"dev": true
 		},
 		"@types/lodash": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"workers-prod": "SEQUELIZE_MAX_CONNECTIONS=1 NODE_PATH=./dist/server/client:./dist/server WORKER=true node dist/server/workers/init"
 	},
 	"dependencies": {
-		"@benrbray/prosemirror-math": "0.2.2",
+		"@benrbray/prosemirror-math": "git+https://github.com/pubpub/prosemirror-math#a053679075243838cf3aeef2196d3bb497d33807",
 		"@blueprintjs/core": "^3.24.0",
 		"@blueprintjs/icons": "^3.14.0",
 		"@blueprintjs/select": "^3.12.0",
@@ -191,6 +191,7 @@
 		"@storybook/addon-viewport": "^6.4.0",
 		"@storybook/react": "^6.4.0",
 		"@types/jest": "^26.0.16",
+		"@types/katex": "^0.14.0",
 		"@types/prosemirror-model": "^1.13.2",
 		"@types/prosemirror-state": "^1.2.7",
 		"@types/prosemirror-view": "^1.19.1",

--- a/server/editor/api.ts
+++ b/server/editor/api.ts
@@ -1,8 +1,8 @@
-import katex from 'katex';
 import request from 'request-promise';
 
 import app from 'server/server';
 import { getStructuredCitations } from 'server/utils/citations';
+import { renderToKatexString } from 'utils/katex';
 
 app.post('/api/editor/citation-format', (req, res) => {
 	const { structuredValues, citationStyleKind, inlineStyleKind } = req.body;
@@ -13,7 +13,7 @@ app.post('/api/editor/citation-format', (req, res) => {
 
 app.post('/api/editor/latex-render', (req, res) => {
 	try {
-		const renderedHTML = katex.renderToString(req.body.value, {
+		const renderedHTML = renderToKatexString(req.body.value, {
 			displayMode: req.body.isBlock,
 			throwOnError: false,
 		});

--- a/utils/katex.ts
+++ b/utils/katex.ts
@@ -1,0 +1,9 @@
+import katex, { KatexOptions } from 'katex';
+
+export const renderToKatexString = (tex: string, options: KatexOptions) => {
+	try {
+		return katex.renderToString(tex, options);
+	} catch (e: unknown) {
+		return `<div class="parse-error">(math error)</div>`;
+	}
+};

--- a/workers/tasks/import/rules.ts
+++ b/workers/tasks/import/rules.ts
@@ -1,8 +1,8 @@
-import * as katex from 'katex';
 import md5 from 'crypto-js/md5';
 import { RuleSet, pandocUtils, transformUtils, transformers } from '@pubpub/prosemirror-pandoc';
 
 import { editorSchema } from 'components/Editor';
+import { renderToKatexString } from 'utils/katex';
 
 const { createAttr, flatten, intersperse, textFromStrSpace, textToStrSpace } = transformUtils;
 
@@ -222,7 +222,7 @@ rules.toProsemirrorNode('RawInline', (node, { transform }) => {
 			type: 'equation',
 			attrs: {
 				value: content,
-				html: katex.renderToString(content, {
+				html: renderToKatexString(content, {
 					displayMode: false,
 					throwOnError: false,
 				}),


### PR DESCRIPTION
See https://github.com/KaTeX/KaTeX/issues/3680 for a detailed writeup of our problem. I'm likely to propose a patch to KaTeX at some point, but to keep PubPub afloat we make the following changes here:

1. Fork `@benrbray/prosemirror-math` so that it catches all errors that KaTeX could throw (our changes [here](https://github.com/pubpub/prosemirror-math/commit/ccf5737f75485925a25515818a1516ee59e76f90))
2. Write our own wrapper around KaTeX that also catches all errors

_Test plan:_

- Add a suspicious Unicode character like `𝛾` to a math node
- Make sure it doesn't immediately brick the Pub
- Refresh and make sure it doesn't brick the server-side render of the Pub  