### PR TITLE
Enhance: Dashboard menu navigation

### DIFF
--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { getDashUrl } from 'utils/dashboard';
 import { usePageContext } from 'utils/hooks';
 import { Avatar, Icon, IconName, MenuItem } from 'components';
-import { getPrimaryCollection } from 'utils/collections/primary';
+import { getPrimaryCollectionPub } from 'utils/collections/primary';
 import { Collection, Pub } from 'types';
 
 require('./scopeDropdown.scss');
@@ -22,10 +22,19 @@ type Props = {
 	isDashboard?: boolean;
 };
 
-const getPrimaryOrFirstCollection = (activePub: Pub | undefined): Collection | undefined => {
+const getPrimaryOrFirstCollectionPub = (
+	activePub: Pub | undefined,
+	communityData,
+): Collection | undefined => {
 	if (!activePub || !activePub.collectionPubs || activePub.collectionPubs.length === 0)
 		return undefined;
-	return getPrimaryCollection(activePub.collectionPubs) || activePub.collectionPubs[0].collection;
+	const primaryOrFirstCollectionPub =
+		getPrimaryCollectionPub(activePub.collectionPubs) || activePub.collectionPubs[0];
+	const collection = communityData.collections.find(
+		(availableCollection: Collection) =>
+			primaryOrFirstCollectionPub.collectionId === availableCollection.id,
+	);
+	return collection;
 };
 
 const ScopeDropdown = (props: Props) => {
@@ -35,7 +44,10 @@ const ScopeDropdown = (props: Props) => {
 	const { canManageCommunity } = scopeData.activePermissions;
 	const collectionSlug = locationData.params.collectionSlug || locationData.query.collectionSlug;
 	const pubSlug = locationData.params.pubSlug;
-	const nonActiveDashboardCollection = getPrimaryOrFirstCollection(activePub);
+	const nonActiveDashboardCollectionPub = getPrimaryOrFirstCollectionPub(
+		activePub,
+		communityData,
+	);
 	const scopes: Scope[] = [];
 	scopes.push({
 		type: 'Community',
@@ -65,14 +77,15 @@ const ScopeDropdown = (props: Props) => {
 			}),
 		});
 	}
-	if (!activeCollection && nonActiveDashboardCollection) {
+	if (!activeCollection && nonActiveDashboardCollectionPub) {
+		console.log('nonActive', nonActiveDashboardCollectionPub);
 		scopes.push({
 			type: 'Collection',
 			icon: 'collection',
-			title: nonActiveDashboardCollection.title,
-			avatar: nonActiveDashboardCollection.avatar,
+			title: nonActiveDashboardCollectionPub.title,
+			avatar: nonActiveDashboardCollectionPub.avatar,
 			href: getDashUrl({
-				collectionSlug: nonActiveDashboardCollection.slug,
+				collectionSlug: nonActiveDashboardCollectionPub.slug,
 			}),
 		});
 	}

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -15,7 +15,9 @@ type Scope = {
 	iconSize?: number;
 	title: string;
 	avatar: undefined | string;
+	slug: string;
 	href: string;
+	showSettings: boolean;
 };
 
 type Props = {
@@ -41,7 +43,7 @@ const ScopeDropdown = (props: Props) => {
 	const { isDashboard } = props;
 	const { locationData, communityData, scopeData, pageData } = usePageContext();
 	const { activeCollection, activePub } = scopeData.elements;
-	const { canManageCommunity } = scopeData.activePermissions;
+	const { canManageCommunity, canManage } = scopeData.activePermissions;
 	const collectionSlug = locationData.params.collectionSlug || locationData.query.collectionSlug;
 	const pubSlug = locationData.params.pubSlug;
 	const nonActiveDashboardCollectionPub = getPrimaryOrFirstCollectionPub(
@@ -54,7 +56,9 @@ const ScopeDropdown = (props: Props) => {
 		icon: 'office',
 		title: communityData.title,
 		avatar: communityData.avatar,
+		slug: '',
 		href: getDashUrl({}),
+		showSettings: canManageCommunity,
 	});
 	if (pageData && canManageCommunity && !isDashboard) {
 		scopes.push({
@@ -63,7 +67,9 @@ const ScopeDropdown = (props: Props) => {
 			iconSize: 12,
 			title: pageData.title,
 			avatar: pageData.avatar,
+			slug: pageData.slug || 'home',
 			href: getDashUrl({ mode: 'pages', subMode: pageData.slug || 'home' }),
+			showSettings: canManageCommunity,
 		});
 	}
 	if (activeCollection) {
@@ -72,21 +78,24 @@ const ScopeDropdown = (props: Props) => {
 			icon: 'collection',
 			title: activeCollection.title,
 			avatar: activeCollection.avatar,
+			slug: collectionSlug,
 			href: getDashUrl({
 				collectionSlug,
 			}),
+			showSettings: canManageCommunity,
 		});
 	}
 	if (!activeCollection && nonActiveDashboardCollectionPub) {
-		console.log('nonActive', nonActiveDashboardCollectionPub);
 		scopes.push({
 			type: 'Collection',
 			icon: 'collection',
 			title: nonActiveDashboardCollectionPub.title,
 			avatar: nonActiveDashboardCollectionPub.avatar,
+			slug: nonActiveDashboardCollectionPub.slug,
 			href: getDashUrl({
 				collectionSlug: nonActiveDashboardCollectionPub.slug,
 			}),
+			showSettings: canManageCommunity,
 		});
 	}
 	if (activePub) {
@@ -95,10 +104,12 @@ const ScopeDropdown = (props: Props) => {
 			icon: 'pubDoc',
 			title: activePub.title,
 			avatar: activePub.avatar,
+			slug: pubSlug,
 			href: getDashUrl({
 				collectionSlug,
 				pubSlug,
 			}),
+			showSettings: canManage,
 		});
 	}
 
@@ -113,19 +124,52 @@ const ScopeDropdown = (props: Props) => {
 							key={scope.type}
 							text={
 								<div className={`scope-item item-${index}`}>
-									<div className="top">
-										<Icon icon={scope.icon} iconSize={scope.iconSize || 10} />
-										{scope.type}
+									<div className="content">
+										<div className="top">
+											<Icon
+												icon={scope.icon}
+												iconSize={scope.iconSize || 10}
+											/>
+											{scope.type}
+										</div>
+										<div className="bottom">
+											<Avatar
+												avatar={scope.avatar}
+												initials={scope.title[0]}
+												width={18}
+												isBlock={true}
+											/>
+											{scope.title}
+										</div>
 									</div>
-									<div className="bottom">
-										<Avatar
-											avatar={scope.avatar}
-											initials={scope.title[0]}
-											width={18}
-											isBlock={true}
-										/>
-										{scope.title}
-									</div>
+									{scope.showSettings && scope.type !== 'Page' && (
+										<div className="settings">
+											<a href={`${scope.href}/settings`}>
+												<Icon icon="cog" iconSize={12} />
+											</a>
+											<a href={`${scope.href}/members`}>
+												<Icon icon="people" iconSize={12} />
+											</a>
+											<a href={`${scope.href}/impact`}>
+												<Icon icon="dashboard" iconSize={12} />
+											</a>
+											{scope.type === 'Collection' && (
+												<a href={`/${scope.href}/layout`}>
+													<Icon icon="page-layout" iconSize={12} />
+												</a>
+											)}
+											<a href={`/${scope.slug}`}>
+												<Icon icon="globe" iconSize={12} />
+											</a>
+										</div>
+									)}
+									{scope.showSettings && scope.type === 'Page' && (
+										<div className="settings">
+											<a href={`/${scope.slug}`}>
+												<Icon icon="globe" iconSize={12} />
+											</a>
+										</div>
+									)}
 								</div>
 							}
 						/>

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -35,9 +35,7 @@ const ScopeDropdown = (props: Props) => {
 	const { canManageCommunity } = scopeData.activePermissions;
 	const collectionSlug = locationData.params.collectionSlug || locationData.query.collectionSlug;
 	const pubSlug = locationData.params.pubSlug;
-	console.log('activePub', activePub);
 	const nonActiveDashboardCollection = getPrimaryOrFirstCollection(activePub);
-	console.log('nonactive', nonActiveDashboardCollection);
 	const scopes: Scope[] = [];
 	scopes.push({
 		type: 'Community',

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -4,6 +4,8 @@ import classNames from 'classnames';
 import { getDashUrl } from 'utils/dashboard';
 import { usePageContext } from 'utils/hooks';
 import { Avatar, Icon, IconName, MenuItem } from 'components';
+import { getPrimaryCollection } from 'utils/collections/primary';
+import { Collection, Pub } from 'types';
 
 require('./scopeDropdown.scss');
 
@@ -20,6 +22,12 @@ type Props = {
 	isDashboard?: boolean;
 };
 
+const getPrimaryOrFirstCollection = (activePub: Pub | undefined): Collection | undefined => {
+	if (!activePub || !activePub.collectionPubs || activePub.collectionPubs.length === 0)
+		return undefined;
+	return getPrimaryCollection(activePub.collectionPubs) || activePub.collectionPubs[0].collection;
+};
+
 const ScopeDropdown = (props: Props) => {
 	const { isDashboard } = props;
 	const { locationData, communityData, scopeData, pageData } = usePageContext();
@@ -27,7 +35,9 @@ const ScopeDropdown = (props: Props) => {
 	const { canManageCommunity } = scopeData.activePermissions;
 	const collectionSlug = locationData.params.collectionSlug || locationData.query.collectionSlug;
 	const pubSlug = locationData.params.pubSlug;
-
+	console.log('activePub', activePub);
+	const nonActiveDashboardCollection = getPrimaryOrFirstCollection(activePub);
+	console.log('nonactive', nonActiveDashboardCollection);
 	const scopes: Scope[] = [];
 	scopes.push({
 		type: 'Community',
@@ -54,6 +64,17 @@ const ScopeDropdown = (props: Props) => {
 			avatar: activeCollection.avatar,
 			href: getDashUrl({
 				collectionSlug,
+			}),
+		});
+	}
+	if (!activeCollection && nonActiveDashboardCollection) {
+		scopes.push({
+			type: 'Collection',
+			icon: 'collection',
+			title: nonActiveDashboardCollection.title,
+			avatar: nonActiveDashboardCollection.avatar,
+			href: getDashUrl({
+				collectionSlug: nonActiveDashboardCollection.slug,
 			}),
 		});
 	}

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -34,7 +34,7 @@ const canManageCollection = (
 			collection.id === availableCollection.id &&
 			collection.members.find(
 				(member) =>
-					member.id === loggedInUserId &&
+					member.userId === loggedInUserId &&
 					(member.permissions === 'manage' || member.permissions === 'admin'),
 			),
 	);

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -24,6 +24,22 @@ type Props = {
 	isDashboard?: boolean;
 };
 
+const canManageCollection = (
+	communityCollections: any[],
+	availableCollection: Collection,
+	loggedInUserId: string | null,
+): boolean => {
+	return !!communityCollections.find(
+		(collection) =>
+			collection.id === availableCollection.id &&
+			collection.members.find(
+				(member) =>
+					member.id === loggedInUserId &&
+					(member.permissions === 'manage' || member.permissions === 'admin'),
+			),
+	);
+};
+
 const getPrimaryOrFirstCollectionPub = (
 	activePub: Pub | undefined,
 	communityData,
@@ -41,7 +57,7 @@ const getPrimaryOrFirstCollectionPub = (
 
 const ScopeDropdown = (props: Props) => {
 	const { isDashboard } = props;
-	const { locationData, communityData, scopeData, pageData } = usePageContext();
+	const { loginData, locationData, communityData, scopeData, pageData } = usePageContext();
 	const { activeCollection, activePub } = scopeData.elements;
 	const { canManageCommunity, canManage } = scopeData.activePermissions;
 	const collectionSlug = locationData.params.collectionSlug || locationData.query.collectionSlug;
@@ -82,7 +98,9 @@ const ScopeDropdown = (props: Props) => {
 			href: getDashUrl({
 				collectionSlug,
 			}),
-			showSettings: canManageCommunity,
+			showSettings:
+				canManageCommunity ||
+				canManageCollection(communityData.collections, activeCollection, loginData.id),
 		});
 	}
 	if (!activeCollection && nonActiveDashboardCollectionPub) {
@@ -95,7 +113,13 @@ const ScopeDropdown = (props: Props) => {
 			href: getDashUrl({
 				collectionSlug: nonActiveDashboardCollectionPub.slug,
 			}),
-			showSettings: canManageCommunity,
+			showSettings:
+				canManageCommunity ||
+				canManageCollection(
+					communityData.collections,
+					nonActiveDashboardCollectionPub,
+					loginData.id,
+				),
 		});
 	}
 	if (activePub) {

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -6,6 +6,7 @@ import { usePageContext } from 'utils/hooks';
 import { Avatar, Icon, IconName, MenuItem } from 'components';
 import { getPrimaryCollectionPub } from 'utils/collections/primary';
 import { Collection, Pub } from 'types';
+import { pubPubIcons } from 'client/utils/icons';
 
 require('./scopeDropdown.scss');
 
@@ -69,7 +70,7 @@ const ScopeDropdown = (props: Props) => {
 	const scopes: Scope[] = [];
 	scopes.push({
 		type: 'Community',
-		icon: 'office',
+		icon: pubPubIcons.community,
 		title: communityData.title,
 		avatar: communityData.avatar,
 		href: getDashUrl({}),
@@ -78,7 +79,7 @@ const ScopeDropdown = (props: Props) => {
 	if (pageData && canManageCommunity && !isDashboard) {
 		scopes.push({
 			type: 'Page',
-			icon: 'page-layout',
+			icon: pubPubIcons.page,
 			iconSize: 12,
 			title: pageData.title,
 			avatar: pageData.avatar,
@@ -90,7 +91,7 @@ const ScopeDropdown = (props: Props) => {
 	if (activeCollection) {
 		scopes.push({
 			type: 'Collection',
-			icon: 'collection',
+			icon: pubPubIcons.collection,
 			title: activeCollection.title,
 			avatar: activeCollection.avatar,
 			slug: collectionSlug,
@@ -105,7 +106,7 @@ const ScopeDropdown = (props: Props) => {
 	if (!activeCollection && nonActiveDashboardCollectionPub) {
 		scopes.push({
 			type: 'Collection',
-			icon: 'collection',
+			icon: pubPubIcons.collection,
 			title: nonActiveDashboardCollectionPub.title,
 			avatar: nonActiveDashboardCollectionPub.avatar,
 			slug: nonActiveDashboardCollectionPub.slug,
@@ -124,7 +125,7 @@ const ScopeDropdown = (props: Props) => {
 	if (activePub) {
 		scopes.push({
 			type: 'Pub',
-			icon: 'pubDoc',
+			icon: pubPubIcons.pub,
 			title: activePub.title,
 			avatar: activePub.avatar,
 			slug: `pub/${pubSlug}`,
@@ -174,7 +175,7 @@ const ScopeDropdown = (props: Props) => {
 													mode: 'settings',
 												})}
 											>
-												<Icon icon="cog" iconSize={12} />
+												<Icon icon={pubPubIcons.settings} iconSize={12} />
 											</a>
 											<a
 												href={getDashUrl({
@@ -183,7 +184,7 @@ const ScopeDropdown = (props: Props) => {
 													mode: 'members',
 												})}
 											>
-												<Icon icon="people" iconSize={12} />
+												<Icon icon={pubPubIcons.member} iconSize={12} />
 											</a>
 											<a
 												href={getDashUrl({
@@ -192,7 +193,7 @@ const ScopeDropdown = (props: Props) => {
 													mode: 'impact',
 												})}
 											>
-												<Icon icon="dashboard" iconSize={12} />
+												<Icon icon={pubPubIcons.impact} iconSize={12} />
 											</a>
 											{scope.type === 'Collection' && (
 												<a
@@ -202,7 +203,7 @@ const ScopeDropdown = (props: Props) => {
 														mode: 'layout',
 													})}
 												>
-													<Icon icon="page-layout" iconSize={12} />
+													<Icon icon={pubPubIcons.layout} iconSize={12} />
 												</a>
 											)}
 											<a href={`/${scope.slug || '/'}`}>

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -15,7 +15,7 @@ type Scope = {
 	iconSize?: number;
 	title: string;
 	avatar: undefined | string;
-	slug: string;
+	slug?: string;
 	href: string;
 	showSettings: boolean;
 };
@@ -72,7 +72,6 @@ const ScopeDropdown = (props: Props) => {
 		icon: 'office',
 		title: communityData.title,
 		avatar: communityData.avatar,
-		slug: '',
 		href: getDashUrl({}),
 		showSettings: canManageCommunity,
 	});
@@ -128,7 +127,7 @@ const ScopeDropdown = (props: Props) => {
 			icon: 'pubDoc',
 			title: activePub.title,
 			avatar: activePub.avatar,
-			slug: pubSlug,
+			slug: `pub/${pubSlug}`,
 			href: getDashUrl({
 				collectionSlug,
 				pubSlug,
@@ -168,28 +167,52 @@ const ScopeDropdown = (props: Props) => {
 									</div>
 									{scope.showSettings && scope.type !== 'Page' && (
 										<div className="settings">
-											<a href={`${scope.href}/settings`}>
+											<a
+												href={getDashUrl({
+													collectionSlug,
+													pubSlug,
+													mode: 'settings',
+												})}
+											>
 												<Icon icon="cog" iconSize={12} />
 											</a>
-											<a href={`${scope.href}/members`}>
+											<a
+												href={getDashUrl({
+													collectionSlug,
+													pubSlug,
+													mode: 'members',
+												})}
+											>
 												<Icon icon="people" iconSize={12} />
 											</a>
-											<a href={`${scope.href}/impact`}>
+											<a
+												href={getDashUrl({
+													collectionSlug,
+													pubSlug,
+													mode: 'impact',
+												})}
+											>
 												<Icon icon="dashboard" iconSize={12} />
 											</a>
 											{scope.type === 'Collection' && (
-												<a href={`/${scope.href}/layout`}>
+												<a
+													href={getDashUrl({
+														collectionSlug,
+														pubSlug,
+														mode: 'layout',
+													})}
+												>
 													<Icon icon="page-layout" iconSize={12} />
 												</a>
 											)}
-											<a href={`/${scope.slug}`}>
+											<a href={`/${scope.slug || '/'}`}>
 												<Icon icon="globe" iconSize={12} />
 											</a>
 										</div>
 									)}
 									{scope.showSettings && scope.type === 'Page' && (
 										<div className="settings">
-											<a href={`/${scope.slug}`}>
+											<a href={`/${scope.slug || '/'}`}>
 												<Icon icon="globe" iconSize={12} />
 											</a>
 										</div>

--- a/client/components/ScopeDropdown/scopeDropdown.scss
+++ b/client/components/ScopeDropdown/scopeDropdown.scss
@@ -1,3 +1,5 @@
+@import '../../containers/DashboardOverview/overviewStyles.scss';
+
 .scope-dropdown-component {
 	font-size: 12px;
 	letter-spacing: 0.5px;
@@ -9,7 +11,9 @@
 		opacity: 0.5;
 	}
 	.scope-item {
-		padding: 5px 30px;
+		display: flex;
+		justify-content: space-between;
+		padding: 5px 10px;
 		.top {
 			text-transform: uppercase;
 			opacity: 0.5;
@@ -28,6 +32,19 @@
 			align-items: flex-start;
 			.avatar-component {
 				margin-right: 12px;
+			}
+		}
+		.settings {
+			display: flex;
+			align-items: top;
+			justify-content: space-around;
+			a {
+				padding: 0 3px;
+				margin: 0 2px;
+				color: $light-grey;
+				&:hover {
+					color: $medium-grey;
+				}
 			}
 		}
 	}

--- a/server/utils/queryHelpers/scopeGet.ts
+++ b/server/utils/queryHelpers/scopeGet.ts
@@ -169,6 +169,12 @@ getScopeElements = async (scopeInputs) => {
 					model: CollectionPub,
 					as: 'collectionPubs',
 					attributes: ['id', 'pubId', 'collectionId'],
+					include: [
+						{
+							model: Collection,
+							as: 'collection',
+						},
+					],
 				},
 				{
 					model: Release,

--- a/server/utils/queryHelpers/scopeGet.ts
+++ b/server/utils/queryHelpers/scopeGet.ts
@@ -169,12 +169,6 @@ getScopeElements = async (scopeInputs) => {
 					model: CollectionPub,
 					as: 'collectionPubs',
 					attributes: ['id', 'pubId', 'collectionId'],
-					include: [
-						{
-							model: Collection,
-							as: 'collection',
-						},
-					],
 				},
 				{
 					model: Release,


### PR DESCRIPTION
Resolves #788.

This PR basically does two things:

1. If a Pub is in a Collection and that collection is not 'Active', grabs the primary or first one and puts it as a scope in the dashboard menu.

2. If you can manage the community, collection, or Pub, adds icons to appropriate levels of the dashboard menu to make it more convenient to jump to various settings pages.

<img width="368" alt="Screen Shot 2022-08-16 at 18 43 43" src="https://user-images.githubusercontent.com/639110/184997903-d9370c9c-377f-4b56-bb81-00e40287b4ff.png">

It could probably be released right now and be fine. Some outstanding issues/questions for a follow:
- We should talk about which settings to show for which levels. Collections are really long! And I didn't even include submissions, which I probably should?
- Also, it probably doesn't need to show the globe icon if you are on the public-facing version of a collection/page/pub already, but figuring that out felt complex.

_Test Plan_
Make sure the dashboard menu and the icons work as expected when visiting:

- A homepage
- A page that isn't a homepage!
- A collection layout (e.g. the public view of a collection)
- A pub not in a collection, released and draft
- A pub in a primary collection, released and draft
- A pub in an "active" collection (e.g. has `readingCollection=abcd1234` as a url param), released and draft
- A pub in a collection that isn't the primary collection, released and draft
- An unreleased pub
- All the dashboard pages you can think of
- Repeat on mobile
- Visit a pub where you do have management access to the pub but not to the primary collection of a pub and make sure the settings icons on both the collection and community do not appear, but the pub settings icons do.
- Visit a pub where you do not have management access to the pub and make sure no settings icons appear.
- Visit a pub, page, and collection on a community where you do not have community management access and make sure no settings appear.