### PR TITLE
Fix: actual first or primary

### DIFF
--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -219,7 +219,9 @@ const ScopeDropdown = (props: Props) => {
 											)}
 											<a
 												href={`/${
-													(scope.slugs && 'pub/' + scope.slugs.pubSlug) ||
+													(scope.slugs &&
+														scope.slugs.pubSlug &&
+														'pub/' + scope.slugs.pubSlug) ||
 													(scope.slugs && scope.slugs.collectionSlug)
 												}`}
 											>

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -5,6 +5,7 @@ import { getDashUrl } from 'utils/dashboard';
 import { usePageContext } from 'utils/hooks';
 import { Avatar, Icon, IconName, MenuItem } from 'components';
 import { getPrimaryCollectionPub } from 'utils/collections/primary';
+import { sortByRank } from 'utils/rank';
 import { Collection, Pub } from 'types';
 import { pubPubIcons } from 'client/utils/icons';
 
@@ -49,8 +50,7 @@ const getPrimaryOrFirstCollectionPub = (
 		return undefined;
 	const primaryOrFirstCollectionPub =
 		getPrimaryCollectionPub(activePub.collectionPubs) ||
-		activePub.collectionPubs.sort((a, b) => (a.pubRank > b.pubRank ? 1 : -1))[0];
-	console.log(primaryOrFirstCollectionPub);
+		sortByRank(activePub.collectionPubs, 'pubRank')[0];
 	const collection = communityData.collections.find(
 		(availableCollection: Collection) =>
 			primaryOrFirstCollectionPub.collectionId === availableCollection.id,

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -48,7 +48,9 @@ const getPrimaryOrFirstCollectionPub = (
 	if (!activePub || !activePub.collectionPubs || activePub.collectionPubs.length === 0)
 		return undefined;
 	const primaryOrFirstCollectionPub =
-		getPrimaryCollectionPub(activePub.collectionPubs) || activePub.collectionPubs[0];
+		getPrimaryCollectionPub(activePub.collectionPubs) ||
+		activePub.collectionPubs.sort((a, b) => (a.pubRank > b.pubRank ? 1 : -1))[0];
+	console.log(primaryOrFirstCollectionPub);
 	const collection = communityData.collections.find(
 		(availableCollection: Collection) =>
 			primaryOrFirstCollectionPub.collectionId === availableCollection.id,

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import classNames from 'classnames';
 
 import { getDashUrl } from 'utils/dashboard';
@@ -65,7 +65,10 @@ const ScopeDropdown = (props: Props) => {
 	const { canManageCommunity, canManage } = scopeData.activePermissions;
 	const collectionSlug = locationData.params.collectionSlug || locationData.query.collectionSlug;
 	const pubSlug = locationData.params.pubSlug;
-	const nonActiveDashboardCollectionPub = getPrimaryOrFirstCollection(activePub, communityData);
+	const nonActiveDashboardCollectionPub = useMemo(
+		() => getPrimaryOrFirstCollection(activePub, communityData),
+		[activePub, communityData],
+	);
 	const scopes: Scope[] = [];
 	scopes.push({
 		type: 'Community',

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -17,7 +17,11 @@ type Scope = {
 	iconSize?: number;
 	title: string;
 	avatar: undefined | string;
-	slug?: string;
+	slugs?: {
+		collectionSlug?: string;
+		pubSlug?: string;
+		pageSlug?: string;
+	};
 	href: string;
 	showSettings: boolean;
 };
@@ -85,7 +89,7 @@ const ScopeDropdown = (props: Props) => {
 			iconSize: 12,
 			title: pageData.title,
 			avatar: pageData.avatar,
-			slug: pageData.slug || 'home',
+			slugs: { pageSlug: pageData.slug || 'home' },
 			href: getDashUrl({ mode: 'pages', subMode: pageData.slug || 'home' }),
 			showSettings: canManageCommunity,
 		});
@@ -96,7 +100,7 @@ const ScopeDropdown = (props: Props) => {
 			icon: pubPubIcons.collection,
 			title: activeCollection.title,
 			avatar: activeCollection.avatar,
-			slug: collectionSlug,
+			slugs: { collectionSlug },
 			href: getDashUrl({
 				collectionSlug,
 			}),
@@ -111,7 +115,7 @@ const ScopeDropdown = (props: Props) => {
 			icon: pubPubIcons.collection,
 			title: nonActiveDashboardCollectionPub.title,
 			avatar: nonActiveDashboardCollectionPub.avatar,
-			slug: nonActiveDashboardCollectionPub.slug,
+			slugs: { collectionSlug: nonActiveDashboardCollectionPub.slug },
 			href: getDashUrl({
 				collectionSlug: nonActiveDashboardCollectionPub.slug,
 			}),
@@ -130,7 +134,7 @@ const ScopeDropdown = (props: Props) => {
 			icon: pubPubIcons.pub,
 			title: activePub.title,
 			avatar: activePub.avatar,
-			slug: `pub/${pubSlug}`,
+			slugs: { pubSlug: `${pubSlug}` },
 			href: getDashUrl({
 				collectionSlug,
 				pubSlug,
@@ -172,8 +176,9 @@ const ScopeDropdown = (props: Props) => {
 										<div className="settings">
 											<a
 												href={getDashUrl({
-													collectionSlug,
-													pubSlug,
+													collectionSlug:
+														scope.slugs && scope.slugs.collectionSlug,
+													pubSlug: scope.slugs && scope.slugs.pubSlug,
 													mode: 'settings',
 												})}
 											>
@@ -181,8 +186,9 @@ const ScopeDropdown = (props: Props) => {
 											</a>
 											<a
 												href={getDashUrl({
-													collectionSlug,
-													pubSlug,
+													collectionSlug:
+														scope.slugs && scope.slugs.collectionSlug,
+													pubSlug: scope.slugs && scope.slugs.pubSlug,
 													mode: 'members',
 												})}
 											>
@@ -190,8 +196,9 @@ const ScopeDropdown = (props: Props) => {
 											</a>
 											<a
 												href={getDashUrl({
-													collectionSlug,
-													pubSlug,
+													collectionSlug:
+														scope.slugs && scope.slugs.collectionSlug,
+													pubSlug: scope.slugs && scope.slugs.pubSlug,
 													mode: 'impact',
 												})}
 											>
@@ -200,22 +207,33 @@ const ScopeDropdown = (props: Props) => {
 											{scope.type === 'Collection' && (
 												<a
 													href={getDashUrl({
-														collectionSlug,
-														pubSlug,
+														collectionSlug:
+															scope.slugs &&
+															scope.slugs.collectionSlug,
+														pubSlug: scope.slugs && scope.slugs.pubSlug,
 														mode: 'layout',
 													})}
 												>
 													<Icon icon={pubPubIcons.layout} iconSize={12} />
 												</a>
 											)}
-											<a href={`/${scope.slug || '/'}`}>
+											<a
+												href={`/${
+													(scope.slugs && 'pub/' + scope.slugs.pubSlug) ||
+													(scope.slugs && scope.slugs.collectionSlug)
+												}`}
+											>
 												<Icon icon="globe" iconSize={12} />
 											</a>
 										</div>
 									)}
 									{scope.showSettings && scope.type === 'Page' && (
 										<div className="settings">
-											<a href={`/${scope.slug || '/'}`}>
+											<a
+												href={`/${
+													(scope.slugs && scope.slugs.pageSlug) || '/'
+												}`}
+											>
 												<Icon icon="globe" iconSize={12} />
 											</a>
 										</div>

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -42,7 +42,7 @@ const canManageCollection = (
 	);
 };
 
-const getPrimaryOrFirstCollectionPub = (
+const getPrimaryOrFirstCollection = (
 	activePub: Pub | undefined,
 	communityData,
 ): Collection | undefined => {
@@ -65,10 +65,7 @@ const ScopeDropdown = (props: Props) => {
 	const { canManageCommunity, canManage } = scopeData.activePermissions;
 	const collectionSlug = locationData.params.collectionSlug || locationData.query.collectionSlug;
 	const pubSlug = locationData.params.pubSlug;
-	const nonActiveDashboardCollectionPub = getPrimaryOrFirstCollectionPub(
-		activePub,
-		communityData,
-	);
+	const nonActiveDashboardCollectionPub = getPrimaryOrFirstCollection(activePub, communityData);
 	const scopes: Scope[] = [];
 	scopes.push({
 		type: 'Community',

--- a/server/utils/queryHelpers/scopeGet.ts
+++ b/server/utils/queryHelpers/scopeGet.ts
@@ -168,7 +168,7 @@ getScopeElements = async (scopeInputs) => {
 				{
 					model: CollectionPub,
 					as: 'collectionPubs',
-					attributes: ['id', 'pubId', 'collectionId'],
+					attributes: ['id', 'pubId', 'collectionId', 'pubRank'],
 				},
 				{
 					model: Release,

--- a/server/utils/queryHelpers/scopeGet.ts
+++ b/server/utils/queryHelpers/scopeGet.ts
@@ -169,6 +169,13 @@ getScopeElements = async (scopeInputs) => {
 					model: CollectionPub,
 					as: 'collectionPubs',
 					attributes: ['id', 'pubId', 'collectionId', 'pubRank'],
+					include: [
+						{
+							model: Collection,
+							as: 'collection',
+							attributes: ['kind', 'isPublic'],
+						},
+					],
 				},
 				{
 					model: Release,


### PR DESCRIPTION
Actually grabs the first or primary collection, and in so doing moves us closer to doing it all in ScopeGet.

_To Test_
1. Visit a pub where the primary collection is not the first one in the ordered list and make sure the primary still shows as the collection in the dash menu.
2. Visit a pub where there is no primary collections and all other collections are ordered in non-alpha order and make sure the first ordered collection shows in the dash menu.