### PR TITLE
fix: add nodetype patch for referencing block equations

### DIFF
--- a/client/components/Editor/schemas/reference.ts
+++ b/client/components/Editor/schemas/reference.ts
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { DOMOutputSpec } from 'prosemirror-model';
 import { useDocumentState, useDeferredNode } from '@pubpub/prosemirror-reactive';
 
-import { buildLabel } from '../utils/references';
+import { buildLabel, getReferenceableNodeType } from '../utils/references';
 import { NodeLabelMap, ReferenceableNodeType } from '../types';
 
 export default {
@@ -29,7 +29,7 @@ export default {
 							return null;
 						}
 
-						const nodeType = target.type.name;
+						const nodeType = getReferenceableNodeType(target);
 						const label = (nodeLabels as NodeLabelMap)[
 							nodeType as ReferenceableNodeType
 						];

--- a/client/components/Editor/utils/references.ts
+++ b/client/components/Editor/utils/references.ts
@@ -14,7 +14,7 @@ export type NodeReference = {
 	label: string;
 };
 
-const getReferenceableNodeType = (node): ReferenceableNodeType =>
+export const getReferenceableNodeType = (node): ReferenceableNodeType =>
 	node.type.name === 'math_display' ? 'block_equation' : node.type.name;
 
 export const nodeDefaults = {


### PR DESCRIPTION
Makes block equations reference-able.

_Test plan_

1. Go to/create a pub with a math node
2. reference that math node
3. sha-bayum
