### PR TITLE
bug: Prevent css override

### DIFF
--- a/client/containers/Pub/PubHeader/Review/review.scss
+++ b/client/containers/Pub/PubHeader/Review/review.scss
@@ -2,9 +2,20 @@
 	position: absolute;
 	right: 0;
 	top: 100%;
+	color: black;
 
 	.review-button {
 		padding-top: 18px;
+		.bp3-button {
+			.bp3-icon {
+				color: white !important;
+			}
+			&:hover {
+				.bp3-icon {
+					color: white !important;
+				}
+			}
+		}
 		.bp3-button-text {
 			color: white;
 		}


### PR DESCRIPTION
the color property of children of `.pub-header-background` can be overwritten. specifying the top-level color for the `.review-component selector` fixes this. 
<img width="1668" alt="image" src="https://user-images.githubusercontent.com/34730449/187942794-12d75c98-57f4-4f78-b885-034b9cd3d928.png">


also there was code to specify the icon color of the submit button. we thought it was unnecessary but it is. 
<img width="160" alt="image" src="https://user-images.githubusercontent.com/34730449/187944030-82880593-7202-4bf5-abf3-25103c786f8d.png">

Before: 
<img width="604" alt="image" src="https://user-images.githubusercontent.com/34730449/187941572-a6122e0b-16ee-4cfe-9b2c-302459817104.png">

After:
<img width="591" alt="image" src="https://user-images.githubusercontent.com/34730449/187942219-ce89187f-8f38-4401-89f5-37c5d1afd8e5.png">

