### PR TITLE
bump forked prosemirror-math to get history plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"workers-prod": "SEQUELIZE_MAX_CONNECTIONS=1 NODE_PATH=./dist/server/client:./dist/server WORKER=true node dist/server/workers/init"
 	},
 	"dependencies": {
-		"@benrbray/prosemirror-math": "git+https://github.com/pubpub/prosemirror-math#a053679075243838cf3aeef2196d3bb497d33807",
+		"@benrbray/prosemirror-math": "git+https://github.com/pubpub/prosemirror-math#a0fe5661d122d04278fc769e0bcb5254785d7abe",
 		"@blueprintjs/core": "^3.24.0",
 		"@blueprintjs/icons": "^3.14.0",
 		"@blueprintjs/select": "^3.12.0",


### PR DESCRIPTION
like it says on the tin

brings `prosemirror-history` compatibility to the `prosemirror-math` plugin, enabling undo and redo while remaining within a math node selection.