### PR TITLE
add custom CSS retrieval to search, 404, and user profile routes

### DIFF
--- a/server/routes/noMatch.tsx
+++ b/server/routes/noMatch.tsx
@@ -5,23 +5,26 @@ import app from 'server/server';
 import { handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
+import { getCustomScriptsForCommunity } from 'server/customScript/queries';
 
-app.get('/*', (req, res, next) => {
-	res.status(404);
-
-	return getInitialData(req)
-		.then((initialData) => {
-			return renderToNodeStream(
-				res,
-				<Html
-					chunkName="NoMatch"
-					initialData={initialData}
-					headerComponents={generateMetaComponents({
-						initialData,
-						title: `Not Found · ${initialData.communityData.title}`,
-					})}
-				/>,
-			);
-		})
-		.catch(handleErrors(req, res, next));
+app.get('/*', async (req, res, next) => {
+	try {
+		res.status(404);
+		const initialData = await getInitialData(req);
+		const customScripts = await getCustomScriptsForCommunity(initialData.communityData.id);
+		return renderToNodeStream(
+			res,
+			<Html
+				chunkName="NoMatch"
+				initialData={initialData}
+				customScripts={customScripts}
+				headerComponents={generateMetaComponents({
+					initialData,
+					title: `Not Found · ${initialData.communityData.title}`,
+				})}
+			/>,
+		);
+	} catch (err) {
+		return handleErrors(req, res, next)(err);
+	}
 });

--- a/server/routes/search.tsx
+++ b/server/routes/search.tsx
@@ -6,6 +6,7 @@ import app from 'server/server';
 import { handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
+import { getCustomScriptsForCommunity } from 'server/customScript/queries';
 import { InitialData } from 'types';
 
 const client = algoliasearch(process.env.ALGOLIA_ID!, process.env.ALGOLIA_KEY!);
@@ -54,6 +55,7 @@ const createFilter = (
 app.get('/search', async (req, res, next) => {
 	try {
 		const initialData = await getInitialData(req);
+		const customScripts = await getCustomScriptsForCommunity(initialData.communityData.id);
 
 		const pubsSearchKey = client.generateSecuredApiKey(searchKey, {
 			filters: createFilter(
@@ -65,7 +67,6 @@ app.get('/search', async (req, res, next) => {
 		const pagesSearchKey = client.generateSecuredApiKey(searchKey, {
 			filters: createFilter(initialData, ['isPublic'], ['pageAccessIds']),
 		});
-
 		const searchData = {
 			searchId,
 			pubsSearchKey,
@@ -77,6 +78,7 @@ app.get('/search', async (req, res, next) => {
 			<Html
 				chunkName="Search"
 				initialData={initialData}
+				customScripts={customScripts}
 				viewData={{ searchData }}
 				headerComponents={generateMetaComponents({
 					initialData,

--- a/server/routes/user.tsx
+++ b/server/routes/user.tsx
@@ -6,11 +6,13 @@ import { getUser } from 'server/utils/queryHelpers';
 import { handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
+import { getCustomScriptsForCommunity } from 'server/customScript/queries';
 import { isUserAffiliatedWithCommunity } from 'server/community/queries';
 
 app.get(['/user/:slug', '/user/:slug/:mode'], async (req, res, next) => {
 	try {
 		const initialData = await getInitialData(req);
+		const customScripts = await getCustomScriptsForCommunity(initialData.communityData.id);
 		const userData = await getUser(req.params.slug, initialData);
 		const isNewishUser = Date.now() - userData.createdAt.valueOf() < 1000 * 86400 * 30;
 
@@ -29,6 +31,7 @@ app.get(['/user/:slug', '/user/:slug/:mode'], async (req, res, next) => {
 			<Html
 				chunkName="User"
 				initialData={initialData}
+				customScripts={customScripts}
 				viewData={{ userData }}
 				headerComponents={generateMetaComponents({
 					initialData,


### PR DESCRIPTION
addresses #2264, bringing the community custom css to search, 404, and profile routes

_test plan_
1. set some identifiable custom css from the community settings (e.g. set background-color on html)
2. navigate to each of the following routes, confirm presence of custom CSS:
* [Search](https://demo.pubpub.org/search)
* [404](https://demo.pubpub.org/this-cant-be-a-real-page)
* [User profile pages](demo://tghp.pubpub.org/user/pubpub-team)