### PR TITLE
fix: Unescape entities like &amp; when updating Pub titles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
 				"lodash.pick": "^4.4.0",
 				"lodash.pickby": "^4.6.0",
 				"lodash.throttle": "^4.1.1",
+				"lodash.unescape": "^4.0.1",
 				"mailgun.js": "^2.0.1",
 				"mudder": "^1.0.4",
 				"mutationobserver-shim": "^0.3.3",
@@ -26984,6 +26985,11 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
 			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+		},
+		"node_modules/lodash.unescape": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+			"integrity": "sha512-DhhGRshNS1aX6s5YdBE3njCCouPgnG29ebyHvImlZzXZf2SHgt+J08DHgytTPnpywNbO1Y8mNUFyQuIDBq2JZg=="
 		},
 		"node_modules/lodash.uniq": {
 			"version": "4.5.0",
@@ -59002,6 +59008,11 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
 			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+		},
+		"lodash.unescape": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+			"integrity": "sha512-DhhGRshNS1aX6s5YdBE3njCCouPgnG29ebyHvImlZzXZf2SHgt+J08DHgytTPnpywNbO1Y8mNUFyQuIDBq2JZg=="
 		},
 		"lodash.uniq": {
 			"version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
 		"lodash.pick": "^4.4.0",
 		"lodash.pickby": "^4.6.0",
 		"lodash.throttle": "^4.1.1",
+		"lodash.unescape": "^4.0.1",
 		"mailgun.js": "^2.0.1",
 		"mudder": "^1.0.4",
 		"mutationobserver-shim": "^0.3.3",

--- a/server/pub/queries.ts
+++ b/server/pub/queries.ts
@@ -1,4 +1,5 @@
 import striptags from 'striptags';
+import unescape from 'lodash.unescape';
 
 import { Collection, Community, Pub, PubAttribution, Member } from 'server/models';
 import { setPubSearchData, deletePubSearchData } from 'server/utils/search';
@@ -102,7 +103,7 @@ export const updatePub = (inputValues, updatePermissions, actorId) => {
 		filteredValues.htmlTitle = filteredValues.title;
 	}
 	if (filteredValues.htmlTitle) {
-		filteredValues.title = striptags(filteredValues.htmlTitle);
+		filteredValues.title = unescape(striptags(filteredValues.htmlTitle));
 	}
 
 	return Pub.update(filteredValues, {


### PR DESCRIPTION
Quick one!

_Test plan:_
- Create a new Pub
- Change its title to something with an ampersand in it
- Verify that after you refresh the page, the Pub title includes `&` and not `&amp;`

