### PR TITLE
fix: Profiles on www

### DIFF
--- a/client/components/PubPreview/PubPreview.tsx
+++ b/client/components/PubPreview/PubPreview.tsx
@@ -119,10 +119,16 @@ const PubPreview = (props: Props) => {
 								className="community-banner"
 								style={{ backgroundColor: communityData.accentColorDark }}
 							>
-								<img
-									alt={`in Community ${communityData.title}`}
-									src={resizedHeaderLogo}
-								/>
+								{resizedHeaderLogo ? (
+									<img
+										src={resizedHeaderLogo}
+										alt={`in Community ${communityData.title}`}
+									/>
+								) : (
+									<span style={{ color: communityData.accentColorLight }}>
+										{communityData.title}
+									</span>
+								)}
 							</a>
 						)}
 						<a href={pubLink} title={pubData.title}>

--- a/server/routes/user.tsx
+++ b/server/routes/user.tsx
@@ -12,7 +12,9 @@ import { isUserAffiliatedWithCommunity } from 'server/community/queries';
 app.get(['/user/:slug', '/user/:slug/:mode'], async (req, res, next) => {
 	try {
 		const initialData = await getInitialData(req);
-		const customScripts = await getCustomScriptsForCommunity(initialData.communityData.id);
+		const customScripts = !initialData.locationData.isBasePubPub
+			? await getCustomScriptsForCommunity(initialData.communityData.id)
+			: undefined;
 		const userData = await getUser(req.params.slug, initialData);
 		const isNewishUser = Date.now() - userData.createdAt.valueOf() < 1000 * 86400 * 30;
 


### PR DESCRIPTION
Currently broken because they attempt to load custom CSS scripts even on WWW. This fixes that, and also adds a quick fix for cases where there's no community header image.

_Test plan_
- Visit a profile on www, make sure it loads
- Visit a profile not on www with some custom css, make sure it loads with custom CSS
- Make sure that Pubs from a community where there's no header image load as a block with accentColorDark as the background and accentColorLight as the text.