### PR TITLE
Add data-tab-related-count attribute to allow access in CSS to tabs in User Profile

### DIFF
--- a/client/containers/User/UserNav.tsx
+++ b/client/containers/User/UserNav.tsx
@@ -19,8 +19,8 @@ const defaultProps = {
 
 const UserNav = function (props) {
 	const tabs = [
-		{ id: 0, label: `All Pubs (${props.allPubsCount})`, path: '' },
-		{ id: 1, label: `Authored Pubs (${props.authoredPubsCount})`, path: '/authored' },
+		{ id: 0, label: 'All Pubs', path: '', count: props.allPubsCount },
+		{ id: 1, label: 'Authored Pubs', path: '/authored', count: props.authoredPubsCount },
 		// { id: 1, label: 'All Pubs', path: '/pubs' },
 		// { id: 2, label: 'Discussions', path: '/discussions' },
 	];
@@ -41,8 +41,9 @@ const UserNav = function (props) {
 										? 'true'
 										: 'false'
 								}
+								data-tab-related-count={tab.count}
 							>
-								{tab.label}
+								{tab.label} {typeof tab.count !== 'undefined' && `(${tab.count})`}
 							</a>
 						);
 					})}


### PR DESCRIPTION
This allows pubs to style based on the count via `[data-tab-related-count="0"]`, or use it via `attr(data-tab-related-count)` in CSS. 

We want it for the latter, so that we can change the wording here, but still have the count
(e.g. `:before { content: 'Custom Title (' attr(data-tab-related-count) ')'; }`

This only changes the way this content is output and doesn't change any behaviour, the result to the user will be indistinguishable but increases the surface area for extendibility.