### PR TITLE
fix: Allow reviews to be submitted on Spubs

### DIFF
--- a/client/components/FileUploadButton/fileUploadButton.scss
+++ b/client/components/FileUploadButton/fileUploadButton.scss
@@ -1,16 +1,5 @@
 .file-upload-button-component {
 	display: block;
-	.upload-button {
-		position: relative;
-		label {
-			position: absolute;
-			left: 0;
-			right: 0;
-			top: 0;
-			bottom: 0;
-			cursor: pointer;
-		}
-	}
 	input.file-input {
 		display: none;
 	}

--- a/client/containers/Pub/PubDocument/PubDocument.tsx
+++ b/client/containers/Pub/PubDocument/PubDocument.tsx
@@ -34,7 +34,7 @@ const PubDocument = () => {
 	const { isViewingHistory } = historyData;
 	const { communityData, scopeData } = usePageContext();
 	const { canEdit, canEditDraft } = scopeData.activePermissions;
-	const { isReview } = pubData;
+	const { isReviewingPub } = pubData;
 	const mainContentRef = useRef<null | HTMLDivElement>(null);
 	const sideContentRef = useRef(null);
 	const editorWrapperRef = useRef(null);
@@ -59,7 +59,7 @@ const PubDocument = () => {
 			<div className="pub-grid">
 				<div className="main-content" ref={mainContentRef}>
 					<PubMaintenanceNotice pubData={pubData} />
-					{!isReview && (
+					{!isReviewingPub && (
 						<PubHistoricalNotice pubData={pubData} historyData={historyData} />
 					)}
 					<PubEdgeListing
@@ -90,7 +90,7 @@ const PubDocument = () => {
 					/>
 				</div>
 				<div className="side-content" ref={sideContentRef}>
-					{isViewingHistory && !isReview && (
+					{isViewingHistory && !isReviewingPub && (
 						<PubHistoryViewer
 							historyData={historyData}
 							pubData={pubData}

--- a/client/containers/Pub/PubHeader/DraftReleaseButtons.tsx
+++ b/client/containers/Pub/PubHeader/DraftReleaseButtons.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import TimeAgo from 'react-timeago';
 
 import { DialogLauncher, PubReleaseDialog, PubReleaseReviewDialog } from 'components';
+import { PatchFn, PubPageData } from 'types';
 import { Menu, MenuItem } from 'components/Menu';
 import { pubUrl } from 'utils/canonicalUrls';
 import { formatDate } from 'utils/dates';
 import { usePageContext } from 'utils/hooks';
 
-import { PatchFn, PubPageData } from 'types';
+import { usePubContext } from '../pubHooks';
 import ResponsiveHeaderButton from './ResponsiveHeaderButton';
 
 require('./draftReleaseButtons.scss');
@@ -45,8 +46,10 @@ const getCanCreateRelease = (latestRelease, latestKey) => {
 const DraftReleaseButtons = (props: DraftReleaseButtonsProps) => {
 	const { historyData, pubData, updatePubData } = props;
 	const { communityData, scopeData } = usePageContext();
+	const { submissionState } = usePubContext();
 	const { canView, canViewDraft, canAdmin, canCreateReviews } = scopeData.activePermissions;
-	const { isRelease, isReview } = pubData;
+	const { isRelease, isReviewingPub } = pubData;
+	const shouldShowReleaseReviewButton = canCreateReviews && !isReviewingPub && !submissionState;
 
 	const renderForRelease = () => {
 		const { releases, releaseNumber } = pubData;
@@ -64,7 +67,7 @@ const DraftReleaseButtons = (props: DraftReleaseButtonsProps) => {
 						}}
 					/>
 				)}
-				{!isReview && (
+				{!isReviewingPub && (
 					<Menu
 						className="releases-menu"
 						aria-label="Choose a historical release of this Pub"
@@ -138,7 +141,7 @@ const DraftReleaseButtons = (props: DraftReleaseButtonsProps) => {
 						outerLabel={{ bottom: 'view latest release', top: 'see published version' }}
 					/>
 				)}
-				{canAdmin && !isReview && (
+				{canAdmin && !isReviewingPub && (
 					<DialogLauncher
 						renderLauncherElement={({ openDialog }) => (
 							<ResponsiveHeaderButton
@@ -167,7 +170,7 @@ const DraftReleaseButtons = (props: DraftReleaseButtonsProps) => {
 						)}
 					</DialogLauncher>
 				)}
-				{canCreateReviews && !isReview && (
+				{shouldShowReleaseReviewButton && (
 					<DialogLauncher
 						renderLauncherElement={({ openDialog }) => (
 							<ResponsiveHeaderButton

--- a/client/containers/Pub/PubHeader/PubHeader.tsx
+++ b/client/containers/Pub/PubHeader/PubHeader.tsx
@@ -74,6 +74,20 @@ const PubHeader = (props: Props) => {
 		setShowingDetails(!showingDetails);
 	};
 
+	const renderStickyPart = () => {
+		if (sticky) {
+			if (pubData.isReviewingPub) {
+				return (
+					<ClientOnly>
+						<ReviewHeaderSticky />
+					</ClientOnly>
+				);
+			}
+			return <PubHeaderSticky />;
+		}
+		return null;
+	};
+
 	return (
 		<PubHeaderBackground
 			className={classNames('pub-header-component', showingDetails && 'showing-details')}
@@ -102,13 +116,7 @@ const PubHeader = (props: Props) => {
 				)}
 				<ToggleDetailsButton showingDetails={showingDetails} onClick={toggleDetails} />
 			</GridWrapper>
-			{!pubData.isReviewingPub && sticky ? (
-				<PubHeaderSticky />
-			) : (
-				<ClientOnly>
-					<ReviewHeaderSticky />
-				</ClientOnly>
-			)}
+			{renderStickyPart()}
 		</PubHeaderBackground>
 	);
 };

--- a/client/containers/Pub/PubHeader/PubHeader.tsx
+++ b/client/containers/Pub/PubHeader/PubHeader.tsx
@@ -102,7 +102,7 @@ const PubHeader = (props: Props) => {
 				)}
 				<ToggleDetailsButton showingDetails={showingDetails} onClick={toggleDetails} />
 			</GridWrapper>
-			{!pubData.isReview && sticky ? (
+			{!pubData.isReviewingPub && sticky ? (
 				<PubHeaderSticky />
 			) : (
 				<ClientOnly>

--- a/client/containers/Pub/PubHeader/TitleGroup.tsx
+++ b/client/containers/Pub/PubHeader/TitleGroup.tsx
@@ -16,12 +16,12 @@ type Props = {
 
 const TitleGroup = (props: Props) => {
 	const { pubData, updatePubData } = props;
-	const { title, htmlTitle, description, isRelease, isReview } = pubData;
+	const { title, htmlTitle, description, isRelease, isReviewingPub } = pubData;
 	const { communityData, scopeData, featureFlags } = usePageContext();
 	const { submissionState } = usePubContext();
 	const isUnsubmitted = submissionState?.submission.status === 'incomplete';
 	const { canManage } = scopeData.activePermissions;
-	const canModify = canManage && !isRelease && !isUnsubmitted && !isReview;
+	const canModify = canManage && !isRelease && !isUnsubmitted && !isReviewingPub;
 	const publishedDateString = getPubPublishedDateString(pubData);
 
 	const renderBylineEditor = () => {

--- a/client/containers/Pub/usePubBodyState.ts
+++ b/client/containers/Pub/usePubBodyState.ts
@@ -25,7 +25,7 @@ export const usePubBodyState = (options: Options): PubBodyState => {
 			initialDocKey,
 			isInMaintenanceMode,
 			isRelease,
-			isReview,
+			isReviewingPub,
 			discussions,
 		},
 		submissionState,
@@ -117,7 +117,7 @@ export const usePubBodyState = (options: Options): PubBodyState => {
 		};
 	}
 
-	if (isReview) {
+	if (isReviewingPub) {
 		return {
 			editorKey: 'review',
 			isReadOnly: true,

--- a/client/containers/Pub/usePubSubmissionState.ts
+++ b/client/containers/Pub/usePubSubmissionState.ts
@@ -40,7 +40,7 @@ const createSubmissionPreview = (doc: DocJson, abstract: DocJson) => {
 
 const getInitialSubmissionState = (pub: PubPageData): null | UpdatablePubSubmissionState => {
 	const { submission } = pub;
-	if (submission && !pub.isRelease && !pub.isReview) {
+	if (submission && !pub.isRelease && !pub.isReviewingPub) {
 		const { status } = submission;
 		return {
 			selectedTab: status === 'incomplete' ? 'instructions' : 'preview',

--- a/server/routes/pubDocument.tsx
+++ b/server/routes/pubDocument.tsx
@@ -70,13 +70,11 @@ const getEnrichedPubData = async ({
 	initialData,
 	historyKey = null,
 	releaseNumber = null,
-	isReview = false,
 }: {
 	pubSlug: string;
 	initialData: InitialData;
 	historyKey?: null | number;
 	releaseNumber?: null | number;
-	isReview?: boolean;
 }) => {
 	const pubData = await getPubForRequest({
 		slug: pubSlug,
@@ -85,7 +83,6 @@ const getEnrichedPubData = async ({
 		getSubmissions: true,
 		getDraft: true,
 		getDiscussions: true,
-		isReview,
 	});
 
 	if (!pubData) {
@@ -279,12 +276,12 @@ app.get(
 				pubSlug,
 				initialData,
 				historyKey: hasHistoryKey ? historyKey : null,
-				isReview: true,
 			}),
 			getMembers(initialData),
 		]).then(([enrichedPubData, membersData]) => ({
 			...enrichedPubData,
 			membersData,
+			isReviewingPub: true,
 		}));
 		const customScripts = await getCustomScriptsForCommunity(initialData.communityData.id);
 		return renderPubDocument(res, pubData, initialData, customScripts);

--- a/server/utils/queryHelpers/pubGet.ts
+++ b/server/utils/queryHelpers/pubGet.ts
@@ -38,12 +38,11 @@ type GetPubForRequestOptions = PubGetOptions & {
 	slug: string;
 	initialData: InitialData;
 	releaseNumber?: number | null;
-	isReview?: boolean;
 };
 
 export const getPubForRequest = async (options: GetPubForRequestOptions) => {
-	const { slug, initialData, releaseNumber = null, isReview, ...pubGetOptions } = options;
+	const { slug, initialData, releaseNumber = null, ...pubGetOptions } = options;
 	const communityId = initialData.communityData.id;
 	const pubData = await getPub({ slug, communityId }, pubGetOptions);
-	return sanitizePub(pubData, initialData, releaseNumber, isReview);
+	return sanitizePub(pubData, initialData, releaseNumber);
 };

--- a/server/utils/queryHelpers/pubSanitize.ts
+++ b/server/utils/queryHelpers/pubSanitize.ts
@@ -34,7 +34,6 @@ export default (
 	pubData,
 	initialData,
 	releaseNumber: number | null = null,
-	isReview: boolean = false,
 ): null | SanitizedPubData => {
 	const { loginData, scopeData } = initialData;
 	const { activePermissions } = scopeData;
@@ -108,7 +107,6 @@ export default (
 		exports: getFilteredExports(pubData, isRelease),
 		collectionPubs: filteredCollectionPubs,
 		isRelease,
-		isReview,
 		releases: sortedReleases,
 		releaseNumber,
 	};

--- a/server/utils/queryHelpers/scopeGet.ts
+++ b/server/utils/queryHelpers/scopeGet.ts
@@ -387,8 +387,7 @@ getActivePermissions = async (
 		activePublicPermissions.canViewDraft || activePublicPermissions.canEditDraft;
 
 	const canEdit = permissionLevelIndex > 0;
-	const canCreateReviews =
-		!activePub?.submission && (canEdit || activePublicPermissions.canCreateReviews);
+	const canCreateReviews = canEdit || activePublicPermissions.canCreateReviews;
 
 	return {
 		activePermission: permissionLevelIndex > -1 ? permissionLevels[permissionLevelIndex] : null,

--- a/types/pub.ts
+++ b/types/pub.ts
@@ -136,13 +136,12 @@ export type PubPageData = DefinitelyHas<Omit<Pub, 'discussions'>, 'collectionPub
 		editHash: Maybe<string>;
 		reviewHash: Maybe<string>;
 		isRelease: boolean;
-		isReview: boolean;
+		isReviewingPub: boolean;
 		isInMaintenanceMode?: boolean;
 		firebaseToken?: string;
 		initialStructuredCitations: boolean;
 		releaseNumber: Maybe<number>;
 		submission?: DefinitelyHas<Submission, 'submissionWorkflow'>;
-		iSubmission: boolean;
 		subscription: null | UserSubscription;
 	};
 
@@ -179,7 +178,6 @@ export type SanitizedPubData = Pub & {
 	discussions: Discussion[];
 	collectionPubs: CollectionPubWithAttributions[];
 	isRelease: boolean;
-	isReview: boolean;
 	releases: Release[];
 	releaseNumber: number | null;
 };


### PR DESCRIPTION
Resolves #2295 

The error described therein turned out to be down to an intentional line of code in `getScope()`:

```ts
canCreateReviews = !activePub.submission && ...
```

I added this check while developing Submissions because at the time the feature was intended to be mutually exclusive with Reviews — this is no longer the case. The practical effect of the change at the time was to hide the "Request Release" button in the Pub header. I think we want to continue to hide that, so I've moved this check to the frontend.

_Test plan:_
- Visit a Collection with open submissions to create a Spub
- Verify that the Request Release button is not shown
- (optional) Complete the submission process
- Visit `/pub/<slug>/review/1` and verify that you can add a review from the little dropdown bit

I also fixed two peripherally related issues here:

- A boolean logic error that was causing the `<ReviewHeaderSticky>` to appear when it shouldn't
- A bizarre (and bizarrely old) chunk of CSS that was mangling the `<FileUploadButton>`