### PR TITLE
feature: code blocks w/ plugin

### DIFF
--- a/client/components/Editor/plugins/code.ts
+++ b/client/components/Editor/plugins/code.ts
@@ -1,0 +1,21 @@
+import { undo, redo } from 'prosemirror-history';
+import {
+	codeMirrorBlockPlugin,
+	defaultSettings,
+	languageLoaders,
+	legacyLanguageLoaders,
+} from 'prosemirror-codemirror-block';
+
+export default (schema) => {
+	if (schema.nodes.code_block) {
+		return [
+			codeMirrorBlockPlugin({
+				...defaultSettings,
+				languageLoaders: { ...languageLoaders, ...legacyLanguageLoaders },
+				undo,
+				redo,
+			}),
+		];
+	}
+	return [];
+};

--- a/client/components/Editor/plugins/code.ts
+++ b/client/components/Editor/plugins/code.ts
@@ -1,16 +1,68 @@
 import { undo, redo } from 'prosemirror-history';
 import {
+	CodeBlockSettings,
 	codeMirrorBlockPlugin,
 	defaultSettings,
 	languageLoaders,
 	legacyLanguageLoaders,
 } from 'prosemirror-codemirror-block';
 
+import { EditorView } from 'prosemirror-view';
+import { Node } from 'prosemirror-model';
+
+export const myCreateSelect = (
+	settings: CodeBlockSettings,
+	dom: HTMLElement,
+	node: Node,
+	view: EditorView,
+	getPos: (() => number) | boolean,
+) => {
+	if (!settings.languageLoaders) return () => {};
+	const wrapper = document.createElement('div');
+	wrapper.className = 'bp3-html-select codeblock-select-wrapper';
+	const select = document.createElement('select');
+	const carets = document.createElement('span');
+	carets.className = 'bp3-icon bp3-icon-double-caret-vertical';
+	wrapper.append(select);
+	wrapper.append(carets);
+	select.className = 'codeblock-select';
+	const noneOption = document.createElement('option');
+	noneOption.value = 'none';
+	noneOption.textContent = settings.languageNameMap?.none || 'none';
+	select.append(noneOption);
+	Object.keys(languageLoaders)
+		.sort()
+		.forEach((lang) => {
+			if (settings.languageWhitelist && !settings.languageWhitelist.includes(lang)) return;
+			const option = document.createElement('option');
+			option.value = lang;
+			option.textContent = settings.languageNameMap?.[lang] || lang;
+			select.append(option);
+		});
+	select.value = node.attrs.lang || 'none';
+	dom.prepend(wrapper);
+	select.onchange = async (e) => {
+		if (!(e.target instanceof HTMLSelectElement)) return;
+		const lang = e.target.value;
+		if (typeof getPos === 'function') {
+			view.dispatch(
+				view.state.tr.setNodeMarkup(getPos(), undefined, {
+					...node.attrs,
+					lang,
+				}),
+			);
+		}
+	};
+	// Delete code.
+	return () => {};
+};
+
 export default (schema) => {
 	if (schema.nodes.code_block) {
 		return [
 			codeMirrorBlockPlugin({
 				...defaultSettings,
+				createSelect: myCreateSelect,
 				languageLoaders: { ...languageLoaders, ...legacyLanguageLoaders },
 				undo,
 				redo,

--- a/client/components/Editor/plugins/code.ts
+++ b/client/components/Editor/plugins/code.ts
@@ -6,11 +6,11 @@ import {
 	languageLoaders,
 	legacyLanguageLoaders,
 } from 'prosemirror-codemirror-block';
-
 import { EditorView } from 'prosemirror-view';
 import { Node } from 'prosemirror-model';
+import { Classes } from '@blueprintjs/core';
 
-export const myCreateSelect = (
+const createSelect = (
 	settings: CodeBlockSettings,
 	dom: HTMLElement,
 	node: Node,
@@ -19,10 +19,14 @@ export const myCreateSelect = (
 ) => {
 	if (!settings.languageLoaders) return () => {};
 	const wrapper = document.createElement('div');
-	wrapper.className = 'bp3-html-select codeblock-select-wrapper';
+	wrapper.classList.add(Classes.HTML_SELECT, 'codeblock-select-wrapper');
 	const select = document.createElement('select');
 	const carets = document.createElement('span');
-	carets.className = 'bp3-icon bp3-icon-double-caret-vertical';
+	carets.classList.add(
+		Classes.ICON,
+		Classes.ICON_LARGE,
+		'bp3-icon bp3-icon-double-caret-vertical',
+	);
 	wrapper.append(select);
 	wrapper.append(carets);
 	select.className = 'codeblock-select';
@@ -62,7 +66,7 @@ export default (schema) => {
 		return [
 			codeMirrorBlockPlugin({
 				...defaultSettings,
-				createSelect: myCreateSelect,
+				createSelect,
 				languageLoaders: { ...languageLoaders, ...legacyLanguageLoaders },
 				undo,
 				redo,

--- a/client/components/Editor/plugins/code.ts
+++ b/client/components/Editor/plugins/code.ts
@@ -22,11 +22,7 @@ const createSelect = (
 	wrapper.classList.add(Classes.HTML_SELECT, 'codeblock-select-wrapper');
 	const select = document.createElement('select');
 	const carets = document.createElement('span');
-	carets.classList.add(
-		Classes.ICON,
-		Classes.ICON_LARGE,
-		'bp3-icon bp3-icon-double-caret-vertical',
-	);
+	carets.classList.add(Classes.ICON, 'bp3-icon-caret-down');
 	wrapper.append(select);
 	wrapper.append(carets);
 	select.className = 'codeblock-select';
@@ -57,7 +53,6 @@ const createSelect = (
 			);
 		}
 	};
-	// Delete code.
 	return () => {};
 };
 

--- a/client/components/Editor/plugins/index.ts
+++ b/client/components/Editor/plugins/index.ts
@@ -17,6 +17,7 @@ import buildPlaceholder from './placeholder';
 import buildPaste from './paste';
 import buildReactive from './reactive';
 import buildTable from './table';
+import buildCode from './code';
 import buildReferences from './references';
 import { PluginLoader, PluginsOptions } from '../types';
 
@@ -48,6 +49,7 @@ export const standardPlugins = {
 	reactive: buildReactive,
 	paste: buildPaste,
 	mathPlugin: buildMath,
+	codePlugin: buildCode,
 };
 
 const getSortedPlugins = (plugins: Record<string, null | PluginLoader>): PluginLoader[] => {

--- a/client/components/Editor/plugins/keymap.ts
+++ b/client/components/Editor/plugins/keymap.ts
@@ -21,6 +21,7 @@ import { undo, redo } from 'prosemirror-history';
 import { undoInputRule } from 'prosemirror-inputrules';
 import { keymap } from 'prosemirror-keymap';
 import { mathBackspaceCmd } from '@benrbray/prosemirror-math';
+import { codeBlockArrowHandlers } from 'prosemirror-codemirror-block';
 
 import { splitBlockPreservingAttrs } from '../commands';
 
@@ -127,6 +128,9 @@ export default (schema) => {
 			bind(`Shift-Ctrl-${index}`, setBlockType(schema.nodes.heading, { level: index }));
 			bind(`Alt-Ctrl-${index}`, setBlockType(schema.nodes.heading, { level: index }));
 		}
+	}
+	if (schema.nodes.code_block) {
+		Object.entries(codeBlockArrowHandlers).forEach(([key, cmd]) => bind(key, cmd));
 	}
 	if (schema.nodes.horizontal_rule) {
 		bind('Mod-_', (state, dispatch) => {

--- a/client/components/Editor/schemas/base.ts
+++ b/client/components/Editor/schemas/base.ts
@@ -196,6 +196,7 @@ export const baseNodes: { [key: string]: NodeSpec } = {
 		content: 'text*',
 		group: 'block',
 		attrs: {
+			lang: { default: 'javascript' },
 			id: { default: null },
 		},
 		code: true,

--- a/client/components/Editor/styles/base.scss
+++ b/client/components/Editor/styles/base.scss
@@ -12,5 +12,6 @@
 	@include figure-queries;
 	@import './file.scss';
 	@import './table.scss';
+	@import './code.scss';
 	@import './placeholder.scss';
 }

--- a/client/components/Editor/styles/code.scss
+++ b/client/components/Editor/styles/code.scss
@@ -1,0 +1,15 @@
+.codeblock-select {
+    position: absolute;
+    right: 0;
+    z-index: 100;
+    opacity: 0;
+    transition: all 0.3s ease;
+    margin: 6px 14px;
+}
+.codeblock-root {
+    position: relative;
+}
+
+.codeblock-root:hover .codeblock-select {
+    opacity: 1;
+}

--- a/client/components/Editor/styles/code.scss
+++ b/client/components/Editor/styles/code.scss
@@ -1,15 +1,16 @@
-.codeblock-select {
+.codeblock-select-wrapper {
 	position: absolute;
-	right: 0;
+	left: 0;
+	top: 100%;
 	z-index: 100;
 	opacity: 0;
 	transition: all 0.3s ease;
-	margin: 6px 14px;
 }
+
 .codeblock-root {
 	position: relative;
 }
 
-.codeblock-root:hover .codeblock-select {
+.codeblock-root:hover .codeblock-select-wrapper {
 	opacity: 1;
 }

--- a/client/components/Editor/styles/code.scss
+++ b/client/components/Editor/styles/code.scss
@@ -1,15 +1,15 @@
 .codeblock-select {
-    position: absolute;
-    right: 0;
-    z-index: 100;
-    opacity: 0;
-    transition: all 0.3s ease;
-    margin: 6px 14px;
+	position: absolute;
+	right: 0;
+	z-index: 100;
+	opacity: 0;
+	transition: all 0.3s ease;
+	margin: 6px 14px;
 }
 .codeblock-root {
-    position: relative;
+	position: relative;
 }
 
 .codeblock-root:hover .codeblock-select {
-    opacity: 1;
+	opacity: 1;
 }

--- a/client/components/Editor/utils/nodes.ts
+++ b/client/components/Editor/utils/nodes.ts
@@ -1,5 +1,6 @@
 import { Node } from 'prosemirror-model';
 import { EditorView } from 'prosemirror-view';
+import { EditorState } from 'prosemirror-state';
 
 export const updateNodeAttrsById = (editorView: EditorView, id: string, attrs: Node['attrs']) => {
 	const {
@@ -33,4 +34,11 @@ export const insertNodeIntoEditor = (view: EditorView, nodeType: string, attrs?:
 		const transaction = tr.replaceSelectionWith(node);
 		view.dispatch(transaction);
 	}
+};
+
+export const isDescendantOf = (nodeTypeName: string, state: EditorState): boolean => {
+	const { $anchor } = state.selection;
+	for (let d = $anchor.depth; d > 0; d--)
+		if ($anchor.node(d).type.name === nodeTypeName) return true;
+	return false;
 };

--- a/client/components/Editor/utils/nodes.ts
+++ b/client/components/Editor/utils/nodes.ts
@@ -1,6 +1,6 @@
 import { Node } from 'prosemirror-model';
 import { EditorView } from 'prosemirror-view';
-import { EditorState } from 'prosemirror-state';
+import { Selection } from 'prosemirror-state';
 
 export const updateNodeAttrsById = (editorView: EditorView, id: string, attrs: Node['attrs']) => {
 	const {
@@ -36,8 +36,8 @@ export const insertNodeIntoEditor = (view: EditorView, nodeType: string, attrs?:
 	}
 };
 
-export const isDescendantOf = (nodeTypeName: string, state: EditorState): boolean => {
-	const { $anchor } = state.selection;
+export const isDescendantOf = (nodeTypeName: string, selection: Selection): boolean => {
+	const { $anchor } = selection;
 	for (let d = $anchor.depth; d > 0; d--)
 		if ($anchor.node(d).type.name === nodeTypeName) return true;
 	return false;

--- a/client/components/FormattingBar/buttons.ts
+++ b/client/components/FormattingBar/buttons.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {
+	codeBlockToggle,
 	alignTextCenter,
 	alignTextLeft,
 	alignTextRight,
@@ -19,7 +20,6 @@ import {
 	superscriptToggle,
 } from '../Editor/commands';
 import { getCurrentNodeLabels, EditorChangeObject } from '../Editor';
-
 import {
 	ControlsMath,
 	ControlsFootnoteCitation,
@@ -65,7 +65,7 @@ const nodeControls = (
 	};
 };
 
-const showOrTriggerTable = (editorChangeObject) => {
+const showOrTriggerTable = (editorChangeObject: EditorChangeObject): boolean => {
 	const { selectionInTable, selection } = editorChangeObject;
 	return (
 		selectionInTable &&
@@ -182,6 +182,39 @@ export const code: FormattingBarButtonData = {
 	command: codeToggle,
 };
 
+export const codeBlock: FormattingBarButtonData = {
+	key: 'code-block',
+	title: 'Code Block',
+	icon: 'code-block',
+	command: codeBlockToggle,
+};
+
+export const table: FormattingBarButtonData = {
+	key: 'table',
+	title: 'Table',
+	icon: 'th',
+	insertNodeType: 'table',
+	controls: {
+		captureFocusOnMount: false,
+		indicate: ({ selectionInTable }) => selectionInTable,
+		show: showOrTriggerTable,
+		trigger: showOrTriggerTable,
+		floatingPosition: positionNearSelection,
+		component: ControlsTable,
+	},
+};
+
+export const math: FormattingBarButtonData = {
+	key: 'math',
+	title: 'Math',
+	icon: 'function',
+	insertNodeType: 'math_inline',
+	controls: nodeControls(ControlsMath, ['math_inline', 'math_display'], {
+		floatingPosition: positionNearSelection,
+		showCloseButton: false,
+	}),
+};
+
 export const subscript: FormattingBarButtonData = {
 	key: 'subscript',
 	title: 'Subscript',
@@ -253,32 +286,6 @@ export const horizontalRule: FormattingBarButtonData = {
 	icon: 'minus',
 };
 
-export const table: FormattingBarButtonData = {
-	key: 'table',
-	title: 'Table',
-	icon: 'th',
-	insertNodeType: 'table',
-	controls: {
-		captureFocusOnMount: false,
-		indicate: ({ selectionInTable }) => selectionInTable,
-		show: showOrTriggerTable,
-		trigger: showOrTriggerTable,
-		floatingPosition: positionNearSelection,
-		component: ControlsTable,
-	},
-};
-
-export const math: FormattingBarButtonData = {
-	key: 'math',
-	title: 'Math',
-	icon: 'function',
-	insertNodeType: 'math_inline',
-	controls: nodeControls(ControlsMath, ['math_inline', 'math_display'], {
-		floatingPosition: positionNearSelection,
-		showCloseButton: false,
-	}),
-};
-
 export const media: FormattingBarButtonData = {
 	key: 'media',
 	title: 'Media',
@@ -310,6 +317,7 @@ export const reviewButtonSet = [
 		numberedList,
 		blockquote,
 		code,
+		codeBlock,
 		subscript,
 		superscript,
 		strikethrough,
@@ -337,6 +345,7 @@ export const fullButtonSet = [
 		numberedList,
 		blockquote,
 		code,
+		codeBlock,
 		subscript,
 		superscript,
 		strikethrough,
@@ -361,6 +370,7 @@ export const layoutEditorButtonSet = [
 		numberedList,
 		blockquote,
 		code,
+		codeBlock,
 		subscript,
 		superscript,
 		strikethrough,

--- a/client/containers/Pub/PubDocument/PubInlineMenu.tsx
+++ b/client/containers/Pub/PubDocument/PubInlineMenu.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import uuidv4 from 'uuid/v4';
 import { Button } from '@blueprintjs/core';
-import { EditorState } from 'prosemirror-state';
 
 import { pubUrl } from 'utils/canonicalUrls';
 import { usePageContext } from 'utils/hooks';
@@ -30,7 +29,7 @@ const PubInlineMenu = () => {
 			selection.empty ||
 			(selection as any).$anchorCell ||
 			collabData.editorChangeObject!.selectedNode ||
-			isDescendantOf('code_block', collabData.editorChangeObject! as any as EditorState)
+			isDescendantOf('code_block', collabData.editorChangeObject!.selection)
 		);
 	}, [collabData.editorChangeObject, selection]);
 	const selectionBoundingBox: Record<string, any> =

--- a/client/containers/Pub/PubDocument/PubInlineMenu.tsx
+++ b/client/containers/Pub/PubDocument/PubInlineMenu.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import uuidv4 from 'uuid/v4';
 import { Button } from '@blueprintjs/core';
+import { EditorState } from 'prosemirror-state';
 
 import { pubUrl } from 'utils/canonicalUrls';
 import { usePageContext } from 'utils/hooks';
 import { Icon, ClickToCopyButton } from 'components';
 import { FormattingBar, buttons } from 'components/FormattingBar';
-import { setLocalHighlight, moveToEndOfSelection } from 'components/Editor';
+import { setLocalHighlight, moveToEndOfSelection, isDescendantOf } from 'components/Editor';
 
 import { usePubContext } from '../pubHooks';
 
@@ -22,18 +23,20 @@ const PubInlineMenu = () => {
 	const { pubData, collabData, historyData, pubBodyState } = usePubContext();
 	const { communityData, scopeData } = usePageContext();
 	const { canView, canCreateDiscussions } = scopeData.activePermissions;
-	const selection = collabData.editorChangeObject!.selection || {};
+	const selection = collabData.editorChangeObject!.selection;
+	const shouldHide = useMemo(() => {
+		return (
+			!selection ||
+			selection.empty ||
+			(selection as any).$anchorCell ||
+			collabData.editorChangeObject!.selectedNode ||
+			isDescendantOf('code_block', collabData.editorChangeObject! as any as EditorState)
+		);
+	}, [collabData.editorChangeObject, selection]);
 	const selectionBoundingBox: Record<string, any> =
 		collabData.editorChangeObject!.selectionBoundingBox || {};
 
-	if (
-		!collabData.editorChangeObject!.selection ||
-		selection.empty ||
-		(selection as any).$anchorCell ||
-		collabData.editorChangeObject!.selectedNode
-	) {
-		return null;
-	}
+	if (shouldHide) return null;
 
 	const topPosition =
 		window.scrollY +

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,6 +101,7 @@
 				"pretty-bytes": "^5.6.0",
 				"prompt": "^1.0.0",
 				"prop-types": "^15.7.2",
+				"prosemirror-codemirror-block": "^0.2.15",
 				"prosemirror-collab": "^1.2.2",
 				"prosemirror-commands": "^1.1.4",
 				"prosemirror-compress-pubpub": "0.0.3",
@@ -2517,6 +2518,398 @@
 				"node": ">=0.1.95"
 			}
 		},
+		"node_modules/@codemirror/autocomplete": {
+			"version": "0.19.15",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.15.tgz",
+			"integrity": "sha512-GQWzvvuXxNUyaEk+5gawbAD8s51/v2Chb++nx0e2eGWrphWk42isBtzOMdc3DxrxrZtPZ55q2ldNp+6G8KJLIQ==",
+			"dependencies": {
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.4",
+				"@codemirror/text": "^0.19.2",
+				"@codemirror/tooltip": "^0.19.12",
+				"@codemirror/view": "^0.19.0",
+				"@lezer/common": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/closebrackets": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.2.tgz",
+			"integrity": "sha512-ClMPzPcPP0eQiDcVjtVPl6OLxgdtZSYDazsvT0AKl70V1OJva0eHgl4/6kCW3RZ0pb2n34i9nJz4eXCmK+TYDA==",
+			"deprecated": "As of 0.20.0, this package has been merged into @codemirror/autocomplete",
+			"dependencies": {
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/rangeset": "^0.19.0",
+				"@codemirror/state": "^0.19.2",
+				"@codemirror/text": "^0.19.0",
+				"@codemirror/view": "^0.19.44"
+			}
+		},
+		"node_modules/@codemirror/commands": {
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.8.tgz",
+			"integrity": "sha512-65LIMSGUGGpY3oH6mzV46YWRrgao6NmfJ+AuC7jNz3K5NPnH6GCV1H5I6SwOFyVbkiygGyd0EFwrWqywTBD1aw==",
+			"dependencies": {
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/matchbrackets": "^0.19.0",
+				"@codemirror/state": "^0.19.2",
+				"@codemirror/text": "^0.19.6",
+				"@codemirror/view": "^0.19.22",
+				"@lezer/common": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/comment": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.1.tgz",
+			"integrity": "sha512-uGKteBuVWAC6fW+Yt8u27DOnXMT/xV4Ekk2Z5mRsiADCZDqYvryrJd6PLL5+8t64BVyocwQwNfz1UswYS2CtFQ==",
+			"deprecated": "As of 0.20.0, this package has been merged into @codemirror/commands",
+			"dependencies": {
+				"@codemirror/state": "^0.19.9",
+				"@codemirror/text": "^0.19.0",
+				"@codemirror/view": "^0.19.0"
+			}
+		},
+		"node_modules/@codemirror/fold": {
+			"version": "0.19.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.4.tgz",
+			"integrity": "sha512-0SNSkRSOa6gymD6GauHa3sxiysjPhUC0SRVyTlvL52o0gz9GHdc8kNqNQskm3fBtGGOiSriGwF/kAsajRiGhVw==",
+			"deprecated": "As of 0.20.0, this package has been merged into @codemirror/language",
+			"dependencies": {
+				"@codemirror/gutter": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/rangeset": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/view": "^0.19.22"
+			}
+		},
+		"node_modules/@codemirror/gutter": {
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.9.tgz",
+			"integrity": "sha512-PFrtmilahin1g6uL27aG5tM/rqR9DZzZYZsIrCXA5Uc2OFTFqx4owuhoU9hqfYxHp5ovfvBwQ+txFzqS4vog6Q==",
+			"deprecated": "As of 0.20.0, this package has been merged into @codemirror/view",
+			"dependencies": {
+				"@codemirror/rangeset": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/view": "^0.19.23"
+			}
+		},
+		"node_modules/@codemirror/highlight": {
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.8.tgz",
+			"integrity": "sha512-v/lzuHjrYR8MN2mEJcUD6fHSTXXli9C1XGYpr+ElV6fLBIUhMTNKR3qThp611xuWfXfwDxeL7ppcbkM/MzPV3A==",
+			"deprecated": "As of 0.20.0, this package has been split between @lezer/highlight and @codemirror/language",
+			"dependencies": {
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/rangeset": "^0.19.0",
+				"@codemirror/state": "^0.19.3",
+				"@codemirror/view": "^0.19.39",
+				"@lezer/common": "^0.15.0",
+				"style-mod": "^4.0.0"
+			}
+		},
+		"node_modules/@codemirror/lang-cpp": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-0.19.1.tgz",
+			"integrity": "sha512-BGvZkfcqcalAwxocuE9DhH6gqflm5IjL/8mGTzc8bHzeP1N4innK8qo2G69ohEML4LDZv4WyXc3y4C9/zsGCGQ==",
+			"dependencies": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@lezer/cpp": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/lang-css": {
+			"version": "0.19.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-0.19.3.tgz",
+			"integrity": "sha512-tyCUJR42/UlfOPLb94/p7dN+IPsYSIzHbAHP2KQHANj0I+Orqp+IyIOS++M8TuCX4zkWh9dvi8s92yy/Tn8Ifg==",
+			"dependencies": {
+				"@codemirror/autocomplete": "^0.19.0",
+				"@codemirror/highlight": "^0.19.6",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@lezer/css": "^0.15.2"
+			}
+		},
+		"node_modules/@codemirror/lang-html": {
+			"version": "0.19.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.4.tgz",
+			"integrity": "sha512-GpiEikNuCBeFnS+/TJSeanwqaOfNm8Kkp9WpVNEPZCLyW1mAMCuFJu/3xlWYeWc778Hc3vJqGn3bn+cLNubgCA==",
+			"dependencies": {
+				"@codemirror/autocomplete": "^0.19.0",
+				"@codemirror/highlight": "^0.19.6",
+				"@codemirror/lang-css": "^0.19.0",
+				"@codemirror/lang-javascript": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@lezer/common": "^0.15.0",
+				"@lezer/html": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/lang-java": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-0.19.1.tgz",
+			"integrity": "sha512-yA3kcW2GgY0mC2a9dE+uRxGxPWeykfE/GqEPk4TSmhuU4ndmyDgM5QQP7pgnYSZmv2vKoyf4x7NMg8AF7lKXHQ==",
+			"dependencies": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@lezer/java": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/lang-javascript": {
+			"version": "0.19.7",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.7.tgz",
+			"integrity": "sha512-DL9f3JLqOEHH9cIwEqqjnP5bkjdVXeECksLtV+/MbPm+l4H+AG+PkwZaJQ2oR1GfPZKh8MVSIE94aGWNkJP8WQ==",
+			"dependencies": {
+				"@codemirror/autocomplete": "^0.19.0",
+				"@codemirror/highlight": "^0.19.7",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/lint": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/view": "^0.19.0",
+				"@lezer/javascript": "^0.15.1"
+			}
+		},
+		"node_modules/@codemirror/lang-json": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-0.19.2.tgz",
+			"integrity": "sha512-fgUWR58Is59P5D/tiazX6oTczioOCDYqjFT5PEBAmLBFMSsRqcnJE0xNO1snrhg7pWEFDq5wR/oN0eZhkeR6Gg==",
+			"dependencies": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@lezer/json": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/lang-lezer": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-lezer/-/lang-lezer-0.19.1.tgz",
+			"integrity": "sha512-Ba1NIDvsw67CDJ7rql2iMxZ6eVrMsRajmbna/Ijq9OV9r6qricnsiwNnNPTfdtCpek3gm9P/U4gqFMbrnV11DA==",
+			"dependencies": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@lezer/common": "^0.15.0",
+				"@lezer/lezer": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/lang-markdown": {
+			"version": "0.19.6",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-0.19.6.tgz",
+			"integrity": "sha512-ojoHeLgv1Rfu0GNGsU0bCtXAIp5dy4VKjndHScITQdlCkS/+SAIfuoeowEx+nMAQwTxI+/9fQZ3xdZVznGFYug==",
+			"dependencies": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/lang-html": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.3",
+				"@codemirror/view": "^0.19.0",
+				"@lezer/common": "^0.15.0",
+				"@lezer/markdown": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/lang-php": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-0.19.1.tgz",
+			"integrity": "sha512-Q6djLACHu1J6XbnxWlEPCiyqqDrlZLi9QtjY6b9vqdkq/GOsNaXVv44nDY8DD6Bxi5yYRTJ3yh8XzsKuJgztjQ==",
+			"dependencies": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/lang-html": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@lezer/common": "^0.15.0",
+				"@lezer/php": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/lang-python": {
+			"version": "0.19.5",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-0.19.5.tgz",
+			"integrity": "sha512-MQf7t0k6+i9KCzlFCI8EY+jjwyXLy5AwjmXsMyMCMbOw/97j70jFZYrs7Mm7RJakNE2rypWhnLGlyBTSYMqR5g==",
+			"dependencies": {
+				"@codemirror/highlight": "^0.19.7",
+				"@codemirror/language": "^0.19.0",
+				"@lezer/python": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/lang-rust": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-0.19.2.tgz",
+			"integrity": "sha512-SEXsO7Qf2gktRvVhHMc0Mq4HzPBpFcQlrlcinafy6VFXavWs+QAIB8UAuLG/igOc3PrIHbZFlyEhVUIGstox8w==",
+			"dependencies": {
+				"@codemirror/highlight": "^0.19.7",
+				"@codemirror/language": "^0.19.0",
+				"@lezer/rust": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/lang-sql": {
+			"version": "0.19.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-0.19.4.tgz",
+			"integrity": "sha512-4FqLC8aNe1iCDyAWbJmSqa8K7rgz2xTwW36V35z4oiyLoyOLsCayKIwoQqp5DNIq2ckGCsyzotgxXKpgtg/pgg==",
+			"dependencies": {
+				"@codemirror/autocomplete": "^0.19.0",
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/lang-wast": {
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-0.19.0.tgz",
+			"integrity": "sha512-mr/Bp4k8+fJ0P8/Q6L45pnX7/bDBk4VP8ahYrTdvHo+UaOqBBhBFtBqBikvX8ZDQiUTfuZ4tnJE2QtOvmFsuzg==",
+			"dependencies": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/lang-xml": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-0.19.2.tgz",
+			"integrity": "sha512-9VIjxvqcH1sk8bmYbxQon0lXhVZgdHdfjGes+e4Akgvb43aMBDNvIQVALwrCb+XMEHTxLUMQtrsBN0G64yCUXw==",
+			"dependencies": {
+				"@codemirror/autocomplete": "^0.19.0",
+				"@codemirror/highlight": "^0.19.6",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@lezer/common": "^0.15.0",
+				"@lezer/xml": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/language": {
+			"version": "0.19.10",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.10.tgz",
+			"integrity": "sha512-yA0DZ3RYn2CqAAGW62VrU8c4YxscMQn45y/I9sjBlqB1e2OTQLg4CCkMBuMSLXk4xaqjlsgazeOQWaJQOKfV8Q==",
+			"dependencies": {
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/text": "^0.19.0",
+				"@codemirror/view": "^0.19.0",
+				"@lezer/common": "^0.15.5",
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/legacy-modes": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-0.19.1.tgz",
+			"integrity": "sha512-vYPLsD/ON+3SXhlGj9Qb3fpFNNU3Ya/AtDiv/g3OyqVzhh5vs5rAnOvk8xopGWRwppdhlNPD9VyXjiOmZUQtmQ==",
+			"dependencies": {
+				"@codemirror/stream-parser": "^0.19.0"
+			}
+		},
+		"node_modules/@codemirror/lint": {
+			"version": "0.19.6",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.6.tgz",
+			"integrity": "sha512-Pbw1Y5kHVs2J+itQ0uez3dI4qY9ApYVap7eNfV81x1/3/BXgBkKfadaw0gqJ4h4FDG7OnJwb0VbPsjJQllHjaA==",
+			"dependencies": {
+				"@codemirror/gutter": "^0.19.4",
+				"@codemirror/panel": "^0.19.0",
+				"@codemirror/rangeset": "^0.19.1",
+				"@codemirror/state": "^0.19.4",
+				"@codemirror/tooltip": "^0.19.16",
+				"@codemirror/view": "^0.19.22",
+				"crelt": "^1.0.5"
+			}
+		},
+		"node_modules/@codemirror/matchbrackets": {
+			"version": "0.19.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/matchbrackets/-/matchbrackets-0.19.4.tgz",
+			"integrity": "sha512-VFkaOKPNudAA5sGP1zikRHCEKU0hjYmkKpr04pybUpQvfTvNJXlReCyP0rvH/1iEwAGPL990ZTT+QrLdu4MeEA==",
+			"deprecated": "As of 0.20.0, this package has been merged into @codemirror/language",
+			"dependencies": {
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/view": "^0.19.0",
+				"@lezer/common": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/panel": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.1.tgz",
+			"integrity": "sha512-sYeOCMA3KRYxZYJYn5PNlt9yNsjy3zTNTrbYSfVgjgL9QomIVgOJWPO5hZ2sTN8lufO6lw0vTBsIPL9MSidmBg==",
+			"deprecated": "As of 0.20.0, this package has been merged into @codemirror/view",
+			"dependencies": {
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/view": "^0.19.0"
+			}
+		},
+		"node_modules/@codemirror/rangeset": {
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.9.tgz",
+			"integrity": "sha512-V8YUuOvK+ew87Xem+71nKcqu1SXd5QROMRLMS/ljT5/3MCxtgrRie1Cvild0G/Z2f1fpWxzX78V0U4jjXBorBQ==",
+			"deprecated": "As of 0.20.0, this package has been merged into @codemirror/state",
+			"dependencies": {
+				"@codemirror/state": "^0.19.0"
+			}
+		},
+		"node_modules/@codemirror/rectangular-selection": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/rectangular-selection/-/rectangular-selection-0.19.2.tgz",
+			"integrity": "sha512-AXK/p5eGwFJ9GJcLfntqN4dgY+XiIF7eHfXNQJX5HhQLSped2wJE6WuC1rMEaOlcpOqlb9mrNi/ZdUjSIj9mbA==",
+			"deprecated": "As of 0.20.0, this package has been merged into @codemirror/view",
+			"dependencies": {
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/text": "^0.19.4",
+				"@codemirror/view": "^0.19.48"
+			}
+		},
+		"node_modules/@codemirror/search": {
+			"version": "0.19.10",
+			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.10.tgz",
+			"integrity": "sha512-qjubm69HJixPBWzI6HeEghTWOOD8NXiHOTRNvdizqs8xWRuFChq9zkjD3XiAJ7GXSTzCuQJnAP9DBBGCLq4ZIA==",
+			"dependencies": {
+				"@codemirror/panel": "^0.19.0",
+				"@codemirror/rangeset": "^0.19.0",
+				"@codemirror/state": "^0.19.3",
+				"@codemirror/text": "^0.19.0",
+				"@codemirror/view": "^0.19.34",
+				"crelt": "^1.0.5"
+			}
+		},
+		"node_modules/@codemirror/state": {
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
+			"integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
+			"dependencies": {
+				"@codemirror/text": "^0.19.0"
+			}
+		},
+		"node_modules/@codemirror/stream-parser": {
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.19.9.tgz",
+			"integrity": "sha512-WTmkEFSRCetpk8xIOvV2yyXdZs3DgYckM0IP7eFi4ewlxWnJO/H4BeJZLs4wQaydWsAqTQoDyIwNH1BCzK5LUQ==",
+			"deprecated": "As of 0.20.0, this package has been merged into @codemirror/language",
+			"dependencies": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/text": "^0.19.0",
+				"@lezer/common": "^0.15.0",
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@codemirror/text": {
+			"version": "0.19.6",
+			"resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
+			"integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA==",
+			"deprecated": "As of 0.20.0, this package has been merged into @codemirror/state"
+		},
+		"node_modules/@codemirror/tooltip": {
+			"version": "0.19.16",
+			"resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.16.tgz",
+			"integrity": "sha512-zxKDHryUV5/RS45AQL+wOeN+i7/l81wK56OMnUPoTSzCWNITfxHn7BToDsjtrRKbzHqUxKYmBnn/4hPjpZ4WJQ==",
+			"deprecated": "As of 0.20.0, this package has been merged into @codemirror/view",
+			"dependencies": {
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/view": "^0.19.0"
+			}
+		},
+		"node_modules/@codemirror/view": {
+			"version": "0.19.48",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.48.tgz",
+			"integrity": "sha512-0eg7D2Nz4S8/caetCTz61rK0tkHI17V/d15Jy0kLOT8dTLGGNJUponDnW28h2B6bERmPlVHKh8MJIr5OCp1nGw==",
+			"dependencies": {
+				"@codemirror/rangeset": "^0.19.5",
+				"@codemirror/state": "^0.19.3",
+				"@codemirror/text": "^0.19.0",
+				"style-mod": "^4.0.0",
+				"w3c-keyname": "^2.2.4"
+			}
+		},
 		"node_modules/@colors/colors": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -4411,6 +4804,115 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"node_modules/@lezer/common": {
+			"version": "0.15.12",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
+			"integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig=="
+		},
+		"node_modules/@lezer/cpp": {
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-0.15.3.tgz",
+			"integrity": "sha512-QE5YxhnoQ4eJH9G2h5r+m4Zq7d/0NmA0eAnZmiOVggI7a3jpODIXZeJbkUPf4U2yzNCSWAGpZVk8XxkA+cTZvA==",
+			"dependencies": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@lezer/css": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-0.15.2.tgz",
+			"integrity": "sha512-tnMOMZY0Zs6JQeVjqfmREYMV0GnmZR1NitndLWioZMD6mA7VQF/PPKPmJX1f+ZgVZQc5Am0df9mX3aiJnNJlKQ==",
+			"dependencies": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@lezer/html": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@lezer/html/-/html-0.15.1.tgz",
+			"integrity": "sha512-0ZYVhu+RwN6ZMM0gNnTxenRAdoycKc2wvpLfMjP0JkKR0vMxhtuLaIpsq9KW2Mv6l7ux5vdjq8CQ7fKDvia8KA==",
+			"dependencies": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@lezer/java": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@lezer/java/-/java-0.15.0.tgz",
+			"integrity": "sha512-Od2Ugo93XjLxCIEKlrwJfacmSMd7lEnkVQgBjMsZofjwEKZ2Y2ue6URntMFFiftTlNXbE29vYbweWYluEq+Cdw==",
+			"dependencies": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@lezer/javascript": {
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-0.15.3.tgz",
+			"integrity": "sha512-8jA2NpOfpWwSPZxRhd9BxK2ZPvGd7nLE3LFTJ5AbMhXAzMHeMjneV6GEVd7dAIee85dtap0jdb6bgOSO0+lfwA==",
+			"dependencies": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@lezer/json": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@lezer/json/-/json-0.15.0.tgz",
+			"integrity": "sha512-OsMjjBkTkeQ15iMCu5U1OiBubRC4V9Wm03zdIlUgNZ20aUPx5DWDRqUc5wG41JXVSj7Lxmo+idlFCfBBdxB8sw==",
+			"dependencies": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@lezer/lezer": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@lezer/lezer/-/lezer-0.15.0.tgz",
+			"integrity": "sha512-PodEAcUKtqZNgecEWsSHHBK6tJtzumqIa8/+RAXaFySWvittyADmFHxu0Mm88NqOIOWL3X0F13d+bnHwQJDW5Q==",
+			"dependencies": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@lezer/lr": {
+			"version": "0.15.8",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
+			"integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
+			"dependencies": {
+				"@lezer/common": "^0.15.0"
+			}
+		},
+		"node_modules/@lezer/markdown": {
+			"version": "0.15.6",
+			"resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-0.15.6.tgz",
+			"integrity": "sha512-1XXLa4q0ZthryUEfO47ipvZHxNb+sCKoQIMM9dKs5vXZOBbgF2Vah/GL3g26BFIAEc2uCv4VQnI+lSrv58BT3g==",
+			"dependencies": {
+				"@lezer/common": "^0.15.0"
+			}
+		},
+		"node_modules/@lezer/php": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@lezer/php/-/php-0.15.0.tgz",
+			"integrity": "sha512-kU3QSOko0jsv3RLhABPrRD4wEhaWYh2Uh0lTj9Q9BOsBJ5SoADfifO4gHkEDav7AgL/j+ulkKiHiilciTa/RaQ==",
+			"dependencies": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@lezer/python": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@lezer/python/-/python-0.15.1.tgz",
+			"integrity": "sha512-Xdb2nh+FoxR8ssEADGsroDtsnP+EDhiPpW9zhER3h+6cpGtZ2e9Oq/Rwn9nFQRiKCfMT+AQaqC3ZgAbhbnumyQ==",
+			"dependencies": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@lezer/rust": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-0.15.1.tgz",
+			"integrity": "sha512-9R7Mcfe/XWodpT7bYNKoOmEAN+AOHHfma9QUTdEhqduzd1G4qsdQkGSMPfsqt24sZCkQ1EREbE/lmEp4YxTlcA==",
+			"dependencies": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"node_modules/@lezer/xml": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-0.15.1.tgz",
+			"integrity": "sha512-vVh01enxM9hSGOcFtztmX+Pa460HDq5jIeft9bDCe17PUOU0nAbfo883I3cW9lUOcmWNQ3btbkmXMGjRszJE6g==",
+			"dependencies": {
+				"@lezer/lr": "^0.15.0"
 			}
 		},
 		"node_modules/@mdx-js/mdx": {
@@ -14621,6 +15123,11 @@
 				"prop-types": "^15.0.0",
 				"react": "^0.14.0 || ^15.0.0 || ^16.0.0"
 			}
+		},
+		"node_modules/crelt": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
+			"integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
 		},
 		"node_modules/cross-spawn": {
 			"version": "6.0.5",
@@ -30344,6 +30851,47 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/prosemirror-codemirror-block": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/prosemirror-codemirror-block/-/prosemirror-codemirror-block-0.2.15.tgz",
+			"integrity": "sha512-uWKxQZe0y6lEGDBqHFtBjyM72fx/MvJ6kNkWYRxdfs7uEUhHEuPr0jfwF4S5Eec5Nh14MEUBB3Lsa236n6reGw==",
+			"dependencies": {
+				"@codemirror/autocomplete": "^0.19.12",
+				"@codemirror/closebrackets": "^0.19.0",
+				"@codemirror/commands": "^0.19.8",
+				"@codemirror/comment": "^0.19.0",
+				"@codemirror/fold": "^0.19.3",
+				"@codemirror/gutter": "^0.19.9",
+				"@codemirror/highlight": "^0.19.7",
+				"@codemirror/lang-cpp": "^0.19.1",
+				"@codemirror/lang-css": "^0.19.3",
+				"@codemirror/lang-html": "^0.19.4",
+				"@codemirror/lang-java": "^0.19.1",
+				"@codemirror/lang-javascript": "^0.19.7",
+				"@codemirror/lang-json": "^0.19.1",
+				"@codemirror/lang-lezer": "^0.19.1",
+				"@codemirror/lang-markdown": "^0.19.5",
+				"@codemirror/lang-php": "^0.19.1",
+				"@codemirror/lang-python": "^0.19.4",
+				"@codemirror/lang-rust": "^0.19.1",
+				"@codemirror/lang-sql": "^0.19.4",
+				"@codemirror/lang-wast": "^0.19.0",
+				"@codemirror/lang-xml": "^0.19.2",
+				"@codemirror/language": "^0.19.7",
+				"@codemirror/legacy-modes": "^0.19.0",
+				"@codemirror/matchbrackets": "^0.19.3",
+				"@codemirror/rectangular-selection": "^0.19.1",
+				"@codemirror/search": "^0.19.6",
+				"@codemirror/state": "^0.19.6",
+				"@codemirror/stream-parser": "^0.19.5",
+				"@codemirror/view": "^0.19.40"
+			},
+			"peerDependencies": {
+				"prosemirror-commands": "^1.1.4",
+				"prosemirror-model": "^1.15.0",
+				"prosemirror-state": "^1.3.3"
+			}
+		},
 		"node_modules/prosemirror-collab": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
@@ -34356,6 +34904,11 @@
 			"engines": {
 				"node": ">= 0.12.0"
 			}
+		},
+		"node_modules/style-mod": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
+			"integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
 		},
 		"node_modules/style-to-object": {
 			"version": "0.3.0",
@@ -39835,6 +40388,386 @@
 				"minimist": "^1.2.0"
 			}
 		},
+		"@codemirror/autocomplete": {
+			"version": "0.19.15",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.15.tgz",
+			"integrity": "sha512-GQWzvvuXxNUyaEk+5gawbAD8s51/v2Chb++nx0e2eGWrphWk42isBtzOMdc3DxrxrZtPZ55q2ldNp+6G8KJLIQ==",
+			"requires": {
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.4",
+				"@codemirror/text": "^0.19.2",
+				"@codemirror/tooltip": "^0.19.12",
+				"@codemirror/view": "^0.19.0",
+				"@lezer/common": "^0.15.0"
+			}
+		},
+		"@codemirror/closebrackets": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.2.tgz",
+			"integrity": "sha512-ClMPzPcPP0eQiDcVjtVPl6OLxgdtZSYDazsvT0AKl70V1OJva0eHgl4/6kCW3RZ0pb2n34i9nJz4eXCmK+TYDA==",
+			"requires": {
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/rangeset": "^0.19.0",
+				"@codemirror/state": "^0.19.2",
+				"@codemirror/text": "^0.19.0",
+				"@codemirror/view": "^0.19.44"
+			}
+		},
+		"@codemirror/commands": {
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.8.tgz",
+			"integrity": "sha512-65LIMSGUGGpY3oH6mzV46YWRrgao6NmfJ+AuC7jNz3K5NPnH6GCV1H5I6SwOFyVbkiygGyd0EFwrWqywTBD1aw==",
+			"requires": {
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/matchbrackets": "^0.19.0",
+				"@codemirror/state": "^0.19.2",
+				"@codemirror/text": "^0.19.6",
+				"@codemirror/view": "^0.19.22",
+				"@lezer/common": "^0.15.0"
+			}
+		},
+		"@codemirror/comment": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.1.tgz",
+			"integrity": "sha512-uGKteBuVWAC6fW+Yt8u27DOnXMT/xV4Ekk2Z5mRsiADCZDqYvryrJd6PLL5+8t64BVyocwQwNfz1UswYS2CtFQ==",
+			"requires": {
+				"@codemirror/state": "^0.19.9",
+				"@codemirror/text": "^0.19.0",
+				"@codemirror/view": "^0.19.0"
+			}
+		},
+		"@codemirror/fold": {
+			"version": "0.19.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.4.tgz",
+			"integrity": "sha512-0SNSkRSOa6gymD6GauHa3sxiysjPhUC0SRVyTlvL52o0gz9GHdc8kNqNQskm3fBtGGOiSriGwF/kAsajRiGhVw==",
+			"requires": {
+				"@codemirror/gutter": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/rangeset": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/view": "^0.19.22"
+			}
+		},
+		"@codemirror/gutter": {
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.9.tgz",
+			"integrity": "sha512-PFrtmilahin1g6uL27aG5tM/rqR9DZzZYZsIrCXA5Uc2OFTFqx4owuhoU9hqfYxHp5ovfvBwQ+txFzqS4vog6Q==",
+			"requires": {
+				"@codemirror/rangeset": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/view": "^0.19.23"
+			}
+		},
+		"@codemirror/highlight": {
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.8.tgz",
+			"integrity": "sha512-v/lzuHjrYR8MN2mEJcUD6fHSTXXli9C1XGYpr+ElV6fLBIUhMTNKR3qThp611xuWfXfwDxeL7ppcbkM/MzPV3A==",
+			"requires": {
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/rangeset": "^0.19.0",
+				"@codemirror/state": "^0.19.3",
+				"@codemirror/view": "^0.19.39",
+				"@lezer/common": "^0.15.0",
+				"style-mod": "^4.0.0"
+			}
+		},
+		"@codemirror/lang-cpp": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-0.19.1.tgz",
+			"integrity": "sha512-BGvZkfcqcalAwxocuE9DhH6gqflm5IjL/8mGTzc8bHzeP1N4innK8qo2G69ohEML4LDZv4WyXc3y4C9/zsGCGQ==",
+			"requires": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@lezer/cpp": "^0.15.0"
+			}
+		},
+		"@codemirror/lang-css": {
+			"version": "0.19.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-0.19.3.tgz",
+			"integrity": "sha512-tyCUJR42/UlfOPLb94/p7dN+IPsYSIzHbAHP2KQHANj0I+Orqp+IyIOS++M8TuCX4zkWh9dvi8s92yy/Tn8Ifg==",
+			"requires": {
+				"@codemirror/autocomplete": "^0.19.0",
+				"@codemirror/highlight": "^0.19.6",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@lezer/css": "^0.15.2"
+			}
+		},
+		"@codemirror/lang-html": {
+			"version": "0.19.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.4.tgz",
+			"integrity": "sha512-GpiEikNuCBeFnS+/TJSeanwqaOfNm8Kkp9WpVNEPZCLyW1mAMCuFJu/3xlWYeWc778Hc3vJqGn3bn+cLNubgCA==",
+			"requires": {
+				"@codemirror/autocomplete": "^0.19.0",
+				"@codemirror/highlight": "^0.19.6",
+				"@codemirror/lang-css": "^0.19.0",
+				"@codemirror/lang-javascript": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@lezer/common": "^0.15.0",
+				"@lezer/html": "^0.15.0"
+			}
+		},
+		"@codemirror/lang-java": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-0.19.1.tgz",
+			"integrity": "sha512-yA3kcW2GgY0mC2a9dE+uRxGxPWeykfE/GqEPk4TSmhuU4ndmyDgM5QQP7pgnYSZmv2vKoyf4x7NMg8AF7lKXHQ==",
+			"requires": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@lezer/java": "^0.15.0"
+			}
+		},
+		"@codemirror/lang-javascript": {
+			"version": "0.19.7",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.7.tgz",
+			"integrity": "sha512-DL9f3JLqOEHH9cIwEqqjnP5bkjdVXeECksLtV+/MbPm+l4H+AG+PkwZaJQ2oR1GfPZKh8MVSIE94aGWNkJP8WQ==",
+			"requires": {
+				"@codemirror/autocomplete": "^0.19.0",
+				"@codemirror/highlight": "^0.19.7",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/lint": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/view": "^0.19.0",
+				"@lezer/javascript": "^0.15.1"
+			}
+		},
+		"@codemirror/lang-json": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-0.19.2.tgz",
+			"integrity": "sha512-fgUWR58Is59P5D/tiazX6oTczioOCDYqjFT5PEBAmLBFMSsRqcnJE0xNO1snrhg7pWEFDq5wR/oN0eZhkeR6Gg==",
+			"requires": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@lezer/json": "^0.15.0"
+			}
+		},
+		"@codemirror/lang-lezer": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-lezer/-/lang-lezer-0.19.1.tgz",
+			"integrity": "sha512-Ba1NIDvsw67CDJ7rql2iMxZ6eVrMsRajmbna/Ijq9OV9r6qricnsiwNnNPTfdtCpek3gm9P/U4gqFMbrnV11DA==",
+			"requires": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@lezer/common": "^0.15.0",
+				"@lezer/lezer": "^0.15.0"
+			}
+		},
+		"@codemirror/lang-markdown": {
+			"version": "0.19.6",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-0.19.6.tgz",
+			"integrity": "sha512-ojoHeLgv1Rfu0GNGsU0bCtXAIp5dy4VKjndHScITQdlCkS/+SAIfuoeowEx+nMAQwTxI+/9fQZ3xdZVznGFYug==",
+			"requires": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/lang-html": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.3",
+				"@codemirror/view": "^0.19.0",
+				"@lezer/common": "^0.15.0",
+				"@lezer/markdown": "^0.15.0"
+			}
+		},
+		"@codemirror/lang-php": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-0.19.1.tgz",
+			"integrity": "sha512-Q6djLACHu1J6XbnxWlEPCiyqqDrlZLi9QtjY6b9vqdkq/GOsNaXVv44nDY8DD6Bxi5yYRTJ3yh8XzsKuJgztjQ==",
+			"requires": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/lang-html": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@lezer/common": "^0.15.0",
+				"@lezer/php": "^0.15.0"
+			}
+		},
+		"@codemirror/lang-python": {
+			"version": "0.19.5",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-0.19.5.tgz",
+			"integrity": "sha512-MQf7t0k6+i9KCzlFCI8EY+jjwyXLy5AwjmXsMyMCMbOw/97j70jFZYrs7Mm7RJakNE2rypWhnLGlyBTSYMqR5g==",
+			"requires": {
+				"@codemirror/highlight": "^0.19.7",
+				"@codemirror/language": "^0.19.0",
+				"@lezer/python": "^0.15.0"
+			}
+		},
+		"@codemirror/lang-rust": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-0.19.2.tgz",
+			"integrity": "sha512-SEXsO7Qf2gktRvVhHMc0Mq4HzPBpFcQlrlcinafy6VFXavWs+QAIB8UAuLG/igOc3PrIHbZFlyEhVUIGstox8w==",
+			"requires": {
+				"@codemirror/highlight": "^0.19.7",
+				"@codemirror/language": "^0.19.0",
+				"@lezer/rust": "^0.15.0"
+			}
+		},
+		"@codemirror/lang-sql": {
+			"version": "0.19.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-0.19.4.tgz",
+			"integrity": "sha512-4FqLC8aNe1iCDyAWbJmSqa8K7rgz2xTwW36V35z4oiyLoyOLsCayKIwoQqp5DNIq2ckGCsyzotgxXKpgtg/pgg==",
+			"requires": {
+				"@codemirror/autocomplete": "^0.19.0",
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@codemirror/lang-wast": {
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-0.19.0.tgz",
+			"integrity": "sha512-mr/Bp4k8+fJ0P8/Q6L45pnX7/bDBk4VP8ahYrTdvHo+UaOqBBhBFtBqBikvX8ZDQiUTfuZ4tnJE2QtOvmFsuzg==",
+			"requires": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@codemirror/lang-xml": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-0.19.2.tgz",
+			"integrity": "sha512-9VIjxvqcH1sk8bmYbxQon0lXhVZgdHdfjGes+e4Akgvb43aMBDNvIQVALwrCb+XMEHTxLUMQtrsBN0G64yCUXw==",
+			"requires": {
+				"@codemirror/autocomplete": "^0.19.0",
+				"@codemirror/highlight": "^0.19.6",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@lezer/common": "^0.15.0",
+				"@lezer/xml": "^0.15.0"
+			}
+		},
+		"@codemirror/language": {
+			"version": "0.19.10",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.10.tgz",
+			"integrity": "sha512-yA0DZ3RYn2CqAAGW62VrU8c4YxscMQn45y/I9sjBlqB1e2OTQLg4CCkMBuMSLXk4xaqjlsgazeOQWaJQOKfV8Q==",
+			"requires": {
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/text": "^0.19.0",
+				"@codemirror/view": "^0.19.0",
+				"@lezer/common": "^0.15.5",
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@codemirror/legacy-modes": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-0.19.1.tgz",
+			"integrity": "sha512-vYPLsD/ON+3SXhlGj9Qb3fpFNNU3Ya/AtDiv/g3OyqVzhh5vs5rAnOvk8xopGWRwppdhlNPD9VyXjiOmZUQtmQ==",
+			"requires": {
+				"@codemirror/stream-parser": "^0.19.0"
+			}
+		},
+		"@codemirror/lint": {
+			"version": "0.19.6",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.6.tgz",
+			"integrity": "sha512-Pbw1Y5kHVs2J+itQ0uez3dI4qY9ApYVap7eNfV81x1/3/BXgBkKfadaw0gqJ4h4FDG7OnJwb0VbPsjJQllHjaA==",
+			"requires": {
+				"@codemirror/gutter": "^0.19.4",
+				"@codemirror/panel": "^0.19.0",
+				"@codemirror/rangeset": "^0.19.1",
+				"@codemirror/state": "^0.19.4",
+				"@codemirror/tooltip": "^0.19.16",
+				"@codemirror/view": "^0.19.22",
+				"crelt": "^1.0.5"
+			}
+		},
+		"@codemirror/matchbrackets": {
+			"version": "0.19.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/matchbrackets/-/matchbrackets-0.19.4.tgz",
+			"integrity": "sha512-VFkaOKPNudAA5sGP1zikRHCEKU0hjYmkKpr04pybUpQvfTvNJXlReCyP0rvH/1iEwAGPL990ZTT+QrLdu4MeEA==",
+			"requires": {
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/view": "^0.19.0",
+				"@lezer/common": "^0.15.0"
+			}
+		},
+		"@codemirror/panel": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.1.tgz",
+			"integrity": "sha512-sYeOCMA3KRYxZYJYn5PNlt9yNsjy3zTNTrbYSfVgjgL9QomIVgOJWPO5hZ2sTN8lufO6lw0vTBsIPL9MSidmBg==",
+			"requires": {
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/view": "^0.19.0"
+			}
+		},
+		"@codemirror/rangeset": {
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.9.tgz",
+			"integrity": "sha512-V8YUuOvK+ew87Xem+71nKcqu1SXd5QROMRLMS/ljT5/3MCxtgrRie1Cvild0G/Z2f1fpWxzX78V0U4jjXBorBQ==",
+			"requires": {
+				"@codemirror/state": "^0.19.0"
+			}
+		},
+		"@codemirror/rectangular-selection": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/rectangular-selection/-/rectangular-selection-0.19.2.tgz",
+			"integrity": "sha512-AXK/p5eGwFJ9GJcLfntqN4dgY+XiIF7eHfXNQJX5HhQLSped2wJE6WuC1rMEaOlcpOqlb9mrNi/ZdUjSIj9mbA==",
+			"requires": {
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/text": "^0.19.4",
+				"@codemirror/view": "^0.19.48"
+			}
+		},
+		"@codemirror/search": {
+			"version": "0.19.10",
+			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.10.tgz",
+			"integrity": "sha512-qjubm69HJixPBWzI6HeEghTWOOD8NXiHOTRNvdizqs8xWRuFChq9zkjD3XiAJ7GXSTzCuQJnAP9DBBGCLq4ZIA==",
+			"requires": {
+				"@codemirror/panel": "^0.19.0",
+				"@codemirror/rangeset": "^0.19.0",
+				"@codemirror/state": "^0.19.3",
+				"@codemirror/text": "^0.19.0",
+				"@codemirror/view": "^0.19.34",
+				"crelt": "^1.0.5"
+			}
+		},
+		"@codemirror/state": {
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
+			"integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
+			"requires": {
+				"@codemirror/text": "^0.19.0"
+			}
+		},
+		"@codemirror/stream-parser": {
+			"version": "0.19.9",
+			"resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.19.9.tgz",
+			"integrity": "sha512-WTmkEFSRCetpk8xIOvV2yyXdZs3DgYckM0IP7eFi4ewlxWnJO/H4BeJZLs4wQaydWsAqTQoDyIwNH1BCzK5LUQ==",
+			"requires": {
+				"@codemirror/highlight": "^0.19.0",
+				"@codemirror/language": "^0.19.0",
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/text": "^0.19.0",
+				"@lezer/common": "^0.15.0",
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@codemirror/text": {
+			"version": "0.19.6",
+			"resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
+			"integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA=="
+		},
+		"@codemirror/tooltip": {
+			"version": "0.19.16",
+			"resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.16.tgz",
+			"integrity": "sha512-zxKDHryUV5/RS45AQL+wOeN+i7/l81wK56OMnUPoTSzCWNITfxHn7BToDsjtrRKbzHqUxKYmBnn/4hPjpZ4WJQ==",
+			"requires": {
+				"@codemirror/state": "^0.19.0",
+				"@codemirror/view": "^0.19.0"
+			}
+		},
+		"@codemirror/view": {
+			"version": "0.19.48",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.48.tgz",
+			"integrity": "sha512-0eg7D2Nz4S8/caetCTz61rK0tkHI17V/d15Jy0kLOT8dTLGGNJUponDnW28h2B6bERmPlVHKh8MJIr5OCp1nGw==",
+			"requires": {
+				"@codemirror/rangeset": "^0.19.5",
+				"@codemirror/state": "^0.19.3",
+				"@codemirror/text": "^0.19.0",
+				"style-mod": "^4.0.0",
+				"w3c-keyname": "^2.2.4"
+			}
+		},
 		"@colors/colors": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -41387,6 +42320,115 @@
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"@lezer/common": {
+			"version": "0.15.12",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
+			"integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig=="
+		},
+		"@lezer/cpp": {
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-0.15.3.tgz",
+			"integrity": "sha512-QE5YxhnoQ4eJH9G2h5r+m4Zq7d/0NmA0eAnZmiOVggI7a3jpODIXZeJbkUPf4U2yzNCSWAGpZVk8XxkA+cTZvA==",
+			"requires": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@lezer/css": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-0.15.2.tgz",
+			"integrity": "sha512-tnMOMZY0Zs6JQeVjqfmREYMV0GnmZR1NitndLWioZMD6mA7VQF/PPKPmJX1f+ZgVZQc5Am0df9mX3aiJnNJlKQ==",
+			"requires": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@lezer/html": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@lezer/html/-/html-0.15.1.tgz",
+			"integrity": "sha512-0ZYVhu+RwN6ZMM0gNnTxenRAdoycKc2wvpLfMjP0JkKR0vMxhtuLaIpsq9KW2Mv6l7ux5vdjq8CQ7fKDvia8KA==",
+			"requires": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@lezer/java": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@lezer/java/-/java-0.15.0.tgz",
+			"integrity": "sha512-Od2Ugo93XjLxCIEKlrwJfacmSMd7lEnkVQgBjMsZofjwEKZ2Y2ue6URntMFFiftTlNXbE29vYbweWYluEq+Cdw==",
+			"requires": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@lezer/javascript": {
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-0.15.3.tgz",
+			"integrity": "sha512-8jA2NpOfpWwSPZxRhd9BxK2ZPvGd7nLE3LFTJ5AbMhXAzMHeMjneV6GEVd7dAIee85dtap0jdb6bgOSO0+lfwA==",
+			"requires": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@lezer/json": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@lezer/json/-/json-0.15.0.tgz",
+			"integrity": "sha512-OsMjjBkTkeQ15iMCu5U1OiBubRC4V9Wm03zdIlUgNZ20aUPx5DWDRqUc5wG41JXVSj7Lxmo+idlFCfBBdxB8sw==",
+			"requires": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@lezer/lezer": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@lezer/lezer/-/lezer-0.15.0.tgz",
+			"integrity": "sha512-PodEAcUKtqZNgecEWsSHHBK6tJtzumqIa8/+RAXaFySWvittyADmFHxu0Mm88NqOIOWL3X0F13d+bnHwQJDW5Q==",
+			"requires": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@lezer/lr": {
+			"version": "0.15.8",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
+			"integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
+			"requires": {
+				"@lezer/common": "^0.15.0"
+			}
+		},
+		"@lezer/markdown": {
+			"version": "0.15.6",
+			"resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-0.15.6.tgz",
+			"integrity": "sha512-1XXLa4q0ZthryUEfO47ipvZHxNb+sCKoQIMM9dKs5vXZOBbgF2Vah/GL3g26BFIAEc2uCv4VQnI+lSrv58BT3g==",
+			"requires": {
+				"@lezer/common": "^0.15.0"
+			}
+		},
+		"@lezer/php": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@lezer/php/-/php-0.15.0.tgz",
+			"integrity": "sha512-kU3QSOko0jsv3RLhABPrRD4wEhaWYh2Uh0lTj9Q9BOsBJ5SoADfifO4gHkEDav7AgL/j+ulkKiHiilciTa/RaQ==",
+			"requires": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@lezer/python": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@lezer/python/-/python-0.15.1.tgz",
+			"integrity": "sha512-Xdb2nh+FoxR8ssEADGsroDtsnP+EDhiPpW9zhER3h+6cpGtZ2e9Oq/Rwn9nFQRiKCfMT+AQaqC3ZgAbhbnumyQ==",
+			"requires": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@lezer/rust": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-0.15.1.tgz",
+			"integrity": "sha512-9R7Mcfe/XWodpT7bYNKoOmEAN+AOHHfma9QUTdEhqduzd1G4qsdQkGSMPfsqt24sZCkQ1EREbE/lmEp4YxTlcA==",
+			"requires": {
+				"@lezer/lr": "^0.15.0"
+			}
+		},
+		"@lezer/xml": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-0.15.1.tgz",
+			"integrity": "sha512-vVh01enxM9hSGOcFtztmX+Pa460HDq5jIeft9bDCe17PUOU0nAbfo883I3cW9lUOcmWNQ3btbkmXMGjRszJE6g==",
+			"requires": {
+				"@lezer/lr": "^0.15.0"
 			}
 		},
 		"@mdx-js/mdx": {
@@ -49208,6 +50250,11 @@
 				"gud": "^1.0.0",
 				"warning": "^4.0.3"
 			}
+		},
+		"crelt": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
+			"integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
 		},
 		"cross-spawn": {
 			"version": "6.0.5",
@@ -61432,6 +62479,42 @@
 				"xtend": "^4.0.0"
 			}
 		},
+		"prosemirror-codemirror-block": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/prosemirror-codemirror-block/-/prosemirror-codemirror-block-0.2.15.tgz",
+			"integrity": "sha512-uWKxQZe0y6lEGDBqHFtBjyM72fx/MvJ6kNkWYRxdfs7uEUhHEuPr0jfwF4S5Eec5Nh14MEUBB3Lsa236n6reGw==",
+			"requires": {
+				"@codemirror/autocomplete": "^0.19.12",
+				"@codemirror/closebrackets": "^0.19.0",
+				"@codemirror/commands": "^0.19.8",
+				"@codemirror/comment": "^0.19.0",
+				"@codemirror/fold": "^0.19.3",
+				"@codemirror/gutter": "^0.19.9",
+				"@codemirror/highlight": "^0.19.7",
+				"@codemirror/lang-cpp": "^0.19.1",
+				"@codemirror/lang-css": "^0.19.3",
+				"@codemirror/lang-html": "^0.19.4",
+				"@codemirror/lang-java": "^0.19.1",
+				"@codemirror/lang-javascript": "^0.19.7",
+				"@codemirror/lang-json": "^0.19.1",
+				"@codemirror/lang-lezer": "^0.19.1",
+				"@codemirror/lang-markdown": "^0.19.5",
+				"@codemirror/lang-php": "^0.19.1",
+				"@codemirror/lang-python": "^0.19.4",
+				"@codemirror/lang-rust": "^0.19.1",
+				"@codemirror/lang-sql": "^0.19.4",
+				"@codemirror/lang-wast": "^0.19.0",
+				"@codemirror/lang-xml": "^0.19.2",
+				"@codemirror/language": "^0.19.7",
+				"@codemirror/legacy-modes": "^0.19.0",
+				"@codemirror/matchbrackets": "^0.19.3",
+				"@codemirror/rectangular-selection": "^0.19.1",
+				"@codemirror/search": "^0.19.6",
+				"@codemirror/state": "^0.19.6",
+				"@codemirror/stream-parser": "^0.19.5",
+				"@codemirror/view": "^0.19.40"
+			}
+		},
 		"prosemirror-collab": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.2.2.tgz",
@@ -64635,6 +65718,11 @@
 				"loader-utils": "^1.1.0",
 				"schema-utils": "^1.0.0"
 			}
+		},
+		"style-mod": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
+			"integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
 		},
 		"style-to-object": {
 			"version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
 		"pretty-bytes": "^5.6.0",
 		"prompt": "^1.0.0",
 		"prop-types": "^15.7.2",
+		"prosemirror-codemirror-block": "^0.2.15",
 		"prosemirror-collab": "^1.2.2",
 		"prosemirror-commands": "^1.1.4",
 		"prosemirror-compress-pubpub": "0.0.3",


### PR DESCRIPTION
We are going with this approach!

_Test Plan_
create code block in a pub and play with them generally. Steps below. NB: the code blocks behave as a text block, which is to say, they are not deletable if they are the only text block in the document just as the only `paragraph` block would not be deletable. We can change this behavior, but it would be a departure from block behavior to accommodate image-block-like behavior.
Make sure to hit each of the below:
+ create a code block by typing three backticks to enter it
+ create a code block by clicking the lego-block-shaped codeblock toggle button in the formatting bar
+ create a code block by selecting `code` from the dropdown at the left edge of the formatting bar
+ exit the codeblock by pressing `return` from an empty line in the codeblock
+ exit the codeblock by navigating to the right from the last character (per NB above, this is impossible if there isn't a following text block to navigate into)
+ while inside a codeblock, select different language syntax highlighting grammars, then reload the page
+ copy + paste into/out of codeblocks
+ delete codeblocks with backspace (provided there is a text node above the codeblock in the document)

TODO:
+ implement the language selector dropdown component using Blueprint components for visual consistency, using the `createSelect` api from the vendor module.
+ PDF export