### PR TITLE
fix/update: add metadata for collections and fix filter

### DIFF
--- a/client/components/Layout/LayoutCollectionHeader.tsx
+++ b/client/components/Layout/LayoutCollectionHeader.tsx
@@ -35,7 +35,7 @@ const MetadataDetails = (props: Props) => {
 
 	const excludedMetadataFields = ['doi', 'url'];
 	const fields = getOrderedCollectionMetadataFields(collection).filter(
-		(x) => !excludedMetadataFields.includes[x.name],
+		(x) => !excludedMetadataFields.includes(x.name),
 	);
 
 	return (
@@ -70,7 +70,6 @@ const LayoutCollectionHeader = (props: Props) => {
 	const bylineContributors = contributors.filter((c) => c.isAuthor);
 	const schema = getSchemaForKind(collection.kind)!;
 	const doi = getCollectionDoi(collection);
-
 	const detailsRowElements = [
 		!hideCollectionKind && (
 			<div className="collection-kind" key={0}>

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -96,8 +96,8 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			/>,
 			<meta key="t3" name="twitter:title" content={titleWithContext} />,
 			<meta key="t4" name="twitter:image:alt" content={titleWithContext} />,
-			<meta key="t5" name="citation_title" content={collection ? collection.title : title} />,
-			<meta key="t6" name="dc.title" content={collection ? collection.title : title} />,
+			<meta key="t5" name="citation_title" content={collection?.title ?? title} />,
+			<meta key="t6" name="dc.title" content={collection?.title ?? title} />,
 		];
 	}
 
@@ -300,24 +300,14 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 		];
 	}
 
-	if (doi || collection?.metadata?.doi) {
+	const finalDoi = doi || collection?.metadata?.doi;
+
+	if (finalDoi) {
 		outputComponents = [
 			...outputComponents,
-			<meta
-				key="doi1"
-				name="citation_doi"
-				content={`doi:${doi || collection?.metadata?.doi}`}
-			/>,
-			<meta
-				key="doi2"
-				property="dc.identifier"
-				content={`doi:${doi || collection?.metadata?.doi}`}
-			/>,
-			<meta
-				key="doi3"
-				property="prism.doi"
-				content={`doi:${doi || collection?.metadata?.doi}`}
-			/>,
+			<meta key="doi1" name="citation_doi" content={`doi:${finalDoi}`} />,
+			<meta key="doi2" property="dc.identifier" content={`doi:${finalDoi}`} />,
+			<meta key="doi3" property="prism.doi" content={`doi:${finalDoi}`} />,
 		];
 	}
 	if (notes) {

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -89,11 +89,15 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 		outputComponents = [
 			...outputComponents,
 			<title key="t1">{titleWithContext}</title>,
-			<meta key="t2" property="og:title" content={titleWithContext} />,
+			<meta
+				key="t2"
+				property="og:title"
+				content={collection?.kind === 'book' ? collection.title : title}
+			/>,
 			<meta key="t3" name="twitter:title" content={titleWithContext} />,
 			<meta key="t4" name="twitter:image:alt" content={titleWithContext} />,
-			<meta key="t5" name="citation_title" content={title} />,
-			<meta key="t6" name="dc.title" content={title} />,
+			<meta key="t5" name="citation_title" content={collection ? collection.title : title} />,
+			<meta key="t6" name="dc.title" content={collection ? collection.title : title} />,
 		];
 	}
 
@@ -118,7 +122,13 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			<meta
 				key="u2"
 				property="og:type"
-				content={url.indexOf('/pub/') > -1 ? 'article' : 'website'}
+				content={
+					collection?.kind === 'book'
+						? 'book'
+						: url.indexOf('/pub/') > -1
+						? 'article'
+						: 'website'
+				}
 			/>,
 		];
 	}
@@ -140,20 +150,31 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 					content={collection.metadata?.electronicIssn}
 				/>,
 				<meta key="c5" name="citation_issn" content={collection.metadata?.printIssn} />,
+				<meta
+					key="c6"
+					name="citation_date"
+					content={collection.metadata?.publicationDate}
+				/>,
 			];
 		}
 		if (collection.kind === 'book') {
 			outputComponents = [
 				...outputComponents,
-				<meta key="c6" name="citation_inbook_title" content={collection.title} />,
 				<meta key="c7" name="citation_book_title" content={collection.title} />,
 				<meta key="c8" name="citation_isbn" content={collection.metadata?.isbn} />,
+				<meta
+					key="c9"
+					name="citation_date"
+					content={collection.metadata?.publicationDate}
+				/>,
 			];
 		}
 		if (collection.kind === 'conference') {
 			outputComponents = [
 				...outputComponents,
-				<meta key="c9" name="citation_conference_title" content={collection.title} />,
+				<meta key="c10" name="citation_conference_title" content={collection.title} />,
+				<meta key="c11" name="citation_conferenceName" content={collection.title} />,
+				<meta key="c9" name="citation_date" content={collection.metadata?.date} />,
 			];
 		}
 	}
@@ -279,15 +300,26 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 		];
 	}
 
-	if (doi) {
+	if (doi || collection?.metadata?.doi) {
 		outputComponents = [
 			...outputComponents,
-			<meta key="doi1" name="citation_doi" content={`doi:${doi}`} />,
-			<meta key="doi2" property="dc.identifier" content={`doi:${doi}`} />,
-			<meta key="doi3" property="prism.doi" content={`doi:${doi}`} />,
+			<meta
+				key="doi1"
+				name="citation_doi"
+				content={`doi:${doi || collection?.metadata?.doi}`}
+			/>,
+			<meta
+				key="doi2"
+				property="dc.identifier"
+				content={`doi:${doi || collection?.metadata?.doi}`}
+			/>,
+			<meta
+				key="doi3"
+				property="prism.doi"
+				content={`doi:${doi || collection?.metadata?.doi}`}
+			/>,
 		];
 	}
-
 	if (notes) {
 		const citationNoteTags = notes.map((note, i) => {
 			// https://github.com/yannickcr/eslint-plugin-react/issues/1123


### PR DESCRIPTION
Improves Collection-level metadata for Zotero/Mendeley/etc. and fixes a bug where DOIs were appearing twice in collection headers.

_Test plan_
- Visit any collection with a DOI and make sure it only shows once in the collection header block
- Visit Conference and Issue collections with all metadata filled in. Make sure: citation_doi and citation_date HTML metadata are set according to the collection metadata.
- Visit a Book collection. Make sure citation_title, og:title, citation_book_title, citation_DOI are set according to metadata. Make sure og:type is set to 'book'.
- Visit a tag collection and make sure no metadata is set except basic og metadata.
- Visit pages and pubs in and out of collections and make sure they load as expected.

Thanks to @tefkah for initial pull request and fixes.