### PR TITLE
update: Allow private Collections to act as Primary Collection

### DIFF
--- a/client/containers/DashboardOverview/CollectionOverview/PubMenu.tsx
+++ b/client/containers/DashboardOverview/CollectionOverview/PubMenu.tsx
@@ -118,7 +118,7 @@ const PubMenu = (props: Props) => {
 	const renderNonTagButtons = () => {
 		return (
 			<>
-				{collection.isPublic && renderPrimaryCollectionButton()}
+				{renderPrimaryCollectionButton()}
 				<MenuButton
 					aria-label="Collection context hint"
 					buttonProps={{

--- a/utils/collections/primary.ts
+++ b/utils/collections/primary.ts
@@ -3,7 +3,7 @@ import { Collection, CollectionPub } from 'types';
 
 const isPrimaryCollectionCandidate = (collectionPub: CollectionPub) => {
 	const { collection } = collectionPub;
-	return collection && collection.kind !== 'tag' && collection.isPublic;
+	return collection && collection.kind !== 'tag';
 };
 
 export const getPrimaryCollection = (collectionPubs: CollectionPub[]) => {


### PR DESCRIPTION
Currently, any _non-tag, public Collection_ is eligible to act as a Pub's Primary Collection. You can choose which of those Collections will be primary in Pub settings:

<img width="555" alt="image" src="https://user-images.githubusercontent.com/2208769/199324661-357bba1f-2b51-47d0-a6a2-dc7c533d3d46.png">

This change removes the requirement that the Collection be public. This stipulation was originally added to prevent leakage of private Collection information in Crossref deposits and exports. But in practice, this usually doesn't matter. If a Pub has a Crossref deposit or PDFs floating around in public, "the cat is out of the bag" and it doesn't matter if a private Collection title or URL makes it into the world.

Allowing a Collection to be primary before it goes public makes it much easier for Community admins to reason about how its Pubs will behave, and — here's the kicker — it's absolutely a requirement to enable Collection-level cascading settings.

_Test plan:_
Add a Pub to a private, non-tag Collection and make sure that:
- In the Collection overview, the Collection is indicated as the Pub's primary Collection (darkened star)
- The Collection appears in the Pub's exports and DOI deposit preview
- Any later Pubs in the Collection are shown in "read next"
etc etc...