### PR TITLE
enhancement: add canonical url to pub metadata

### DIFF
--- a/server/routes/pubDocument.tsx
+++ b/server/routes/pubDocument.tsx
@@ -3,6 +3,7 @@ import slowDown from 'express-slow-down';
 
 import { getPubPageContextTitle } from 'utils/pubPageTitle';
 import { getPrimaryCollection } from 'utils/collections/primary';
+import { pubUrl } from 'utils/canonicalUrls';
 import { getPdfDownloadUrl, getTextAbstract, getGoogleScholarNotes } from 'utils/pub/metadata';
 import { chooseCollectionForPub } from 'client/utils/collections';
 import Html from 'server/Html';
@@ -58,6 +59,7 @@ const renderPubDocument = (res, pubData, initialData, customScripts) => {
 				initialData,
 				notes: getGoogleScholarNotes(Object.values(pubData.initialStructuredCitations)),
 				publishedAt: getPubPublishedDate(pubData),
+				canonicalUrl: pubUrl(initialData.communityData, pubData),
 				textAbstract: pubData.initialDoc ? getTextAbstract(pubData.initialDoc) : '',
 				title: pubData.title,
 				unlisted: !pubData.isRelease,


### PR DESCRIPTION
addresses #2282
Adds canonical url to pub so that all releases carry the correct target for the most-recent-release url.

### Test Plan
+ open a 2nd or 3rd release for a pub
+ inspect the `<head>` content of the pub in browser
+ confirm presence of line like the following:
`<link rel="canonical" href="http://localhost:9876/pub/b439jo24">`