### PR TITLE
fix: Dashboard Menu position in header nav (#2218)

### DIFF
--- a/client/components/GlobalControls/GlobalControls.tsx
+++ b/client/components/GlobalControls/GlobalControls.tsx
@@ -48,7 +48,7 @@ const GlobalControls = (props: Props) => {
 			<Menu
 				aria-label="Dashboard menu"
 				placement="bottom-end"
-				menuStyle={{ zIndex: 20 }}
+				menuStyle={{ zIndex: 20, left: '30px' }}
 				disclosure={
 					<GlobalControlsButton
 						mobile={{ icon: 'settings' }}


### PR DESCRIPTION
This change affects non-mobile browsers also by moving the popover to the right by 30px, but that looks fine. So we'll stick to this solution for now.