### PR TITLE
fix: Include `structuredValue` as HTML in Pandoc footnotes

### DIFF
--- a/workers/tasks/export/notes.ts
+++ b/workers/tasks/export/notes.ts
@@ -12,7 +12,8 @@ export type PandocNote = {
 	id: string;
 	cslJson: Record<string, any>;
 	hasStructuredContent: boolean;
-	unstructuredHtml: string;
+	unstructuredHtml: null | undefined | string;
+	structuredHtml: null | undefined | string;
 };
 
 export type PandocNotes = Record<string, PandocNote>;
@@ -76,12 +77,20 @@ export const getPandocNotesById = (notesData: NotesData): PandocNotes => {
 	const notes = [...citations, ...footnotes];
 	const index: PandocNotes = {};
 	notes.forEach((note) => {
+		const { unstructuredValue: unstructuredHtml, structuredValue } = note;
 		const { hasStructuredContent, cslJson } = getCslJsonForNote(note, renderedStructuredValues);
+		const structuredHtmlFullOfDivs = renderedStructuredValues[structuredValue]?.html;
+		const structuredHtmlWithBareStyling = structuredHtmlFullOfDivs
+			? sanitizeHtml(structuredHtmlFullOfDivs, {
+					allowedTags: ['b', 'i', 'strong', 'em', 'a'],
+			  })
+			: null;
 		index[note.id] = {
 			id: getIdForNote(cslJson, note.id),
 			cslJson,
 			hasStructuredContent,
-			unstructuredHtml: note.unstructuredValue,
+			unstructuredHtml,
+			structuredHtml: structuredHtmlWithBareStyling,
 		};
 	});
 	return index;

--- a/workers/tasks/import/rules.ts
+++ b/workers/tasks/import/rules.ts
@@ -322,10 +322,9 @@ rules.transform('Note', 'footnote', {
 		};
 	},
 	fromProsemirrorNode: (node, { resources }) => {
-		const { value: unstructuredValue } = node.attrs;
-		const { unstructuredHtml } = resources.note(node.attrs.id);
-		const unstructuredBlocks = unstructuredValue && htmlStringToPandocBlocks(unstructuredValue);
-		const structuredBlocks = unstructuredHtml && htmlStringToPandocBlocks(unstructuredHtml);
+		const { unstructuredHtml, structuredHtml } = resources.note(node.attrs.id);
+		const unstructuredBlocks = unstructuredHtml && htmlStringToPandocBlocks(unstructuredHtml);
+		const structuredBlocks = structuredHtml && htmlStringToPandocBlocks(structuredHtml);
 		const content = [structuredBlocks, unstructuredBlocks].reduce(
 			(acc, next) => [...acc, ...(next || [])],
 			[],


### PR DESCRIPTION
Resolves #2296

There is a goof (in recent code that I wrote) that double-adds the `unstructuredValue` of a footnote (the rich text content) instead of including `structuredValue` (from Cite.js) as well. This fixes that. We also strip most of the HTML content from the structured value so it appears cleanly in Markdown.

_Test plan:_
Create a Pub containing a footnote with a structured and unstructured value. Export it to Markdown and Word and verify that both are shown in the footnote.