### PR TITLE
dev: Update `chokidar`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -179,7 +179,7 @@
 				"@typescript-eslint/parser": "^5.3.0",
 				"autoprefixer": "^9.5.0",
 				"chalk": "^2.4.2",
-				"chokidar": "^3.0.1",
+				"chokidar": "^3.5.3",
 				"concurrently": "^4.1.0",
 				"cpy-cli": "^3.1.1",
 				"dedent": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
 		"@typescript-eslint/parser": "^5.3.0",
 		"autoprefixer": "^9.5.0",
 		"chalk": "^2.4.2",
-		"chokidar": "^3.0.1",
+		"chokidar": "^3.5.3",
 		"concurrently": "^4.1.0",
 		"cpy-cli": "^3.1.1",
 		"dedent": "^0.7.0",


### PR DESCRIPTION
[`chokidar`](https://www.npmjs.com/package/chokidar) an npm package that abstracts over `fs.watchFile()` and some other platform-specific APIs for detecting when files change. We use it in the hot-reloading code, which is recently giving us trouble. I updated it to the latest version, and things seem a _little_ better, though I don't know if this is really the fix. Still, it's harmless to try!

_Test plan:_
Start your dev server and make sure hot reloading of server-side code is happening!