### PR TITLE
dev: Add node_modules and dist excludes to tsconfig to help VSCode

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,11 @@
 {
+	// This "exclude" solves a specific problem that I (Ian, 2022) have been having related to
+	// this VSCode issue: https://github.com/microsoft/vscode/issues/31188. VSCode uses this file
+	// to detect files in the working directory that should be excluded. I don't believe this
+	// should have any effect on our TS builds since "exclude" only removes files from the "include"
+	// array (which we specify in the client/server specific .tsconfig.json files) and those don't
+	// contain node_modules/ or dist/ to begin with.
+	"exclude": ["**/node_modules/*", "**/dist/*"],
 	"compilerOptions": {
 		/* Visit https://aka.ms/tsconfig.json to read more about this file */
 


### PR DESCRIPTION
See the inline comment — this is specifically to appease VSCode and I'm hoping that (1) it has no effect on our builds and (2) we can remove it eventually.

_Test plan:_
If it builds in CI, it's good to go!