### PR TITLE
feature: Restore Pub to previous point in history

### DIFF
--- a/client/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/client/components/ConfirmDialog/ConfirmDialog.tsx
@@ -3,14 +3,15 @@
  * (bring your own button) -- it renders a `renderButton` prop with an `open` callback that can be
  * attached to a Button onClick handler, or anything else.
  */
-import React, { useState } from 'react';
-import { Button, Classes, Dialog, Intent } from '@blueprintjs/core';
+import React, { useCallback, useState } from 'react';
+import { Button, Callout, Classes, Dialog, Intent } from '@blueprintjs/core';
 
 import { Callback } from 'types';
 
 type Props = {
 	cancelLabel?: React.ReactNode;
 	children: (opts: { open: Callback }) => React.ReactNode;
+	errorState?: (error: any) => React.ReactNode;
 	confirmLabel: React.ReactNode;
 	intent?: Intent;
 	onConfirm: () => unknown;
@@ -27,23 +28,40 @@ const ConfirmDialog = (props: Props) => {
 		onConfirm,
 		text,
 		title,
+		errorState,
 	} = props;
 	const [isOpen, setIsOpen] = useState(false);
+	const [isLoading, setIsLoading] = useState(false);
+	const [error, setError] = useState(null);
+
+	const handleClose = useCallback(() => setIsOpen(false), []);
+
+	const handleConfirm = useCallback(() => {
+		setError(null);
+		const onConfirmResult = onConfirm();
+		if (onConfirmResult instanceof Promise) {
+			setIsLoading(true);
+			onConfirmResult
+				.then(handleClose)
+				.catch(setError)
+				.finally(() => setIsLoading(false));
+		} else {
+			setIsOpen(false);
+		}
+	}, [onConfirm, handleClose]);
+
 	return (
 		<React.Fragment>
 			{children({ open: () => setIsOpen(true) })}
-			<Dialog isOpen={isOpen} title={title}>
-				<div className={Classes.DIALOG_BODY}>{text}</div>
+			<Dialog isOpen={isOpen} title={title} onClose={handleClose}>
+				<div className={Classes.DIALOG_BODY}>
+					{text}
+					{error && errorState && <Callout intent="danger">{errorState(error)}</Callout>}
+				</div>
 				<div className={Classes.DIALOG_FOOTER}>
 					<div className={Classes.DIALOG_FOOTER_ACTIONS}>
-						<Button onClick={() => setIsOpen(false)}>{cancelLabel}</Button>
-						<Button
-							intent={intent}
-							onClick={() => {
-								setIsOpen(false);
-								onConfirm();
-							}}
-						>
+						<Button onClick={handleClose}>{cancelLabel}</Button>
+						<Button loading={isLoading} intent={intent} onClick={handleConfirm}>
 							{confirmLabel}
 						</Button>
 					</div>

--- a/client/components/PubHistoryViewer/RestoreHistoryDialog.tsx
+++ b/client/components/PubHistoryViewer/RestoreHistoryDialog.tsx
@@ -1,0 +1,73 @@
+import React, { useCallback, useMemo } from 'react';
+
+import { Callback } from 'types';
+import { ConfirmDialog } from 'components';
+import { apiFetch } from 'client/utils/apiFetch';
+import { usePubData } from 'client/containers/Pub/pubHooks';
+
+import { renderTimeLabelForDate } from './utils';
+
+type Props = {
+	historyKey: number;
+	dateForHistoryKey: null | Date;
+	children: React.ComponentProps<typeof ConfirmDialog>['children'];
+	onRestore: Callback;
+};
+
+const reassurance = (
+	<>
+		The existing draft contents will remain in your Pub's history. You can always restore back
+		to the current state if you wish.
+	</>
+);
+
+const renderError = () => {
+	return <>There was a problem restoring the Pub contents.</>;
+};
+
+const RestoreHistoryDialog = (props: Props) => {
+	const { children, historyKey, dateForHistoryKey, onRestore } = props;
+	const { editHash, id: pubId } = usePubData();
+
+	const confirmText = useMemo(() => {
+		if (dateForHistoryKey) {
+			const { date, time } = renderTimeLabelForDate(dateForHistoryKey);
+			return (
+				<>
+					<p>
+						Ready to restore this Pub draft back to its contents on{' '}
+						<b>
+							{date} at {time}
+						</b>
+						?
+					</p>
+					<p>{reassurance}</p>
+				</>
+			);
+		}
+		return null;
+	}, [dateForHistoryKey]);
+
+	const handleConfirm = useCallback(async () => {
+		await apiFetch.post('/api/pubHistory/restore', {
+			pubId,
+			accessHash: editHash,
+			historyKey,
+		});
+		onRestore();
+	}, [editHash, historyKey, onRestore, pubId]);
+
+	return (
+		<ConfirmDialog
+			confirmLabel="Restore"
+			title="Restore Pub draft"
+			text={confirmText}
+			errorState={renderError}
+			onConfirm={handleConfirm}
+		>
+			{children}
+		</ConfirmDialog>
+	);
+};
+
+export default RestoreHistoryDialog;

--- a/client/components/PubHistoryViewer/pubHistoryViewer.scss
+++ b/client/components/PubHistoryViewer/pubHistoryViewer.scss
@@ -77,4 +77,18 @@ $bp: vendor.$bp-namespace;
 		background: darken(white, 4%);
 		border: 4px solid darken(white, 4%);
 	}
+
+	.release-menu-item {
+		align-items: center;
+		.visit-release-button {
+			color: white;
+			opacity: 0;
+		}
+		&:hover,
+		&:focus-within {
+			.visit-release-button {
+				opacity: 1;
+			}
+		}
+	}
 }

--- a/client/components/PubHistoryViewer/utils.ts
+++ b/client/components/PubHistoryViewer/utils.ts
@@ -1,0 +1,7 @@
+import { formatDate } from 'utils/dates';
+
+export const renderTimeLabelForDate = (date: Date) => {
+	const dateLabel = formatDate(date);
+	const timeLabel = formatDate(date, { includeDate: false, includeTime: true });
+	return { date: dateLabel, time: timeLabel };
+};

--- a/server/pubHistory/api.ts
+++ b/server/pubHistory/api.ts
@@ -2,12 +2,17 @@ import app, { wrap } from 'server/server';
 import { getPubDraftDoc } from 'server/utils/firebaseAdmin';
 
 import { getPermissions } from './permissions';
+import { restorePubDraftToHistoryKey } from './queries';
+
+const parseHistoryKey = (providedHistoryKey: any) => {
+	const historyKeyInt = parseInt(providedHistoryKey, 10);
+	return Number.isNaN(historyKeyInt) ? null : historyKeyInt;
+};
 
 const getRequestIds = (req) => {
 	const user = req.user || {};
 	const { pubId, communityId, historyKey: providedHistoryKey, accessHash } = req.query;
-	const historyKeyInt = parseInt(providedHistoryKey, 10);
-	const historyKey = Number.isNaN(historyKeyInt) ? null : historyKeyInt;
+	const historyKey = parseHistoryKey(providedHistoryKey);
 	return {
 		userId: user.id,
 		pubId,
@@ -30,6 +35,26 @@ app.get(
 		if (canCreateExport) {
 			const draftDocInfo = await getPubDraftDoc(pubId, historyKey);
 			return res.status(200).json(draftDocInfo);
+		}
+		return res.status(403).json({});
+	}),
+);
+
+app.post(
+	'/api/pubHistory/restore',
+	wrap(async (req, res) => {
+		const userId = req.user?.id;
+		const { pubId, historyKey: providedHistoryKey, accessHash } = req.body;
+		const historyKey = parseHistoryKey(providedHistoryKey);
+		const { canRestoreHistory } = await getPermissions({
+			userId,
+			pubId,
+			accessHash,
+			historyKey,
+		});
+		if (canRestoreHistory && typeof historyKey === 'number') {
+			await restorePubDraftToHistoryKey({ userId, pubId, historyKey });
+			return res.status(200).json({});
 		}
 		return res.status(403).json({});
 	}),

--- a/server/pubHistory/permissions.ts
+++ b/server/pubHistory/permissions.ts
@@ -3,12 +3,12 @@ import { getScope } from 'server/utils/queryHelpers';
 export const getPermissions = async ({ userId, pubId, accessHash, historyKey }) => {
 	const {
 		elements: { activePub },
-		activePermissions: { canView, canViewDraft },
+		activePermissions: { canView, canViewDraft, canEdit },
 	} = await getScope({
 		pubId,
 		loginId: userId,
 		accessHash,
 	});
 	const isReleaseKey = activePub.releases.some((release) => release.historyKey === historyKey);
-	return { canCreateExport: isReleaseKey || canView || canViewDraft };
+	return { canCreateExport: isReleaseKey || canView || canViewDraft, canRestoreHistory: canEdit };
 };

--- a/server/pubHistory/queries.ts
+++ b/server/pubHistory/queries.ts
@@ -1,0 +1,27 @@
+import { Slice } from 'prosemirror-model';
+
+import { editFirebaseDraftByRef, getPubDraftDoc, getPubDraftRef } from 'server/utils/firebaseAdmin';
+import { jsonToNode } from 'client/components/Editor';
+import { assert } from 'utils/assert';
+
+type RestorePubOptions = {
+	pubId: string;
+	historyKey: number;
+	userId: string;
+};
+
+export const restorePubDraftToHistoryKey = async (options: RestorePubOptions) => {
+	const { pubId, userId, historyKey } = options;
+	assert(typeof historyKey === 'number' && historyKey >= 0);
+	const pubDraftRef = await getPubDraftRef(pubId);
+	const { doc } = await getPubDraftDoc(pubDraftRef, historyKey);
+	const editor = await editFirebaseDraftByRef(pubDraftRef, userId);
+
+	editor.transform((tr, schema) => {
+		const currentDoc = editor.getDoc();
+		const replacementDoc = jsonToNode(doc, schema);
+		tr.replace(0, currentDoc.content.size, new Slice(replacementDoc.content, 0, 0));
+	});
+
+	await editor.writeChange();
+};

--- a/server/utils/firebaseAdmin.ts
+++ b/server/utils/firebaseAdmin.ts
@@ -61,11 +61,11 @@ const maybeAddKeyTimestampPair = (key, timestamp) => {
 };
 
 export const getPubDraftDoc = async (
-	pubId: string,
+	pubIdOrRef: string | firebase.database.Reference,
 	historyKey: null | number = null,
 	createMissingCheckpoints = false,
 ): Promise<PubDraftInfo> => {
-	const draftRef = await getPubDraftRef(pubId);
+	const draftRef = typeof pubIdOrRef === 'string' ? await getPubDraftRef(pubIdOrRef) : pubIdOrRef;
 	const [
 		{ doc, docIsFromCheckpoint, key: currentKey, timestamp: currentTimestamp, checkpointMap },
 		{ timestamp: firstTimestamp, key: firstKey },


### PR DESCRIPTION
As a little thursday afternoon treat I've added a button to the Pub history viewer that lets you restore Pub contents back to a specific point in history. Users with edit access to a Pub draft will see it here:

![image](https://user-images.githubusercontent.com/2208769/201185815-8387cb80-c20e-4eb5-94a0-b08683dc8bac.png)

When you click that, you get this dialog:

![image](https://user-images.githubusercontent.com/2208769/201186180-875c1fc8-53a6-4bbf-a6af-217a50c6de23.png)

When you click _that_, we:

- Grab the document at the current `historyKey`
- Create a new Prosemirror `ReplaceStep` that replaces the old document in its entirety with the new one
- Write that step into a Firebase change

The history remains append-only — if you want to undo your revert, you can just go back one step and revert from there.

I decided to do this on the server side. Although we have all the information we need to execute this on the client, we'd actually need to:

- Place the target document in some intermediate state
- Manipulate the Pub page state so the history viewer disappears
- Wait until the Pub collab plugin loads again
- And finally, fire the `ReplaceStep` into the editor with a new transaction.

This starts to feel brittle, so I just created an API route that does this instead.

_Test plan:_
Visit a Pub and add a bunch of contents...keep typing...good. Now click the draft history button in the Pub header. Use the new restore controls to revert back to a previous state. Then verify that the old state is still in the history and you can revert back to _that_. Refresh the page and verify that nothing has gone terribly wrong.