### PR TITLE
fix: Launch the Review editor with a `<PopoverButton>`

### DIFF
--- a/client/components/Popover/PopoverButton.tsx
+++ b/client/components/Popover/PopoverButton.tsx
@@ -9,21 +9,19 @@ type Props = {
 	'aria-label': string;
 	className?: string;
 	children: React.ReactElement;
-	component: React.ComponentType<any>;
-	[key: string]: any;
+	component: () => React.ReactNode;
 	placement?: PopoverState['placement'];
 	gutter?: number;
 };
 
 const PopoverButton = (props: Props) => {
 	const {
-		component: Component,
+		component,
 		'aria-label': ariaLabel,
 		children,
 		className,
 		placement = 'bottom-end',
 		gutter = 5,
-		...restProps
 	} = props;
 	const popover = usePopoverState({ unstable_fixed: false, placement, gutter });
 	return (
@@ -44,9 +42,7 @@ const PopoverButton = (props: Props) => {
 				tabIndex={0}
 				{...popover}
 			>
-				<Card elevation={2}>
-					<Component {...restProps} />
-				</Card>
+				<Card elevation={2}>{component()}</Card>
 			</Popover>
 		</>
 	);

--- a/client/containers/Pub/PubDocument/PubBottom/LicenseSection.tsx
+++ b/client/containers/Pub/PubDocument/PubBottom/LicenseSection.tsx
@@ -60,7 +60,6 @@ const LicenseSection = () => {
 						component={() => <FacetEditor facetName="License" selfContained />}
 						placement="top-end"
 						aria-label="Edit license"
-						facetName="License"
 					>
 						<AccentedIconButton icon="edit" accentColor={iconColor} />
 					</PopoverButton>

--- a/client/containers/Pub/PubHeader/PubHeaderContent.tsx
+++ b/client/containers/Pub/PubHeader/PubHeaderContent.tsx
@@ -83,11 +83,7 @@ const PubHeaderContent = (props: Props) => {
 		<div className="pub-header-content-component">
 			{renderTop()}
 			<TitleGroup pubData={pubData} updatePubData={updateAndSavePubData} />
-			<UtilityButtons
-				onShowHeaderDetails={onShowHeaderDetails}
-				pubData={pubData}
-				updatePubData={updateAndSavePubData}
-			/>
+			<UtilityButtons onShowHeaderDetails={onShowHeaderDetails} pubData={pubData} />
 			{!isInMaintenanceMode && (
 				<DraftReleaseButtons
 					pubData={pubData}

--- a/client/containers/Pub/PubHeader/Review/Review.tsx
+++ b/client/containers/Pub/PubHeader/Review/Review.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Button, Card, Elevation } from '@blueprintjs/core';
+import { Button } from '@blueprintjs/core';
 import Color from 'color';
 
 import { DocJson, Community } from 'types';

--- a/client/containers/Pub/PubHeader/Review/Review.tsx
+++ b/client/containers/Pub/PubHeader/Review/Review.tsx
@@ -34,27 +34,25 @@ const Review = (props: Props) => {
 
 	return (
 		<div className="review-component">
-			<Card interactive={true} elevation={Elevation.TWO}>
-				<div className="review-border" style={{ borderColor: bgColor }}>
-					<ReviewEditor setReviewDoc={updateReview} reviewDoc={review} />
-				</div>
-				<div className="review-button">
-					<Button
-						icon="document-share"
-						onClick={onSubmit}
-						minimal={true}
-						loading={isLoading}
-						className="review-submission-button"
-						style={{ background: bgColor }}
-						intent="primary"
-						disabled={isEmptyDoc(review as DocJson)}
-						onMouseEnter={() => setHover(true)}
-						onMouseLeave={() => setHover(false)}
-					>
-						Submit Review
-					</Button>
-				</div>
-			</Card>
+			<div className="review-border" style={{ borderColor: bgColor }}>
+				<ReviewEditor setReviewDoc={updateReview} reviewDoc={review} />
+			</div>
+			<div className="review-button">
+				<Button
+					icon="document-share"
+					onClick={onSubmit}
+					minimal={true}
+					loading={isLoading}
+					className="review-submission-button"
+					style={{ background: bgColor }}
+					intent="primary"
+					disabled={isEmptyDoc(review as DocJson)}
+					onMouseEnter={() => setHover(true)}
+					onMouseLeave={() => setHover(false)}
+				>
+					Submit Review
+				</Button>
+			</div>
 		</div>
 	);
 };

--- a/client/containers/Pub/PubHeader/Review/ReviewEditor.tsx
+++ b/client/containers/Pub/PubHeader/Review/ReviewEditor.tsx
@@ -11,7 +11,7 @@ type Props = {
 const ReviewEditor = React.forwardRef((props: Props, ref: any) => {
 	const { setReviewDoc, reviewDoc } = props;
 
-	const handleEdit = useCallback((doc) => setReviewDoc(doc.toJSON() as DocJson), []);
+	const handleEdit = useCallback((doc) => setReviewDoc(doc.toJSON() as DocJson), [setReviewDoc]);
 
 	return (
 		<div className="review-editor-component" ref={ref}>

--- a/client/containers/Pub/PubHeader/Review/ReviewEditor.tsx
+++ b/client/containers/Pub/PubHeader/Review/ReviewEditor.tsx
@@ -8,13 +8,13 @@ type Props = {
 	reviewDoc: DocJson;
 };
 
-const ReviewEditor = React.forwardRef((props: Props, ref: any) => {
+const ReviewEditor = (props: Props) => {
 	const { setReviewDoc, reviewDoc } = props;
 
 	const handleEdit = useCallback((doc) => setReviewDoc(doc.toJSON() as DocJson), [setReviewDoc]);
 
 	return (
-		<div className="review-editor-component" ref={ref}>
+		<div className="review-editor-component">
 			<MinimalEditor
 				getButtons={(buttons) => buttons.reviewButtonSet}
 				onEdit={handleEdit}
@@ -25,6 +25,6 @@ const ReviewEditor = React.forwardRef((props: Props, ref: any) => {
 			/>
 		</div>
 	);
-});
+};
 
 export default ReviewEditor;

--- a/client/containers/Pub/PubHeader/Review/ReviewEditor.tsx
+++ b/client/containers/Pub/PubHeader/Review/ReviewEditor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { MinimalEditor } from 'components';
 import { DocJson } from 'types';
@@ -8,14 +8,16 @@ type Props = {
 	reviewDoc: DocJson;
 };
 
-const ReviewEditor = (props: Props) => {
+const ReviewEditor = React.forwardRef((props: Props, ref: any) => {
 	const { setReviewDoc, reviewDoc } = props;
 
+	const handleEdit = useCallback((doc) => setReviewDoc(doc.toJSON() as DocJson), []);
+
 	return (
-		<div className="review-editor-component">
+		<div className="review-editor-component" ref={ref}>
 			<MinimalEditor
 				getButtons={(buttons) => buttons.reviewButtonSet}
-				onEdit={(doc) => setReviewDoc(doc.toJSON() as DocJson)}
+				onEdit={handleEdit}
 				useFormattingBar
 				focusOnLoad={true}
 				initialContent={reviewDoc}
@@ -23,6 +25,6 @@ const ReviewEditor = (props: Props) => {
 			/>
 		</div>
 	);
-};
+});
 
 export default ReviewEditor;

--- a/client/containers/Pub/PubHeader/Review/review.scss
+++ b/client/containers/Pub/PubHeader/Review/review.scss
@@ -3,11 +3,6 @@
 $bp: vendor.$bp-namespace;
 
 .review-component {
-	position: absolute;
-	right: 0;
-	top: 100%;
-	color: black;
-
 	.review-button {
 		padding-top: 18px;
 		.#{$bp}-button {

--- a/client/containers/Pub/PubHeader/ReviewHeaderSticky.tsx
+++ b/client/containers/Pub/PubHeader/ReviewHeaderSticky.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { Button, AnchorButton } from '@blueprintjs/core';
 
 import { usePageContext } from 'utils/hooks';
 import { pubUrl } from 'utils/canonicalUrls';
-import { Icon, PopoverButton } from 'components';
+import { PopoverButton } from 'components';
 import { apiFetch } from 'client/utils/apiFetch';
 import { useLocalStorage } from 'client/utils/useLocalStorage';
 import { getEmptyDoc } from 'client/components/Editor';
@@ -26,8 +26,6 @@ const ReviewHeaderSticky = () => {
 		loginData: { fullName },
 	} = usePageContext();
 	const { viewHash } = pubData;
-
-	useEffect(() => console.log('mount RHS'), []);
 
 	const [visible, setVisible] = useState(false);
 	const [reviewTitle, setReviewTitle] = useState('Untitled Review');

--- a/client/containers/Pub/PubHeader/ReviewHeaderSticky.tsx
+++ b/client/containers/Pub/PubHeader/ReviewHeaderSticky.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button, AnchorButton } from '@blueprintjs/core';
 
 import { usePageContext } from 'utils/hooks';
 import { pubUrl } from 'utils/canonicalUrls';
-import { Icon } from 'components';
+import { Icon, PopoverButton } from 'components';
 import { apiFetch } from 'client/utils/apiFetch';
 import { useLocalStorage } from 'client/utils/useLocalStorage';
 import { getEmptyDoc } from 'client/components/Editor';
@@ -27,6 +27,8 @@ const ReviewHeaderSticky = () => {
 	} = usePageContext();
 	const { viewHash } = pubData;
 
+	useEffect(() => console.log('mount RHS'), []);
+
 	const [visible, setVisible] = useState(false);
 	const [reviewTitle, setReviewTitle] = useState('Untitled Review');
 	const [reviewerName, setReviewerName] = useState('');
@@ -34,7 +36,6 @@ const ReviewHeaderSticky = () => {
 	const [isLoading, setIsLoading] = useState(false);
 	const [isSaving, setIsSaving] = useState(false);
 	const [createdReview, setCreatedReview] = useState(false);
-	const [showReview, setShowReview] = useState(true);
 	const [reviewNumber, setReviewNumber] = useState(0);
 	const [saved, setSaved] = useState(false);
 
@@ -90,15 +91,6 @@ const ReviewHeaderSticky = () => {
 			});
 	};
 
-	const renderReview = () => (
-		<Review
-			communityData={communityData}
-			onSubmit={() => setVisible(true)}
-			isLoading={isLoading}
-			review={review}
-			updateReview={updatingReviewDoc}
-		/>
-	);
 	const reviewPath = `/dash/pub/${pubData.slug}/reviews/${reviewNumber}`;
 	const isMember = memberData.length > 0;
 	const userFilter = canManage && isMember;
@@ -121,7 +113,6 @@ const ReviewHeaderSticky = () => {
 			<div className="sticky-section">
 				<div className="sticky-title">{pubData.title}</div>
 				<div className="side-content">
-					{showReview && renderReview()}
 					<div className="sticky-buttons">
 						<div className="sticky-review-text">review</div>
 						{isSaving && (
@@ -147,12 +138,20 @@ const ReviewHeaderSticky = () => {
 							isUser={isUser}
 							reviewerFooterButtons={reviewerFooterButtons}
 						/>
-
-						<Button
-							minimal
-							icon={<Icon icon="expand-all" />}
-							onClick={() => setShowReview(!showReview)}
-						/>
+						<PopoverButton
+							aria-label="Open Review dropdown"
+							component={() => (
+								<Review
+									communityData={communityData}
+									onSubmit={() => setVisible(true)}
+									isLoading={isLoading}
+									review={review}
+									updateReview={updatingReviewDoc}
+								/>
+							)}
+						>
+							<Button minimal icon="expand-all" />
+						</PopoverButton>
 					</div>
 				</div>
 			</div>

--- a/client/containers/Pub/PubHeader/UtilityButtons.tsx
+++ b/client/containers/Pub/PubHeader/UtilityButtons.tsx
@@ -4,7 +4,7 @@ import { usePageContext } from 'utils/hooks';
 import { getDashUrl } from 'utils/dashboard';
 import { DialogLauncher, PubShareDialog, PopoverButton, FacetEditor } from 'components';
 
-import { Callback, PatchFn, PubPageData } from 'types';
+import { Callback, PubPageData } from 'types';
 import CitationsPreview from './CitationsPreview';
 import Download from './Download';
 import PubToc from './PubToc';
@@ -14,12 +14,11 @@ import Social from './Social';
 type Props = {
 	onShowHeaderDetails: Callback;
 	pubData: PubPageData;
-	updatePubData: PatchFn<PubPageData>;
 };
 
 const UtilityButtons = (props: Props) => {
-	const { onShowHeaderDetails, pubData, updatePubData } = props;
-	const { communityData, scopeData } = usePageContext();
+	const { onShowHeaderDetails, pubData } = props;
+	const { scopeData } = usePageContext();
 	const { isRelease, membersData } = pubData;
 	const { canManage } = scopeData.activePermissions;
 	return (
@@ -33,9 +32,6 @@ const UtilityButtons = (props: Props) => {
 				<PopoverButton
 					component={() => <FacetEditor facetName="PubHeaderTheme" selfContained />}
 					className="pub-header-popover"
-					updatePubData={updatePubData}
-					pubData={pubData}
-					communityData={communityData}
 					aria-label="Pub header theme options"
 				>
 					<SmallHeaderButton label="Edit theme" labelPosition="left" icon="clean" />
@@ -68,9 +64,8 @@ const UtilityButtons = (props: Props) => {
 				</DialogLauncher>
 			)}
 			<PopoverButton
-				component={CitationsPreview}
+				component={() => <CitationsPreview pubData={pubData} />}
 				className="pub-header-popover"
-				pubData={pubData}
 				aria-label="Cite this Pub"
 			>
 				<SmallHeaderButton

--- a/client/containers/Pub/PubHeader/collections/CollectionsBar.tsx
+++ b/client/containers/Pub/PubHeader/collections/CollectionsBar.tsx
@@ -114,9 +114,8 @@ const CollectionsBar = (props: Props) => {
 		return (
 			<PopoverButton
 				className="collections-bar-component_collections-popover"
-				component={PubCollectionsListing}
+				component={() => <PubCollectionsListing {...pubCollectionsListingProps} />}
 				aria-label="Add or edit Pub Collections"
-				{...pubCollectionsListingProps}
 			>
 				{button}
 			</PopoverButton>


### PR DESCRIPTION
Resolves #2334

A recent code change — I'm betting the facets merge — changed the Pub header so it has `overflow: hidden` set in a way that cuts off the new Review dropdown in the header. The best way to solve this problem is to put the `<Review>` component in a `<PopoverButton>` so it isn't a DOM child of the Pub header  — this method provides better keyboard accessibility as well.

I thought this would be a simple fix:

```tsx
<PopoverButton component={() => <Review {...} />} />
```

I just added some new `<FacetEditors>` to buttons in exactly the same way! But this caused the review editor to blur on every keystroke, making it unusably janky. So I checked to see how often the `<Review>` component was mounting:

```ts
// in Review.tsx
useEffect(() => console.log("<Review> mounted"), []);
```

and it turned out to be basically every keystroke. The root of this issue is inside of `<PopoverButton>`. It takes a `component` prop, which it interprets as a React component rather than a render function, and renders it like this:

```tsx
<Component {...restProps} />
```

Here, `restProps` are just arbitrary props spread into the `<PopoverButton>` component. So the usage as I originally imagined it was something like this:

```tsx
// If you want to render this inside of a <PopoverButton>:
<Review review={review} isLoading={isLoading} />

// Then you do this:
<PopoverButton component={Review} review={review} isLoading={isLoading} />
```

This is...a little goofy. It's hard to remember the pattern, and it reduces our ability to typecheck component usage. In fact, even though I developed this component, I had forgotten this fact, and started to use it this way:

```tsx
<PopoverButton component={() => <Review review={review} isLoading={isLoading} />} />
```

It's worth stopping to marvel that this worked at all. If you trace this into `<PopoverButton>` and do a few replacements in your head:

```tsx
// Start with this (from above):
<Component {...restProps} />

// "De-sugar" the TSX syntax into the React API:
React.createElement(Component, restProps)

// Substitute the provided prop values:
React.createElement(() => <Review review={review} isLoading={isLoading} />, {})
```

This sort of works, because a vanilla JS function that returns a React node is a valid React component! But, because it's an anonymous function, a new version of it is created every time the component renders. And from React's perspective, it's like we're creating a new _kind_ of React component on every render. So it has no choice but to unmount the existing version and re-mount the new one, even though they do exactly the same thing! I didn't catch this in previous usages, because the inner contents weren't quite so stateful as a text editor.

So to recap:

1. The existing `<PopoverButton>` API is clunky and even I forgot how it's supposed to work
2. I started using it in a different way that subtly breaks React conventions
3. When I tried it with a state-heavy child component I learned that it was unmounting and mounting each render

The solution is simple:

```tsx
// Replace this:
<Component {...restProps} />

// With this:
{Component(restProps)}

// And then notice that we no longer need `restProps`, and the function name can be lowercase:
{component()}
```

Of course, the return value of `component()` is still `React.createElement(Review, { review, isLoading })`. But React is smart enough to know that `Review` is the same function each time, and avoid a re-mount.

So there's an interesting tale of comoponent API evolution and React lifecycle debugging for ya.

_Test plan:_
- Visit a Review URL for a Pub (`/pub/<slug>/review`) and verify that you can open the Review dropdown on the Pub header
- Try a few existing <PopoverButton>` instances and make sure they still work, such as the theme editor or citation dropdown that are also in the Pub header.