### PR TITLE
fix: Pass a DepositTarget into DOI settings

### DIFF
--- a/client/containers/DashboardSettings/PubSettings/Doi.tsx
+++ b/client/containers/DashboardSettings/PubSettings/Doi.tsx
@@ -243,8 +243,7 @@ class Doi extends Component<Props, State> {
 			canIssueDoi &&
 			// a deposit has not been submitted yet for this work
 			!(justSetDoi || pubData.crossrefDepositRecordId) &&
-			// the Pub is not a supplement to another work
-			// and the community has a custom, hardcoded DOI prefix
+			// and the Community has a custom DOI prefix
 			this.props.depositTarget &&
 			doiPrefix !== PUBPUB_DOI_PREFIX
 		);
@@ -315,7 +314,7 @@ class Doi extends Component<Props, State> {
 
 		return (
 			<>
-				{!pubData.doi && <p>A DOI can be set for each Pub by admins of this community.</p>}
+				{!pubData.doi && <p>A DOI can be set for each Pub by admins of this Community.</p>}
 				{this.disabledDueToUnmanagedPrefix() && (
 					<Callout intent="warning">
 						This Pub cannot be deposited to Crossref via PubPub because there is no

--- a/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
+++ b/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
@@ -12,7 +12,7 @@ import {
 	FacetEditor,
 	TitleEditor,
 } from 'components';
-import { Pub, PubWithCollections } from 'types';
+import { DepositTarget, Pub, PubWithCollections } from 'types';
 import { apiFetch } from 'client/utils/apiFetch';
 import { slugifyString } from 'utils/strings';
 import { usePageContext, usePendingChanges } from 'utils/hooks';
@@ -29,6 +29,7 @@ import DashboardSettingsFrame, { Subtab } from '../DashboardSettingsFrame';
 type Props = {
 	settingsData: {
 		pubData: PubWithCollections;
+		depositTarget?: DepositTarget;
 	};
 };
 
@@ -163,6 +164,7 @@ const PubSettings = (props: Props) => {
 					communityData={communityData}
 					updatePubData={updatePersistedPubData}
 					canIssueDoi={canAdminCommunity}
+					depositTarget={settingsData.depositTarget}
 				/>
 			</SettingsSection>
 		);

--- a/server/routes/dashboardSettings.tsx
+++ b/server/routes/dashboardSettings.tsx
@@ -7,10 +7,15 @@ import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
 import { getPubForRequest } from 'server/utils/queryHelpers';
+import { getCommunityDepositTarget } from 'server/depositTarget/queries';
 
 const getSettingsData = async (pubSlug, initialData) => {
+	const baseSettingsData = {
+		depositTarget: await getCommunityDepositTarget(initialData.communityData.id),
+	};
 	if (pubSlug) {
 		return {
+			...baseSettingsData,
 			pubData: await getPubForRequest({
 				slug: pubSlug,
 				initialData,
@@ -18,7 +23,7 @@ const getSettingsData = async (pubSlug, initialData) => {
 			}),
 		};
 	}
-	return {};
+	return baseSettingsData;
 };
 
 app.get(


### PR DESCRIPTION
Resolves #2343

Another facets merge issue here :/ Looks like we lost the `depositTarget` that was being passed down into `PubSettings`. In the future we could consider loading it as an association to `initialData.community` instead, but I like that we're only loading it precisely where it's needed here.

_Test plan:_
- On your devserver, switch to a Community with an associated `DepositTarget` (like `mitp-arch`)
- Create and release a new Pub
- From Pub Settings, start the process of depositing the Pub and verify that you can customize the DOI suffix with this control:

![image](https://user-images.githubusercontent.com/2208769/201763884-03b8a8cc-bde0-4780-a39c-15bfe65d5338.png)
