### PR TITLE
Generate exports if discovered missing when `/download` is hit

### DIFF
--- a/server/release/queries.ts
+++ b/server/release/queries.ts
@@ -128,3 +128,7 @@ export const createRelease = async ({
 
 	return release.toJSON();
 };
+
+export const getReleasesForPub = (pubId: string): Promise<ReleaseType[]> => {
+	return Release.findAll({ where: { pubId } });
+};

--- a/server/routes/pubDownloads.ts
+++ b/server/routes/pubDownloads.ts
@@ -8,7 +8,7 @@ import { getInitialData } from 'server/utils/initData';
 import { getPubForRequest } from 'server/utils/queryHelpers';
 import { getBestDownloadUrl } from 'utils/pub/downloads';
 import { defer } from 'server/utils/deferred';
-import { createLatestPubExports } from 'server/export/queries';
+import { createPubExportsForLatestRelease } from 'server/export/queries';
 
 app.get(
 	['/pub/:pubSlug/download', '/pub/:pubSlug/download/:format'],
@@ -35,7 +35,7 @@ app.get(
 		// an auto-generated PDF. We generally shouldn't get into this state, since those are
 		// generated when a Pub is released -- and this route only works for released Pubs.
 		defer(async () => {
-			await createLatestPubExports(pubData.id);
+			await createPubExportsForLatestRelease(pubData.id);
 		});
 
 		throw new NotFoundError();

--- a/server/routes/pubDownloads.ts
+++ b/server/routes/pubDownloads.ts
@@ -7,6 +7,8 @@ import { ForbiddenError, NotFoundError } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { getPubForRequest } from 'server/utils/queryHelpers';
 import { getBestDownloadUrl } from 'utils/pub/downloads';
+import { defer } from 'server/utils/deferred';
+import { createLatestPubExports } from 'server/export/queries';
 
 app.get(
 	['/pub/:pubSlug/download', '/pub/:pubSlug/download/:format'],
@@ -28,6 +30,13 @@ app.get(
 				return promisify(pipeline)(downloadResponse.body, res);
 			}
 		}
+
+		// If there's no download URL then we'll want to regenerate the Pub's exports to produce
+		// an auto-generated PDF. We generally shouldn't get into this state, since those are
+		// generated when a Pub is released -- and this route only works for released Pubs.
+		defer(async () => {
+			await createLatestPubExports(pubData.id);
+		});
 
 		throw new NotFoundError();
 	}),


### PR DESCRIPTION
Resolves #2333 by making sure we regenerate a PDF export for a Pub's latest release if we are, for whatever reason, unable to retrieve one when the Pub's `/download` route is hit.

_Test plan:_
Create a Pub, release it, and then remove all of its exports (by `pubId` in the `Exports` table). Then visit `/pub/<slug>/download` and verify that, shortly after, those exports are recreated (it should be sufficient to check for new rows in the `Exports` table).