### PR TITLE
Kill author and implement contributor taxonomy

### DIFF
--- a/client/components/AttributionEditor/AttributionEditor.tsx
+++ b/client/components/AttributionEditor/AttributionEditor.tsx
@@ -24,7 +24,7 @@ type OwnProps = {
 };
 
 const defaultProps = {
-	listOnBylineText: 'List on byline',
+	listOnBylineText: 'Byline attribution',
 	onPersistStateChange: () => {},
 	promiseWrapper: (x) => x,
 	hasEmptyState: true,

--- a/client/components/AttributionEditor/AttributionRow.tsx
+++ b/client/components/AttributionEditor/AttributionRow.tsx
@@ -93,7 +93,7 @@ const AttributionRow = (props: Props) => {
 								marginRight: '1em',
 							}}
 						>
-							Listed on byline
+							Assigned byline attribution
 						</span>
 					)}
 					{!canEdit &&

--- a/client/components/CollectionAttributionEditor/CollectionAttributionEditor.tsx
+++ b/client/components/CollectionAttributionEditor/CollectionAttributionEditor.tsx
@@ -21,7 +21,7 @@ const CollectionAttributionEditor = (props: Props) => {
 			canEdit={canEdit}
 			hasEmptyState={false}
 			attributions={attributions!}
-			listOnBylineText="List on Collection byline"
+			listOnBylineText="Collection byline attribution"
 			promiseWrapper={pendingPromise}
 			onUpdateAttributions={onUpdateAttributions}
 			identifyingProps={{

--- a/client/components/LayoutEditor/LayoutEditorCollectionHeader/PreviewElements.tsx
+++ b/client/components/LayoutEditor/LayoutEditorCollectionHeader/PreviewElements.tsx
@@ -19,7 +19,7 @@ const PreviewElements = (props: Props) => {
 			<Checkbox
 				checked={!hideByline}
 				onChange={() => onChange({ hideByline: !hideByline })}
-				label="Byline"
+				label="Attributions"
 			/>
 			<Checkbox
 				disabled={hideByline}

--- a/client/components/LayoutEditor/LayoutEditorPubs/PreviewElements.tsx
+++ b/client/components/LayoutEditor/LayoutEditorPubs/PreviewElements.tsx
@@ -18,7 +18,7 @@ type PreviewElementField =
 	| 'hideEdges';
 
 const labelsForPreviewElementFields: Record<PreviewElementField, string> = {
-	hideByline: 'Byline',
+	hideByline: 'Attributions',
 	hideContributors: 'Contributors',
 	hideDates: 'Dates',
 	hideDescription: 'Description',

--- a/client/components/PubEdge/PubEdgeEditor.tsx
+++ b/client/components/PubEdge/PubEdgeEditor.tsx
@@ -76,7 +76,7 @@ const PubEdgeEditor = (props: PubEdgeEditorProps) => {
 			}
 			bylineElement={
 				<TagInput
-					placeholder="Add authors for this publication"
+					placeholder="Add contributors to this publication"
 					values={contributors}
 					onChange={(value) =>
 						void onUpdateExternalPublication({ contributors: value as string[] })

--- a/client/containers/DashboardEdges/DashboardEdges.tsx
+++ b/client/containers/DashboardEdges/DashboardEdges.tsx
@@ -133,7 +133,7 @@ const DashboardEdges = (props: Props) => {
 					<NonIdealState
 						icon="layout-auto"
 						title="No connections from other Pubs"
-						description="When other authors add connections to this Pub, they will be listed here."
+						description="When other contributors add connections from their Pubs to this Pub, they will be listed here."
 					/>
 				)}
 			/>

--- a/client/containers/DashboardEdges/DashboardEdges.tsx
+++ b/client/containers/DashboardEdges/DashboardEdges.tsx
@@ -133,7 +133,7 @@ const DashboardEdges = (props: Props) => {
 					<NonIdealState
 						icon="layout-auto"
 						title="No connections from other Pubs"
-						description="When other contributors add connections from their Pubs to this Pub, they will be listed here."
+						description="Corresponding connections will be created here when users connect to this Pub from another."
 					/>
 				)}
 			/>

--- a/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
+++ b/client/containers/DashboardOverview/CollectionOverview/DashboardCollectionOverview.tsx
@@ -61,7 +61,7 @@ const getQuickActionsForCollection = (collection: Collection): QuickAction[] => 
 			href: getDashUrl({ collectionSlug, mode: 'settings', section: 'metadata' }),
 		},
 		collection.kind !== 'tag' && {
-			label: 'Edit attribution',
+			label: 'Edit contributors',
 			icon: 'edit',
 			href: getDashUrl({ collectionSlug, mode: 'settings', section: 'attribution' }),
 		},

--- a/client/containers/Pub/PubDocument/PubBottom/Discussions/LabelFilter.tsx
+++ b/client/containers/Pub/PubDocument/PubBottom/Discussions/LabelFilter.tsx
@@ -205,8 +205,7 @@ class LabelFilter extends Component<Props, State> {
 												content={
 													label.publicApply ? (
 														<span>
-															All discussion contributors can apply
-															this label.
+															All discussants can apply this label.
 														</span>
 													) : (
 														<span>
@@ -305,9 +304,7 @@ class LabelFilter extends Component<Props, State> {
 									<Tooltip
 										content={
 											label.publicApply ? (
-												<span>
-													All discussion authors can apply this label.
-												</span>
+												<span>All discussants can apply this label.</span>
 											) : (
 												<span>Only managers can apply this label.</span>
 											)

--- a/client/containers/Pub/PubDocument/PubBottom/Discussions/LabelFilter.tsx
+++ b/client/containers/Pub/PubDocument/PubBottom/Discussions/LabelFilter.tsx
@@ -205,8 +205,8 @@ class LabelFilter extends Component<Props, State> {
 												content={
 													label.publicApply ? (
 														<span>
-															All discussion contributors can apply this
-															label.
+															All discussion contributors can apply
+															this label.
 														</span>
 													) : (
 														<span>

--- a/client/containers/Pub/PubDocument/PubBottom/Discussions/LabelFilter.tsx
+++ b/client/containers/Pub/PubDocument/PubBottom/Discussions/LabelFilter.tsx
@@ -205,7 +205,7 @@ class LabelFilter extends Component<Props, State> {
 												content={
 													label.publicApply ? (
 														<span>
-															All discussion authors can apply this
+															All discussion contributors can apply this
 															label.
 														</span>
 													) : (

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/LabelSelect.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/LabelSelect.tsx
@@ -116,7 +116,7 @@ class LabelSelect extends Component<Props, State> {
 												<Tooltip
 													content={
 														label.publicApply
-															? 'All discussion authors can apply this label.'
+															? 'All discussion contributors can apply this label.'
 															: 'Only managers can apply this label.'
 													}
 												>

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/LabelSelect.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/LabelSelect.tsx
@@ -116,7 +116,7 @@ class LabelSelect extends Component<Props, State> {
 												<Tooltip
 													content={
 														label.publicApply
-															? 'All discussion contributors can apply this label.'
+															? 'All discussants can apply this label.'
 															: 'Only managers can apply this label.'
 													}
 												>

--- a/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ManageTools.tsx
+++ b/client/containers/Pub/PubDocument/PubDiscussions/Discussion/ManageTools.tsx
@@ -10,7 +10,7 @@ import DiscussionReanchor from './DiscussionReanchor';
 
 const sortLabels = {
 	chronological: 'Sort chronologically',
-	alphabetical: 'Sort by author surname',
+	alphabetical: 'Sort by contributor surname',
 } as const;
 
 export type SortType = keyof typeof sortLabels;

--- a/client/containers/Pub/PubDocument/PubFileImport/MetadataEditor.tsx
+++ b/client/containers/Pub/PubDocument/PubFileImport/MetadataEditor.tsx
@@ -99,8 +99,8 @@ const ProposedAttribution = ({ attribution, onUpdateAttribution }: ProposedAttri
 			<Button
 				aria-label={
 					ignored
-						? `Add ${name} to Pub attribution`
-						: `Remove ${name} from Pub attribution`
+						? `Add ${name} to Pub contributors`
+						: `Remove ${name} from Pub contributors`
 				}
 				onClick={handleToggleIgnored}
 				icon={ignored ? 'small-plus' : 'small-cross'}
@@ -247,7 +247,7 @@ const MetadataEditor = (props: MetadataEditorProps) => {
 		if (attributions && attributions.length) {
 			return (
 				<>
-					<h6>Authors</h6>
+					<h6>Contributors</h6>
 					{attributions.map((attr, index) => (
 						<ProposedAttribution
 							// eslint-disable-next-line react/no-array-index-key

--- a/client/containers/Pub/PubDocument/PubFileImport/MetadataEditor.tsx
+++ b/client/containers/Pub/PubDocument/PubFileImport/MetadataEditor.tsx
@@ -247,7 +247,7 @@ const MetadataEditor = (props: MetadataEditorProps) => {
 		if (attributions && attributions.length) {
 			return (
 				<>
-					<h6>Contributors</h6>
+					<h6>Attributions</h6>
 					{attributions.map((attr, index) => (
 						<ProposedAttribution
 							// eslint-disable-next-line react/no-array-index-key

--- a/client/containers/Pub/PubHeader/BylineEditButton.tsx
+++ b/client/containers/Pub/PubHeader/BylineEditButton.tsx
@@ -12,7 +12,7 @@ type Props = {
 const BylineEditButton = (props: Props) => {
 	const { onClick } = props;
 	return (
-		<Button className="byline-edit-button-component" onClick={onClick} aria-label="Edit byline">
+		<Button className="byline-edit-button-component" onClick={onClick} aria-label="Edit Pub contributors">
 			<div className="icon-box pub-header-themed-box pub-header-themed-box-hover-target">
 				<Icon icon="edit2" iconSize={14} />
 			</div>

--- a/client/containers/Pub/PubHeader/BylineEditButton.tsx
+++ b/client/containers/Pub/PubHeader/BylineEditButton.tsx
@@ -12,7 +12,11 @@ type Props = {
 const BylineEditButton = (props: Props) => {
 	const { onClick } = props;
 	return (
-		<Button className="byline-edit-button-component" onClick={onClick} aria-label="Edit Pub contributors">
+		<Button
+			className="byline-edit-button-component"
+			onClick={onClick}
+			aria-label="Edit Pub contributors"
+		>
 			<div className="icon-box pub-header-themed-box pub-header-themed-box-hover-target">
 				<Icon icon="edit2" iconSize={14} />
 			</div>

--- a/client/containers/Pub/PubHeader/TitleGroup.tsx
+++ b/client/containers/Pub/PubHeader/TitleGroup.tsx
@@ -53,7 +53,7 @@ const TitleGroup = (props: Props) => {
 
 	const renderBylineEmptyState = () => {
 		if (canModify) {
-			return <span className="pub-header-themed-secondary">Edit byline</span>;
+			return <span className="pub-header-themed-secondary">Edit Pub contributors</span>;
 		}
 		return null;
 	};

--- a/client/containers/User/UserNav.tsx
+++ b/client/containers/User/UserNav.tsx
@@ -21,7 +21,7 @@ const defaultProps = {
 const UserNav = function (props) {
 	const tabs = [
 		{ id: 0, label: 'All Pubs', path: '', count: props.allPubsCount },
-		{ id: 1, label: 'Authored Pubs', path: '/authored', count: props.authoredPubsCount },
+		{ id: 1, label: 'Attributed Pubs', path: '/authored', count: props.authoredPubsCount },
 		// { id: 1, label: 'All Pubs', path: '/pubs' },
 		// { id: 2, label: 'Discussions', path: '/discussions' },
 	];

--- a/server/discussion/__tests__/api.test.ts
+++ b/server/discussion/__tests__/api.test.ts
@@ -17,7 +17,7 @@ const couldApplyManagedLabel = {
 };
 
 const publicLabel = {
-	title: 'Contributors can apply this label to their own discussions',
+	title: 'All discussants can apply this label',
 	publicApply: true,
 	id: uuid.v4(),
 };

--- a/server/discussion/__tests__/api.test.ts
+++ b/server/discussion/__tests__/api.test.ts
@@ -17,7 +17,7 @@ const couldApplyManagedLabel = {
 };
 
 const publicLabel = {
-	title: 'Authors can apply this label to their own discussions',
+	title: 'Contributors can apply this label to their own discussions',
 	publicApply: true,
 	id: uuid.v4(),
 };

--- a/server/pub/__tests__/queryMany.test.ts
+++ b/server/pub/__tests__/queryMany.test.ts
@@ -245,7 +245,7 @@ describe('queryPubIds', () => {
 		]);
 	});
 
-	it('Filters for Pubs by a title or author term', async () => {
+	it('Filters for Pubs by a title or contributor term', async () => {
 		const { p1, p2, p4 } = models;
 		await expectPubIdsForQuery({ ordering: collectionRankOrdering, term: 'please' }, [p1]);
 		await expectPubIdsForQuery({ ordering: collectionRankOrdering, term: 'guy' }, [p2]);


### PR DESCRIPTION
Addresses #2261 - eliminates "author" in all instances where a wider range of contributor roles should be represented, and implements clean attribution/contribution taxonomy. 