### PR TITLE
feature: Superadmin dash and `LandingPageFeature` manager

### DIFF
--- a/client/components/DragDropListing/DragDropOrdering.tsx
+++ b/client/components/DragDropListing/DragDropOrdering.tsx
@@ -4,7 +4,11 @@ import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 import DragDropListing, { Props as DragDropListingProps, MinimalItem } from './DragDropListing';
 
 type Props<Item extends MinimalItem> = {
-	onReorderItems: (reorderedItems: Item[]) => unknown;
+	onReorderItems: (
+		reorderedItems: Item[],
+		reorderedItem: Item,
+		destinationIndex: number,
+	) => unknown;
 	getReorderedItem?: (item: Item, listWithItemRemoved: Item[]) => Item;
 } & Omit<DragDropListingProps<Item>, 'droppableId'>;
 
@@ -22,7 +26,7 @@ const DragDropOrdering = <Item extends MinimalItem>(props: Props<Item>) => {
 				? getReorderedItem(removedItem, nextItems)
 				: removedItem;
 			nextItems.splice(destinationIndex, 0, reorderedItem);
-			onReorderItems(nextItems);
+			onReorderItems(nextItems, reorderedItem, destinationIndex);
 		}
 	};
 

--- a/client/containers/App/App.tsx
+++ b/client/containers/App/App.tsx
@@ -37,7 +37,7 @@ const App = (props: Props) => {
 	const { communityData, locationData, scopeData } = pageContextProps;
 
 	const pathObject = getPaths(viewData, locationData, chunkName);
-	const { ActiveComponent, hideNav, hideFooter, isDashboard } = pathObject;
+	const { ActiveComponent, hideNav, hideFooter, hideHeader, isDashboard } = pathObject;
 
 	// Our debugging lifeline
 	if (typeof window !== 'undefined') {
@@ -47,6 +47,7 @@ const App = (props: Props) => {
 
 	const showNav = !hideNav && !communityData.hideNav && !isDashboard;
 	const showFooter = !hideFooter && !isDashboard;
+	const showHeader = !hideHeader;
 	return (
 		<PageContext.Provider value={pageContextProps}>
 			<FacetsStateProvider
@@ -60,7 +61,7 @@ const App = (props: Props) => {
 						)}
 						<SkipLink targetId="main-content">Skip to main content</SkipLink>
 						<LegalBanner />
-						<Header />
+						{showHeader && <Header />}
 						{showNav && <NavBar />}
 						{isDashboard && (
 							<MobileAware

--- a/client/containers/App/paths.ts
+++ b/client/containers/App/paths.ts
@@ -33,6 +33,7 @@ import {
 	Pub,
 	Search,
 	Signup,
+	SuperAdminDashboard,
 	User,
 	UserCreate,
 } from 'containers';
@@ -180,6 +181,12 @@ export default (viewData, locationData, chunkName) => {
 			ActiveComponent: Signup,
 			hideNav: true,
 			hideFooter: true,
+		},
+		SuperAdminDashboard: {
+			ActiveComponent: SuperAdminDashboard,
+			hideNav: true,
+			hideFooter: true,
+			hideHeader: true,
 		},
 		User: {
 			ActiveComponent: User,

--- a/client/containers/DashboardSettings/CommunitySettings/CommunitySettings.tsx
+++ b/client/containers/DashboardSettings/CommunitySettings/CommunitySettings.tsx
@@ -72,6 +72,7 @@ const CommunitySettings = () => {
 			},
 			loginData: {
 				id: null,
+				isSuperAdmin: false,
 			},
 		};
 	}, [pageContext, communityData]);

--- a/client/containers/SuperAdminDashboard/LandingPageFeatures/FeaturedCommunityItem.tsx
+++ b/client/containers/SuperAdminDashboard/LandingPageFeatures/FeaturedCommunityItem.tsx
@@ -1,0 +1,79 @@
+import React, { useMemo } from 'react';
+import { Button, Icon, Tag, Tooltip } from '@blueprintjs/core';
+
+import { LandingPageCommunityFeature } from 'types';
+import { DialogLauncher } from 'components';
+import { communityUrl } from 'utils/canonicalUrls';
+import { validateCommunityLandingPageFeature } from 'utils/landingPage/validate';
+
+import FeaturedCommunityPayloadDialog from './FeaturedCommunityPayloadDialog';
+
+type Props = {
+	feature: LandingPageCommunityFeature;
+	onUpdateFeature: (feature: LandingPageCommunityFeature) => unknown;
+};
+
+const FeaturedCommunityItem = (props: Props) => {
+	const { feature, onUpdateFeature } = props;
+	const { community } = feature;
+
+	const isFeatureValid = useMemo(() => {
+		return !!validateCommunityLandingPageFeature(feature);
+	}, [feature]);
+
+	const renderTag = () => {
+		if (isFeatureValid) {
+			return (
+				<Tooltip content="Displayed on landing page">
+					<Tag icon="tick" intent="success">
+						Valid
+					</Tag>
+				</Tooltip>
+			);
+		}
+		return (
+			<Tooltip
+				content={
+					<>
+						This item will not be displayed on the landing page until you use the{' '}
+						<Icon icon="edit" /> button to add the required info.
+					</>
+				}
+			>
+				<Tag icon="warning-sign" intent="warning">
+					Missing info
+				</Tag>
+			</Tooltip>
+		);
+	};
+
+	return (
+		<div className="landing-page-community-feature">
+			<div className="title-group">
+				<a href={communityUrl(community)}>{community.title}</a>
+				{renderTag()}
+			</div>
+			<DialogLauncher
+				renderLauncherElement={({ openDialog }) => (
+					<Button icon="edit" minimal onClick={openDialog} />
+				)}
+			>
+				{({ isOpen, onClose }) => (
+					<FeaturedCommunityPayloadDialog
+						isOpen={isOpen}
+						onClose={onClose}
+						feature={feature}
+						onSavePayload={(next) =>
+							onUpdateFeature({
+								...feature,
+								payload: next,
+							})
+						}
+					/>
+				)}
+			</DialogLauncher>
+		</div>
+	);
+};
+
+export default FeaturedCommunityItem;

--- a/client/containers/SuperAdminDashboard/LandingPageFeatures/FeaturedCommunityPayloadDialog.tsx
+++ b/client/containers/SuperAdminDashboard/LandingPageFeatures/FeaturedCommunityPayloadDialog.tsx
@@ -1,0 +1,119 @@
+import React, { useCallback, useState } from 'react';
+import { Classes, Button, Dialog, Radio, RadioGroup } from '@blueprintjs/core';
+
+import { LandingPageCommunityFeature } from 'types';
+import { InputField, MinimalEditor, ColorInput, ImageUpload } from 'components';
+import { apiFetch } from 'client/utils/apiFetch';
+
+require('./featuredCommunityPayloadDialog.scss');
+
+type Props = {
+	isOpen: boolean;
+	onClose: () => unknown;
+	feature: LandingPageCommunityFeature;
+	onSavePayload: (payload: LandingPageCommunityFeature['payload']) => unknown;
+};
+
+const FeaturedCommunityPayloadDialog = (props: Props) => {
+	const { isOpen, onClose, feature, onSavePayload } = props;
+	const { community } = feature;
+	const [payload, setPayload] = useState(feature.payload);
+	const [isSaving, setIsSaving] = useState(false);
+	const backgroundColorType = payload?.backgroundColor ? 'custom' : 'community';
+
+	const handleSaveClick = useCallback(async () => {
+		setIsSaving(true);
+		await apiFetch.put('api/landingPageFeatures', {
+			landingPageFeature: {
+				id: feature.id,
+				payload,
+			},
+		});
+		onSavePayload(payload);
+		setIsSaving(false);
+		onClose();
+	}, [payload, onClose, onSavePayload, feature.id]);
+
+	const handleUpdatePayload = useCallback(
+		(next: Partial<LandingPageCommunityFeature['payload']>) => {
+			setPayload((p) => ({ backgroundColor: null, ...p, ...next }));
+		},
+		[],
+	);
+
+	const handleColorSelectionChanged = useCallback(
+		(evt: any) => {
+			handleUpdatePayload({
+				backgroundColor: evt.target.value === 'community' ? null : '#fff',
+			});
+		},
+		[handleUpdatePayload],
+	);
+
+	const renderInner = () => {
+		return (
+			<>
+				<InputField label="Image">
+					<ImageUpload
+						helperText="Recommended: 900x500px"
+						canClear
+						defaultImage={payload?.imageUrl}
+						onNewImage={(imageUrl) => handleUpdatePayload({ imageUrl })}
+					/>
+				</InputField>
+				<InputField label="Quote">
+					<MinimalEditor
+						initialContent={payload?.quote}
+						onContent={({ content }) => handleUpdatePayload({ quote: content })}
+					/>
+				</InputField>
+				<InputField label="Highlights">
+					<MinimalEditor
+						initialContent={payload?.highlights}
+						onContent={({ content }) => handleUpdatePayload({ highlights: content })}
+					/>
+				</InputField>
+				<InputField label="Background color">
+					<RadioGroup
+						selectedValue={backgroundColorType}
+						onChange={handleColorSelectionChanged}
+					>
+						<Radio value="community">
+							Use the Community dark accent color as the background
+						</Radio>
+						<Radio value="custom">
+							Use a custom color{backgroundColorType === 'custom' ? ':' : ''}
+						</Radio>
+					</RadioGroup>
+					{backgroundColorType === 'custom' && (
+						<ColorInput
+							value={payload?.backgroundColor}
+							onChange={(color) =>
+								handleUpdatePayload({ backgroundColor: color.hex })
+							}
+						/>
+					)}
+				</InputField>
+			</>
+		);
+	};
+
+	return (
+		<Dialog isOpen={isOpen} className="featured-community-payload-dialog-component">
+			<div className={Classes.DIALOG_HEADER}>
+				Update details for&nbsp;<b>{community.title}</b>
+			</div>
+			<div className={Classes.DIALOG_BODY}>{renderInner()}</div>
+			<div className={Classes.DIALOG_FOOTER}>
+				<div className={Classes.DIALOG_FOOTER_ACTIONS}>
+					<Button onClick={onClose}>Cancel</Button>
+					<Button intent="primary" onClick={handleSaveClick} loading={isSaving}>
+						Save
+					</Button>
+				</div>
+			</div>
+		</Dialog>
+	);
+};
+
+export default FeaturedCommunityPayloadDialog;

--- a/client/containers/SuperAdminDashboard/LandingPageFeatures/LandingPageFeatureManager.tsx
+++ b/client/containers/SuperAdminDashboard/LandingPageFeatures/LandingPageFeatureManager.tsx
@@ -1,0 +1,154 @@
+import React, { useCallback, useState } from 'react';
+import { Button, InputGroup } from '@blueprintjs/core';
+
+import { DragDropOrdering, Icon } from 'components';
+import { LandingPageFeatureKind, LandingPageFeatureOfKind } from 'types';
+import { apiFetch } from 'client/utils/apiFetch';
+import { findRankInRankedList } from 'utils/rank';
+
+require('./landingPageFeatureManager.scss');
+
+export type RenderFeatureProps<Kind extends LandingPageFeatureKind> = {
+	feature: LandingPageFeatureOfKind<Kind>;
+	onUpdateFeature: (feature: LandingPageFeatureOfKind<Kind>) => unknown;
+};
+
+type Props<Kind extends LandingPageFeatureKind> = {
+	kind: Kind;
+	initialFeatures: LandingPageFeatureOfKind<Kind>[];
+	renderFeature: (props: RenderFeatureProps<Kind>) => React.ReactNode;
+	placeholder: string;
+};
+
+const LandingPageFeatureManager = <Kind extends LandingPageFeatureKind>(props: Props<Kind>) => {
+	const { initialFeatures, renderFeature, placeholder, kind } = props;
+	const [featureInputValue, setFeatureInputValue] = useState('');
+	const [inputHasError, setInputHasError] = useState(false);
+	const [features, setFeatures] = useState(initialFeatures);
+
+	const handleAddFeature = useCallback(async () => {
+		try {
+			const newFeature = await apiFetch.post('/api/landingPageFeatures', {
+				proposal: featureInputValue,
+				proposalKind: kind,
+				rank: findRankInRankedList(features, 0),
+			});
+			setFeatures([newFeature, ...features]);
+		} catch (_) {
+			setInputHasError(true);
+		} finally {
+			setFeatureInputValue('');
+		}
+	}, [featureInputValue, kind, features]);
+
+	const handleUpdateFeature = useCallback((nextFeature: LandingPageFeatureOfKind<Kind>) => {
+		setFeatures((currentFeatures) => {
+			return currentFeatures.map((f) => {
+				if (f.id === nextFeature.id) {
+					return nextFeature;
+				}
+				return f;
+			});
+		});
+		// Wants type Kind as a dep
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	const handleRemoveFeature = useCallback(
+		async (featureId: string) => {
+			setFeatures(features.filter((f) => f.id !== featureId));
+			try {
+				await apiFetch.delete('/api/landingPageFeatures', {
+					landingPageFeature: {
+						id: featureId,
+					},
+				});
+			} catch (_) {
+				setFeatures(features);
+			}
+		},
+		[features],
+	);
+
+	const handleReorderFeatures = useCallback(
+		async (
+			nextFeatures: LandingPageFeatureOfKind<Kind>[],
+			reorderedFeature: LandingPageFeatureOfKind<Kind>,
+			reorderedToIndex: number,
+		) => {
+			setFeatures(nextFeatures);
+			const rank = findRankInRankedList(
+				nextFeatures.filter((f) => f.id !== reorderedFeature.id),
+				reorderedToIndex,
+			);
+			try {
+				await apiFetch.put('/api/landingPageFeatures', {
+					landingPageFeature: {
+						id: reorderedFeature.id,
+						rank,
+					},
+				});
+			} catch (_) {
+				setFeatures(features);
+			}
+		},
+		// Wants type Kind as a dep
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[features],
+	);
+
+	const handleInputKeyDown = useCallback(
+		(e: any) => {
+			setInputHasError(false);
+			if (e.key === 'Enter') {
+				handleAddFeature();
+			}
+		},
+		[handleAddFeature],
+	);
+
+	const renderFeatureFrame = (feature: LandingPageFeatureOfKind<Kind>, dragHandleProps: any) => {
+		return (
+			<div className="feature-wrapper">
+				{dragHandleProps && (
+					<span className="drag-handle" {...dragHandleProps}>
+						<Icon icon="drag-handle-vertical" />
+					</span>
+				)}
+				<div className="feature-content">
+					{renderFeature({ feature, onUpdateFeature: handleUpdateFeature })}
+				</div>
+				<Button
+					className="close-button"
+					minimal
+					icon="cross"
+					onClick={() => handleRemoveFeature(feature.id)}
+				/>
+			</div>
+		);
+	};
+
+	return (
+		<div className="landing-page-feature-manager-component">
+			<InputGroup
+				large
+				className="main-input"
+				intent={inputHasError ? 'danger' : 'none'}
+				placeholder={placeholder}
+				onKeyDown={handleInputKeyDown}
+				value={featureInputValue}
+				onChange={(e) => setFeatureInputValue(e.target.value)}
+				rightElement={<Button minimal large icon="add" onClick={handleAddFeature} />}
+			/>
+			<DragDropOrdering
+				withDragHandles
+				items={features}
+				onReorderItems={handleReorderFeatures}
+				droppableType={kind}
+				renderItem={renderFeatureFrame}
+			/>
+		</div>
+	);
+};
+
+export default LandingPageFeatureManager;

--- a/client/containers/SuperAdminDashboard/LandingPageFeatures/LandingPageFeatures.tsx
+++ b/client/containers/SuperAdminDashboard/LandingPageFeatures/LandingPageFeatures.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import { SettingsSection } from 'components';
+import { pubUrl, communityUrl } from 'utils/canonicalUrls';
+import { LandingPageFeatures as LandingPageFeaturesType } from 'types';
+
+import LandingPageFeatureManager, { RenderFeatureProps } from './LandingPageFeatureManager';
+import FeaturedCommunityItem from './FeaturedCommunityItem';
+
+require('./landingPageFeatures.scss');
+
+type Props = {
+	landingPageFeatures: LandingPageFeaturesType<false>;
+};
+
+const LandingPageFeatures = (props: Props) => {
+	const { landingPageFeatures } = props;
+
+	const renderPubFeature = ({ feature }: RenderFeatureProps<'pub'>) => {
+		const { pub } = feature;
+		const { community } = pub;
+		return (
+			<div className="landing-page-pub-feature">
+				<div className="title">
+					<a href={pubUrl(community, pub)}>{pub.title}</a>
+				</div>
+				<div className="community">
+					in <a href={communityUrl(community)}>{community.title}</a>
+				</div>
+			</div>
+		);
+	};
+
+	const renderCommunityFeature = ({
+		feature,
+		onUpdateFeature,
+	}: RenderFeatureProps<'community'>) => {
+		return <FeaturedCommunityItem feature={feature} onUpdateFeature={onUpdateFeature} />;
+	};
+
+	return (
+		<div className="landing-page-features-component">
+			<SettingsSection key={0} title="Pubs">
+				<LandingPageFeatureManager
+					kind="pub"
+					placeholder="Enter a Pub slug or URL"
+					initialFeatures={landingPageFeatures.pub}
+					renderFeature={renderPubFeature}
+				/>
+			</SettingsSection>
+			<SettingsSection key={1} title="Communities">
+				<LandingPageFeatureManager
+					kind="community"
+					placeholder="Enter a Community subdomain or URL"
+					initialFeatures={landingPageFeatures.community}
+					renderFeature={renderCommunityFeature}
+				/>
+			</SettingsSection>
+		</div>
+	);
+};
+
+export default LandingPageFeatures;

--- a/client/containers/SuperAdminDashboard/LandingPageFeatures/featuredCommunityPayloadDialog.scss
+++ b/client/containers/SuperAdminDashboard/LandingPageFeatures/featuredCommunityPayloadDialog.scss
@@ -1,8 +1,8 @@
 .featured-community-payload-dialog-component {
-    .input-field-component {
-        .bp3-label {
-            font-weight: bold;
-            margin-bottom: 5px !important;
-        }
-    }
+	.input-field-component {
+		.bp3-label {
+			font-weight: bold;
+			margin-bottom: 5px !important;
+		}
+	}
 }

--- a/client/containers/SuperAdminDashboard/LandingPageFeatures/featuredCommunityPayloadDialog.scss
+++ b/client/containers/SuperAdminDashboard/LandingPageFeatures/featuredCommunityPayloadDialog.scss
@@ -1,0 +1,8 @@
+.featured-community-payload-dialog-component {
+    .input-field-component {
+        .bp3-label {
+            font-weight: bold;
+            margin-bottom: 5px !important;
+        }
+    }
+}

--- a/client/containers/SuperAdminDashboard/LandingPageFeatures/index.ts
+++ b/client/containers/SuperAdminDashboard/LandingPageFeatures/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LandingPageFeatures';

--- a/client/containers/SuperAdminDashboard/LandingPageFeatures/landingPageFeatureManager.scss
+++ b/client/containers/SuperAdminDashboard/LandingPageFeatures/landingPageFeatureManager.scss
@@ -1,0 +1,73 @@
+@keyframes shake {
+	0% {
+		transform: translateX(0);
+	}
+	25% {
+		transform: translateX(2px);
+	}
+	50% {
+		transform: translateX(-2px);
+	}
+	75% {
+		transform: translateX(2px);
+	}
+	100% {
+		transform: translateX(0);
+	}
+}
+
+.landing-page-feature-manager-component {
+	.main-input.bp3-intent-danger {
+		animation: shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
+	}
+
+	.feature-wrapper {
+		display: flex;
+		align-items: center;
+		margin-top: 10px;
+		margin-bottom: 10px;
+		.drag-handle {
+			margin-right: 5px;
+		}
+		.feature-content {
+			flex-grow: 1;
+		}
+		.close-button {
+			align-self: flex-end;
+		}
+	}
+
+	.landing-page-pub-feature {
+		.title {
+			font-size: 1.2em;
+			font-weight: 600;
+			a {
+				text-decoration: none;
+				&:hover {
+					text-decoration: underline;
+				}
+			}
+		}
+	}
+
+	.landing-page-community-feature {
+		display: flex;
+		align-items: center;
+		font-size: 1.2em;
+		font-weight: 600;
+		justify-content: space-between;
+		.title-group {
+			display: flex;
+			align-items: center;
+			a {
+				text-decoration: none;
+				&:hover {
+					text-decoration: underline;
+				}
+			}
+			.bp3-tag {
+				margin-left: 4px;
+			}
+		}
+	}
+}

--- a/client/containers/SuperAdminDashboard/LandingPageFeatures/landingPageFeatures.scss
+++ b/client/containers/SuperAdminDashboard/LandingPageFeatures/landingPageFeatures.scss
@@ -1,0 +1,5 @@
+.landing-page-features-component {
+    .settings-section-component {
+        margin-bottom: 20px;
+    }
+}

--- a/client/containers/SuperAdminDashboard/LandingPageFeatures/landingPageFeatures.scss
+++ b/client/containers/SuperAdminDashboard/LandingPageFeatures/landingPageFeatures.scss
@@ -1,5 +1,5 @@
 .landing-page-features-component {
-    .settings-section-component {
-        margin-bottom: 20px;
-    }
+	.settings-section-component {
+		margin-bottom: 20px;
+	}
 }

--- a/client/containers/SuperAdminDashboard/SuperAdminDashboard.tsx
+++ b/client/containers/SuperAdminDashboard/SuperAdminDashboard.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import { GridWrapper } from 'components';
+import { getSuperAdminTabUrl, SuperAdminTabKind } from 'utils/superAdmin';
+
+import { superAdminTabs } from './tabs';
+
+require('./superAdminDashboard.scss');
+
+type Props = {
+	tabKind: SuperAdminTabKind;
+	tabProps: Record<string, any>;
+};
+
+const SuperAdminDashboard = (props: Props) => {
+	const { tabKind, tabProps } = props;
+	const { component: TabComponent } = superAdminTabs[tabKind];
+
+	const renderTabLinks = () => {
+		return Object.keys(superAdminTabs).map((key) => {
+			const { title } = superAdminTabs[key];
+			return (
+				<a
+					className={classNames('link', tabKind === key && 'current')}
+					href={getSuperAdminTabUrl(key as any)}
+					key={key}
+				>
+					{title}
+				</a>
+			);
+		});
+	};
+
+	return (
+		<GridWrapper columnClassName="superadmin-dashboard-component">
+			<h1>
+				<span className="supreme">Superadmin</span> Dashboard
+			</h1>
+			<div className="superadmin-tab-links">{renderTabLinks()}</div>
+			<TabComponent {...tabProps} />
+		</GridWrapper>
+	);
+};
+
+export default SuperAdminDashboard;

--- a/client/containers/SuperAdminDashboard/index.ts
+++ b/client/containers/SuperAdminDashboard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SuperAdminDashboard';

--- a/client/containers/SuperAdminDashboard/superAdminDashboard.scss
+++ b/client/containers/SuperAdminDashboard/superAdminDashboard.scss
@@ -1,0 +1,29 @@
+$accent: #ed1c24;
+
+.superadmin-dashboard-component {
+	.supreme {
+		background-color: $accent;
+		color: white;
+		padding: 2px 8px;
+		letter-spacing: -0.01em;
+		font-style: italic;
+	}
+
+	.superadmin-tab-links {
+		margin-bottom: 1em;
+		a.link {
+			text-decoration: none;
+			font-size: 14px;
+			margin-right: 10px;
+			padding: 3px;
+			&:hover,
+			&:focus {
+				text-decoration: underline;
+			}
+			&.current {
+				color: white;
+				background-color: black;
+			}
+		}
+	}
+}

--- a/client/containers/SuperAdminDashboard/tabs.tsx
+++ b/client/containers/SuperAdminDashboard/tabs.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { SuperAdminTabKind } from 'utils/superAdmin';
+
+import LandingPageFeatures from './LandingPageFeatures';
+import CommunitySpam from './CommunitySpam';
+
+type SuperAdminTab = {
+	title: string;
+	component: React.FC<any>;
+};
+
+export const superAdminTabs: Record<SuperAdminTabKind, SuperAdminTab> = {
+	landingPageFeatures: {
+		title: 'Landing Page features',
+		component: LandingPageFeatures,
+	},
+	spam: {
+		title: 'Spam Communities',
+		component: CommunitySpam,
+	},
+};

--- a/client/containers/SuperAdminDashboard/tabs.tsx
+++ b/client/containers/SuperAdminDashboard/tabs.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { SuperAdminTabKind } from 'utils/superAdmin';
 
 import LandingPageFeatures from './LandingPageFeatures';
-import CommunitySpam from './CommunitySpam';
 
 type SuperAdminTab = {
 	title: string;
@@ -14,9 +13,5 @@ export const superAdminTabs: Record<SuperAdminTabKind, SuperAdminTab> = {
 	landingPageFeatures: {
 		title: 'Landing Page features',
 		component: LandingPageFeatures,
-	},
-	spam: {
-		title: 'Spam Communities',
-		component: CommunitySpam,
 	},
 };

--- a/client/containers/index.ts
+++ b/client/containers/index.ts
@@ -34,5 +34,6 @@ export { default as Legal } from './Legal/Legal';
 export { default as Pub } from './Pub/Pub';
 export { default as Search } from './Search/Search';
 export { default as Signup } from './Signup/Signup';
+export { default as SuperAdminDashboard } from './SuperAdminDashboard';
 export { default as User } from './User/User';
 export { default as UserCreate } from './UserCreate/UserCreate';

--- a/server/apiRoutes.ts
+++ b/server/apiRoutes.ts
@@ -1,3 +1,5 @@
+import { isProd } from 'utils/environment';
+
 require('./activityItem/api');
 require('./collectionAttribution/api');
 require('./collection/api');
@@ -11,6 +13,7 @@ require('./editor/api');
 require('./export/api');
 require('./facets/api');
 require('./import/api');
+require('./landingPageFeature/api');
 require('./layout/api');
 require('./logout/api');
 require('./login/api');
@@ -41,7 +44,7 @@ require('./userNotificationPreferences/api');
 require('./userSubscription/api');
 require('./workerTask/api');
 
-if (process.env.NODE_ENV !== 'production') {
+if (!isProd()) {
 	// eslint-disable-next-line global-require
 	require('./dev/api');
 }

--- a/server/landingPageFeature/__tests__/api.test.ts
+++ b/server/landingPageFeature/__tests__/api.test.ts
@@ -1,0 +1,75 @@
+import { setup, login, modelize } from 'stubstub';
+
+import { LandingPageFeature } from 'server/models';
+
+const models = modelize`
+	User superadmin {
+        isSuperAdmin: true
+    }
+    Community c1 {
+        Member {
+            permissions: "admin"
+            User rando {}
+        }
+        Pub p1 {
+            Release {}
+        }
+        Pub p2 {
+            Release {}
+        }
+        Pub p3 {}
+    }
+    LandingPageFeature l1 {
+        pub: p1
+        rank: "h"
+    }
+`;
+
+setup(beforeAll, async () => {
+	await models.resolve();
+});
+
+it('forbids non-superadmins from creating/modifying/deleting LandingPageFeatures', async () => {
+	const { rando, l1, p2 } = models;
+	const agent = await login(rando);
+	await agent
+		.post('/api/landingPageFeatures')
+		.send({ proposal: p2.slug, proposalKind: 'pub' })
+		.expect(403);
+	await agent
+		.put('/api/landingPageFeatures')
+		.send({ landingPageFeature: { id: l1.id, rank: 'zzz' } })
+		.expect(403);
+	await agent
+		.delete('/api/landingPageFeatures')
+		.send({ landingPageFeature: { id: l1.id } })
+		.expect(403);
+});
+
+it('allows superadmins to create/modify/delete LandingPageFeatures', async () => {
+	const { superadmin, p2 } = models;
+	const agent = await login(superadmin);
+	const { body: l2 } = await agent
+		.post('/api/landingPageFeatures')
+		.send({ proposal: p2.slug, proposalKind: 'pub', rank: '0' })
+		.expect(201);
+	expect(l2.pubId).toEqual(p2.id);
+	await agent
+		.put('/api/landingPageFeatures')
+		.send({ landingPageFeature: { id: l2.id, rank: 'zzz' } })
+		.expect(200);
+	await agent
+		.delete('/api/landingPageFeatures')
+		.send({ landingPageFeature: { id: l2.id } })
+		.expect(200);
+	expect(await LandingPageFeature.count({ where: { id: l2.id } })).toEqual(0);
+});
+
+it('will not create LandingPageFeatures for unreleased Pubs', async () => {
+	const { superadmin, p3 } = models;
+	const agent = await login(superadmin);
+	await agent
+		.post('/api/landingPageFeatures')
+		.send({ proposal: p3.slug, proposalKind: 'pub' })
+		.expect(404);
+});

--- a/server/landingPageFeature/api.ts
+++ b/server/landingPageFeature/api.ts
@@ -1,0 +1,57 @@
+import app, { wrap } from 'server/server';
+import { ForbiddenError, NotFoundError } from 'server/utils/errors';
+
+import { canModifyLandingPageFeatures } from './permissions';
+import { getProposedFeature } from './propose';
+import {
+	createLandingPageFeature,
+	destroyLandingPageFeature,
+	updateLandingPageFeature,
+} from './queries';
+
+app.post(
+	'/api/landingPageFeatures',
+	wrap(async (req, res) => {
+		const { proposal, proposalKind, rank } = req.body;
+		const canCreate = await canModifyLandingPageFeatures({ userId: req.user?.id });
+		if (!canCreate) {
+			throw new ForbiddenError();
+		}
+		const proposalResult = await getProposedFeature({ proposal, proposalKind });
+		if (proposalResult) {
+			const newFeature = await createLandingPageFeature({ ...proposalResult, rank });
+			return res.status(201).send(newFeature);
+		}
+		throw new NotFoundError();
+	}),
+);
+
+app.put(
+	'/api/landingPageFeatures',
+	wrap(async (req, res) => {
+		const {
+			landingPageFeature: { id, rank, payload },
+		} = req.body;
+		const canUpdate = await canModifyLandingPageFeatures({ userId: req.user?.id });
+		if (!canUpdate) {
+			throw new ForbiddenError();
+		}
+		await updateLandingPageFeature({ id, rank, payload });
+		return res.status(200).send({});
+	}),
+);
+
+app.delete(
+	'/api/landingPageFeatures',
+	wrap(async (req, res) => {
+		const {
+			landingPageFeature: { id },
+		} = req.body;
+		const canDestroy = await canModifyLandingPageFeatures({ userId: req.user?.id });
+		if (!canDestroy) {
+			throw new ForbiddenError();
+		}
+		await destroyLandingPageFeature({ id });
+		return res.status(200).send({});
+	}),
+);

--- a/server/landingPageFeature/model.ts
+++ b/server/landingPageFeature/model.ts
@@ -1,0 +1,39 @@
+export default (sequelize, dataTypes) => {
+	return sequelize.define(
+		'LandingPageFeature',
+		{
+			id: sequelize.idType,
+			communityId: { type: dataTypes.UUID, allowNull: true },
+			pubId: { type: dataTypes.UUID, allowNull: true },
+			rank: { type: dataTypes.TEXT, allowNull: false },
+			payload: { type: dataTypes.JSONB, allowNull: true },
+		},
+		{
+			indexes: [
+				{
+					fields: ['communityId'],
+					unique: true,
+				},
+				{
+					fields: ['pubId'],
+					unique: true,
+				},
+			],
+			classMethods: {
+				associate: (models) => {
+					const { Pub, Community, LandingPageFeature } = models;
+					LandingPageFeature.belongsTo(Pub, {
+						onDelete: 'CASCADE',
+						as: 'pub',
+						foreignKey: 'pubId',
+					});
+					LandingPageFeature.belongsTo(Community, {
+						onDelete: 'CASCADE',
+						as: 'community',
+						foreignKey: 'communityId',
+					});
+				},
+			},
+		},
+	);
+};

--- a/server/landingPageFeature/permissions.ts
+++ b/server/landingPageFeature/permissions.ts
@@ -1,0 +1,5 @@
+import { isUserSuperAdmin } from 'server/user/queries';
+
+export const canModifyLandingPageFeatures = ({ userId }: { userId: string }) => {
+	return isUserSuperAdmin({ userId });
+};

--- a/server/landingPageFeature/propose.ts
+++ b/server/landingPageFeature/propose.ts
@@ -1,0 +1,71 @@
+import { Op } from 'sequelize';
+
+import { Community, Pub } from 'server/models';
+import { buildPubOptions } from 'server/utils/queryHelpers';
+import { parseUrl } from 'utils/urls';
+
+type GetProposedFeatureOptions = {
+	proposal: string;
+	proposalKind: 'pub' | 'community';
+};
+
+type ProposalResult = null | { pubId: string } | { communityId: string };
+
+const extractCommunityQueryFromHostname = async (hostname: string) => {
+	const communityName = hostname.split('.')[0];
+	return {
+		[Op.or]: [{ domain: hostname }, { subdomain: communityName }],
+	};
+};
+
+const getCommunityFromHostname = async (hostname: string) => {
+	const community = await Community.findOne({
+		where: extractCommunityQueryFromHostname(hostname),
+	});
+	return community;
+};
+
+const extractPubQuery = async (proposal: string) => {
+	const url = parseUrl(proposal);
+	if (url) {
+		const { pathname, hostname } = url;
+		const matches = pathname.match(/^\/pub\/(\w+)/);
+		const community = await getCommunityFromHostname(hostname);
+		if (matches && community) {
+			const slug = matches[1];
+			return { slug };
+		}
+	}
+	return { slug: proposal };
+};
+
+const extractCommunityQuery = async (proposal: string) => {
+	const url = parseUrl(proposal);
+	if (url) {
+		const { hostname } = url;
+		return extractCommunityQueryFromHostname(hostname);
+	}
+	return {
+		[Op.or]: [{ domain: proposal }, { subdomain: proposal }],
+	};
+};
+
+export const getProposedFeature = async (
+	options: GetProposedFeatureOptions,
+): Promise<ProposalResult> => {
+	const { proposal, proposalKind } = options;
+	if (proposalKind === 'pub') {
+		const pubQuery = await extractPubQuery(proposal);
+		const pub = await Pub.findOne({ where: pubQuery, ...buildPubOptions({}) });
+		if (pub && pub.releases.length > 0) {
+			return { pubId: pub.id };
+		}
+	} else if (proposalKind === 'community') {
+		const communityQuery = await extractCommunityQuery(proposal);
+		const community = await Community.findOne({ where: communityQuery });
+		if (community) {
+			return { communityId: community.id };
+		}
+	}
+	return null;
+};

--- a/server/landingPageFeature/queries.ts
+++ b/server/landingPageFeature/queries.ts
@@ -1,0 +1,74 @@
+import * as types from 'types';
+import { Community, LandingPageFeature, Pub } from 'server/models';
+import { splitArrayOn } from 'utils/arrays';
+import { buildPubOptions } from 'server/utils/queryHelpers';
+import { validateCommunityLandingPageFeature } from 'utils/landingPage/validate';
+
+const landingPageFeatureIncludes = [
+	{ model: Pub, as: 'pub', ...buildPubOptions({ getCommunity: true, getCollections: true }) },
+	{ model: Community, as: 'community' },
+];
+
+type GetLandingPageFeaturesOptions<Validated extends boolean> = {
+	onlyValidItems?: Validated;
+};
+
+export const getLandingPageFeatures = async <Validated extends boolean = true>(
+	options: GetLandingPageFeaturesOptions<Validated> = {},
+): Promise<types.LandingPageFeatures<Validated>> => {
+	const { onlyValidItems = true } = options;
+	const features: types.LandingPageFeature[] = await LandingPageFeature.findAll({
+		include: landingPageFeatureIncludes,
+		order: [['rank', 'ASC']],
+	});
+	const [pubFeatures, communityFeatures] = splitArrayOn(features, (f) => !!f.pub);
+	const sanitizedPubFeatures = pubFeatures.filter(
+		(feature) => feature.pub?.releases?.length! > 0,
+	);
+	const validatedCommunityFeatures = onlyValidItems
+		? communityFeatures.filter((feature) => validateCommunityLandingPageFeature(feature as any))
+		: communityFeatures;
+	return {
+		pub: sanitizedPubFeatures as types.LandingPagePubFeature[],
+		community: validatedCommunityFeatures as (Validated extends true
+			? types.ValidLandingPageCommunityFeature
+			: types.LandingPageCommunityFeature)[],
+	};
+};
+
+type CreateLandingPageFeatureOptions = {
+	pubId?: string;
+	communityId?: string;
+	rank: string;
+};
+
+export const createLandingPageFeature = async (
+	options: CreateLandingPageFeatureOptions,
+): Promise<types.LandingPageFeature> => {
+	const { pubId, communityId, rank } = options;
+	const newFeature = await LandingPageFeature.create({ pubId, communityId, rank });
+	return LandingPageFeature.findOne({
+		where: { id: newFeature.id },
+		include: landingPageFeatureIncludes,
+	});
+};
+
+type UpdateLandingPageFeatureOptions = {
+	id: string;
+	rank?: string;
+	payload?: Record<string, any>;
+};
+
+export const updateLandingPageFeature = async (options: UpdateLandingPageFeatureOptions) => {
+	const { id, rank, payload } = options;
+	await LandingPageFeature.update({ rank, payload }, { where: { id }, limit: 1 });
+};
+
+type destroyLandingPageFeatureOptions = {
+	id: string;
+};
+
+export const destroyLandingPageFeature = async (options: destroyLandingPageFeatureOptions) => {
+	const { id } = options;
+	return LandingPageFeature.destroy({ where: { id }, limit: 1 });
+};

--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -8,13 +8,13 @@ import app from 'server/server';
 import { User } from 'server/models';
 
 type SetPasswordData = { hash: string; salt: string };
-type Step1Result = [types.User, null] | [null, types.User];
-type Step2Result = [types.User, null] | [null, SetPasswordData];
-type Step3Result = [types.User, null] | [null, types.User[][]];
+type Step1Result = [types.UserWithPrivateFields, null] | [null, types.UserWithPrivateFields];
+type Step2Result = [types.UserWithPrivateFields, null] | [null, SetPasswordData];
+type Step3Result = [types.UserWithPrivateFields, null] | [null, types.UserWithPrivateFields[][]];
 
 app.post('/api/login', (req, res, next) => {
-	const authenticate = new Promise<types.User | null>((resolve, reject) => {
-		passport.authenticate('local', (authErr: Error, user: types.User) => {
+	const authenticate = new Promise<types.UserWithPrivateFields | null>((resolve, reject) => {
+		passport.authenticate('local', (authErr: Error, user: types.UserWithPrivateFields) => {
 			if (authErr) {
 				return reject(authErr);
 			}
@@ -29,7 +29,7 @@ app.post('/api/login', (req, res, next) => {
 			}
 
 			/* If authentication did not succeed, we need to check if a legacy hash is valid */
-			const findUser: Promise<types.User | null> = User.findOne({
+			const findUser: Promise<types.UserWithPrivateFields | null> = User.findOne({
 				where: { email: req.body.email },
 			});
 

--- a/server/models.ts
+++ b/server/models.ts
@@ -54,6 +54,7 @@ export const ExternalPublication = sequelize.import('./externalPublication/model
 export const FeatureFlag = sequelize.import('./featureFlag/model');
 export const FeatureFlagUser = sequelize.import('./featureFlagUser/model');
 export const FeatureFlagCommunity = sequelize.import('./featureFlagCommunity/model');
+export const LandingPageFeature = sequelize.import('./landingPageFeature/model');
 export const Member = sequelize.import('./member/model');
 export const Merge = sequelize.import('./merge/model');
 export const Organization = sequelize.import('./organization/model');

--- a/server/passwordReset/queries.ts
+++ b/server/passwordReset/queries.ts
@@ -32,7 +32,7 @@ export const createPasswordReset = (
 	return User.findOne({
 		where: email ? { email } : { id: user.id },
 	})
-		.then((userData: types.User) => {
+		.then((userData: types.UserWithPrivateFields) => {
 			if (!userData) {
 				throw new Error("User doesn't exist");
 			}
@@ -47,7 +47,7 @@ export const createPasswordReset = (
 				individualHooks: true,
 			});
 		})
-		.then((updatedUserData: types.User[][]) => {
+		.then((updatedUserData: types.UserWithPrivateFields[][]) => {
 			const updatedUser = updatedUserData[1][0];
 			return sendPasswordResetEmail({
 				toEmail: updatedUser.email,
@@ -69,7 +69,7 @@ export const updatePasswordReset = (
 	return User.findOne({
 		where: whereQuery,
 	})
-		.then((userData: types.User | null) => {
+		.then((userData: types.UserWithPrivateFields | null) => {
 			if (!userData) {
 				throw new Error("User doesn't exist");
 			}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -40,6 +40,7 @@ require('./login'); // Route: '/login'
 require('./legal'); // Route: '/legal'
 require('./search'); // Route: '/search'
 require('./signup'); // Route: '/signup'
+require('./superAdminDashboard'); // Route: /superadmin
 require('./passwordReset'); // Route: ['/password-reset', '/password-reset/:resetHash/:slug']
 require('./userCreate'); // Route: '/user/create/:hash'
 require('./user'); // Route: ['/user/:slug', '/user/:slug/:mode']

--- a/server/routes/superAdminDashboard.tsx
+++ b/server/routes/superAdminDashboard.tsx
@@ -7,21 +7,10 @@ import { ForbiddenError, handleErrors, NotFoundError } from 'server/utils/errors
 import { getInitialData } from 'server/utils/initData';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
 import { getLandingPageFeatures } from 'server/landingPageFeature/queries';
-import { queryCommunitiesForSpamManagement } from 'server/spamTag/communities';
 
 const getTabProps = async (tabKind: SuperAdminTabKind) => {
 	if (tabKind === 'landingPageFeatures') {
 		return { landingPageFeatures: await getLandingPageFeatures({ onlyValidItems: false }) };
-	}
-	if (tabKind === 'spam') {
-		return {
-			communities: await queryCommunitiesForSpamManagement({
-				status: ['unreviewed'],
-				ordering: { field: 'spam-score', direction: 'DESC' },
-				limit: 50,
-				offset: 0,
-			}),
-		};
 	}
 	return {};
 };
@@ -50,7 +39,6 @@ app.get('/superadmin/:tabKind', async (req, res, next) => {
 				headerComponents={generateMetaComponents({
 					initialData,
 					title: 'SuperAdmin · PubPub',
-					description: "Well aren't you special",
 					unlisted: true,
 				})}
 			/>,

--- a/server/routes/superAdminDashboard.tsx
+++ b/server/routes/superAdminDashboard.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import Html from 'server/Html';
+import app from 'server/server';
+import { superAdminTabKinds, SuperAdminTabKind, getSuperAdminTabUrl } from 'utils/superAdmin';
+import { ForbiddenError, handleErrors, NotFoundError } from 'server/utils/errors';
+import { getInitialData } from 'server/utils/initData';
+import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
+import { getLandingPageFeatures } from 'server/landingPageFeature/queries';
+import { queryCommunitiesForSpamManagement } from 'server/spamTag/communities';
+
+const getTabProps = async (tabKind: SuperAdminTabKind) => {
+	if (tabKind === 'landingPageFeatures') {
+		return { landingPageFeatures: await getLandingPageFeatures({ onlyValidItems: false }) };
+	}
+	if (tabKind === 'spam') {
+		return {
+			communities: await queryCommunitiesForSpamManagement({
+				status: ['unreviewed'],
+				ordering: { field: 'spam-score', direction: 'DESC' },
+				limit: 50,
+				offset: 0,
+			}),
+		};
+	}
+	return {};
+};
+
+app.get('/superadmin', async (_, res) => {
+	const [firstTab] = superAdminTabKinds;
+	return res.redirect(getSuperAdminTabUrl(firstTab));
+});
+
+app.get('/superadmin/:tabKind', async (req, res, next) => {
+	try {
+		const { tabKind } = req.params;
+		if (!superAdminTabKinds.includes(tabKind)) {
+			throw new NotFoundError();
+		}
+		const initialData = await getInitialData(req);
+		if (!initialData.loginData.isSuperAdmin) {
+			throw new ForbiddenError();
+		}
+		return renderToNodeStream(
+			res,
+			<Html
+				chunkName="SuperAdminDashboard"
+				initialData={initialData}
+				viewData={{ tabKind, tabProps: await getTabProps(tabKind) }}
+				headerComponents={generateMetaComponents({
+					initialData,
+					title: 'SuperAdmin · PubPub',
+					description: "Well aren't you special",
+					unlisted: true,
+				})}
+			/>,
+		);
+	} catch (err) {
+		return handleErrors(req, res, next)(err);
+	}
+});

--- a/server/user/__tests__/api.test.ts
+++ b/server/user/__tests__/api.test.ts
@@ -1,0 +1,43 @@
+import { setup, login, modelize } from 'stubstub';
+
+import { User } from 'server/models';
+
+const models = modelize`
+    User user {}
+    Signup signup {
+        email: "tonywalnuts@gmail.com"
+        hash: "hash"
+        completed: false
+        count: 1
+    }
+`;
+
+setup(beforeAll, models.resolve);
+
+describe('/api/users', () => {
+	it('does not allow a user to register as a superadmin', async () => {
+		const { email, hash } = models.signup;
+		const agent = await login();
+		await agent
+			.post('/api/users')
+			.send({
+				email,
+				hash,
+				firstName: 'Tony',
+				lastName: 'Walnuts',
+				password: 'oh!',
+				isSuperAdmin: true,
+			})
+			.expect(201);
+		const createdUser = await User.findOne({ where: { email } });
+		expect(createdUser.isSuperAdmin).toEqual(false);
+	});
+
+	it('does not allow existing users to make themselves a superadmin', async () => {
+		const { user } = models;
+		const agent = await login(user);
+		await agent.put('/api/users').send({ userId: user.id, isSuperAdmin: true }).expect(201);
+		const userNow = await User.findOne({ where: { id: user.id } });
+		expect(userNow.isSuperAdmin).toEqual(false);
+	});
+});

--- a/server/user/model.ts
+++ b/server/user/model.ts
@@ -53,6 +53,7 @@ export default (sequelize, dataTypes) => {
 			hash: { type: dataTypes.TEXT, allowNull: false },
 			salt: { type: dataTypes.TEXT, allowNull: false },
 			gdprConsent: { type: dataTypes.BOOLEAN, defaultValue: null },
+			isSuperAdmin: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
 		},
 		{
 			classMethods: {

--- a/server/user/permissions.ts
+++ b/server/user/permissions.ts
@@ -2,7 +2,7 @@ import { Signup } from 'server/models';
 import { isUserSuperAdmin } from './queries';
 
 export const getPermissions = async ({ userId, submittedUserId, email, hash }) => {
-	const isSuperAdmin = await isUserSuperAdmin(userId);
+	const isSuperAdmin = await isUserSuperAdmin({ userId });
 	const signUpData = await Signup.findOne({
 		where: { hash, email },
 		attributes: ['email', 'hash', 'completed'],
@@ -33,6 +33,7 @@ export const getPermissions = async ({ userId, submittedUserId, email, hash }) =
 	];
 
 	const isAuthenticated = submittedUserId === userId || isSuperAdmin;
+
 	return {
 		create: signUpData,
 		update: isAuthenticated && editProps,

--- a/server/user/permissions.ts
+++ b/server/user/permissions.ts
@@ -1,8 +1,8 @@
 import { Signup } from 'server/models';
-import { checkIfSuperAdmin } from 'server/utils/queryHelpers/scopeGet';
+import { isUserSuperAdmin } from './queries';
 
 export const getPermissions = async ({ userId, submittedUserId, email, hash }) => {
-	const isSuperAdmin = checkIfSuperAdmin(userId);
+	const isSuperAdmin = await isUserSuperAdmin(userId);
 	const signUpData = await Signup.findOne({
 		where: { hash, email },
 		attributes: ['email', 'hash', 'completed'],

--- a/server/user/queries.ts
+++ b/server/user/queries.ts
@@ -1,6 +1,7 @@
 import { Op } from 'sequelize';
 import { promisify } from 'util';
 
+import * as types from 'types';
 import { User, Signup } from 'server/models';
 import { slugifyString } from 'utils/strings';
 import { subscribeUser } from 'server/utils/mailchimp';
@@ -58,43 +59,44 @@ export const createUser = (inputValues) => {
 
 export const updateUser = (inputValues, updatePermissions, req) => {
 	// Filter to only allow certain fields to be updated
-	const filteredValues = {};
+	const filteredValues: Record<string, any> = {};
 	Object.keys(inputValues).forEach((key) => {
 		if (updatePermissions.includes(key)) {
 			filteredValues[key] = inputValues[key];
 		}
 	});
-	// @ts-expect-error ts-migrate(2339) FIXME: Property 'slug' does not exist on type '{}'.
 	if (filteredValues.slug) {
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'slug' does not exist on type '{}'.
 		filteredValues.slug = slugifyString(filteredValues.slug);
 	}
-	// @ts-expect-error ts-migrate(2339) FIXME: Property 'firstName' does not exist on type '{}'.
 	if (filteredValues.firstName) {
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'firstName' does not exist on type '{}'.
 		filteredValues.firstName = filteredValues.firstName.trim();
 	}
-	// @ts-expect-error ts-migrate(2339) FIXME: Property 'lastName' does not exist on type '{}'.
 	if (filteredValues.lastName) {
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'lastName' does not exist on type '{}'.
 		filteredValues.lastName = filteredValues.lastName.trim();
 	}
 
-	// @ts-expect-error ts-migrate(2339) FIXME: Property 'firstName' does not exist on type '{}'.
 	if (filteredValues.firstName && filteredValues.lastName) {
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'fullName' does not exist on type '{}'.
 		filteredValues.fullName = `${filteredValues.firstName} ${filteredValues.lastName}`;
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'initials' does not exist on type '{}'.
 		filteredValues.initials = `${filteredValues.firstName[0]}${filteredValues.lastName[0]}`;
 	}
+
+	// A bit of extra paranoia
+	delete filteredValues.isSuperAdmin;
 
 	return User.update(filteredValues, {
 		where: { id: inputValues.userId },
 	}).then(() => {
-		// @ts-expect-error ts-migrate(2339) FIXME: Property 'fullName' does not exist on type '{}'.
 		if (req.user.fullName !== filteredValues.fullName) {
 			updateUserData(req.user.id);
 		}
 		return filteredValues;
 	});
+};
+
+export const isUserSuperAdmin = async ({ userId }: { userId: undefined | null | string }) => {
+	if (userId) {
+		const user: types.UserWithPrivateFields = await User.findOne({ where: { id: userId } });
+		return user.isSuperAdmin;
+	}
+	return false;
 };

--- a/server/utils/initData.ts
+++ b/server/utils/initData.ts
@@ -46,6 +46,7 @@ export const getInitialData = async (
 		avatar: user.avatar,
 		title: user.title,
 		gdprConsent: user.gdprConsent,
+		isSuperAdmin: user.isSuperAdmin,
 	};
 
 	const shouldForceBasePubPub = !!(isDevelopment() && process.env.FORCE_BASE_PUBPUB);

--- a/server/utils/queryHelpers/scopeGet.ts
+++ b/server/utils/queryHelpers/scopeGet.ts
@@ -14,6 +14,7 @@ import {
 	SubmissionWorkflow,
 } from 'server/models';
 
+import { isUserSuperAdmin } from 'server/user/queries';
 import { FacetsError } from 'facets';
 import { fetchFacetsForScope } from 'server/facets';
 import { ensureSerialized, stripFalsyIdsFromQuery } from './util';
@@ -308,11 +309,6 @@ getScopeMemberData = async (scopeInputs, scopeElements) => {
 	});
 };
 
-export const checkIfSuperAdmin = (userId) => {
-	const adminIds = ['b242f616-7aaa-479c-8ee5-3933dcf70859'];
-	return adminIds.includes(userId);
-};
-
 getActivePermissions = async (
 	scopeInputs,
 	scopeElements,
@@ -320,7 +316,7 @@ getActivePermissions = async (
 	scopeMemberData,
 ) => {
 	const { activePub, activeCollection, activeCommunity, inactiveCollections } = scopeElements;
-	const isSuperAdmin = checkIfSuperAdmin(scopeInputs.loginId);
+	const isSuperAdmin = await isUserSuperAdmin({ userId: scopeInputs.loginId });
 	const permissionLevels: MemberPermission[] = ['view', 'edit', 'manage', 'admin'];
 	let defaultPermissionIndex = -1;
 	[activePub, activeCollection, activeCommunity, ...inactiveCollections]

--- a/stubstub/modelize/builders.js
+++ b/stubstub/modelize/builders.js
@@ -32,6 +32,7 @@ builders.User = async (args = {}) => {
 		initials = firstName.slice(0, 1).toUpperCase() + lastName.slice(0, 1).toUpperCase(),
 		password = 'password123',
 		id,
+		isSuperAdmin,
 	} = args;
 	const sha3hashedPassword = SHA3(password).toString(encHex);
 	return new Promise((resolve, reject) =>
@@ -44,6 +45,7 @@ builders.User = async (args = {}) => {
 				email,
 				slug,
 				initials,
+				isSuperAdmin,
 				passwordDigest: 'sha512',
 			},
 			sha3hashedPassword,

--- a/tools/migrations/2022_08_23_addIsSuperAdmin.js
+++ b/tools/migrations/2022_08_23_addIsSuperAdmin.js
@@ -1,0 +1,11 @@
+export const up = async ({ Sequelize, sequelize }) => {
+	await sequelize.queryInterface.addColumn('Users', 'isSuperAdmin', {
+		type: Sequelize.BOOLEAN,
+		allowNull: false,
+		defaultValue: false,
+	});
+};
+
+export const down = async ({ sequelize }) => {
+	await sequelize.queryInterface.removeColumn('Users', 'isSuperAdmin');
+};

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,6 +9,7 @@ export * from './discussion';
 export * from './doc';
 export * from './facets';
 export * from './featureFlag';
+export * from './landingPageFeature';
 export * from './json';
 export * from './license';
 export * from './member';

--- a/types/landingPageFeature.ts
+++ b/types/landingPageFeature.ts
@@ -1,0 +1,41 @@
+import { Community, DefinitelyHas, DocJson, Pub } from 'types';
+
+export type LandingPageFeature = {
+	id: string;
+	communityId: null | string;
+	pubId: null | string;
+	rank: string;
+	createdAt: string;
+	updatedAt: string;
+	pub?: null | DefinitelyHas<Pub, 'attributions' | 'collectionPubs' | 'community' | 'releases'>;
+	community?: null | Community;
+	payload: null | Record<string, any>;
+};
+
+export type LandingPageFeatureKind = 'pub' | 'community';
+
+export type LandingPagePubFeature = DefinitelyHas<LandingPageFeature, 'pub'>;
+
+export type LandingPageCommunityFeature = DefinitelyHas<LandingPageFeature, 'community'>;
+
+export type ValidLandingPageCommunityFeature = LandingPageCommunityFeature & {
+	payload: {
+		imageUrl: string;
+		quote: DocJson;
+		highlights: DocJson;
+		backgroundColor?: string | undefined;
+	};
+};
+
+export type LandingPageFeatureOfKind<Kind extends LandingPageFeatureKind> = Kind extends 'pub'
+	? LandingPagePubFeature
+	: Kind extends 'community'
+	? LandingPageCommunityFeature
+	: never;
+
+export type LandingPageFeatures<Validated extends boolean = true> = {
+	pub: LandingPagePubFeature[];
+	community: (Validated extends true
+		? ValidLandingPageCommunityFeature
+		: LandingPageCommunityFeature)[];
+};

--- a/types/request.ts
+++ b/types/request.ts
@@ -21,6 +21,7 @@ export type LoginData = {
 	avatar?: string;
 	title?: string;
 	gdprConsent?: string;
+	isSuperAdmin: boolean;
 };
 
 export type LocationData = {

--- a/types/user.ts
+++ b/types/user.ts
@@ -21,6 +21,10 @@ export type User = MinimalUser & {
 	twitter: string;
 	github: string;
 	googleScholar: string;
+};
+
+export type UserWithPrivateFields = User & {
+	isSuperAdmin: boolean;
 	passwordDigest: string;
 	hash: string;
 	salt: string;

--- a/utils/landingPage/validate.ts
+++ b/utils/landingPage/validate.ts
@@ -1,0 +1,28 @@
+import { LandingPageCommunityFeature, ValidLandingPageCommunityFeature } from 'types';
+import {
+	isAlwaysValid,
+	isNonEmptyDocJson,
+	isNonEmptyString,
+	isTruthyAnd,
+	RecordValidator,
+	validate,
+} from 'utils/validate';
+
+const communityFeaturePayloadValidator: RecordValidator<
+	ValidLandingPageCommunityFeature['payload']
+> = {
+	imageUrl: isNonEmptyString,
+	quote: isTruthyAnd(isNonEmptyDocJson),
+	highlights: isTruthyAnd(isNonEmptyDocJson),
+	backgroundColor: isAlwaysValid,
+};
+
+export const validateCommunityLandingPageFeature = (
+	feature: LandingPageCommunityFeature,
+): null | LandingPageCommunityFeature => {
+	const { payload } = feature;
+	if (payload && validate(payload, communityFeaturePayloadValidator, true).isValidated) {
+		return feature as LandingPageCommunityFeature;
+	}
+	return null;
+};

--- a/utils/superAdmin.ts
+++ b/utils/superAdmin.ts
@@ -1,0 +1,7 @@
+export const superAdminTabKinds = ['landingPageFeatures', 'spam'] as const;
+
+export const getSuperAdminTabUrl = (tabKind: SuperAdminTabKind) => {
+	return `/superadmin/${tabKind}` as const;
+};
+
+export type SuperAdminTabKind = typeof superAdminTabKinds[number];

--- a/utils/superAdmin.ts
+++ b/utils/superAdmin.ts
@@ -1,4 +1,4 @@
-export const superAdminTabKinds = ['landingPageFeatures', 'spam'] as const;
+export const superAdminTabKinds = ['landingPageFeatures'] as const;
 
 export const getSuperAdminTabUrl = (tabKind: SuperAdminTabKind) => {
 	return `/superadmin/${tabKind}` as const;

--- a/utils/validate.ts
+++ b/utils/validate.ts
@@ -17,7 +17,7 @@ export type ValidationResult<Rec extends AnyRecord> = {
 	validatedFields: ValidatedFields<Rec>;
 };
 
-export const isNonEmptyString = (str: string) => str.length > 0;
+export const isNonEmptyString = (str: string) => typeof str === 'string' && str.length > 0;
 
 export const isNonEmptyDocJson = (docJson: DocJson) => {
 	return !isEmptyDoc(docJson);
@@ -43,6 +43,7 @@ export const isValidEmailList = (emailList: string[]) =>
 export const validate = <Rec extends AnyRecord>(
 	rec: Rec,
 	validator: RecordValidator<Rec>,
+	requireFullRecord = false,
 ): ValidationResult<Rec> => {
 	const validatedFields = Object.entries(rec).reduce(
 		(partial: Partial<ValidatedFields<Rec>>, [key, value]) => {
@@ -57,8 +58,11 @@ export const validate = <Rec extends AnyRecord>(
 		},
 		{},
 	) as ValidatedFields<Rec>;
+	const isValidated = requireFullRecord
+		? Object.keys(validator).every((key) => validatedFields[key])
+		: !Object.values(validatedFields).some((val) => !val);
 	return {
 		validatedFields,
-		isValidated: !Object.values(validatedFields).some((val) => !val),
+		isValidated,
 	};
 };


### PR DESCRIPTION
This PR adds some new stuff that came out of the landing page refresh effort. I'm pulling it out of the `landing-page-refresh` branch to get a clean diff for the spam-fighting work.

- The concept of "superadmin users" (that will be all of us!)
- A new superadmin dashboard for us to manage PubPub-wide things
- The first tab of said dashboard, which exists to manage the Pubs and Communities that we feature on the landing page.

![image](https://user-images.githubusercontent.com/2208769/205152922-dfad9f2f-70bc-48ee-bf60-da1df9396f6a.png)

_Test plan:_

- Run the unit tests for managing landing page features: `npm run test-dev server/landingPageFeature`
- Make your account a superadmin in the dev database and check that you can use it to administrate any community
- Check that as a superadmin (and only then) you can visit `/superadmin/landingPageFeatures`
- Use this page to add/remove/manipulate featured items