### PR TITLE
feature: Hide spam Communities from the world

### DIFF
--- a/client/containers/App/App.tsx
+++ b/client/containers/App/App.tsx
@@ -18,6 +18,7 @@ import { hydrateWrapper } from 'client/utils/hydrateWrapper';
 import SideMenu from './SideMenu';
 import Breadcrumbs from './Breadcrumbs';
 import BottomMenu from './BottomMenu';
+import SpamBanner from './SpamBanner';
 
 import getPaths from './paths';
 import { usePageState } from './usePageState';
@@ -55,6 +56,7 @@ const App = (props: Props) => {
 			>
 				<RKProvider>
 					<div id="app" className={classNames({ dashboard: isDashboard })}>
+						{communityData.spamTag?.status === 'confirmed-spam' && <SpamBanner />}
 						<AccentStyle communityData={communityData} isNavHidden={!showNav} />
 						{(locationData.isDuqDuq || locationData.isQubQub) && (
 							<div className="duqduq-warning">Development Environment</div>

--- a/client/containers/App/SpamBanner.tsx
+++ b/client/containers/App/SpamBanner.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { Icon } from 'components';
+
+require('./spamBanner.scss');
+
+const SpamBanner = () => {
+	return (
+		<div className="spam-banner-component">
+			<Icon icon="error" iconSize={16} />
+			<div className="text">
+				We have determined that your Community violates PubPub's{' '}
+				<a href="/legal/terms">Terms of Service</a>, and it is now hidden from visitors. If
+				you believe this judgement was made in error, please{' '}
+				<a href="mailto:help@pubpub.org">contact us</a>.
+			</div>
+		</div>
+	);
+};
+
+export default SpamBanner;

--- a/client/containers/App/spamBanner.scss
+++ b/client/containers/App/spamBanner.scss
@@ -1,0 +1,19 @@
+.spam-banner-component {
+    position: fixed;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    background: sienna;
+    color: white;
+    padding: 20px;
+    width: 100%;
+    z-index: 100;
+
+    a {
+        color: white;
+    }
+
+    > .text {
+        margin-left: 10px;
+    }
+}

--- a/server/member/queries.ts
+++ b/server/member/queries.ts
@@ -96,3 +96,17 @@ export const getMembersForScope = async (
 	}
 	return Member.findAll({ where: { communityId: scope.communityId } });
 };
+
+type IsUserMemberOfScopeOptions = {
+	userId: null | string;
+	scope: types.ScopeId;
+};
+
+export const isUserMemberOfScope = async (options: IsUserMemberOfScopeOptions) => {
+	const { userId, scope } = options;
+	if (!userId) {
+		return false;
+	}
+	const membersOfScope = await getMembersForScope(scope);
+	return membersOfScope.some((member) => member.userId === userId);
+};

--- a/server/utils/errors.ts
+++ b/server/utils/errors.ts
@@ -4,6 +4,7 @@ import { ForbiddenSlugStatus } from 'types';
 
 export enum PubPubApplicationError {
 	ForbiddenSlug = 'forbidden-slug',
+	CommunityIsSpam = 'community-is-spam',
 }
 
 class PubPubBaseError extends Error {
@@ -24,6 +25,11 @@ export const PubPubError = {
 			super(PubPubApplicationError.ForbiddenSlug, 'Forbidden slug');
 			this.desiredSlug = desiredSlug;
 			this.slugStatus = slugStatus;
+		}
+	},
+	CommunityIsSpamError: class extends PubPubBaseError {
+		constructor() {
+			super(PubPubApplicationError.CommunityIsSpam, 'Community is spam');
 		}
 	},
 };
@@ -61,7 +67,10 @@ export class NotFoundError extends HTTPStatusError {
 
 export const handleErrors = (req, res, next) => {
 	return (err) => {
-		if (err.message === 'Community Not Found') {
+		if (
+			err.message === 'Community Not Found' ||
+			err instanceof PubPubError.CommunityIsSpamError
+		) {
 			return res
 				.status(404)
 				.sendFile(resolve(__dirname, '../errorPages/communityNotFound.html'));

--- a/server/utils/queryHelpers/communityGet.ts
+++ b/server/utils/queryHelpers/communityGet.ts
@@ -1,4 +1,4 @@
-import { Collection, Community, Page, Member, ScopeSummary } from 'server/models';
+import { Collection, Community, Page, Member, ScopeSummary, SpamTag } from 'server/models';
 import { Community as CommunityType, DefinitelyHas } from 'types';
 
 export default (
@@ -30,6 +30,10 @@ export default (
 			{
 				model: ScopeSummary,
 				as: 'scopeSummary',
+			},
+			{
+				model: SpamTag,
+				as: 'spamTag',
 			},
 		],
 	}).then((communityResult) => {


### PR DESCRIPTION
This resolves #2374 and is the final piece of our spam-fighting work. With this PR, A Community that has been marked spam will now fail to load for anyone who is not logged in as one of its Members. Those Members will see a banner that explains the situation:

<img width="1904" alt="image" src="https://user-images.githubusercontent.com/2208769/205713095-1733b0a3-49d6-49ed-a12d-72ade30e3dc0.png">

Test plan:
- Visit `/superadmin/spam` and ban the `demo` Community
- Visit your devserver while logged out and verify that you cannot see it
- Visit your devserver while logged in and verify that you can see it (along with the new banner)