### PR TITLE
enhancement: Comment Share URL and Routing

### DIFF
--- a/client/components/PubShareDialog/PubShareDialog.tsx
+++ b/client/components/PubShareDialog/PubShareDialog.tsx
@@ -63,10 +63,7 @@ const AccessHashOptions = (props: SharedProps) => {
 
 	const createAccessUrl = (accessHash: string | undefined, options?: UrlOptions) =>
 		pubUrl(communityData, pubData, { accessHash, ...options });
-	const reviewAccessUrl = createAccessUrl(reviewHash, {
-		historyKey: historyData.currentKey,
-		isReview: true,
-	});
+
 	return (
 		<div className="access-hash-options">
 			<p>
@@ -75,10 +72,25 @@ const AccessHashOptions = (props: SharedProps) => {
 			</p>
 			{viewHash && renderCopyLabelComponent('View', createAccessUrl(viewHash, { isDraft }))}
 			{featureFlags.comments &&
+				renderCopyLabelComponent(
+					'Draft Comment',
+					createAccessUrl(commentHash, {
+						historyKey: historyData.currentKey,
+						isDraft: true,
+					}),
+				)}
+			{featureFlags.comments &&
 				pubData.releases.length > 0 &&
 				renderCopyLabelComponent('Release Comment', createAccessUrl(commentHash))}
 			{editHash && renderCopyLabelComponent('Edit', createAccessUrl(editHash, { isDraft }))}
-			{featureFlags.reviews && renderCopyLabelComponent('Review', reviewAccessUrl)}
+			{featureFlags.reviews &&
+				renderCopyLabelComponent(
+					'Draft Feedback',
+					createAccessUrl(reviewHash, { isDraft }),
+				)}
+			{featureFlags.comments &&
+				pubData.releases.length > 0 &&
+				renderCopyLabelComponent('Release Feedback', createAccessUrl(reviewHash))}
 		</div>
 	);
 };

--- a/client/components/PubShareDialog/PubShareDialog.tsx
+++ b/client/components/PubShareDialog/PubShareDialog.tsx
@@ -88,7 +88,7 @@ const AccessHashOptions = (props: SharedProps) => {
 					'Draft Feedback',
 					createAccessUrl(reviewHash, { isDraft }),
 				)}
-			{featureFlags.comments &&
+			{featureFlags.reviews &&
 				pubData.releases.length > 0 &&
 				renderCopyLabelComponent('Release Feedback', createAccessUrl(reviewHash))}
 		</div>

--- a/client/components/PubShareDialog/PubShareDialog.tsx
+++ b/client/components/PubShareDialog/PubShareDialog.tsx
@@ -26,7 +26,7 @@ type PubShareDialogProps = SharedProps & {
 	onClose: (...args: any[]) => any;
 };
 
-type UrlOption = {
+type UrlOptions = {
 	isDraft?: boolean;
 	historyKey?: number;
 	isReview?: boolean;
@@ -61,7 +61,7 @@ const AccessHashOptions = (props: SharedProps) => {
 	};
 	const isDraft = !isRelease;
 
-	const createAccessUrl = (accessHash: string | undefined, options?: UrlOption) =>
+	const createAccessUrl = (accessHash: string | undefined, options?: UrlOptions) =>
 		pubUrl(communityData, pubData, { accessHash, ...options });
 	const reviewAccessUrl = createAccessUrl(reviewHash, {
 		historyKey: historyData.currentKey,

--- a/client/components/PubShareDialog/PubShareDialog.tsx
+++ b/client/components/PubShareDialog/PubShareDialog.tsx
@@ -31,7 +31,7 @@ type UrlOptions = {
 	historyKey?: number;
 	isReview?: boolean;
 };
-
+console.log('will a psuh work since gh is down');
 const getHelperText = (activeTargetName, activeTargetType, canModifyMembers) => {
 	if (canModifyMembers) {
 		const containingPubsString =

--- a/client/components/PubShareDialog/PubShareDialog.tsx
+++ b/client/components/PubShareDialog/PubShareDialog.tsx
@@ -26,6 +26,12 @@ type PubShareDialogProps = SharedProps & {
 	onClose: (...args: any[]) => any;
 };
 
+type UrlOption = {
+	isDraft?: boolean;
+	historyKey?: number;
+	isReview?: boolean;
+};
+
 const getHelperText = (activeTargetName, activeTargetType, canModifyMembers) => {
 	if (canModifyMembers) {
 		const containingPubsString =
@@ -42,7 +48,7 @@ const AccessHashOptions = (props: SharedProps) => {
 	const { pubData } = props;
 	const { communityData, featureFlags } = usePageContext();
 	const { historyData } = usePubContext();
-	const { commentHash, reviewHash, viewHash, editHash, releases, isRelease } = pubData;
+	const { commentHash, reviewHash, viewHash, editHash, isRelease } = pubData;
 	const renderCopyLabelComponent = (label, url) => {
 		return (
 			<ControlGroup className="hash-row">
@@ -54,13 +60,13 @@ const AccessHashOptions = (props: SharedProps) => {
 		);
 	};
 	const isDraft = !isRelease;
-	const createAccessUrl = (accessHash, options) =>
+
+	const createAccessUrl = (accessHash: string | undefined, options?: UrlOption) =>
 		pubUrl(communityData, pubData, { accessHash, ...options });
 	const reviewAccessUrl = createAccessUrl(reviewHash, {
 		historyKey: historyData.currentKey,
 		isReview: true,
 	});
-	const releaseCount = releases ? releases.length : 0;
 	return (
 		<div className="access-hash-options">
 			<p>
@@ -69,19 +75,8 @@ const AccessHashOptions = (props: SharedProps) => {
 			</p>
 			{viewHash && renderCopyLabelComponent('View', createAccessUrl(viewHash, { isDraft }))}
 			{featureFlags.comments &&
-				renderCopyLabelComponent(
-					'Draft Comment',
-					createAccessUrl(commentHash, {
-						isComment: true,
-						historyKey: historyData.currentKey,
-					}),
-				)}
-			{featureFlags.comments &&
 				pubData.releases.length > 0 &&
-				renderCopyLabelComponent(
-					'Release Comment',
-					createAccessUrl(commentHash, { isComment: true, releaseNumber: releaseCount }),
-				)}
+				renderCopyLabelComponent('Release Comment', createAccessUrl(commentHash))}
 			{editHash && renderCopyLabelComponent('Edit', createAccessUrl(editHash, { isDraft }))}
 			{featureFlags.reviews && renderCopyLabelComponent('Review', reviewAccessUrl)}
 		</div>

--- a/client/components/PubShareDialog/PubShareDialog.tsx
+++ b/client/components/PubShareDialog/PubShareDialog.tsx
@@ -31,7 +31,7 @@ type UrlOptions = {
 	historyKey?: number;
 	isReview?: boolean;
 };
-console.log('will a psuh work since gh is down');
+
 const getHelperText = (activeTargetName, activeTargetType, canModifyMembers) => {
 	if (canModifyMembers) {
 		const containingPubsString =

--- a/server/routes/pubDocument.tsx
+++ b/server/routes/pubDocument.tsx
@@ -148,9 +148,9 @@ app.get('/pub/:pubSlug/release/:releaseNumber', speedLimiter, async (req, res, n
 	}
 	try {
 		const { releaseNumber: releaseNumberString, pubSlug } = req.params;
-		const { access } = req.query;
-		console.log(access);
+
 		const initialData = await getInitialDataForPub(req);
+		console.log(initialData.locationData.query);
 		const customScripts = await getCustomScriptsForCommunity(initialData.communityData.id);
 		const releaseNumber = parseInt(releaseNumberString, 10);
 		if (Number.isNaN(releaseNumber) || releaseNumber < 1) {

--- a/server/routes/pubDocument.tsx
+++ b/server/routes/pubDocument.tsx
@@ -7,7 +7,7 @@ import { pubUrl } from 'utils/canonicalUrls';
 import { getPdfDownloadUrl, getTextAbstract, getGoogleScholarNotes } from 'utils/pub/metadata';
 import { chooseCollectionForPub } from 'client/utils/collections';
 import Html from 'server/Html';
-import app, { wrap } from 'server/server';
+import app from 'server/server';
 import { handleErrors, NotFoundError, ForbiddenError } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { getCustomScriptsForCommunity } from 'server/customScript/queries';

--- a/server/routes/pubDocument.tsx
+++ b/server/routes/pubDocument.tsx
@@ -148,6 +148,8 @@ app.get('/pub/:pubSlug/release/:releaseNumber', speedLimiter, async (req, res, n
 	}
 	try {
 		const { releaseNumber: releaseNumberString, pubSlug } = req.params;
+		const { access } = req.query;
+		console.log(access);
 		const initialData = await getInitialDataForPub(req);
 		const customScripts = await getCustomScriptsForCommunity(initialData.communityData.id);
 		const releaseNumber = parseInt(releaseNumberString, 10);
@@ -278,62 +280,5 @@ app.get(
 		}));
 		const customScripts = await getCustomScriptsForCommunity(initialData.communityData.id);
 		return renderPubDocument(res, pubData, initialData, customScripts);
-	}),
-);
-
-app.get(
-	['/pub/:pubSlug/comment/:historyKey/'],
-	wrap(async (req, res, next) => {
-		if (!hostIsValid(req, 'community')) {
-			return next();
-		}
-
-		const initialData = await getInitialDataForPub(req);
-		const { historyKey: historyKeyString, pubSlug } = req.params;
-		const { canView } = initialData.scopeData.activePermissions;
-		const { hasHistoryKey, historyKey } = checkHistoryKey(historyKeyString);
-		const customScripts = await getCustomScriptsForCommunity(initialData.communityData.id);
-
-		if (!canView) {
-			throw new NotFoundError();
-		}
-
-		const pubData = await getEnrichedPubData({
-			pubSlug,
-			initialData,
-			historyKey: hasHistoryKey ? historyKey : null,
-			isAVisitingCommenter: true,
-		});
-
-		return renderPubDocument(res, pubData, initialData, customScripts);
-	}),
-);
-
-app.get(
-	['/pub/:pubSlug/comment/release/:releaseNumber'],
-	wrap(async (req, res, next) => {
-		if (!hostIsValid(req, 'community')) {
-			return next();
-		}
-		try {
-			const { releaseNumber: releaseNumberString, pubSlug } = req.params;
-			const initialData = await getInitialDataForPub(req);
-			const customScripts = await getCustomScriptsForCommunity(initialData.communityData.id);
-			const releaseNumber = parseInt(releaseNumberString, 10);
-			if (Number.isNaN(releaseNumber) || releaseNumber < 1) {
-				throw new NotFoundError();
-			}
-
-			const pubData = await getEnrichedPubData({
-				pubSlug,
-				releaseNumber,
-				initialData,
-				isAVisitingCommenter: true,
-			});
-
-			return renderPubDocument(res, pubData, initialData, customScripts);
-		} catch (err) {
-			return handleErrors(req, res, next)(err);
-		}
 	}),
 );

--- a/server/utils/queryHelpers/pubGet.ts
+++ b/server/utils/queryHelpers/pubGet.ts
@@ -58,14 +58,8 @@ type GetPubForRequestOptions = PubGetOptions & {
 };
 
 export const getPubForRequest = async (options: GetPubForRequestOptions) => {
-	const {
-		slug,
-		initialData,
-		releaseNumber = null,
-		isAVisitingCommenter,
-		...pubGetOptions
-	} = options;
+	const { slug, initialData, releaseNumber = null, ...pubGetOptions } = options;
 	const communityId = initialData.communityData.id;
 	const pubData = await getPub({ slug, communityId }, pubGetOptions);
-	return sanitizePub(pubData, initialData, releaseNumber, isAVisitingCommenter);
+	return sanitizePub(pubData, initialData, releaseNumber);
 };

--- a/server/utils/queryHelpers/pubSanitize.ts
+++ b/server/utils/queryHelpers/pubSanitize.ts
@@ -36,7 +36,6 @@ export default (
 	pubData,
 	initialData,
 	releaseNumber: number | null = null,
-	isAVisitingCommenter: boolean = false,
 ): null | SanitizedPubData => {
 	const { loginData, scopeData } = initialData;
 	const { activePermissions } = scopeData;
@@ -108,7 +107,6 @@ export default (
 		exports: getFilteredExports(pubData, isRelease),
 		collectionPubs: filteredCollectionPubs,
 		isRelease,
-		isAVisitingCommenter,
 		releases: sortedReleases,
 		releaseNumber,
 	};

--- a/types/pub.ts
+++ b/types/pub.ts
@@ -170,7 +170,6 @@ export type SanitizedPubData = Pub & {
 	discussions: Discussion[];
 	collectionPubs: CollectionPubWithAttributions[];
 	isRelease: boolean;
-	isAVisitingCommenter: boolean;
 	releases: Release[];
 	releaseNumber: number | null;
 };

--- a/utils/canonicalUrls.js
+++ b/utils/canonicalUrls.js
@@ -42,29 +42,10 @@ export const pubUrl = (community, pub, options = {}) => {
 		download,
 		hash,
 		isReview,
-		isComment,
 	} = options;
 
 	if (isReview && historyKey && accessHash) {
 		baseUrl = `${baseUrl}/review/${historyKey}`;
-		const url = queryString.stringifyUrl(
-			{ url: baseUrl, query: { access: accessHash, ...query } },
-			{ skipNull: true },
-		);
-		return url;
-	}
-
-	if (isComment && accessHash && historyKey) {
-		baseUrl = `${baseUrl}/comment/${historyKey}`;
-		const url = queryString.stringifyUrl(
-			{ url: baseUrl, query: { access: accessHash, ...query } },
-			{ skipNull: true },
-		);
-		return url;
-	}
-
-	if (isComment && accessHash && releaseNumber) {
-		baseUrl = `${baseUrl}/comment/release/${releaseNumber}`;
 		const url = queryString.stringifyUrl(
 			{ url: baseUrl, query: { access: accessHash, ...query } },
 			{ skipNull: true },

--- a/utils/canonicalUrls.js
+++ b/utils/canonicalUrls.js
@@ -41,17 +41,7 @@ export const pubUrl = (community, pub, options = {}) => {
 		query,
 		download,
 		hash,
-		isReview,
 	} = options;
-
-	if (isReview && historyKey && accessHash) {
-		baseUrl = `${baseUrl}/review/${historyKey}`;
-		const url = queryString.stringifyUrl(
-			{ url: baseUrl, query: { access: accessHash, ...query } },
-			{ skipNull: true },
-		);
-		return url;
-	}
 
 	if (download) {
 		const downloadType = typeof download === 'string' ? `/${download}` : '';


### PR DESCRIPTION
adressess #2357 #2363 


This removes duplicate routes and provides a generic share link for commenters. 


test plan:

Release a pub.
Go to a draft pub. Grab the review comment link
make sure the link is in the form `/pub/<slug>?access=<commentHash>`

navigate to the route.

as both a logged-in and logged-out user make comments.