### PR TITLE
Adds Tooltips to Components

### DIFF
--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -8,6 +8,7 @@ import { getPrimaryCollectionPub } from 'utils/collections/primary';
 import { sortByRank } from 'utils/rank';
 import { Collection, Pub } from 'types';
 import { pubPubIcons } from 'client/utils/icons';
+import { Tooltip } from '@blueprintjs/core';
 
 require('./scopeDropdown.scss');
 
@@ -178,7 +179,9 @@ const ScopeDropdown = (props: Props) => {
 												mode: 'settings',
 											})}
 										>
-											<Icon icon={pubPubIcons.settings} iconSize={12} />
+											<Tooltip content="View settings">
+												<Icon icon={pubPubIcons.settings} iconSize={12} />
+											</Tooltip>
 										</a>
 										<a
 											href={getDashUrl({
@@ -188,7 +191,9 @@ const ScopeDropdown = (props: Props) => {
 												mode: 'members',
 											})}
 										>
-											<Icon icon={pubPubIcons.member} iconSize={12} />
+											<Tooltip content="View members">
+												<Icon icon={pubPubIcons.member} iconSize={12} />
+											</Tooltip>
 										</a>
 										<a
 											href={getDashUrl({
@@ -198,7 +203,9 @@ const ScopeDropdown = (props: Props) => {
 												mode: 'impact',
 											})}
 										>
-											<Icon icon={pubPubIcons.impact} iconSize={12} />
+											<Tooltip content="View impact">
+												<Icon icon={pubPubIcons.impact} iconSize={12} />
+											</Tooltip>
 										</a>
 										{scope.type === 'Collection' && (
 											<a
@@ -209,7 +216,9 @@ const ScopeDropdown = (props: Props) => {
 													mode: 'layout',
 												})}
 											>
-												<Icon icon={pubPubIcons.layout} iconSize={12} />
+												<Tooltip content="Visit collection">
+													<Icon icon={pubPubIcons.layout} iconSize={12} />
+												</Tooltip>
 											</a>
 										)}
 										<a
@@ -220,7 +229,9 @@ const ScopeDropdown = (props: Props) => {
 												''
 											}`}
 										>
-											<Icon icon="globe" iconSize={12} />
+											<Tooltip content={`${scope.title} landing page`}>
+												<Icon icon="globe" iconSize={12} />
+											</Tooltip>
 										</a>
 									</div>
 								)}
@@ -231,7 +242,9 @@ const ScopeDropdown = (props: Props) => {
 												(scope.slugs && scope.slugs.pageSlug) || '/'
 											}`}
 										>
-											<Icon icon="globe" iconSize={12} />
+											<Tooltip content={`${scope.title} landing page`}>
+												<Icon icon="globe" iconSize={12} />
+											</Tooltip>
 										</a>
 									</div>
 								)}

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -179,7 +179,7 @@ const ScopeDropdown = (props: Props) => {
 												mode: 'settings',
 											})}
 										>
-											<Tooltip content="View settings">
+											<Tooltip content="Settings">
 												<Icon icon={pubPubIcons.settings} iconSize={12} />
 											</Tooltip>
 										</a>
@@ -191,7 +191,7 @@ const ScopeDropdown = (props: Props) => {
 												mode: 'members',
 											})}
 										>
-											<Tooltip content="View members">
+											<Tooltip content="Members">
 												<Icon icon={pubPubIcons.member} iconSize={12} />
 											</Tooltip>
 										</a>
@@ -203,7 +203,7 @@ const ScopeDropdown = (props: Props) => {
 												mode: 'impact',
 											})}
 										>
-											<Tooltip content="View impact">
+											<Tooltip content="Impact">
 												<Icon icon={pubPubIcons.impact} iconSize={12} />
 											</Tooltip>
 										</a>
@@ -216,7 +216,7 @@ const ScopeDropdown = (props: Props) => {
 													mode: 'layout',
 												})}
 											>
-												<Tooltip content="Visit collection">
+												<Tooltip content="Layout">
 													<Icon icon={pubPubIcons.layout} iconSize={12} />
 												</Tooltip>
 											</a>
@@ -229,7 +229,7 @@ const ScopeDropdown = (props: Props) => {
 												''
 											}`}
 										>
-											<Tooltip content={`${scope.title} landing page`}>
+											<Tooltip content="Home">
 												<Icon icon="globe" iconSize={12} />
 											</Tooltip>
 										</a>
@@ -242,7 +242,7 @@ const ScopeDropdown = (props: Props) => {
 												(scope.slugs && scope.slugs.pageSlug) || '/'
 											}`}
 										>
-											<Tooltip content={`${scope.title} landing page`}>
+											<Tooltip content="Home">
 												<Icon icon="globe" iconSize={12} />
 											</Tooltip>
 										</a>

--- a/client/components/ScopeDropdown/ScopeDropdown.tsx
+++ b/client/components/ScopeDropdown/ScopeDropdown.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import classNames from 'classnames';
 
-import { getDashUrl } from 'utils/dashboard';
+import { getDashUrl, DashboardMode } from 'utils/dashboard';
 import { usePageContext } from 'utils/hooks';
 import { Avatar, Icon, IconName, MenuItem } from 'components';
 import { getPrimaryCollectionPub } from 'utils/collections/primary';
@@ -144,6 +144,22 @@ const ScopeDropdown = (props: Props) => {
 		});
 	}
 
+	const renderDropddownButton = function (scope: Scope, mode: DashboardMode, icon: IconName) {
+		return (
+			<a
+				href={getDashUrl({
+					collectionSlug: scope.slugs && scope.slugs.collectionSlug,
+					pubSlug: scope.slugs && scope.slugs.pubSlug,
+					mode,
+				})}
+			>
+				<Tooltip content={mode.charAt(0).toUpperCase() + mode.slice(1)}>
+					<Icon icon={icon} iconSize={12} />
+				</Tooltip>
+			</a>
+		);
+	};
+
 	return (
 		<div className={classNames('scope-dropdown-component', isDashboard && 'in-dashboard')}>
 			{isDashboard && <div className="intro">Select Scope:</div>}
@@ -171,56 +187,23 @@ const ScopeDropdown = (props: Props) => {
 								</div>
 								{scope.showSettings && scope.type !== 'Page' && (
 									<div className="settings">
-										<a
-											href={getDashUrl({
-												collectionSlug:
-													scope.slugs && scope.slugs.collectionSlug,
-												pubSlug: scope.slugs && scope.slugs.pubSlug,
-												mode: 'settings',
-											})}
-										>
-											<Tooltip content="Settings">
-												<Icon icon={pubPubIcons.settings} iconSize={12} />
-											</Tooltip>
-										</a>
-										<a
-											href={getDashUrl({
-												collectionSlug:
-													scope.slugs && scope.slugs.collectionSlug,
-												pubSlug: scope.slugs && scope.slugs.pubSlug,
-												mode: 'members',
-											})}
-										>
-											<Tooltip content="Members">
-												<Icon icon={pubPubIcons.member} iconSize={12} />
-											</Tooltip>
-										</a>
-										<a
-											href={getDashUrl({
-												collectionSlug:
-													scope.slugs && scope.slugs.collectionSlug,
-												pubSlug: scope.slugs && scope.slugs.pubSlug,
-												mode: 'impact',
-											})}
-										>
-											<Tooltip content="Impact">
-												<Icon icon={pubPubIcons.impact} iconSize={12} />
-											</Tooltip>
-										</a>
-										{scope.type === 'Collection' && (
-											<a
-												href={getDashUrl({
-													collectionSlug:
-														scope.slugs && scope.slugs.collectionSlug,
-													pubSlug: scope.slugs && scope.slugs.pubSlug,
-													mode: 'layout',
-												})}
-											>
-												<Tooltip content="Layout">
-													<Icon icon={pubPubIcons.layout} iconSize={12} />
-												</Tooltip>
-											</a>
+										{renderDropddownButton(
+											scope,
+											'settings',
+											pubPubIcons.settings,
 										)}
+										{renderDropddownButton(
+											scope,
+											'members',
+											pubPubIcons.member,
+										)}
+										{renderDropddownButton(scope, 'impact', pubPubIcons.impact)}
+										{scope.type === 'Collection' &&
+											renderDropddownButton(
+												scope,
+												'layout',
+												pubPubIcons.layout,
+											)}
 										<a
 											href={`/${
 												(scope.slugs?.pubSlug &&


### PR DESCRIPTION
solves #2418

tooltips are now in the navigation dropdown 

<img width="520" alt="image" src="https://user-images.githubusercontent.com/34730449/207154032-3307a7bb-82ab-4c0e-aca0-19fca336fa59.png">
