### PR TITLE
fix/enhancement: Mobile table styling

### DIFF
--- a/client/components/Editor/styles/table.scss
+++ b/client/components/Editor/styles/table.scss
@@ -1,10 +1,20 @@
+@import 'styles/mixins.scss';
+
 /* This clunky table, tableWrapper thing is because */
 /* isReadOnly removes the wrapping div, so margins don't */
 /* collapse as expected in all situations. */
 .tableWrapper {
 	margin: 1em 0;
+	@include mobile {
+		overflow-x: scroll;
+	}
 	table {
 		margin: 0em;
+		@include mobile {
+			width: auto;
+			max-width: fit-content;
+			table-layout: auto;
+		}
 	}
 }
 
@@ -25,6 +35,14 @@ table caption {
 	/* :last-child does not work here because the table plugin inserts nodes when resizing */
 	& > p:last-of-type:last-of-type {
 		margin-bottom: 0;
+	}
+}
+
+@include mobile {
+	th,
+	td {
+		min-width: 140px;
+		width: auto;
 	}
 }
 


### PR DESCRIPTION
Adds some pretty meh table styling for mobile, mostly by setting `overflow-x: scroll` on the `tableWrapper` and a sane min-width for th and td (140px). I feel like there has to be a better way to do this, but the only other thing I can figure out is to set `white-space: nowrap` on table cells, which has the effect of...you guessed it...never wrapping, which is not good.

So, this effectively sets the width of every column to the min-width value (currently 140px), regardless of whether a custom width is set, which seems not great but potentially unavoidable (unless we set the table cells not to wrap at all).

<img width="209" alt="Screenshot 2022-12-13 at 19 16 52" src="https://user-images.githubusercontent.com/639110/207473219-b4341049-c00d-4f00-a996-3f843128f4d8.png">

_Test plan_
1. Create a table and don't set any column or table widths
2. View on mobile
3. Make sure columns are at least 140px wide
4. Set the widths of some of the columns, and of the table itself (by adjusting the width of the last border in the table)
5. Make sure columns display at 140px wide