### PR TITLE
Allow fullscreen on iframe embeds

### DIFF
--- a/client/components/Editor/schemas/iframe.ts
+++ b/client/components/Editor/schemas/iframe.ts
@@ -47,6 +47,7 @@ export default {
 						src: node.attrs.url,
 						height: node.attrs.height,
 						'aria-describedby': figcaptionId,
+						allowfullscreen: 'true',
 					},
 				],
 				[

--- a/client/components/FormattingBar/media/MediaCodepen.tsx
+++ b/client/components/FormattingBar/media/MediaCodepen.tsx
@@ -53,6 +53,7 @@ class MediaCodepen extends Component<Props, State> {
 			url: this.state.embedUrl,
 			caption: this.state.embedTitle,
 			align: 'full',
+			allowfullscreen: 'true',
 		});
 	}
 

--- a/client/components/FormattingBar/media/MediaCodepen.tsx
+++ b/client/components/FormattingBar/media/MediaCodepen.tsx
@@ -53,7 +53,6 @@ class MediaCodepen extends Component<Props, State> {
 			url: this.state.embedUrl,
 			caption: this.state.embedTitle,
 			align: 'full',
-			allowfullscreen: 'true',
 		});
 	}
 
@@ -81,7 +80,12 @@ class MediaCodepen extends Component<Props, State> {
 				/>
 				{this.state.isValid && (
 					<div className="preview-wrapper">
-						<iframe frameBorder="none" src={this.state.embedUrl} title="URL preview" />
+						<iframe
+							frameBorder="none"
+							src={this.state.embedUrl}
+							title="URL preview"
+							allowFullScreen
+						/>
 					</div>
 				)}
 				{!this.state.isValid && (

--- a/client/components/FormattingBar/media/MediaIframe.tsx
+++ b/client/components/FormattingBar/media/MediaIframe.tsx
@@ -53,7 +53,12 @@ class MediaIframe extends Component<Props, State> {
 				/>
 				{isValid && (
 					<div className="preview-wrapper">
-						<iframe frameBorder="none" src={this.state.url} title="URL preview" />
+						<iframe
+							frameBorder="none"
+							src={this.state.url}
+							title="URL preview"
+							allowFullScreen
+						/>
 					</div>
 				)}
 				{!isValid && (

--- a/client/components/FormattingBar/media/MediaVimeo.tsx
+++ b/client/components/FormattingBar/media/MediaVimeo.tsx
@@ -54,6 +54,7 @@ class MediaVimeo extends Component<Props, State> {
 			url: this.state.embedUrl,
 			caption: this.state.embedTitle,
 			align: 'full',
+			allowfullscreen: 'true',
 		});
 	}
 

--- a/client/components/FormattingBar/media/MediaVimeo.tsx
+++ b/client/components/FormattingBar/media/MediaVimeo.tsx
@@ -54,7 +54,6 @@ class MediaVimeo extends Component<Props, State> {
 			url: this.state.embedUrl,
 			caption: this.state.embedTitle,
 			align: 'full',
-			allowfullscreen: 'true',
 		});
 	}
 
@@ -82,7 +81,12 @@ class MediaVimeo extends Component<Props, State> {
 				/>
 				{this.state.isValid && (
 					<div className="preview-wrapper">
-						<iframe frameBorder="none" src={this.state.embedUrl} title="URL preview" />
+						<iframe
+							frameBorder="none"
+							src={this.state.embedUrl}
+							title="URL preview"
+							allowFullScreen
+						/>
 					</div>
 				)}
 				{!this.state.isValid && (

--- a/client/components/FormattingBar/media/MediaYoutube.tsx
+++ b/client/components/FormattingBar/media/MediaYoutube.tsx
@@ -59,6 +59,7 @@ class MediaYoutube extends Component<Props, State> {
 			url: this.state.embedUrl,
 			caption: this.state.embedTitle,
 			align: 'full',
+			allowfullscreen: 'true',
 		});
 	}
 

--- a/client/components/FormattingBar/media/MediaYoutube.tsx
+++ b/client/components/FormattingBar/media/MediaYoutube.tsx
@@ -59,7 +59,6 @@ class MediaYoutube extends Component<Props, State> {
 			url: this.state.embedUrl,
 			caption: this.state.embedTitle,
 			align: 'full',
-			allowfullscreen: 'true',
 		});
 	}
 
@@ -87,7 +86,12 @@ class MediaYoutube extends Component<Props, State> {
 				/>
 				{this.state.isValid && (
 					<div className="preview-wrapper">
-						<iframe frameBorder="none" src={this.state.embedUrl} title="URL preview" />
+						<iframe
+							frameBorder="none"
+							src={this.state.embedUrl}
+							title="URL preview"
+							allowFullScreen
+						/>
 					</div>
 				)}
 				{!this.state.isValid && (


### PR DESCRIPTION
Resolves #2360

Adds `allowfullscreen="true"` to iframes inserted with the editor (including youtube, vimeo etc.).

To test, compare: https://demo.duqduq.org/pub/kxf724hk/draft vs https://pubpub-pipel-kalilsn-al-5vkypc.herokuapp.com/pub/kxf724hk/draft