### PR TITLE
update: cleanup some tools

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -123,7 +123,7 @@
 			}
 		},
 		{
-			"files": ["**/*.test.ts", "**/*.test.js"],
+			"files": ["**/*.test.ts", "**/*.test.js", "**/*.test.tsx"],
 			"env": {
 				"jest": true
 			}

--- a/client/components/Editor/schemas/iframe.ts
+++ b/client/components/Editor/schemas/iframe.ts
@@ -47,6 +47,7 @@ export default {
 						src: node.attrs.url,
 						height: node.attrs.height,
 						'aria-describedby': figcaptionId,
+						allowfullscreen: 'true',
 					},
 				],
 				[

--- a/client/components/FormattingBar/media/MediaCodepen.tsx
+++ b/client/components/FormattingBar/media/MediaCodepen.tsx
@@ -80,7 +80,12 @@ class MediaCodepen extends Component<Props, State> {
 				/>
 				{this.state.isValid && (
 					<div className="preview-wrapper">
-						<iframe frameBorder="none" src={this.state.embedUrl} title="URL preview" />
+						<iframe
+							frameBorder="none"
+							src={this.state.embedUrl}
+							title="URL preview"
+							allowFullScreen
+						/>
 					</div>
 				)}
 				{!this.state.isValid && (

--- a/client/components/FormattingBar/media/MediaIframe.tsx
+++ b/client/components/FormattingBar/media/MediaIframe.tsx
@@ -53,7 +53,12 @@ class MediaIframe extends Component<Props, State> {
 				/>
 				{isValid && (
 					<div className="preview-wrapper">
-						<iframe frameBorder="none" src={this.state.url} title="URL preview" />
+						<iframe
+							frameBorder="none"
+							src={this.state.url}
+							title="URL preview"
+							allowFullScreen
+						/>
 					</div>
 				)}
 				{!isValid && (

--- a/client/components/FormattingBar/media/MediaVimeo.tsx
+++ b/client/components/FormattingBar/media/MediaVimeo.tsx
@@ -81,7 +81,12 @@ class MediaVimeo extends Component<Props, State> {
 				/>
 				{this.state.isValid && (
 					<div className="preview-wrapper">
-						<iframe frameBorder="none" src={this.state.embedUrl} title="URL preview" />
+						<iframe
+							frameBorder="none"
+							src={this.state.embedUrl}
+							title="URL preview"
+							allowFullScreen
+						/>
 					</div>
 				)}
 				{!this.state.isValid && (

--- a/client/components/FormattingBar/media/MediaYoutube.tsx
+++ b/client/components/FormattingBar/media/MediaYoutube.tsx
@@ -86,7 +86,12 @@ class MediaYoutube extends Component<Props, State> {
 				/>
 				{this.state.isValid && (
 					<div className="preview-wrapper">
-						<iframe frameBorder="none" src={this.state.embedUrl} title="URL preview" />
+						<iframe
+							frameBorder="none"
+							src={this.state.embedUrl}
+							title="URL preview"
+							allowFullScreen
+						/>
 					</div>
 				)}
 				{!this.state.isValid && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,6 +198,7 @@
 				"@storybook/addon-storyshots": "^6.4.0",
 				"@storybook/addon-viewport": "^6.4.0",
 				"@storybook/react": "^6.4.0",
+				"@types/enzyme": "^3.10.12",
 				"@types/jest": "^26.0.16",
 				"@types/katex": "^0.14.0",
 				"@types/react-beautiful-dnd": "^13.0.0",
@@ -12092,6 +12093,15 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
+		"node_modules/@types/cheerio": {
+			"version": "0.22.31",
+			"resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.31.tgz",
+			"integrity": "sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/clean-css": {
 			"version": "4.2.5",
 			"resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.5.tgz",
@@ -12157,6 +12167,16 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/dom4/-/dom4-2.0.1.tgz",
 			"integrity": "sha512-kSkVAvWmMZiCYtvqjqQEwOmvKwcH+V4uiv3qPQ8pAh1Xl39xggGEo8gHUqV4waYGHezdFw0rKBR8Jt0CrQSDZA=="
+		},
+		"node_modules/@types/enzyme": {
+			"version": "3.10.12",
+			"resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.12.tgz",
+			"integrity": "sha512-xryQlOEIe1TduDWAOphR0ihfebKFSWOXpIsk+70JskCfRfW+xALdnJ0r1ZOTo85F9Qsjk6vtlU7edTYHbls9tA==",
+			"dev": true,
+			"dependencies": {
+				"@types/cheerio": "*",
+				"@types/react": "*"
+			}
 		},
 		"node_modules/@types/estree": {
 			"version": "0.0.51",
@@ -50519,6 +50539,15 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
+		"@types/cheerio": {
+			"version": "0.22.31",
+			"resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.31.tgz",
+			"integrity": "sha512-Kt7Cdjjdi2XWSfrZ53v4Of0wG3ZcmaegFXjMmz9tfNrZSkzzo36G0AL1YqSdcIA78Etjt6E609pt5h1xnQkPUw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/clean-css": {
 			"version": "4.2.5",
 			"resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.5.tgz",
@@ -50583,6 +50612,16 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/dom4/-/dom4-2.0.1.tgz",
 			"integrity": "sha512-kSkVAvWmMZiCYtvqjqQEwOmvKwcH+V4uiv3qPQ8pAh1Xl39xggGEo8gHUqV4waYGHezdFw0rKBR8Jt0CrQSDZA=="
+		},
+		"@types/enzyme": {
+			"version": "3.10.12",
+			"resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.12.tgz",
+			"integrity": "sha512-xryQlOEIe1TduDWAOphR0ihfebKFSWOXpIsk+70JskCfRfW+xALdnJ0r1ZOTo85F9Qsjk6vtlU7edTYHbls9tA==",
+			"dev": true,
+			"requires": {
+				"@types/cheerio": "*",
+				"@types/react": "*"
+			}
 		},
 		"@types/estree": {
 			"version": "0.0.51",

--- a/package.json
+++ b/package.json
@@ -226,6 +226,7 @@
 		"@storybook/addon-storyshots": "^6.4.0",
 		"@storybook/addon-viewport": "^6.4.0",
 		"@storybook/react": "^6.4.0",
+		"@types/enzyme": "^3.10.12",
 		"@types/jest": "^26.0.16",
 		"@types/katex": "^0.14.0",
 		"@types/react-beautiful-dnd": "^13.0.0",

--- a/server/routes/robots.ts
+++ b/server/routes/robots.ts
@@ -9,13 +9,13 @@ const buildRobotsFile = (community) => {
 	if (community) {
 		return stripIndent(`
 			User-agent: *
-			Disallow:
+			Disallow: /login?redirect=*
 			Sitemap: ${communityUrl(community)}/sitemap-index.xml
 		`).trim();
 	}
 	return stripIndent(`
 		User-agent: *
-		Disallow:
+		Disallow: /login?redirect=*
 	`).trim();
 };
 

--- a/server/utils/__tests__/ssr.test.tsx
+++ b/server/utils/__tests__/ssr.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import Adapter from 'enzyme-adapter-react-16';
+import Enzyme, { shallow } from 'enzyme';
+import dataInitial from 'utils/storybook/data/dataInitial';
+import { pubData, attributionsData } from 'utils/storybook/data';
+import { generateMetaComponents } from '../ssr';
+
+Enzyme.configure({ adapter: new Adapter() });
+const defaultProps = {
+	initialData: dataInitial,
+	attributions: pubData.attributions,
+	title: 'Test Pub',
+};
+
+const MetaComponents = (props) => <React.Fragment>{generateMetaComponents(props)}</React.Fragment>;
+
+describe('generateMetaComponents', () => {
+	it('generates citation_author metadata for every author WITHOUT a contributor role as their primary role', () => {
+		const attributions = pubData.attributions.map((att) => ({ ...att }));
+		attributions[0].roles = ['Editor'];
+		attributions[1].roles = ['Test role', 'Editor'];
+
+		const wrap = shallow(<MetaComponents {...defaultProps} attributions={attributions} />);
+		expect(
+			wrap.containsMatchingElement(<meta name="citation_author" content="Weiwei Hsu" />),
+		).toBeFalsy();
+		expect(
+			wrap.containsMatchingElement(<meta name="citation_author" content="Hugh Dubberly" />),
+		).toBeTruthy();
+		expect(
+			wrap.containsMatchingElement(<meta name="citation_author" content="Ian Reynolds" />),
+		).toBeTruthy();
+	});
+
+	it('generates citation_editor metadata for every contributor WITH a contributor role as their primary role', () => {
+		const attributions = pubData.attributions.map((att) => ({ ...att }));
+		attributions[1].roles = ['Series Editor', 'Test role'];
+		attributions[2].roles = ['Test role', 'Writing – Review & Editing'];
+
+		const wrap = shallow(<MetaComponents {...defaultProps} attributions={attributions} />);
+		expect(
+			wrap.containsMatchingElement(<meta name="citation_editor" content="Weiwei Hsu" />),
+		).toBeFalsy();
+		expect(
+			wrap.containsMatchingElement(<meta name="citation_editor" content="Hugh Dubberly" />),
+		).toBeTruthy();
+		expect(
+			wrap.containsMatchingElement(<meta name="citation_editor" content="Ian Reynolds" />),
+		).toBeFalsy();
+	});
+
+	it('generates the expected meta elements', () => {
+		const props = {
+			...defaultProps,
+			attributions: [...attributionsData, ...pubData.attributions],
+		};
+
+		expect(generateMetaComponents(props as any)).toMatchInlineSnapshot(`
+		Array [
+		  <link
+		    href="https://localhost/rss.xml"
+		    rel="alternate"
+		    title="Test Pub RSS Feed"
+		    type="application/rss+xml"
+		  />,
+		  <title>
+		    Test Pub
+		  </title>,
+		  <meta
+		    content="Test Pub"
+		    property="og:title"
+		  />,
+		  <meta
+		    content="Test Pub"
+		    name="twitter:title"
+		  />,
+		  <meta
+		    content="Test Pub"
+		    name="twitter:image:alt"
+		  />,
+		  <meta
+		    content="Test Pub"
+		    name="citation_title"
+		  />,
+		  <meta
+		    content="Test Pub"
+		    name="dc.title"
+		  />,
+		  <meta
+		    content="Joi Ito's PubPub"
+		    property="og:site_name"
+		  />,
+		  <meta
+		    content="Joi Ito's PubPub"
+		    name="citation_journal_title"
+		  />,
+		  <meta
+		    content="https://localhost/login"
+		    property="og:url"
+		  />,
+		  <meta
+		    content="website"
+		    property="og:type"
+		  />,
+		  <link
+		    href="https://assets.pubpub.org/12e422ul/41507920476077.png"
+		    rel="icon"
+		    sizes="256x256"
+		    type="image/png"
+		  />,
+		  Array [
+		    <meta
+		      content="Ian Reynolds"
+		      name="citation_author"
+		    />,
+		    <meta
+		      content="Travis Rich"
+		      name="citation_author"
+		    />,
+		    <meta
+		      content="Catherine Ahearn"
+		      name="citation_author"
+		    />,
+		    <meta
+		      content="Gabriel Stein"
+		      name="citation_author"
+		    />,
+		    <meta
+		      content="Joel Gustafson"
+		      name="citation_author"
+		    />,
+		    <meta
+		      content="Weiwei Hsu"
+		      name="citation_author"
+		    />,
+		    <meta
+		      content="Hugh Dubberly"
+		      name="citation_author"
+		    />,
+		    <meta
+		      content="Ian Reynolds"
+		      name="citation_author"
+		    />,
+		  ],
+		  Array [
+		    <meta
+		      content="Ian Reynolds"
+		      name="dc.creator"
+		    />,
+		    <meta
+		      content="Travis Rich"
+		      name="dc.creator"
+		    />,
+		    <meta
+		      content="Catherine Ahearn"
+		      name="dc.creator"
+		    />,
+		    <meta
+		      content="Gabriel Stein"
+		      name="dc.creator"
+		    />,
+		    <meta
+		      content="Joel Gustafson"
+		      name="dc.creator"
+		    />,
+		    <meta
+		      content="Weiwei Hsu"
+		      name="dc.creator"
+		    />,
+		    <meta
+		      content="Hugh Dubberly"
+		      name="dc.creator"
+		    />,
+		    <meta
+		      content="Ian Reynolds"
+		      name="dc.creator"
+		    />,
+		  ],
+		  Array [],
+		  <meta
+		    content="924988584221879"
+		    property="fb:app_id"
+		  />,
+		  <meta
+		    content="summary"
+		    name="twitter:card"
+		  />,
+		  <meta
+		    content="@pubpub"
+		    name="twitter:site"
+		  />,
+		]
+	`);
+	});
+});

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -16,7 +16,7 @@ type MetaProps = {
 	contextTitle?: string;
 	description?: string;
 	image?: string;
-	attributions?: any[];
+	attributions?: Attribution[];
 	doi?: string;
 	publishedAt?: null | Date;
 	unlisted?: boolean;
@@ -28,7 +28,7 @@ type MetaProps = {
 };
 
 const contributorRoles = ['Writing – Review & Editing', 'Editor', 'Series Editor'];
-const sortAttributions = (foo, bar) => {
+const sortAttributions = (foo: Attribution, bar: Attribution) => {
 	if (foo.order < bar.order) {
 		return -1;
 	}
@@ -220,14 +220,21 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 	}
 
 	if (attributions) {
-		const authors = attributions.sort(sortAttributions).filter((item) => {
-			return item.isAuthor && !item.roles;
-		});
+		const authors: Attribution[] = [];
+		const contributors: Attribution[] = [];
 
 		const getPrimaryRole = (contributor: Attribution) => contributor.roles?.[0];
-		const contributors = attributions.sort(sortAttributions).filter((item) => {
-			const primaryRole = getPrimaryRole(item);
-			return item.isAuthor && primaryRole && contributorRoles.includes(primaryRole);
+
+		attributions.sort(sortAttributions).forEach((attribution) => {
+			if (!attribution.isAuthor) {
+				return;
+			}
+			const primaryRole = getPrimaryRole(attribution);
+			if (primaryRole && contributorRoles.includes(primaryRole)) {
+				contributors.push(attribution);
+			} else {
+				authors.push(attribution);
+			}
 		});
 
 		const citationAuthorTags = authors.map((author) => {

--- a/tools/encrypt.js
+++ b/tools/encrypt.js
@@ -1,6 +1,7 @@
 /* eslint-disable global-require, no-console */
 import { aes256Encrypt, aes256Decrypt } from '../utils/crypto';
 
+// usage: npm run tools encrypt -- --text=text_to_encrypt
 try {
 	require('../config.js');
 } catch {
@@ -9,7 +10,7 @@ try {
 
 const { argv } = require('yargs');
 
-const text = argv._[0];
+const text = argv.text;
 const decrypt = argv.decrypt ?? false;
 const initVec = argv['init-vec'];
 const key = argv.key?.toString() ?? process.env.AES_ENCRYPTION_KEY;

--- a/tools/exportCollection.js
+++ b/tools/exportCollection.js
@@ -16,13 +16,14 @@ const {
 
 const getPubExports = async (pubId, dest) => {
 	const [pubData] = await getPubData([pubId]);
-	const pdfUrl = await getBestDownloadUrl(pubData, 'pdf');
-	const jatsUrl = await getBestDownloadUrl(pubData, 'jats');
+	const pdfUrl = getBestDownloadUrl(pubData, 'pdf');
+	const jatsUrl = getBestDownloadUrl(pubData, 'jats');
 	const finalDest = `${dest}/${pubData.slug}`;
 
 	if (!pdfUrl || !jatsUrl) {
 		console.log('Missing:', pubData.slug);
-		createLatestPubExports(pubId);
+		await createLatestPubExports(pubId);
+		await getPubExports(pubId, dest);
 	} else {
 		fs.mkdirSync(finalDest);
 		if (jatsUrl) {
@@ -57,7 +58,9 @@ const main = async () => {
 			throwIfNo: true,
 		});
 		const dest = `/tmp/${collection.slug}`;
-		fs.rmdirSync(dest, { recursive: true });
+		if (fs.existsSync(dest)) {
+			fs.rmdirSync(dest, { recursive: true });
+		}
 		fs.mkdirSync(dest);
 		await Promise.all(
 			collection.collectionPubs.map((collectionPub) =>

--- a/tools/exportCollection.js
+++ b/tools/exportCollection.js
@@ -9,7 +9,11 @@ import { getPubData } from 'server/rss/queries';
 
 import { promptOkay } from './utils/prompt';
 
-/** Usage: npm run tools exportCollection -- --collectionId collectionId */
+/* Usage: npm run tools exportCollection -- --collectionId=collectionId */
+
+/* Warning: your IP may get blocked by Cloudflare, leading to bad PDF/XML
+streams. The patch is to add your IP in cloudflare's IP list */
+
 const {
 	argv: { collectionId },
 } = require('yargs');
@@ -21,6 +25,11 @@ const getPubExports = async (pubId, dest) => {
 	const finalDest = `${dest}/${pubData.slug}`;
 
 	if (!pdfUrl || !jatsUrl) {
+		/* Note: for some very old pubs, this will fail for JATS becauseo of some historykey
+		mismatch issues. The workaround is to, for those pubs, go into the db and match the
+		historykey of the generated export to the one expected by the getPublicExport URL
+		function.
+		*/
 		console.log('Missing:', pubData.slug);
 		await createLatestPubExports(pubId);
 		await getPubExports(pubId, dest);

--- a/tools/index.js
+++ b/tools/index.js
@@ -31,6 +31,7 @@ const commandFiles = {
 	depositCollectionPubs: './depositCollectionPubs',
 	emailActivityDigest: './emailActivityDigest',
 	emailUsers: './emailUsers',
+	encrypt: './encrypt',
 	exportCollection: './exportCollection',
 	figurelist: './figurelist',
 	firebaseDownload: './firebaseDownload',


### PR DESCRIPTION
- Makes my exportCollection tool actually useful by recursing until all the exports are completed.
- Updates Eric's encrypt tool to be usable via npm run tools, and makes the input a more explicit `--text=text`.