### PR TITLE
Improve mobile experience for content wider than the screen

### DIFF
--- a/client/containers/App/app.scss
+++ b/client/containers/App/app.scss
@@ -5,7 +5,7 @@
 	flex-direction: column;
 	min-height: 100vh;
 	width: 100%;
-	overflow-x: hidden;
+	overflow-x: clip;
 	#main-content {
 		outline: none;
 		flex-grow: 1;

--- a/client/containers/App/app.scss
+++ b/client/containers/App/app.scss
@@ -5,7 +5,6 @@
 	flex-direction: column;
 	min-height: 100vh;
 	width: 100%;
-	overflow-x: clip;
 	#main-content {
 		outline: none;
 		flex-grow: 1;

--- a/client/containers/App/app.scss
+++ b/client/containers/App/app.scss
@@ -4,6 +4,8 @@
 	display: flex;
 	flex-direction: column;
 	min-height: 100vh;
+	width: 100%;
+	overflow-x: hidden;
 	#main-content {
 		outline: none;
 		flex-grow: 1;

--- a/client/containers/Pub/PubDocument/pubBody.scss
+++ b/client/containers/Pub/PubDocument/pubBody.scss
@@ -30,6 +30,7 @@ $pub-body-font-size: if-is-export(14px, 20px);
 		font-weight: 500;
 		font-family: $header-font;
 		letter-spacing: 1px;
+		overflow-x: auto;
 		a {
 			text-decoration: underline;
 		}
@@ -98,6 +99,7 @@ $pub-body-font-size: if-is-export(14px, 20px);
 
 	p {
 		margin: 0em 0em 1em;
+		overflow-x: auto;
 	}
 
 	ul > li::marker {

--- a/client/containers/Pub/PubDocument/pubBody.scss
+++ b/client/containers/Pub/PubDocument/pubBody.scss
@@ -30,6 +30,7 @@ $pub-body-font-size: if-is-export(14px, 20px);
 		font-weight: 500;
 		font-family: $header-font;
 		letter-spacing: 1px;
+		overflow-y: hidden;
 		overflow-x: auto;
 		a {
 			text-decoration: underline;
@@ -99,6 +100,7 @@ $pub-body-font-size: if-is-export(14px, 20px);
 
 	p {
 		margin: 0em 0em 1em;
+		overflow-y: hidden;
 		overflow-x: auto;
 	}
 

--- a/client/containers/Pub/PubDocument/pubBody.scss
+++ b/client/containers/Pub/PubDocument/pubBody.scss
@@ -3,6 +3,7 @@
 $bp: vendor.$bp-namespace;
 
 @import 'styles/variables.scss';
+@import '../pub.scss';
 
 $pub-body-font-size: if-is-export(14px, 20px);
 
@@ -30,8 +31,10 @@ $pub-body-font-size: if-is-export(14px, 20px);
 		font-weight: 500;
 		font-family: $header-font;
 		letter-spacing: 1px;
-		overflow-y: hidden;
-		overflow-x: auto;
+		@include pub-compact-view {
+			overflow-y: hidden;
+			overflow-x: auto;
+		}
 		a {
 			text-decoration: underline;
 		}
@@ -100,8 +103,10 @@ $pub-body-font-size: if-is-export(14px, 20px);
 
 	p {
 		margin: 0em 0em 1em;
-		overflow-y: hidden;
-		overflow-x: auto;
+		@include pub-compact-view {
+			overflow-y: hidden;
+			overflow-x: auto;
+		}
 	}
 
 	ul > li::marker {

--- a/client/styles/base.scss
+++ b/client/styles/base.scss
@@ -18,8 +18,6 @@ body {
 	background-color: #fff;
 	margin: 0;
 	padding: 0;
-	width: 100vw;
-	overflow-x: hidden;
 }
 
 a {


### PR DESCRIPTION
#2351 

This PR fixes the CSS intended to prevent pubpub from being wider than the screen, which didn't work on my browsers. Now if an element (really just math as far as I can tell) is wider than the viewport, it will have internal scrollbars, but the page itself will not expand.

This pub has some examples of content that overflows on small screens:
[duqduq version](https://demo.duqduq.org/pub/hilwxpnd/release/4)
[review app version](https://pubpub-pipel-kalilsn-ov-bfcnoe.herokuapp.com//pub/hilwxpnd/release/4)


Feedback I'm looking for:
- Are there other places where we might need to add an explicit `overflow-x: auto`? It seems like most elements from the editor get wrapped in a `<p>` tag, but I'm not so sure about other parts of the site.
- At intermediate sizes where the discussions are on the right side, should the wide content overflow into the sidebar the way images can?
- Does this need some kind of indicator to let users know that these elements can be scrolled (since it seems like scrollbars are usually hidden by default and we can only style those in webkit browsers)?


