### PR TITLE
bug: Footnotes Won't be Deduped

### DIFF
--- a/utils/notes.ts
+++ b/utils/notes.ts
@@ -40,12 +40,17 @@ const getAlphabetizableValue = (note: RenderedNote) => {
 		.trim();
 };
 
-const getRenderedNotes = (
-	notes: Note[],
-	renderedStructuredValues: RenderedStructuredValues,
-	includeNumbers: boolean,
-): RenderedNote[] => {
-	return unique(notes, (note) => note.fingerprint).map((note, index) => {
+type RenderNoteOptions = {
+	notes: Note[];
+	renderedStructuredValues: RenderedStructuredValues;
+	includeNumbers: boolean;
+	isFootnote: boolean;
+};
+
+const getRenderedNotes = (options: RenderNoteOptions): RenderedNote[] => {
+	const { notes, renderedStructuredValues, includeNumbers, isFootnote } = options;
+	const obj = isFootnote ? notes : unique(notes, (note) => note.fingerprint);
+	return obj.map((note, index) => {
 		return {
 			...note,
 			...(includeNumbers && { number: index + 1 }),
@@ -77,12 +82,18 @@ export const renderNotesForListing = (
 ): ByNoteKind<RenderedNote[]> => {
 	const { citations, footnotes, citationInlineStyle, renderedStructuredValues } = options;
 	const shouldAlphabetizeCitations = citationInlineStyle !== 'count';
-	const renderedFootnotes = getRenderedNotes(footnotes, renderedStructuredValues, true);
-	const renderedCitations = getRenderedNotes(
-		citations,
+	const renderedFootnotes = getRenderedNotes({
+		notes: footnotes,
 		renderedStructuredValues,
-		!shouldAlphabetizeCitations,
-	);
+		includeNumbers: true,
+		isFootnote: true,
+	});
+	const renderedCitations = getRenderedNotes({
+		notes: citations,
+		renderedStructuredValues,
+		includeNumbers: !shouldAlphabetizeCitations,
+		isFootnote: false,
+	});
 	return {
 		footnotes: renderedFootnotes,
 		citations: shouldAlphabetizeCitations

--- a/utils/notes.ts
+++ b/utils/notes.ts
@@ -49,8 +49,8 @@ type RenderNoteOptions = {
 
 const getRenderedNotes = (options: RenderNoteOptions): RenderedNote[] => {
 	const { notes, renderedStructuredValues, includeNumbers, isFootnote } = options;
-	const obj = isFootnote ? notes : unique(notes, (note) => note.fingerprint);
-	return obj.map((note, index) => {
+	const notesObject = isFootnote ? notes : unique(notes, (note) => note.fingerprint);
+	return notesObject.map((note, index) => {
 		return {
 			...note,
 			...(includeNumbers && { number: index + 1 }),


### PR DESCRIPTION
addresses #2383 

Now, all of the footnotes will show

test plan: using this [doc](https://docs.google.com/document/d/1qjnN17jUp8_-iVXVi7ojH0XYzce0MoxwvEOS_oORPs0/edit?usp=sharing) you can test that there are 396 footnotes when importing to pubpub

before there would have only been 3