### PR TITLE
fix(#2442): set citation_title to collection title only if it is not a pub

### DIFF
--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -71,6 +71,11 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;
 	const titleWithContext = contextTitle ? `${title} · ${contextTitle}` : title;
+
+	const isPub = Boolean(url?.includes('/pub/'))
+	const needsBookTitle = collection?.kind === 'book' && !isPub
+
+
 	let outputComponents: any[] = [];
 	if (!initialData.locationData.isBasePubPub) {
 		outputComponents = [
@@ -92,12 +97,12 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			<meta
 				key="t2"
 				property="og:title"
-				content={collection?.kind === 'book' ? collection.title : title}
+				content={needsBookTitle ? collection.title : title}
 			/>,
 			<meta key="t3" name="twitter:title" content={titleWithContext} />,
 			<meta key="t4" name="twitter:image:alt" content={titleWithContext} />,
-			<meta key="t5" name="citation_title" content={collection?.title ?? title} />,
-			<meta key="t6" name="dc.title" content={collection?.title ?? title} />,
+			<meta key="t5" name="citation_title" content={needsBookTitle ? collection?.title : title} />,
+			<meta key="t6" name="dc.title" content={needsBookTitle ? collection?.title : title} />,
 		];
 	}
 
@@ -125,7 +130,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 				content={
 					collection?.kind === 'book'
 						? 'book'
-						: url.indexOf('/pub/') > -1
+						: isPub
 						? 'article'
 						: 'website'
 				}


### PR DESCRIPTION
Because of changes introduced in #2307, Pubs in a Collection will only show the collection title in the `citation_title` etc meta tags, see #2442.

This PR introduces two variables which check whether a page is a Pub, and whether it is a book and thus needs to have it's citation_title and dc.title set to the name of the book.

If the latter is the case, that is done. 

This is not the most elegant way to do this, probably the `og:title` should not be said like this as well.

