### PR TITLE
fix: redirect issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -199,6 +199,7 @@
 				"@storybook/addon-viewport": "^6.4.0",
 				"@storybook/react": "^6.4.0",
 				"@types/enzyme": "^3.10.12",
+				"@types/express": "^4.17.15",
 				"@types/jest": "^26.0.16",
 				"@types/katex": "^0.14.0",
 				"@types/react-beautiful-dnd": "^13.0.0",
@@ -12093,6 +12094,16 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
+		"node_modules/@types/body-parser": {
+			"version": "1.19.2",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+			"integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+			"dev": true,
+			"dependencies": {
+				"@types/connect": "*",
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/cheerio": {
 			"version": "0.22.31",
 			"resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.31.tgz",
@@ -12123,6 +12134,15 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		},
+		"node_modules/@types/connect": {
+			"version": "3.4.35",
+			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+			"integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/d3-color": {
 			"version": "3.1.0",
@@ -12183,6 +12203,29 @@
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
 			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
 			"dev": true
+		},
+		"node_modules/@types/express": {
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
+			"integrity": "sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/body-parser": "*",
+				"@types/express-serve-static-core": "^4.17.31",
+				"@types/qs": "*",
+				"@types/serve-static": "*"
+			}
+		},
+		"node_modules/@types/express-serve-static-core": {
+			"version": "4.17.32",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.32.tgz",
+			"integrity": "sha512-aI5h/VOkxOF2Z1saPy0Zsxs5avets/iaiAJYznQFm5By/pamU31xWKL//epiF4OfUA2qTOc9PV6tCUjhO8wlZA==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*"
+			}
 		},
 		"node_modules/@types/glob": {
 			"version": "7.1.3",
@@ -12363,6 +12406,12 @@
 			"dependencies": {
 				"@types/unist": "*"
 			}
+		},
+		"node_modules/@types/mime": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+			"integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+			"dev": true
 		},
 		"node_modules/@types/min-document": {
 			"version": "2.19.0",
@@ -12546,6 +12595,12 @@
 			"integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
 			"dev": true
 		},
+		"node_modules/@types/range-parser": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+			"integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+			"dev": true
+		},
 		"node_modules/@types/react": {
 			"version": "16.14.26",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.26.tgz",
@@ -12625,6 +12680,16 @@
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
 			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
 			"dev": true
+		},
+		"node_modules/@types/serve-static": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+			"integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+			"dev": true,
+			"dependencies": {
+				"@types/mime": "*",
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/source-list-map": {
 			"version": "0.1.2",
@@ -50539,6 +50604,16 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
+		"@types/body-parser": {
+			"version": "1.19.2",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+			"integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+			"dev": true,
+			"requires": {
+				"@types/connect": "*",
+				"@types/node": "*"
+			}
+		},
 		"@types/cheerio": {
 			"version": "0.22.31",
 			"resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.31.tgz",
@@ -50568,6 +50643,15 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		},
+		"@types/connect": {
+			"version": "3.4.35",
+			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+			"integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/d3-color": {
 			"version": "3.1.0",
@@ -50628,6 +50712,29 @@
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
 			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
 			"dev": true
+		},
+		"@types/express": {
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
+			"integrity": "sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==",
+			"dev": true,
+			"requires": {
+				"@types/body-parser": "*",
+				"@types/express-serve-static-core": "^4.17.31",
+				"@types/qs": "*",
+				"@types/serve-static": "*"
+			}
+		},
+		"@types/express-serve-static-core": {
+			"version": "4.17.32",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.32.tgz",
+			"integrity": "sha512-aI5h/VOkxOF2Z1saPy0Zsxs5avets/iaiAJYznQFm5By/pamU31xWKL//epiF4OfUA2qTOc9PV6tCUjhO8wlZA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*"
+			}
 		},
 		"@types/glob": {
 			"version": "7.1.3",
@@ -50808,6 +50915,12 @@
 			"requires": {
 				"@types/unist": "*"
 			}
+		},
+		"@types/mime": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+			"integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+			"dev": true
 		},
 		"@types/min-document": {
 			"version": "2.19.0",
@@ -50991,6 +51104,12 @@
 			"integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
 			"dev": true
 		},
+		"@types/range-parser": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+			"integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+			"dev": true
+		},
 		"@types/react": {
 			"version": "16.14.26",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.26.tgz",
@@ -51074,6 +51193,16 @@
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
 			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
 			"dev": true
+		},
+		"@types/serve-static": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+			"integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+			"dev": true,
+			"requires": {
+				"@types/mime": "*",
+				"@types/node": "*"
+			}
 		},
 		"@types/source-list-map": {
 			"version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
 		"@storybook/addon-viewport": "^6.4.0",
 		"@storybook/react": "^6.4.0",
 		"@types/enzyme": "^3.10.12",
+		"@types/express": "^4.17.15",
 		"@types/jest": "^26.0.16",
 		"@types/katex": "^0.14.0",
 		"@types/react-beautiful-dnd": "^13.0.0",

--- a/server/depositTarget/queries.ts
+++ b/server/depositTarget/queries.ts
@@ -1,14 +1,21 @@
 import * as types from 'types';
 import { DepositTarget } from 'server/models';
 
+/**
+ * Get the primary deposit target for a Community. The primary deposit target is currently
+ * the first one created for the Community. Eventually, we will allow users to select the
+ * primary deposit target when a Community has more than one.
+ */
 export const getCommunityDepositTarget = (
 	communityId: string,
-	service: types.DepositTarget['service'] = 'crossref',
+	includeCredentials = false,
 ): Promise<types.Maybe<types.DepositTarget>> => {
 	return DepositTarget.findOne({
 		where: {
 			communityId,
-			service,
+		},
+		attributes: {
+			exclude: includeCredentials ? [] : ['username', 'password', 'passwordInitVec'],
 		},
 	});
 };

--- a/server/doi/queries.ts
+++ b/server/doi/queries.ts
@@ -118,7 +118,7 @@ export const getDoiData = (
 		collectionId && findCollection(collectionId),
 		pubId && findPrimaryCollectionPubForPub(pubId),
 		pubId && findPub(pubId),
-		getCommunityDepositTarget(communityId),
+		getCommunityDepositTarget(communityId, true),
 	]).then(([community, collection, collectionPub, pub, depositTarget]) => {
 		const resolvedCollection = collectionPub ? collectionPub.collection : collection;
 		return createDeposit(

--- a/server/doi/submit.ts
+++ b/server/doi/submit.ts
@@ -7,7 +7,7 @@ import { aes256Decrypt } from 'utils/crypto';
 import { expect } from 'utils/assert';
 
 const getDoiLogin = async (communityId: string) => {
-	const depositTarget = await getCommunityDepositTarget(communityId);
+	const depositTarget = await getCommunityDepositTarget(communityId, true);
 	if (depositTarget) {
 		const { username, password, passwordInitVec } = depositTarget;
 		if (username && password && passwordInitVec) {

--- a/server/editor/api.ts
+++ b/server/editor/api.ts
@@ -33,10 +33,10 @@ app.get('/api/editor/embed', (req, res) => {
 		soundcloud: `https://soundcloud.com/oembed?url=${input}&format=json`,
 		twitter: `https://publish.twitter.com/oembed?url=${input}&format=json`,
 	};
-	const oembedUrl = oembedUrls[type];
+	const oembedUrl = oembedUrls[type as string];
 	if (!oembedUrl) {
 		if (type === 'github') {
-			const githubParts = input.split('/');
+			const githubParts = (input as string).split('/');
 			// GitHub API requests require a user agent: https://developer.github.com/v3/#user-agent-required
 			return request(`https://api.github.com/gists/${githubParts[githubParts.length - 1]}`, {
 				json: true,

--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -108,6 +108,7 @@ app.post('/api/login', (req, res, next) => {
 			return updatedUserData[1][0];
 		})
 		.then((user) => {
+			// @ts-expect-error
 			req.logIn(user, (err: string) => {
 				if (err) {
 					throw new Error(err);

--- a/server/logout/api.ts
+++ b/server/logout/api.ts
@@ -2,6 +2,7 @@ import app from 'server/server';
 
 app.get('/api/logout', (req, res) => {
 	res.cookie('gdpr-consent-survives-login', 'no');
+	// @ts-expect-error
 	req.logout();
 	return res.status(200).json('success');
 });

--- a/server/middleware/deduplicateSlash.ts
+++ b/server/middleware/deduplicateSlash.ts
@@ -1,0 +1,18 @@
+/* eslint-disable consistent-return */
+
+import { parse, format } from 'url';
+import { expect } from 'utils/assert';
+
+const DUPLICATE_SLASH_PATTERN = /(\/+)\1/g;
+
+export function deduplicateSlash() {
+	return function deduplicateSlashMiddleware(req: Request, res, next) {
+		const duplicateSlashMatches = req.url.match(DUPLICATE_SLASH_PATTERN);
+		if (duplicateSlashMatches === null) {
+			return next();
+		}
+		const correctedUrl = parse(req.url);
+		correctedUrl.pathname = expect(correctedUrl.pathname).replace(DUPLICATE_SLASH_PATTERN, '/');
+		res.redirect(301, format(correctedUrl));
+	};
+}

--- a/server/passwordReset/api.ts
+++ b/server/passwordReset/api.ts
@@ -1,10 +1,11 @@
 import app from 'server/server';
+import { User } from 'types';
 
 import { createPasswordReset, updatePasswordReset } from './queries';
 
 app.post('/api/password-reset', (req, res) => {
 	const user = req.user || {};
-	return createPasswordReset(req.body, user, req.hostname)
+	return createPasswordReset(req.body, user as User, req.hostname)
 		.then(() => {
 			return res.status(200).json('success');
 		})
@@ -16,7 +17,7 @@ app.post('/api/password-reset', (req, res) => {
 
 app.put('/api/password-reset', (req, res) => {
 	const user = req.user || {};
-	return updatePasswordReset(req.body, user)
+	return updatePasswordReset(req.body, user as User)
 		.then(() => {
 			return res.status(200).json('success');
 		})

--- a/server/review/api.ts
+++ b/server/review/api.ts
@@ -1,4 +1,5 @@
 import app from 'server/server';
+import { expect } from 'utils/assert';
 
 import { getPermissions } from './permissions';
 import { createReview, createReviewRelease, updateReview, destroyReview } from './queries';
@@ -32,7 +33,7 @@ app.post('/api/reviews', (req, res) => {
 				text,
 				content,
 				reviewerName,
-				userData: req.user,
+				userData: expect(req.user),
 			});
 		})
 		.then((newReview) => {

--- a/server/routes/adminDashboard.tsx
+++ b/server/routes/adminDashboard.tsx
@@ -7,6 +7,7 @@ import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
 import { generateMetabaseToken } from 'server/utils/metabase';
+import { User } from 'types';
 
 app.get('/admin', (req, res, next) => {
 	if (!hostIsValid(req, 'pubpub')) {
@@ -29,7 +30,7 @@ app.get('/admin', (req, res, next) => {
 				'6ddd7a7b-c542-4127-b403-33a67eb40ff3',
 				'd29eed4d-d754-4f8c-975e-b34826e6b8d2',
 			];
-			if (!users.includes(user.id)) {
+			if (!users.includes((user as User).id)) {
 				throw new Error('Page Not Found');
 			}
 			const impactData = {

--- a/server/routes/dashboardCollectionOverview.tsx
+++ b/server/routes/dashboardCollectionOverview.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import queryString from 'query-string';
+import queryString, { ParsedQuery } from 'query-string';
 
 import Html from 'server/Html';
 import app from 'server/server';
@@ -23,7 +23,7 @@ app.get('/dash/collection/:collectionSlug', (req, res) => {
 	res.redirect(
 		queryString.stringifyUrl({
 			url: `/dash/collection/${collectionSlug}/overview`,
-			query: req.query,
+			query: req.query as ParsedQuery,
 		}),
 	);
 });

--- a/server/routes/dashboardCommunityOverview.tsx
+++ b/server/routes/dashboardCommunityOverview.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import queryString from 'query-string';
+import queryString, { ParsedQuery } from 'query-string';
 
 import Html from 'server/Html';
 import app from 'server/server';
@@ -10,7 +10,12 @@ import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
 import { getCommunityOverview } from 'server/utils/queryHelpers';
 
 app.get('/dash', (req, res) => {
-	res.redirect(queryString.stringifyUrl({ url: '/dash/overview', query: req.query }));
+	res.redirect(
+		queryString.stringifyUrl({
+			url: '/dash/overview',
+			query: req.query as ParsedQuery,
+		}),
+	);
 });
 
 app.get('/dash/overview', async (req, res, next) => {

--- a/server/routes/pubRedirects.ts
+++ b/server/routes/pubRedirects.ts
@@ -1,4 +1,4 @@
-import queryString from 'query-string';
+import queryString, { ParsedQuery } from 'query-string';
 
 import { isDuqDuq } from 'utils/environment';
 import app from 'server/server';
@@ -64,7 +64,10 @@ app.get('/pub/:slug', async (req, res, next) => {
 				? `${prefix}/release/${pubData.releases.length}`
 				: `${prefix}/draft`;
 
-		const redirectUrl = queryString.stringifyUrl({ url: baseUrl, query: req.query });
+		const redirectUrl = queryString.stringifyUrl({
+			url: baseUrl,
+			query: req.query as ParsedQuery,
+		});
 		return res.redirect(redirectUrl);
 	} catch (err) {
 		return handleErrors(req, res, next)(err);
@@ -94,7 +97,10 @@ app.get(
 				? `${prefix}/release/${parseInt(versionNumber, 10)}`
 				: prefix;
 
-			const redirectUrl = queryString.stringifyUrl({ url: baseUrl, query: req.query });
+			const redirectUrl = queryString.stringifyUrl({
+				url: baseUrl,
+				query: req.query as ParsedQuery,
+			});
 			return res.redirect(redirectUrl);
 		} catch (err) {
 			return handleErrors(req, res, next)(err);

--- a/server/routes/superAdminDashboard.tsx
+++ b/server/routes/superAdminDashboard.tsx
@@ -3,7 +3,12 @@ import React from 'react';
 import * as types from 'types';
 import Html from 'server/Html';
 import app from 'server/server';
-import { superAdminTabKinds, SuperAdminTabKind, getSuperAdminTabUrl } from 'utils/superAdmin';
+import {
+	superAdminTabKinds,
+	SuperAdminTabKind,
+	getSuperAdminTabUrl,
+	isSuperAdminTabKind,
+} from 'utils/superAdmin';
 import { ForbiddenError, handleErrors, NotFoundError } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
@@ -38,7 +43,7 @@ app.get('/superadmin', async (_, res) => {
 app.get('/superadmin/:tabKind', async (req, res, next) => {
 	try {
 		const { tabKind } = req.params;
-		if (!superAdminTabKinds.includes(tabKind)) {
+		if (!isSuperAdminTabKind(tabKind)) {
 			throw new NotFoundError();
 		}
 		const initialData = await getInitialData(req);

--- a/server/search/api.ts
+++ b/server/search/api.ts
@@ -3,7 +3,7 @@ import app from 'server/server';
 import { getSearchUsers } from './queries';
 
 app.get('/api/search/users', (req, res) => {
-	return getSearchUsers(req.query.q)
+	return getSearchUsers(req.query.q as string)
 		.then((searchResults) => {
 			return res.status(200).json(searchResults);
 		})

--- a/server/spamTag/api.ts
+++ b/server/spamTag/api.ts
@@ -1,5 +1,6 @@
 import app, { wrap } from 'server/server';
 import { ForbiddenError } from 'server/utils/errors';
+import { expect } from 'utils/assert';
 
 import { canManipulateSpamTags } from './permissions';
 import { updateSpamTagForCommunity } from './queries';
@@ -20,7 +21,9 @@ app.put(
 
 app.post('/api/spamTags/queryCommunitiesForSpam', async (req, res) => {
 	const { offset, limit, searchTerm, status, ordering } = req.body;
-	const canQuery = await canManipulateSpamTags({ userId: req.user?.id });
+	const canQuery = await canManipulateSpamTags({
+		userId: expect(req.user).id,
+	});
 	if (!canQuery) {
 		throw new ForbiddenError();
 	}

--- a/server/workerTask/api.ts
+++ b/server/workerTask/api.ts
@@ -3,7 +3,7 @@ import app from 'server/server';
 import { getWorkerTask } from './queries';
 
 app.get('/api/workerTasks', (req, res) => {
-	return getWorkerTask(req.query)
+	return getWorkerTask(req.query as { workerTaskId: string })
 		.then((workerTaskData) => {
 			return res.status(201).json(workerTaskData);
 		})

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,11 @@
+import { User } from './user';
+
+export {};
+
+declare global {
+	namespace Express {
+		export interface Request {
+			user?: User;
+		}
+	}
+}

--- a/utils/superAdmin.ts
+++ b/utils/superAdmin.ts
@@ -4,4 +4,7 @@ export const getSuperAdminTabUrl = (tabKind: SuperAdminTabKind) => {
 	return `/superadmin/${tabKind}` as const;
 };
 
+export const isSuperAdminTabKind = (tabKind: string): tabKind is SuperAdminTabKind =>
+	superAdminTabKinds.includes(tabKind as any);
+
 export type SuperAdminTabKind = typeof superAdminTabKinds[number];


### PR DESCRIPTION
Closes #2446 

This PR fixes a couple of minor vulnerabilities:
1. Removes a potential phising attack vector where PubPub would redirect to arbitrary URLs when the pathname began with multiple slashes and were trailed by a single slash, e.g. `http://pubpub.org//google.com/`.
2. Filters sensitive properties from `DepositTarget` models before they are sent to the client when rendering dashboard settings pages (already privileged routes).

I also added `@types/express` so we have typing on our express middleware and route handlers. Still need to type the `wrap` function though.