### PR TITLE
Fix: title handling in meta tags

### DIFF
--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -68,7 +68,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 	} = initialData.communityData;
 
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
-	const isPub = !!initialData.scopeData.elements.activePub;
+	const isPub = !!initialData.scopeData?.elements.activePub;
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;
 	const titleWithContext = contextTitle ? `${title} · ${contextTitle}` : title;

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -69,6 +69,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
 	const isPub = !!initialData.scopeData?.elements.activePub;
+	const useCollectionTitle = !isPub && collection?.title;
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;
 	const titleWithContext = contextTitle ? `${title} · ${contextTitle}` : title;
@@ -93,16 +94,20 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			<meta
 				key="t2"
 				property="og:title"
-				content={!isPub ? collection?.title || title : title}
+				content={useCollectionTitle ? collection.title : title}
 			/>,
 			<meta key="t3" name="twitter:title" content={titleWithContext} />,
 			<meta key="t4" name="twitter:image:alt" content={titleWithContext} />,
 			<meta
 				key="t5"
 				name="citation_title"
-				content={!isPub ? collection?.title || title : title}
+				content={useCollectionTitle ? collection.title : title}
 			/>,
-			<meta key="t6" name="dc.title" content={!isPub ? collection?.title || title : title} />,
+			<meta
+				key="t6"
+				name="dc.title"
+				content={useCollectionTitle ? collection.title : title}
+			/>,
 		];
 	}
 

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -68,6 +68,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 	} = initialData.communityData;
 
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
+	const isPub = !!initialData.scopeData.elements.activePub;
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;
 	const titleWithContext = contextTitle ? `${title} · ${contextTitle}` : title;
@@ -92,12 +93,16 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			<meta
 				key="t2"
 				property="og:title"
-				content={collection?.kind === 'book' ? collection.title : title}
+				content={!isPub ? collection?.title || title : title}
 			/>,
 			<meta key="t3" name="twitter:title" content={titleWithContext} />,
 			<meta key="t4" name="twitter:image:alt" content={titleWithContext} />,
-			<meta key="t5" name="citation_title" content={collection?.title ?? title} />,
-			<meta key="t6" name="dc.title" content={collection?.title ?? title} />,
+			<meta
+				key="t5"
+				name="citation_title"
+				content={!isPub ? collection?.title || title : title}
+			/>,
+			<meta key="t6" name="dc.title" content={!isPub ? collection?.title || title : title} />,
 		];
 	}
 
@@ -122,13 +127,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			<meta
 				key="u2"
 				property="og:type"
-				content={
-					collection?.kind === 'book'
-						? 'book'
-						: url.indexOf('/pub/') > -1
-						? 'article'
-						: 'website'
-				}
+				content={collection?.kind === 'book' ? 'book' : isPub ? 'article' : 'website'}
 			/>,
 		];
 	}

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -68,7 +68,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 	} = initialData.communityData;
 
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
-	const isPub = !!initialData.scopeData.elements.activePub;
+	const isPub = !!initialData.scopeData?.elements.activeIds.pubId;
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;
 	const titleWithContext = contextTitle ? `${title} · ${contextTitle}` : title;

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -68,7 +68,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 	} = initialData.communityData;
 
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
-	const isPub = !!initialData.scopeData?.elements.activeIds.pubId;
+	const isPub = !!initialData.scopeData.elements.activePub;
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;
 	const titleWithContext = contextTitle ? `${title} · ${contextTitle}` : title;


### PR DESCRIPTION
Due to a change in #2307, some Pubs are being given their collections' `dc.title`, `og:title`, and `citation_title`. This lead to some citation managers and scrapers grabbing the collection title instead of the pub title. The behavior we want is:

- If the resource is a Pub, we use its title (without context) for all three.
- If the resource is a collection that has a title, we use the collection title (without context).

This PR accomplishes that.

_Test plan_
1. Visit a pub in a collection. Verify that:
- The page title and twitter title are titleWithContext (`pubTitle • communityTitle`).
- The og:title and dc.title are the pub title (without context)
1. Visit a pub not in a collection. Verify that it loads and that the titles are the same as above.
1. Visit a collection page. Verify that it loads and:
- The page title and twitter title are titleWithContext (usually `collectionTitle • communityTitle`).
- The og:title and dc.title are the collection title (without context)
1. Visit a few other non-pub and non-collection pages (search, homepage, etc.) and verify that the titles are as expected (`PageTitle • CommunityTitle` for all)