### PR TITLE
Hide login button on login pages

### DIFF
--- a/client/components/GlobalControls/LoginButton.tsx
+++ b/client/components/GlobalControls/LoginButton.tsx
@@ -10,6 +10,9 @@ type Props = {
 const LoginButton = (props: Props) => {
 	const { locationData } = props;
 	const { path, queryString } = locationData;
+	if (['/login', '/signup'].includes(path)) {
+		return null;
+	}
 	const redirectString = `?redirect=${path}${queryString.length > 1 ? queryString : ''}`;
 	const loginHref = `/login${redirectString}`;
 	return (


### PR DESCRIPTION
Addresses #2438

The long redirect chain in that issue can be recreated by going to the login page and then repeatedly clicking the login button. However, in my testing, a browser will not actually follow beyond the first one, so I doubt it's causing our mysterious timeouts.

Let me know if this isn't the right solution, but I don't really see a reason to have the login button on the login page or the signup page. Removing those should prevent bots (or inattentive humans) from ending up at those URLs in the first place.