### PR TITLE
404 for nonexistent tabs under /legal

### DIFF
--- a/server/routes/legal.tsx
+++ b/server/routes/legal.tsx
@@ -14,6 +14,9 @@ app.get('/tos', (_, res) => res.redirect('/legal/terms'));
 app.get('/legal', (_, res) => res.redirect('/legal/terms'));
 
 app.get('/legal/:tab', (req, res, next) => {
+	if (!['terms', 'privacy', 'aup', 'settings'].includes(req.params.tab)) {
+		return next();
+	}
 	return getInitialData(req)
 		.then((initialData) => {
 			return renderToNodeStream(

--- a/server/routes/legal.tsx
+++ b/server/routes/legal.tsx
@@ -13,7 +13,7 @@ app.get('/privacy/settings', (_, res) => res.redirect('/legal/settings'));
 app.get('/tos', (_, res) => res.redirect('/legal/terms'));
 app.get('/legal', (_, res) => res.redirect('/legal/terms'));
 
-app.get(['/legal/terms', '/legal/privacy', '/legal/aup', '/legal/settings'], (req, res, next) => {
+app.get('/legal/:tab', (req, res, next) => {
 	return getInitialData(req)
 		.then((initialData) => {
 			return renderToNodeStream(

--- a/server/routes/legal.tsx
+++ b/server/routes/legal.tsx
@@ -13,7 +13,7 @@ app.get('/privacy/settings', (_, res) => res.redirect('/legal/settings'));
 app.get('/tos', (_, res) => res.redirect('/legal/terms'));
 app.get('/legal', (_, res) => res.redirect('/legal/terms'));
 
-app.get('/legal/:tab', (req, res, next) => {
+app.get(['/legal/terms', '/legal/privacy', '/legal/aup', '/legal/settings'], (req, res, next) => {
 	return getInitialData(req)
 		.then((initialData) => {
 			return renderToNodeStream(


### PR DESCRIPTION
Addresses #2445 

Explicitly specifies the routes under `/legal` that pubpub responds to ~since we weren't using the `:tab` parameter anyways.~ <-- untrue as Gabe pointed out below.

To test:

Working legal pages: https://pubpub-pipel-kalilsn-le-xv3ufv.herokuapp.com/legal/terms

404 from a bad route under legal: https://pubpub-pipel-kalilsn-le-xv3ufv.herokuapp.com/legal/term