### PR TITLE
Fix: check for existence of elements in initialData

### DIFF
--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -68,7 +68,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 	} = initialData.communityData;
 
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
-	const isPub = !!initialData.scopeData.elements.activePub;
+	const isPub = !!initialData.scopeData?.elements.activePub;
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;
 	const titleWithContext = contextTitle ? `${title} · ${contextTitle}` : title;

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -69,6 +69,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
 	const isPub = !!initialData.scopeData?.elements.activePub;
+	const useCollectionTitle = !isPub && collection?.title;
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;
 	const titleWithContext = contextTitle ? `${title} · ${contextTitle}` : title;
@@ -93,16 +94,20 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			<meta
 				key="t2"
 				property="og:title"
-				content={!isPub ? collection?.title || title : title}
+				content={useCollectionTitle ? collection.title : title}
 			/>,
 			<meta key="t3" name="twitter:title" content={titleWithContext} />,
 			<meta key="t4" name="twitter:image:alt" content={titleWithContext} />,
 			<meta
 				key="t5"
 				name="citation_title"
-				content={!isPub ? collection?.title || title : title}
+				content={useCollectionTitle ? collection.title : title}
 			/>,
-			<meta key="t6" name="dc.title" content={!isPub ? collection?.title || title : title} />,
+			<meta
+				key="t6"
+				name="dc.title"
+				content={useCollectionTitle ? collection.title : title}
+			/>,
 		];
 	}
 

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -68,6 +68,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 	} = initialData.communityData;
 
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
+	const isPub = !!initialData.scopeData.elements.activePub;
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;
 	const titleWithContext = contextTitle ? `${title} · ${contextTitle}` : title;
@@ -92,12 +93,16 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			<meta
 				key="t2"
 				property="og:title"
-				content={collection?.kind === 'book' ? collection.title : title}
+				content={!isPub ? collection?.title || title : title}
 			/>,
 			<meta key="t3" name="twitter:title" content={titleWithContext} />,
 			<meta key="t4" name="twitter:image:alt" content={titleWithContext} />,
-			<meta key="t5" name="citation_title" content={collection?.title ?? title} />,
-			<meta key="t6" name="dc.title" content={collection?.title ?? title} />,
+			<meta
+				key="t5"
+				name="citation_title"
+				content={!isPub ? collection?.title || title : title}
+			/>,
+			<meta key="t6" name="dc.title" content={!isPub ? collection?.title || title : title} />,
 		];
 	}
 
@@ -122,13 +127,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 			<meta
 				key="u2"
 				property="og:type"
-				content={
-					collection?.kind === 'book'
-						? 'book'
-						: url.indexOf('/pub/') > -1
-						? 'article'
-						: 'website'
-				}
+				content={collection?.kind === 'book' ? 'book' : isPub ? 'article' : 'website'}
 			/>,
 		];
 	}

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -68,7 +68,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 	} = initialData.communityData;
 
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
-	const isPub = !!initialData.scopeData?.elements.activePub;
+	const isPub = !!initialData.scopeData?.elements?.activePub;
 	const useCollectionTitle = !isPub && collection?.title;
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -68,7 +68,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 	} = initialData.communityData;
 
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
-	const isPub = !!initialData.scopeData.elements.activePub;
+	const isPub = !!initialData.scopeData?.elements.activeIds.pubId;
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;
 	const titleWithContext = contextTitle ? `${title} · ${contextTitle}` : title;

--- a/server/utils/ssr.tsx
+++ b/server/utils/ssr.tsx
@@ -68,7 +68,7 @@ export const generateMetaComponents = (metaProps: MetaProps) => {
 	} = initialData.communityData;
 
 	const url = `https://${initialData.locationData.hostname}${initialData.locationData.path}`;
-	const isPub = !!initialData.scopeData?.elements.activeIds.pubId;
+	const isPub = !!initialData.scopeData.elements.activePub;
 	const favicon = initialData.communityData.favicon;
 	const avatar = image || initialData.communityData.avatar;
 	const titleWithContext = contextTitle ? `${title} · ${contextTitle}` : title;


### PR DESCRIPTION
Tests were failing because, on basepubpub/www, `initialData.scopeData.elements` doesn't exist. This adds a check for that.

_Test plan_
1. Load branch on www
2. Make sure homepage, about, search, a user account load. Rss should return 404.