### PR TITLE
fix: ignore credentials when disabling deposits due to unmanaged prefix

### DIFF
--- a/client/containers/DashboardSettings/PubSettings/Doi.tsx
+++ b/client/containers/DashboardSettings/PubSettings/Doi.tsx
@@ -129,10 +129,7 @@ class Doi extends Component<Props, State> {
 	}
 
 	disabledDueToUnmanagedPrefix() {
-		return (
-			this.props.depositTarget &&
-			!(this.props.depositTarget.password && this.props.depositTarget.username)
-		);
+		return this.props.depositTarget && !this.props.depositTarget.isPubPubManaged;
 	}
 
 	handleDeposit(doi) {

--- a/server/depositTarget/queries.ts
+++ b/server/depositTarget/queries.ts
@@ -6,16 +6,31 @@ import { DepositTarget } from 'server/models';
  * the first one created for the Community. Eventually, we will allow users to select the
  * primary deposit target when a Community has more than one.
  */
-export const getCommunityDepositTarget = (
+export const getCommunityDepositTarget = async (
 	communityId: string,
 	includeCredentials = false,
 ): Promise<types.Maybe<types.DepositTarget>> => {
-	return DepositTarget.findOne({
+	const depositTarget = await DepositTarget.findOne({
 		where: {
 			communityId,
 		},
-		attributes: {
-			exclude: includeCredentials ? [] : ['username', 'password', 'passwordInitVec'],
-		},
 	});
+
+	if (!depositTarget) {
+		return undefined;
+	}
+
+	const depositTargetJson = {
+		...depositTarget.get({ plain: true }),
+		isPubPubManaged: Boolean(depositTarget.username),
+	};
+
+	if (includeCredentials) {
+		return depositTargetJson;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const { username, password, passwordInitVec, ...sanitizedDepositTargetJson } =
+		depositTargetJson;
+	return sanitizedDepositTargetJson;
 };

--- a/types/depositTarget.ts
+++ b/types/depositTarget.ts
@@ -6,4 +6,5 @@ export type DepositTarget = {
 	username: string;
 	password: string;
 	passwordInitVec: string;
+	isPubPubManaged?: boolean;
 };


### PR DESCRIPTION
Resolves #2463.

A PubPub-managed Crossref deposit target has a username.

We disable depositing through PubPub if the community has an unmanaged deposit target. Otherwise, PubPub will deposit using the community's configured Crossref credentials (and an optional, customizable prefix). We fall back to PubPub's default prefix and credentials if the community does not have a deposit target.

