### PR TITLE
fix: Make sure ActivityItem is created with new Discussion

### DIFF
--- a/server/activityItem/fetch.ts
+++ b/server/activityItem/fetch.ts
@@ -198,7 +198,9 @@ const getActivityItemAssociationIds = (
 			thread.add(item.payload.threadId);
 			if (item.payload.threadComment) {
 				threadComment.add(item.payload.threadComment.id);
-				user.add(item.payload.threadComment.userId);
+				if (item.payload.threadComment.userId) {
+					user.add(item.payload.threadComment.userId);
+				}
 			}
 		} else if (item.kind === 'pub-review-comment-added') {
 			review.add(item.payload.review.id);

--- a/server/activityItem/queries.ts
+++ b/server/activityItem/queries.ts
@@ -310,6 +310,7 @@ export const createPubReviewCreatedActivityItem = async (reviewId: string) => {
 		id: threadComment.id,
 		text: threadComment.text,
 		userId: threadComment.userId,
+		commenterId: threadComment.commenterId,
 	};
 
 	return createActivityItem({
@@ -357,6 +358,7 @@ export const createPubReviewCommentAddedActivityItem = async (
 				id: threadComment.id,
 				text: threadComment.text,
 				userId: threadComment.userId,
+				commenterId: threadComment.commenterId,
 			},
 			pub: { title: pub.title },
 		},
@@ -553,6 +555,7 @@ export const createPubDiscussionCommentAddedActivityItem = async (
 				id: threadCommentId,
 				text: threadComment.text,
 				userId: threadComment.userId,
+				commenterId: threadComment.commenterId,
 			},
 		},
 	});

--- a/server/discussion/__tests__/api.test.ts
+++ b/server/discussion/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import uuid from 'uuid';
 
-import { setup, login, modelize } from 'stubstub';
+import { setup, login, modelize, expectCreatedActivityItem } from 'stubstub';
 
 import { Discussion, Thread, ThreadComment } from 'server/models';
 
@@ -151,16 +151,33 @@ it('forbids guests from making comments with visibilityAccess=members', async ()
 		.expect(403);
 });
 
-it('creates a database entry', async () => {
+it('creates a database entry (and an ActivityItem)', async () => {
 	const { guest, releasePub } = models;
 	const agent = await login(guest);
 
 	const {
 		body: { id: discussionId },
-	} = await agent
-		.post('/api/discussions')
-		.send(makeDiscussion({ pub: releasePub, text: 'Hello world!', visibilityAccess: 'public' }))
-		.expect(201);
+	} = await expectCreatedActivityItem(
+		agent
+			.post('/api/discussions')
+			.send(
+				makeDiscussion({
+					pub: releasePub,
+					text: 'Hello world!',
+					visibilityAccess: 'public',
+				}),
+			)
+			.expect(201),
+	).toMatchObject({
+		actorId: guest.id,
+		pubId: releasePub.id,
+		kind: 'pub-discussion-comment-added',
+		payload: {
+			threadComment: {
+				text: 'Hello world!',
+			},
+		},
+	});
 
 	const discussion = await Discussion.findOne({ where: { id: discussionId } });
 	const relatedThread = await Thread.findOne({

--- a/server/discussion/queries.ts
+++ b/server/discussion/queries.ts
@@ -82,9 +82,6 @@ export const createDiscussion = async (options: CreateDiscussionOpts) => {
 		userId,
 	} = options;
 
-	const user = userId || null;
-	const commenter = commenterName || null;
-
 	const discussions = await Discussion.findAll({
 		where: { pubId },
 		attributes: ['id', 'pubId', 'number'],
@@ -121,8 +118,8 @@ export const createDiscussion = async (options: CreateDiscussionOpts) => {
 	const { commenterId } = await createThreadComment({
 		text,
 		content,
-		commenterName: commenter,
-		userId: user,
+		commenterName,
+		userId,
 		threadId: newThread.id,
 	});
 

--- a/server/discussion/queries.ts
+++ b/server/discussion/queries.ts
@@ -1,5 +1,4 @@
-/* eslint-disable no-restricted-syntax */
-import { ForbiddenError } from 'server/utils/errors';
+/* eslint-disable no-restricted-syntax */ import { ForbiddenError } from 'server/utils/errors';
 import {
 	Commenter,
 	Discussion,
@@ -11,10 +10,11 @@ import {
 	Visibility,
 	includeUserModel,
 } from 'server/models';
+import { VisibilityAccess, DocJson } from 'types';
 import { getReadableDateInYear } from 'utils/dates';
 import { createDiscussionAnchor } from 'server/discussionAnchor/queries';
-import { createNewThreadWithComment } from 'server/thread/queries';
-import { VisibilityAccess, DocJson } from 'types';
+import { createThreadComment } from 'server/threadComment/queries';
+import { createThread } from 'server/thread/queries';
 
 const findDiscussionWithUser = (id) =>
 	Discussion.findOne({
@@ -103,24 +103,32 @@ export const createDiscussion = async (options: CreateDiscussionOpts) => {
 	const dateString = getReadableDateInYear(new Date());
 	const generatedTitle = `New Discussion on ${dateString}`;
 
-	const { threadId, commenterId } = await createNewThreadWithComment({
-		text,
-		content,
-		commenterName: commenter,
-		userId: user,
-	});
+	const [newVisibility, newThread] = await Promise.all([
+		Visibility.create({ access: visibilityAccess }),
+		createThread(),
+	]);
 
-	const newVisibility = await Visibility.create({ access: visibilityAccess });
 	const newDiscussion = await Discussion.create({
 		id: discussionId,
 		title: title || generatedTitle,
 		number: maxThreadNumber + 1,
-		threadId,
+		threadId: newThread.id,
 		visibilityId: newVisibility.id,
 		userId,
 		pubId,
-		commenterId,
 	});
+
+	const { commenterId } = await createThreadComment({
+		text,
+		content,
+		commenterName: commenter,
+		userId: user,
+		threadId: newThread.id,
+	});
+
+	if (commenterId) {
+		await Discussion.update({ commenterId });
+	}
 
 	if (initAnchorData) {
 		const { from, to, exact, prefix, suffix } = initAnchorData;

--- a/server/review/queries.ts
+++ b/server/review/queries.ts
@@ -13,7 +13,7 @@ import {
 	createReleasedEvent,
 } from '../threadEvent/queries';
 import { createRelease } from '../release/queries';
-import { createThreadComment, CreateThreadOptions } from '../threadComment/queries';
+import { createThreadComment, CreateThreadCommentOptions } from '../threadComment/queries';
 
 type CreateReviewOptions = {
 	pubId: string;
@@ -83,7 +83,7 @@ export const createReview = async ({
 				content,
 				threadId,
 				userId,
-			} as CreateThreadOptions;
+			} as CreateThreadCommentOptions;
 			await createThreadComment(options);
 		}
 	}

--- a/server/thread/queries.ts
+++ b/server/thread/queries.ts
@@ -1,10 +1,6 @@
 import * as types from 'types';
 import { Discussion, Pub, ReviewNew, Visibility, Thread } from 'server/models';
 import { filterUsersAcceptedByVisibility } from 'server/visibility/queries';
-import {
-	createThreadCommentWithUserOrCommenter,
-	CreateThreadWithCommentOptions,
-} from 'server/threadComment/queries';
 
 type FilterUsersOptions = {
 	userIds: string[];
@@ -68,22 +64,6 @@ export const canUserSeeThread = async (options: CanUserSeeThreadOptions): Promis
 	return maybeUserId === userId;
 };
 
-export const createNewThreadWithComment = async (options: CreateThreadWithCommentOptions) => {
-	const { text, content, userId, commenterName } = options;
-	const newThread = await Thread.create({});
-
-	const { threadCommentId, commenterId } = await createThreadCommentWithUserOrCommenter(
-		{
-			text,
-			content,
-			userId,
-			commenterName,
-		},
-		newThread.id,
-	);
-	return {
-		threadId: newThread.id,
-		threadCommentId,
-		commenterId,
-	};
+export const createThread = async (): Promise<types.Thread> => {
+	return Thread.create({});
 };

--- a/server/threadComment/hooks.ts
+++ b/server/threadComment/hooks.ts
@@ -29,6 +29,7 @@ const createActivityItem = async (threadComment: types.ThreadComment) => {
 			await createPubReviewCommentAddedActivityItem(review.id, threadComment.id);
 		}
 	}
+	throw new Error(`Failed to find a parent for threadId=${threadComment.threadId}`);
 };
 
 ThreadComment.afterCreate(async (threadComment: types.ThreadComment) => {

--- a/server/threadComment/hooks.ts
+++ b/server/threadComment/hooks.ts
@@ -18,7 +18,7 @@ const createActivityItem = async (threadComment: types.ThreadComment) => {
 				where: { threadId: threadComment.threadId },
 			});
 			const isReply = numberOfCommentsInThread > 1;
-			await createPubDiscussionCommentAddedActivityItem(
+			return createPubDiscussionCommentAddedActivityItem(
 				discussion.id,
 				threadComment.id,
 				isReply,
@@ -26,10 +26,10 @@ const createActivityItem = async (threadComment: types.ThreadComment) => {
 		}
 		if (parent.type === 'review') {
 			const { value: review } = parent;
-			await createPubReviewCommentAddedActivityItem(review.id, threadComment.id);
+			return createPubReviewCommentAddedActivityItem(review.id, threadComment.id);
 		}
 	}
-	throw new Error(`Failed to find a parent for threadId=${threadComment.threadId}`);
+	return null;
 };
 
 ThreadComment.afterCreate(async (threadComment: types.ThreadComment) => {

--- a/server/threadComment/queries.ts
+++ b/server/threadComment/queries.ts
@@ -2,7 +2,9 @@ import { ThreadComment, includeUserModel, Commenter } from 'server/models';
 import * as types from 'types';
 import { createCommenter } from '../commenter/queries';
 
-const findThreadCommentWithUser = (id) =>
+const findThreadCommentWithUser = (
+	id: string,
+): Promise<types.DefinitelyHas<types.ThreadComment, 'author' | 'commenter'>> =>
 	ThreadComment.findOne({
 		where: { id },
 		include: [includeUserModel({ as: 'author' }), { model: Commenter, as: 'commenter' }],
@@ -33,15 +35,15 @@ export const createThreadCommentWithUserOrCommenter = async (
 	return { threadCommentId: threadComment.id, commenterId: commenter?.id };
 };
 
-export type CreateThreadOptions = {
+export type CreateThreadCommentOptions = {
 	text: string;
 	content: types.DocJson;
 	threadId: string;
-	commenterName?: string;
-	userId?: string;
+	commenterName?: null | string;
+	userId?: null | string;
 };
 
-export const createThreadComment = async (options: CreateThreadOptions) => {
+export const createThreadComment = async (options: CreateThreadCommentOptions) => {
 	const { text, content, commenterName, threadId, userId } = options;
 
 	const user = userId || null;
@@ -52,8 +54,7 @@ export const createThreadComment = async (options: CreateThreadOptions) => {
 		threadId,
 	);
 
-	const threadCommentWithUser = await findThreadCommentWithUser(threadCommentId);
-	return threadCommentWithUser;
+	return findThreadCommentWithUser(threadCommentId);
 };
 
 export const updateThreadComment = (inputValues, updatePermissions) => {

--- a/server/threadComment/queries.ts
+++ b/server/threadComment/queries.ts
@@ -17,24 +17,6 @@ export type CreateThreadWithCommentOptions = {
 	commenterName: null | string;
 };
 
-export const createThreadCommentWithUserOrCommenter = async (
-	options: CreateThreadWithCommentOptions,
-	threadId: string,
-) => {
-	const { text, content, userId, commenterName } = options;
-	const newCommenter = commenterName && (await createCommenter({ name: commenterName }));
-	const userIdOrCommenterId = newCommenter ? { commenterId: newCommenter.id } : { userId };
-	const commenter = newCommenter && 'id' in newCommenter ? newCommenter : null;
-	const threadComment = await ThreadComment.create({
-		text,
-		content,
-		threadId,
-		...userIdOrCommenterId,
-	});
-
-	return { threadCommentId: threadComment.id, commenterId: commenter?.id };
-};
-
 export type CreateThreadCommentOptions = {
 	text: string;
 	content: types.DocJson;
@@ -44,17 +26,19 @@ export type CreateThreadCommentOptions = {
 };
 
 export const createThreadComment = async (options: CreateThreadCommentOptions) => {
-	const { text, content, commenterName, threadId, userId } = options;
+	const { text, content, userId, commenterName, threadId } = options;
 
-	const user = userId || null;
-	const commenter = commenterName || null;
+	const newCommenter = commenterName && (await createCommenter({ name: commenterName }));
+	const userIdOrCommenterId = newCommenter ? { commenterId: newCommenter.id } : { userId };
 
-	const { threadCommentId } = await createThreadCommentWithUserOrCommenter(
-		{ text, content, userId: user, commenterName: commenter },
+	const threadComment = await ThreadComment.create({
+		text,
+		content,
 		threadId,
-	);
+		...userIdOrCommenterId,
+	});
 
-	return findThreadCommentWithUser(threadCommentId);
+	return findThreadCommentWithUser(threadComment.id);
 };
 
 export const updateThreadComment = (inputValues, updatePermissions) => {

--- a/server/userNotification/__tests__/api.test.ts
+++ b/server/userNotification/__tests__/api.test.ts
@@ -24,6 +24,7 @@ const fakePayload: PubDiscussionCommentAddedActivityItem['payload'] = {
 		id: uuid(),
 		text: 'hmm',
 		userId: uuid(),
+		commenterId: null,
 	},
 	threadId: uuid(),
 	discussionId: uuid(),

--- a/types/activity/thread.ts
+++ b/types/activity/thread.ts
@@ -8,7 +8,8 @@ export type ThreadActivityItemBase = InsertableActivityItemBase & {
 		threadComment: {
 			id: string;
 			text: string;
-			userId: string;
+			userId: null | string;
+			commenterId: null | string;
 		};
 	};
 };

--- a/types/thread.ts
+++ b/types/thread.ts
@@ -1,3 +1,4 @@
+import { DocJson } from 'types';
 import { User } from './user';
 import { Discussion } from './discussion';
 import { Review } from './review';
@@ -20,11 +21,12 @@ export type ThreadComment = {
 	createdAt: string;
 	updatedAt: string;
 	text: string;
-	content: {};
-	userId: string;
+	content: DocJson;
+	userId: null | string;
 	threadId: string;
-	author?: User;
-	commenter?: Commenter;
+	commenterId: null | string;
+	author?: null | User;
+	commenter?: null | Commenter;
 };
 
 export type Thread = {

--- a/utils/crossref/__tests__/createDeposit.test.js
+++ b/utils/crossref/__tests__/createDeposit.test.js
@@ -341,7 +341,7 @@ describe('createDeposit', () => {
 		);
 	});
 
-	it.only('uses a DepositTarget to produce a doi prefix', () => {
+	it('uses a DepositTarget to produce a doi prefix', () => {
 		const depositTarget = { doiPrefix: 'abc' };
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		const { doi, ...pubWithouDoi } = pub;


### PR DESCRIPTION
Resolves #2469. Back in #2289 we added a new abstraction that creates a new `Thread` and a `ThreadComment` in the same query function. This is a really good idea, and for months I didn't notice a small problem. When a `ThreadComment` is created, a [Sequelize hook](https://sequelize.org/docs/v6/other-topics/hooks/) fires that wants to create a `pub-discussion-comment-added` item. But unless the parent thread is already associated with a `Discussion`, we can't do that, and no item is created. So we really need to create a Discussion and a Thread and associate the two before we create a comment.

There are other potential fixes here (deferring the hook somehow, or maybe adding another hook to `Discussion.afterCreate`) but for now I've elected to re-order the creation of these items, and add a test that checks that the activity item is created so we'll know if this breaks again.

_Test plan:_

Run the unit tests at:
```
npm run test-dev server/discussion/
```

You can test manually by commenting on a Pub, then visiting the Activity tab of that Pub's dashboard and verifying that a record of your comment exists there.
