### PR TITLE
Only redirect from deduplicateSlash middleware when slashes are removed

### DIFF
--- a/server/middleware/__tests__/deduplicateSlash.test.ts
+++ b/server/middleware/__tests__/deduplicateSlash.test.ts
@@ -1,0 +1,37 @@
+import { deduplicateSlash } from '../deduplicateSlash';
+
+describe('deduplicate Slash Middleware', () => {
+	let mockRes;
+	let mockReq;
+	let nextFn;
+	const dedupeMiddleware = deduplicateSlash();
+
+	beforeEach(() => {
+		mockRes = {
+			redirect: jest.fn(),
+		};
+		mockReq = {
+			url: '',
+		};
+		nextFn = jest.fn();
+	});
+
+	it('redirects to a url with slashes deduplicated', async () => {
+		mockReq.url = '//someotherhost.com';
+		dedupeMiddleware(mockReq, mockRes, nextFn);
+		expect(mockRes.redirect).toBeCalledWith(301, '/someotherhost.com');
+	});
+	it('does not redirect if no duplicate slashes are found', async () => {
+		mockReq.url = '/a/normal/pubpub/route';
+		dedupeMiddleware(mockReq, mockRes, nextFn);
+		expect(mockRes.redirect).not.toBeCalled();
+		expect(nextFn).toBeCalledTimes(1);
+	});
+	it('does not redirect if duplicate slashes are found only in the query string', async () => {
+		mockReq.url =
+			'/api/editor/embed?type=youtube&input=https://www.youtube.com/watch?v=PL9iMPx9CpQ';
+		dedupeMiddleware(mockReq, mockRes, nextFn);
+		expect(mockRes.redirect).not.toBeCalled();
+		expect(nextFn).toBeCalledTimes(1);
+	});
+});

--- a/server/middleware/deduplicateSlash.ts
+++ b/server/middleware/deduplicateSlash.ts
@@ -11,8 +11,14 @@ export function deduplicateSlash() {
 		if (duplicateSlashMatches === null) {
 			return next();
 		}
-		const correctedUrl = parse(req.url);
-		correctedUrl.pathname = expect(correctedUrl.pathname).replace(DUPLICATE_SLASH_PATTERN, '/');
-		res.redirect(301, format(correctedUrl));
+		const parsedUrl = parse(req.url);
+		parsedUrl.pathname = expect(parsedUrl.pathname).replace(DUPLICATE_SLASH_PATTERN, '/');
+		const correctedUrl = format(parsedUrl);
+		// Since we search for duplicate slashes before parsing the URL there are some false
+		// positives we should ignore, such as when the slashes are part of the query string
+		if (correctedUrl === req.url) {
+			return next();
+		}
+		res.redirect(301, correctedUrl);
 	};
 }


### PR DESCRIPTION
Fixes #2468

Editor embeds weren't working because those requests always contained duplicate slashes (`https://`) within the query strings, e.g. `/api/editor/embed?type=youtube&input=https://www.youtube.com/watch?v=PL9iMPx9CpQ`. Since the deduplicateSlashes middleware searches the whole req.url (which is confusingly not a url) string for slashes, but only replaces them in the path. This caused our middleware to send a redirect back to the same URL, creating an infinite loop.