### PR TITLE
Create Link While Typing

### DIFF
--- a/client/components/Editor/plugins/inputRules.ts
+++ b/client/components/Editor/plugins/inputRules.ts
@@ -113,7 +113,6 @@ function linkRule(markType: MarkType) {
 	return new InputRule(
 		HTTP_MAILTO_REGEX,
 		(state: EditorState, match: RegExpMatchArray, start: number, end: number) => {
-			console.log('match: ', match);
 			const resolvedStart = state.doc.resolve(start);
 			if (!resolvedStart.parent.type.allowsMarkType(markType)) return null;
 			const attrs = { type: match[2] === '@' ? 'email' : 'uri' };

--- a/client/components/Editor/plugins/inputRules.ts
+++ b/client/components/Editor/plugins/inputRules.ts
@@ -11,7 +11,6 @@ import {
 } from 'prosemirror-inputrules';
 
 import { makeBlockMathInputRule, REGEX_BLOCK_MATH_DOLLARS } from '@benrbray/prosemirror-math';
-import { CONSOLE } from '@blueprintjs/icons/lib/esm/generated/iconContents';
 
 // : (NodeType) → InputRule
 // Given a blockquote node type, returns an input rule that turns `"> "`
@@ -106,6 +105,7 @@ const inlineMathRule = (
 const blockMathRule = (nodeType) => makeBlockMathInputRule(REGEX_BLOCK_MATH_DOLLARS, nodeType);
 
 const HTTP_MAILTO_REGEX = new RegExp(
+	// eslint-disable-next-line no-useless-escape
 	/(?:(?:(https|http|ftp)+):\/\/)?(?:\S+(?::\S*)?(@))?(?:(?:([a-z0-9][a-z0-9\-]*)?[a-z0-9]+)(?:\.(?:[a-z0-9\-])*[a-z0-9]+)*(?:\.(?:[a-z]{2,})(:\d{1,5})?))(?:\/[^\s]*)?\s$/i,
 );
 const getUriType = (match) => ({ type: match[2] === '@' ? 'email' : 'uri' });

--- a/client/components/Editor/plugins/inputRules.ts
+++ b/client/components/Editor/plugins/inputRules.ts
@@ -114,21 +114,20 @@ function linkRule(markType: MarkType) {
 	return new InputRule(
 		HTTP_MAILTO_REGEX,
 		(state: EditorState, match: RegExpMatchArray, start: number, end: number) => {
-			// console.log('match: ', match);
+			console.log('match: ', match);
 			const resolvedStart = state.doc.resolve(start);
-			const attrs = getUriType(match);
 			if (!resolvedStart.parent.type.allowsMarkType(markType)) return null;
+			const attrs = getUriType(match);
 			const link = match[0].substring(0, match[0].length - 1);
 			const linkAttrs =
 				attrs.type === 'email'
 					? { href: 'mailto:' + link }
 					: { href: link, target: '_blank' };
 			const linkTo = markType.create(linkAttrs);
-			const tr = state.tr
+			return state.tr
 				.removeMark(start, end, markType)
 				.addMark(start, end, linkTo)
 				.insertText(match[5], start);
-			return tr;
 		},
 	);
 }

--- a/client/components/Editor/plugins/inputRules.ts
+++ b/client/components/Editor/plugins/inputRules.ts
@@ -104,6 +104,21 @@ const inlineMathRule = (
 // textblock starting with two dollar signs into a math block.
 const blockMathRule = (nodeType) => makeBlockMathInputRule(REGEX_BLOCK_MATH_DOLLARS, nodeType);
 
+const HTTP_LINK_REGEX =
+	// eslint-disable-next-line no-useless-escape
+	/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
+
+const autoLinkRule = (nodeType: MarkType) =>
+	new InputRule(
+		HTTP_LINK_REGEX,
+		(state: EditorState, match: RegExpMatchArray, start: number, end: number) => {
+			const url = match[1];
+			// what is thisß
+			const startPos = pos.move(-match[0].length);
+			return state.tr.addMark(start, end, nodeType.create({ href: url, title: url }));
+		},
+	);
+
 // : (Schema) → Plugin
 // A set of input rules for creating the basic block quotes, lists,
 // code blocks, and heading.

--- a/client/components/Editor/plugins/inputRules.ts
+++ b/client/components/Editor/plugins/inputRules.ts
@@ -108,16 +108,16 @@ const HTTP_LINK_REGEX =
 	// eslint-disable-next-line no-useless-escape
 	/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
 
-const autoLinkRule = (nodeType: MarkType) =>
-	new InputRule(
-		HTTP_LINK_REGEX,
-		(state: EditorState, match: RegExpMatchArray, start: number, end: number) => {
-			const url = match[1];
-			// what is thisß
-			const startPos = pos.move(-match[0].length);
-			return state.tr.addMark(start, end, nodeType.create({ href: url, title: url }));
-		},
-	);
+// const autoLinkRule = (nodeType: MarkType) =>
+// 	new InputRule(
+// 		HTTP_LINK_REGEX,
+// 		(state: EditorState, match: RegExpMatchArray, start: number, end: number) => {
+// 			const url = match[1];
+// 			// what is thisß
+// 			const startPos = pos.move(-match[0].length);
+// 			return state.tr.addMark(start, end, nodeType.create({ href: url, title: url }));
+// 		},
+// 	);
 
 // : (Schema) → Plugin
 // A set of input rules for creating the basic block quotes, lists,

--- a/client/components/Editor/plugins/inputRules.ts
+++ b/client/components/Editor/plugins/inputRules.ts
@@ -106,9 +106,8 @@ const blockMathRule = (nodeType) => makeBlockMathInputRule(REGEX_BLOCK_MATH_DOLL
 
 const HTTP_MAILTO_REGEX = new RegExp(
 	// eslint-disable-next-line no-useless-escape
-	/(?:(?:(https|http|ftp)+):\/\/)?(?:\S+(?::\S*)?(@))?(?:(?:([a-z0-9][a-z0-9\-]*)?[a-z0-9]+)(?:\.(?:[a-z0-9\-])*[a-z0-9]+)*(?:\.(?:[a-z]{2,})(:\d{1,5})?))(?:\/[^\s]*)?\s$/i,
+	/(?:(?:(https|http|ftp)+):\/\/)?(?:\S+(?::\S*)?(@))?(?:(?:([a-z0-9][a-z0-9\-]*)?[a-z0-9]+)(?:\.(?:[a-z0-9\-])*[a-z0-9]+)*(?:\.(?:[a-z]{2,})(:\d{1,5})?))(?:\/[^\s]*)?\s $/,
 );
-const getUriType = (match) => ({ type: match[2] === '@' ? 'email' : 'uri' });
 
 function linkRule(markType: MarkType) {
 	return new InputRule(
@@ -117,7 +116,7 @@ function linkRule(markType: MarkType) {
 			console.log('match: ', match);
 			const resolvedStart = state.doc.resolve(start);
 			if (!resolvedStart.parent.type.allowsMarkType(markType)) return null;
-			const attrs = getUriType(match);
+			const attrs = { type: match[2] === '@' ? 'email' : 'uri' };
 			const link = match[0].substring(0, match[0].length - 1);
 			const linkAttrs =
 				attrs.type === 'email'

--- a/client/components/Editor/plugins/inputRules.ts
+++ b/client/components/Editor/plugins/inputRules.ts
@@ -104,9 +104,9 @@ const inlineMathRule = (
 // textblock starting with two dollar signs into a math block.
 const blockMathRule = (nodeType) => makeBlockMathInputRule(REGEX_BLOCK_MATH_DOLLARS, nodeType);
 
-const HTTP_LINK_REGEX =
-	// eslint-disable-next-line no-useless-escape
-	/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
+// const HTTP_LINK_REGEX =
+// 	// eslint-disable-next-line no-useless-escape
+// 	/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/g;
 
 // const autoLinkRule = (nodeType: MarkType) =>
 // 	new InputRule(


### PR DESCRIPTION
addresses #2476 

Links will now be automatically created when typing one

https://user-images.githubusercontent.com/34730449/216124349-29aa1540-3a4c-4619-b8ad-5eb6f49510e6.mov



test plan:

open a pub and type out a link.
the link inside the `ControlLink` editor should be the same as the one you typed

now type an email.
be sure the email has a mailto scheme for the email you typed out

