### PR TITLE
Set headersTimeout and keepAliveTimeout higher than heroku router timeout

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -173,7 +173,7 @@ app.use(errorMiddleware);
 /* ------------ */
 const port = process.env.PORT || 9876;
 export const startServer = () => {
-	return app.listen(
+	const server = app.listen(
 		port,
 		// @ts-expect-error
 		(err) => {
@@ -184,4 +184,7 @@ export const startServer = () => {
 			console.info('==> 💻  Send requests to http://localhost:%s', port);
 		},
 	);
+	server.keepAliveTimeout = 31000;
+	server.headersTimeout = 31000;
+	return server;
 };


### PR DESCRIPTION
This PR sets two nodejs server timeouts to 31s, 1s greater than the heroku router's timeout. This will most likely have no effect, but leaving these values unset is well known to cause hard to explain 5xx errors in some environments, so it seems worth testing!

See https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/#the-502-problem for a description of this problem with an AWS load balancer (which may well be involved in the heroku stack).

Related to #2455 

