### PR TITLE
store redirect host on user model in oauth flow

### DIFF
--- a/server/routes/authenticate.tsx
+++ b/server/routes/authenticate.tsx
@@ -1,6 +1,7 @@
 import passport from 'passport';
 import app from 'server/server';
 import { User } from 'server/models';
+import { isDevelopment } from 'utils/environment';
 
 app.get(
 	'/auth/zotero',
@@ -18,8 +19,10 @@ app.get(
 // hand control to passport to use code to grab profile info
 app.get('/auth/zotero/redirect', (req, res, next) => {
 	const host = req.user?.authRedirectHost;
+	const urlBase = isDevelopment() ? 'http://lvh.me:9876' : `https://${host}`;
+
 	passport.authenticate('zotero', {
-		failureRedirect: `${host}/legal/settings?integration=fail`,
-		successRedirect: `${host}/legal/settings?integration=success`,
+		failureRedirect: `${urlBase}/legal/settings?integration=fail`,
+		successRedirect: `${urlBase}/legal/settings?integration=success`,
 	})(req, res, next);
 });

--- a/server/routes/authenticate.tsx
+++ b/server/routes/authenticate.tsx
@@ -1,17 +1,16 @@
 import passport from 'passport';
-import app from 'server/server';
+import app, { wrap } from 'server/server';
 import { User } from 'server/models';
 import { isDevelopment } from 'utils/environment';
 
 app.get(
 	'/auth/zotero',
-	(req, res, next) => {
+	wrap(async (req) => {
 		if (req.user) {
 			const authRedirectHost = req.get('host');
 			User.update({ authRedirectHost }, { where: { id: req.user.id } });
 		}
-		next();
-	},
+	}),
 	passport.authenticate('zotero', { state: 'test' }),
 );
 

--- a/server/routes/authenticate.tsx
+++ b/server/routes/authenticate.tsx
@@ -8,7 +8,7 @@ app.get(
 	wrap(async (req) => {
 		if (req.user) {
 			const authRedirectHost = req.get('host');
-			User.update({ authRedirectHost }, { where: { id: req.user.id } });
+			await User.update({ authRedirectHost }, { where: { id: req.user.id } });
 		}
 	}),
 	passport.authenticate('zotero', { state: 'test' }),

--- a/server/routes/authenticate.tsx
+++ b/server/routes/authenticate.tsx
@@ -1,14 +1,25 @@
 import passport from 'passport';
 import app from 'server/server';
+import { User } from 'server/models';
 
-app.get('/auth/zotero', passport.authenticate('zotero'));
+app.get(
+	'/auth/zotero',
+	(req, res, next) => {
+		if (req.user) {
+			const authRedirectHost = req.get('host');
+			User.update({ authRedirectHost }, { where: { id: req.user.id } });
+		}
+		next();
+	},
+	passport.authenticate('zotero', { state: 'test' }),
+);
 
 // callback route for zotero to redirect to
 // hand control to passport to use code to grab profile info
-app.get(
-	'/auth/zotero/redirect',
+app.get('/auth/zotero/redirect', (req, res, next) => {
+	const host = req.user?.authRedirectHost;
 	passport.authenticate('zotero', {
-		failureRedirect: '/legal/settings?integration=fail',
-		successRedirect: '/legal/settings?integration=success',
-	}),
-);
+		failureRedirect: `${host}/legal/settings?integration=fail`,
+		successRedirect: `${host}/legal/settings?integration=success`,
+	})(req, res, next);
+});

--- a/server/user/model.ts
+++ b/server/user/model.ts
@@ -38,6 +38,7 @@ export default (sequelize, dataTypes) => {
 					isLowercase: true,
 				},
 			},
+			authRedirectHost: { type: dataTypes.TEXT },
 			location: { type: dataTypes.TEXT },
 			website: { type: dataTypes.TEXT },
 			facebook: { type: dataTypes.TEXT },

--- a/tools/migrations/2023_04_17_addAuthRedirect.js
+++ b/tools/migrations/2023_04_17_addAuthRedirect.js
@@ -1,0 +1,9 @@
+export const up = async ({ Sequelize, sequelize }) => {
+	await sequelize.queryInterface.addColumn('Users', 'authRedirectHost', {
+		type: Sequelize.TEXT,
+	});
+};
+
+export const down = async ({ sequelize }) => {
+	await sequelize.queryInterface.removeColumn('Users', 'authRedirectHost');
+};

--- a/types/user.ts
+++ b/types/user.ts
@@ -21,6 +21,7 @@ export type User = MinimalUser & {
 	twitter: string;
 	github: string;
 	googleScholar: string;
+	authRedirectHost?: string;
 };
 
 export type UserWithPrivateFields = User & {


### PR DESCRIPTION
## Issue(s) Resolved

#2598

## Test Plan
Perform oauth flow from 2 consecutive communities
1. log in as community-picker-enabled user (e.g. team@pubpub.org)
2. navigate to user privacy settings
3. if zotero integration is currently active, remove it
4. click 'Activate' for zotero integration
5. proceed through zotero oauth login + screens (credentials available in onepass)
6. after login, you should be returned to user privacy settings page within same community
7. pick a new community
8. return to user privacy settings page
9. zotero integration _should_ be active
10. remove zotero integration
11. perform oauth flow again
12. you should be returned from zotero back to most recently visited community

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
