### PR TITLE
dev: Replace db url with connection pool URL

### DIFF
--- a/server/models.ts
+++ b/server/models.ts
@@ -4,10 +4,11 @@ import { knex } from 'knex';
 
 import { createSequelizeModelsFromFacetDefinitions } from './facets/create';
 
+const database_url = process.env.DATABASE_CONNECTION_POOL_URL || process.env.DATABASE_URL;
 // @ts-expect-error (interpreting this file as vanilla JavaScript from test runner)
-const useSSL = process.env.DATABASE_CONNECTION_POOL_URL.indexOf('localhost') === -1;
+const useSSL = database_url.indexOf('localhost') === -1;
 // @ts-expect-error (interpreting this file as vanilla JavaScript from test runner)
-export const sequelize = new Sequelize(process.env.DATABASE_CONNECTION_POOL_URL, {
+export const sequelize = new Sequelize(database_url, {
 	logging: false,
 	dialectOptions: { ssl: useSSL ? { rejectUnauthorized: false } : false },
 	pool: {

--- a/server/models.ts
+++ b/server/models.ts
@@ -5,9 +5,9 @@ import { knex } from 'knex';
 import { createSequelizeModelsFromFacetDefinitions } from './facets/create';
 
 // @ts-expect-error (interpreting this file as vanilla JavaScript from test runner)
-const useSSL = process.env.DATABASE_URL.indexOf('localhost') === -1;
+const useSSL = process.env.DATABASE_CONNECTION_POOL_URL.indexOf('localhost') === -1;
 // @ts-expect-error (interpreting this file as vanilla JavaScript from test runner)
-export const sequelize = new Sequelize(process.env.DATABASE_URL, {
+export const sequelize = new Sequelize(process.env.DATABASE_CONNECTION_POOL_URL, {
 	logging: false,
 	dialectOptions: { ssl: useSSL ? { rejectUnauthorized: false } : false },
 	pool: {


### PR DESCRIPTION
## Issue(s) Resolved
#2585 

**Note: make sure to update your local config file with new connection pool URLs**

## Test Plan
Mostly a smoke test
- Visit the test app and make sure it loads.
- Visit a few different communities, including www.
- Make sure pubs load, are editable, and can be released
- Make sure pages and layouts can be edited
- Visit a route with a lot of pubs on a page and make sure it loads (e.g. /user/gabriel-stein on www)
- Make sure tests run properly locally (should not use connection pool)

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas
- Used some heroku CLI commands to add the pooling URL to our apps, described here: https://devcenter.heroku.com/articles/postgres-connection-pooling
- Had to manually add the env variables to review apps and the test suite. Should double-check that those target the dev db.
- Updated config.js with new ones. Please double check that the dev and prod db urls are correct.

### Supporting Docs
