### PR TITLE
Revert figure css change

### DIFF
--- a/client/components/Editor/styles/figure.scss
+++ b/client/components/Editor/styles/figure.scss
@@ -2,7 +2,6 @@ figure {
 	display: block;
 	text-align: center;
 	margin: 0;
-	width: 100%;
 
 	& > * {
 		pointer-events: none;
@@ -37,16 +36,12 @@ figure {
 
 	@for $i from 1 through 100 {
 		&[data-size='#{$i}'] {
-			& > :first-child {
-				width: percentage($i * 0.01);
-			}
+			width: percentage($i * 0.01);
 		}
 	}
 
 	&[data-align='full'] {
-		& > :first-child {
-			width: 100%;
-		}
+		width: 100%;
 	}
 
 	figcaption {


### PR DESCRIPTION
## Issue(s) Resolved
https://github.com/pubpub/pubpub/issues/2624 (will close manually once this is deployed).

## Test Plan
On the review instance (or duqduq after this is merged), visit a pub with an image and a link set, and make sure adjusting its size works properly outside of breakout mode. https://demo.duqduq.org/pub/wttb47yk/draft will show this failing!

## Context
This is reverting a change from https://github.com/pubpub/pubpub/pull/2611