### PR TITLE
feat: drop cookie on login/logout for caching

### DIFF
--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -113,6 +113,7 @@ app.post('/api/login', (req, res, next) => {
 				if (err) {
 					throw new Error(err);
 				}
+				res.cookie('pp-cache', 'pp-no-cache');
 				return res.status(201).json('success');
 			});
 		})
@@ -121,7 +122,6 @@ app.post('/api/login', (req, res, next) => {
 			if (unaunthenticatedValues.includes(err.message)) {
 				return res.status(401).json('Login attempt failed');
 			}
-			res.cookie('pp-cache', 'pp-no-cache');
 			return res.status(500).json(err.message);
 		});
 });

--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -121,6 +121,7 @@ app.post('/api/login', (req, res, next) => {
 			if (unaunthenticatedValues.includes(err.message)) {
 				return res.status(401).json('Login attempt failed');
 			}
+			res.cookie('pp-cache', 'pp-no-cache');
 			return res.status(500).json(err.message);
 		});
 });

--- a/server/logout/api.ts
+++ b/server/logout/api.ts
@@ -2,6 +2,7 @@ import app from 'server/server';
 
 app.get('/api/logout', (req, res) => {
 	res.cookie('gdpr-consent-survives-login', 'no');
+	res.cookie('pp-cache', 'pp-cache');
 	// @ts-expect-error
 	req.logout();
 	return res.status(200).json('success');


### PR DESCRIPTION
Adds a cookie for caching when logged in, and changes it when logged out. Went this route instead of a login cookie because it allows us to override it in the future if needed for caching purposes, rather than tying exclusively to login. Decided not to clear it on logout because it allows us to target it specifically in caching controls if needed (though the default will be to cache on pages, collections, and user profiles unless it sees pp-no-cache set).

## Issue(s) Resolved
Closes #2617 

## Test Plan
1. Visit test deployment
2. Logout and clear cookies
3. Login
4. Verify that `pp-cache` is set to `pp-no-cache`
5. Logout
6. Verify that `pp-cache` is set to `pp-cache`
7. Clear cookies
8. Create a new test account
9. Login and verify cookie was set on first login.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas
I was unable to modify the existing cookie because it's simply a session token set by passport.

### Supporting Docs
