### PR TITLE
Safari CSS Webkit Issue

### DIFF
--- a/client/components/Editor/styles/suggestedEdits.scss
+++ b/client/components/Editor/styles/suggestedEdits.scss
@@ -44,7 +44,6 @@ span[data-suggestion-mark='true'][data-suggestion-kind='addition'] {
 
 span[data-suggestion-mark='true'][data-suggestion-kind='removal'] {
 	text-decoration-thickness: 2px;
-	-webkit-text-decoration-thickness: 2px;
 	text-decoration-color: $removal;
 	-webkit-text-decoration-color: $removal;
 	text-decoration-line: line-through;

--- a/client/components/Editor/styles/suggestedEdits.scss
+++ b/client/components/Editor/styles/suggestedEdits.scss
@@ -43,7 +43,12 @@ span[data-suggestion-mark='true'][data-suggestion-kind='addition'] {
 }
 
 span[data-suggestion-mark='true'][data-suggestion-kind='removal'] {
-	text-decoration: 2px $removal line-through;
+	text-decoration: 2px;
+	-webkit-text-decoration: 2px;
+	text-decoration-color: red;
+	-webkit-text-decoration-color: red;
+	text-decoration-line: line-through;
+	-webkit-text-decoration-line: line-through;
 }
 
 span[data-suggestion-mark='true'][data-suggestion-kind='modification'] {

--- a/client/components/Editor/styles/suggestedEdits.scss
+++ b/client/components/Editor/styles/suggestedEdits.scss
@@ -43,10 +43,10 @@ span[data-suggestion-mark='true'][data-suggestion-kind='addition'] {
 }
 
 span[data-suggestion-mark='true'][data-suggestion-kind='removal'] {
-	text-decoration: 2px;
-	-webkit-text-decoration: 2px;
-	text-decoration-color: red;
-	-webkit-text-decoration-color: red;
+	text-decoration-thickness: 2px;
+	-webkit-text-decoration-thickness: 2px;
+	text-decoration-color: $removal;
+	-webkit-text-decoration-color: $removal;
 	text-decoration-line: line-through;
 	-webkit-text-decoration-line: line-through;
 }


### PR DESCRIPTION
## Issue(s) Resolved
#2634 

## Test Plan
Visit Safari browser and another browser and view http://localhost:9876/pub/pegl1ofe/draft
be sure the text looks like below in both browsers

## Screenshots (if applicable)
<img width="1658" alt="image" src="https://user-images.githubusercontent.com/34730449/234622693-0509bac3-a530-4b71-a531-f9274a1941c4.png">
![image](https://user-images.githubusercontent.com/34730449/234622809-170a4731-7a56-45b4-a3d9-0b52931909e4.png)


## Optional

### Notes/Context/Gotchas
the neater one line webkit solution did not work so i split them up

### Supporting Docs
https://stackoverflow.com/questions/51181010/text-decoration-line-through-css-does-not-work-on-safari-with-my-completed-cla