### PR TITLE
Add loop video option

### DIFF
--- a/client/components/Editor/schemas/video.ts
+++ b/client/components/Editor/schemas/video.ts
@@ -38,7 +38,7 @@ export default {
 						size: Number(node.getAttribute('data-size')) || 50,
 						align: node.getAttribute('data-align') || 'center',
 						caption: node.firstChild.getAttribute('alt') || '',
-						loop: !!node.firstChild.getAttribute('loop') || false,
+						loop: !!node.firstChild.getAttribute('loop'),
 					};
 				},
 			},

--- a/client/components/Editor/schemas/video.ts
+++ b/client/components/Editor/schemas/video.ts
@@ -19,6 +19,7 @@ export default {
 			align: { default: 'center' },
 			caption: { default: '' },
 			hideLabel: { default: false },
+			loop: { default: false },
 		},
 		reactiveAttrs: {
 			count: counter({ useNodeLabels: true }),
@@ -37,6 +38,7 @@ export default {
 						size: Number(node.getAttribute('data-size')) || 50,
 						align: node.getAttribute('data-align') || 'center',
 						caption: node.firstChild.getAttribute('alt') || '',
+						loop: !!node.firstChild.getAttribute('loop') || false,
 					};
 				},
 			},
@@ -59,6 +61,7 @@ export default {
 						src: node.attrs.url,
 						alt: node.attrs.caption,
 						'aria-describedby': figcaptionId,
+						loop: node.attrs.loop ? '' : undefined,
 					},
 				],
 				[

--- a/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsMedia/ControlsMedia.tsx
@@ -39,12 +39,13 @@ const ControlsMedia = (props: Props) => {
 		updateAttrs,
 		attrs: { altText },
 	} = pendingAttrs;
-	const { size, align, href, height, caption, url, fullResolution, hideLabel } =
+	const { size, align, href, height, caption, url, fullResolution, hideLabel, loop } =
 		selectedNode.attrs;
 	const nodeSupportsAltText = !!selectedNode.type.spec.attrs?.altText;
 	const canEditHeight = getCanEditNodeHeight(selectedNode);
 	const itemName = getItemName(selectedNode);
 	const nodeLabels = getCurrentNodeLabels(editorChangeObject.view.state);
+	const nodeSupportsLoop = itemName === 'video';
 
 	const canHideLabel =
 		nodeLabels &&
@@ -59,6 +60,11 @@ const ControlsMedia = (props: Props) => {
 	const toggleResize = useCallback(
 		(e: React.MouseEvent) =>
 			updateNode({ fullResolution: (e.target as HTMLInputElement).checked }),
+		[updateNode],
+	);
+
+	const toggleLoop = useCallback(
+		(e: React.MouseEvent) => updateNode({ loop: (e.target as HTMLInputElement).checked }),
 		[updateNode],
 	);
 
@@ -146,6 +152,16 @@ const ControlsMedia = (props: Props) => {
 				/>
 				<UrlControl onChange={(nextHref) => updateNode({ href: nextHref })} value={href} />
 				<SourceControls selectedNode={selectedNode} updateNode={updateNode} />
+				{nodeSupportsLoop && (
+					<div className="controls-row">
+						<Checkbox
+							onClick={toggleLoop}
+							alignIndicator="right"
+							label="Loop video"
+							checked={loop}
+						/>
+					</div>
+				)}
 				<div className="controls-row">
 					{canSelectResizeOptions && (
 						<Checkbox


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #2618

## Test Plan

- Open a pub draft
- Add a video (or choose an existing native video node)
- Turn loop on and off, test that the video does or does not repeat

## Screenshots (if applicable)
Loop option checked:
![image](https://user-images.githubusercontent.com/473542/234628203-d883c39c-bd71-4b30-b30f-7b0c4237056f.png)


Unchecked:
![image](https://user-images.githubusercontent.com/473542/234628095-3532d677-3787-4456-9c9a-727a1d76f692.png)