### PR TITLE
Run link input rule on enter

### DIFF
--- a/client/components/Editor/plugins/inputRules.ts
+++ b/client/components/Editor/plugins/inputRules.ts
@@ -126,11 +126,9 @@ export const linkRuleHandler = (
 		}
 		const emailOrUri = match.groups!.emailOrUri;
 
-		const linkAttrs = match.groups!.atSign
-			? { href: 'mailto:' + emailOrUri }
-			: { href: emailOrUri, target: '_blank' };
+		const href = `${match.groups!.atSign ? 'mailto:' : ''}${emailOrUri}`;
 
-		const link = state.schema.text(emailOrUri, [state.schema.mark(markType, linkAttrs)]);
+		const link = state.schema.text(emailOrUri, [state.schema.mark(markType, { href })]);
 
 		let content;
 		if (appendWhitespace) {

--- a/client/components/Editor/plugins/inputRules.ts
+++ b/client/components/Editor/plugins/inputRules.ts
@@ -131,12 +131,11 @@ export const linkRuleHandler = (
 
 		const link = state.schema.text(emailOrUri, [state.schema.mark(markType, { href })]);
 
-		let content;
+		const content = [link];
+
 		if (appendWhitespace) {
 			const whitespace = state.schema.text(match.groups!.whitespace);
-			content = Fragment.fromArray([link, whitespace]);
-		} else {
-			content = link;
+			content.push(whitespace);
 		}
 
 		return tr.replaceWith(start, end, content);

--- a/client/components/Editor/plugins/inputRules.ts
+++ b/client/components/Editor/plugins/inputRules.ts
@@ -121,8 +121,9 @@ export const linkRuleHandler = (
 ) => {
 	return (state: EditorState, match: RegExpMatchArray, start: number, end: number) => {
 		const resolvedStart = state.doc.resolve(start);
+		const tr = transaction ?? state.tr;
 		if (!resolvedStart.parent.type.allowsMarkType(markType)) {
-			return state.tr;
+			return tr;
 		}
 		const emailOrUri = match.groups!.emailOrUri;
 
@@ -137,8 +138,6 @@ export const linkRuleHandler = (
 		} else {
 			content = link;
 		}
-
-		const tr = transaction ?? state.tr;
 
 		return tr.replaceWith(start, end, content);
 	};

--- a/client/components/Editor/plugins/keymap.ts
+++ b/client/components/Editor/plugins/keymap.ts
@@ -152,6 +152,8 @@ export default (schema) => {
 		);
 	}
 
+	const customBlockSplitter = splitBlockPreservingAttrs(['textAlign', 'rtl']);
+
 	// This command runs the link input rule (converting emails and urls into links) whenever the
 	// user presses enter. Adding this to our enter handler is a hack to make sure the input rule
 	// behavior still works even though input rules don't work across nodes (see
@@ -177,7 +179,7 @@ export default (schema) => {
 			// Call our custom split block command, then add the link marks as part of the same
 			// transaction. This should be safe to do without mapping the start and end positions
 			// because the changes caused by splitBlock will all be after the cursor
-			splitBlockPreservingAttrs(['textAlign', 'rtl'])(state, (tr) => {
+			customBlockSplitter(state, (tr) => {
 				const addLinkMark = linkRuleHandler(schema.marks.link, false, tr);
 				const start = $cursor.pos - match[0].length;
 				const end = $cursor.pos;
@@ -195,7 +197,7 @@ export default (schema) => {
 		newlineInCode,
 		createParagraphNear,
 		liftEmptyBlock,
-		splitBlockPreservingAttrs(['textAlign', 'rtl']),
+		customBlockSplitter,
 	);
 
 	return [keymap(keys), keymap({ ...baseKeymap, Enter: customEnterCommand })];

--- a/client/components/Editor/plugins/keymap.ts
+++ b/client/components/Editor/plugins/keymap.ts
@@ -161,7 +161,10 @@ export default (schema) => {
 	// https://github.com/ProseMirror/prosemirror-inputrules/pull/6#issuecomment-894107661 for
 	// context)
 	const addLinkCommand = (state: EditorState, dispatch?: Dispatch) => {
-		const $cursor = (state.selection as TextSelection).$cursor;
+		if (!(state.selection instanceof TextSelection)) {
+			return false;
+		}
+		const $cursor = state.selection.$cursor;
 		if (!$cursor) {
 			return false;
 		}

--- a/client/components/Editor/plugins/keymap.ts
+++ b/client/components/Editor/plugins/keymap.ts
@@ -22,8 +22,10 @@ import { undoInputRule } from 'prosemirror-inputrules';
 import { keymap } from 'prosemirror-keymap';
 import { mathBackspaceCmd } from '@benrbray/prosemirror-math';
 
+import { EditorState, TextSelection } from 'prosemirror-state';
 import { codeBlockArrowHandlers } from './code';
-import { splitBlockPreservingAttrs } from '../commands';
+import { Dispatch, splitBlockPreservingAttrs } from '../commands';
+import { EMAIL_OR_URI_REGEX, linkRuleHandler } from './inputRules';
 
 const mac = typeof navigator !== 'undefined' ? /Mac/.test(navigator.platform) : false;
 
@@ -150,10 +152,46 @@ export default (schema) => {
 		);
 	}
 
-	// All but the custom block splitting command in this chain are taken from the default
-	// chain in baseKeymap. We provide our own block splitter that preserves text align
-	// attributes between paragraphs.
+	// This command runs the link input rule (converting emails and urls into links) whenever the
+	// user presses enter. Adding this to our enter handler is a hack to make sure the input rule
+	// behavior still works even though input rules don't work across nodes (see
+	// https://discuss.prosemirror.net/t/trigger-inputrule-on-enter/1118/4 and
+	// https://github.com/ProseMirror/prosemirror-inputrules/pull/6#issuecomment-894107661 for
+	// context)
+	const addLinkCommand = (state: EditorState, dispatch?: Dispatch) => {
+		const $cursor = (state.selection as TextSelection).$cursor;
+		if (!$cursor) {
+			return false;
+		}
+		const { nodeBefore } = state.selection.$from;
+		if (!nodeBefore || !nodeBefore.isText) {
+			return false;
+		}
+
+		const match = nodeBefore.text!.match(EMAIL_OR_URI_REGEX);
+		if (!match) {
+			return false;
+		}
+
+		if (dispatch) {
+			// Call our custom split block command, then add the link marks as part of the same
+			// transaction. This should be safe to do without mapping the start and end positions
+			// because the changes caused by splitBlock will all be after the cursor
+			splitBlockPreservingAttrs(['textAlign', 'rtl'])(state, (tr) => {
+				const addLinkMark = linkRuleHandler(schema.marks.link, false, tr);
+				const start = $cursor.pos - match[0].length;
+				const end = $cursor.pos;
+				dispatch(addLinkMark(state, match, start, end));
+			});
+		}
+		return true;
+	};
+
+	// All but the custom block splitting command and the add link command in this chain are taken
+	// from the default chain in baseKeymap. We provide our own block splitter that preserves text
+	// align attributes between paragraphs.
 	const customEnterCommand = chainCommands(
+		addLinkCommand,
 		newlineInCode,
 		createParagraphNear,
 		liftEmptyBlock,


### PR DESCRIPTION
## Issue(s) Resolved
Resolves #2518 

## Test Plan

On the review instance or a local branch, navigate to a pub editor and test:
	- typing a url or email address and pressing space
	- typing a url or email address and pressing enter

Also be sure to test these with and without content preceding and following (like `example.comandarunonsentence`, then press enter after `.com`, or `example.com<inline math node>`)
