### PR TITLE
prevent window nav on ctrl/cmd-click href

### DIFF
--- a/client/components/Menu/MenuItem.tsx
+++ b/client/components/Menu/MenuItem.tsx
@@ -50,7 +50,7 @@ const DisplayMenuItem = React.forwardRef((props: DisplayMenuItemProps, ref) => {
 		if (onDismiss) {
 			onDismiss();
 		}
-		if (href) {
+		if (href && !evt.ctrlKey && !evt.metaKey) {
 			window.open(href, target);
 		}
 	};


### PR DESCRIPTION
## Issue(s) Resolved

#1772

## Test Plan
- while logged in
- open profile avatar dropdown from top-right nav
- use ctrl-click (or cmd-click, if apple user) on 'view profile' link -> should open the profile in background tab
- use ctrl-shift-clik (or cmd-shift-click) on same link -> should open the profile in a new tab and focus that tab while old tab doesn't navigate

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
