### PR TITLE
dev: Cache cookie tweaks

### DIFF
--- a/client/containers/Login/Login.tsx
+++ b/client/containers/Login/Login.tsx
@@ -42,9 +42,13 @@ const Login = () => {
 			}),
 		})
 			.then(() => {
+				const cacheBreaker = Math.round(new Date().getTime() / 1000);
 				window.location.href = locationData.query.redirect
-					? `/${locationData.query.redirect.replace(/^\/+/, '')}`
-					: '/';
+					? `/${locationData.query.redirect.replace(
+							/^\/+/,
+							'',
+					  )}?breakCache=${cacheBreaker}`
+					: `/?breakCache=${cacheBreaker}`;
 				// window.location.href =
 				// 	`/${trimStart(`${locationData.query.redirect}`, '/')}` || '/';
 			})

--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -122,6 +122,7 @@ app.post('/api/login', (req, res, next) => {
 			if (unaunthenticatedValues.includes(err.message)) {
 				return res.status(401).json('Login attempt failed');
 			}
+			res.cookie('pp-cache', 'pp-no-cache');
 			return res.status(500).json(err.message);
 		});
 });

--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -113,7 +113,10 @@ app.post('/api/login', (req, res, next) => {
 				if (err) {
 					throw new Error(err);
 				}
-				res.cookie('pp-cache', 'pp-no-cache');
+				res.cookie('pp-cache', 'pp-no-cache', {
+					...(req.get('host')!.includes('pubpub.org') && { domain: '.pubpub.org' }),
+					...(req.get('host')!.includes('duqduq.org') && { domain: '.duqduq.org' }),
+				});
 				return res.status(201).json('success');
 			});
 		})

--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -114,8 +114,8 @@ app.post('/api/login', (req, res, next) => {
 					throw new Error(err);
 				}
 				res.cookie('pp-cache', 'pp-no-cache', {
-					...(req.get('host')!.includes('pubpub.org') && { domain: '.pubpub.org' }),
-					...(req.get('host')!.includes('duqduq.org') && { domain: '.duqduq.org' }),
+					...(req.get('host')?.includes('pubpub.org') && { domain: '.pubpub.org' }),
+					...(req.get('host')?.includes('duqduq.org') && { domain: '.duqduq.org' }),
 				});
 				return res.status(201).json('success');
 			});

--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -122,7 +122,6 @@ app.post('/api/login', (req, res, next) => {
 			if (unaunthenticatedValues.includes(err.message)) {
 				return res.status(401).json('Login attempt failed');
 			}
-			res.cookie('pp-cache', 'pp-no-cache');
 			return res.status(500).json(err.message);
 		});
 });


### PR DESCRIPTION
Makes two improvements to the cache cookie.

1. Sets a cachebreaker on login redirects so that logged in users don't hit the browser cache on their first redirect and appear logged out. This was happening because, by default, most browsers will hit local cache when using `window.location` to redirect.
2. Adds a wildcard domain to cache cookies (e,g, `*.pubpub.org`). Previously, they would only apply to the subdomain where the user logged in.

## Issue(s) Resolved
n/a

## Test Plan
In the test app:
1. Logout and clear cookies.
2. Open the dev console and preserve history in the networking pane.
3. Login.
4. Make sure the page contains a cachebuster
6. Verify that the `pp-cache` cookie is set to `pp-no-cache` and the domain is `.[domain]` (e.g. `.pubpub.org`)
7. In network history, verify that the request headers for the redirected page contain the `pp-no-cache` cookie
8. Repeat 1-7 with a redirection to a non-login page, e.g. `/dash`

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas
- I also considered setting a cookie on the browser ahead of the redirect, but thought that approach was way less efficient than just setting a cachebuster.

- Locally, `req.host` is set to `.pubpub.org` so this does have to be tested on a test app.

### Supporting Docs
