### PR TITLE
use hostname instead of host, add to logout

### DIFF
--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -114,8 +114,8 @@ app.post('/api/login', (req, res, next) => {
 					throw new Error(err);
 				}
 				res.cookie('pp-cache', 'pp-no-cache', {
-					...(req.get('host')?.includes('pubpub.org') && { domain: '.pubpub.org' }),
-					...(req.get('host')?.includes('duqduq.org') && { domain: '.duqduq.org' }),
+					...(req.get('hostname')?.includes('pubpub.org') && { domain: '.pubpub.org' }),
+					...(req.get('hostname')?.includes('duqduq.org') && { domain: '.duqduq.org' }),
 				});
 				return res.status(201).json('success');
 			});

--- a/server/logout/api.ts
+++ b/server/logout/api.ts
@@ -2,7 +2,10 @@ import app from 'server/server';
 
 app.get('/api/logout', (req, res) => {
 	res.cookie('gdpr-consent-survives-login', 'no');
-	res.cookie('pp-cache', 'pp-cache');
+	res.cookie('pp-cache', 'pp-cache', {
+		...(req.get('hostname')?.includes('pubpub.org') && { domain: '.pubpub.org' }),
+		...(req.get('hostname')?.includes('duqduq.org') && { domain: '.duqduq.org' }),
+	});
 	// @ts-expect-error
 	req.logout();
 	return res.status(200).json('success');


### PR DESCRIPTION
Two more cookie fixes: first, uses hostname to get the actual hostname, not the host, which is for some reason always pubpub.org. Then, uses that hostname to unset the cookie as well.

## Issue(s) Resolved
n/a

## Test Plan
- Load locally
- Logout
- Clear cookies
- Login
- Verify that the pp-cache cookie has the domain localhost
- Logout, verify that the domain is still localhost
- Repeat the above for the test app. Make sure the domain for the cookie is the supplied test app domain

## Notes
Will need to be tested on duqduq before entering prod.