### PR TITLE
allow custom domain for single duqduq community

### DIFF
--- a/server/utils/initData.ts
+++ b/server/utils/initData.ts
@@ -127,10 +127,14 @@ export const getInitialData = async (
 	}
 
 	if (
-		communityData.domain &&
-		whereQuery.subdomain &&
-		process.env.NODE_ENV === 'production' &&
-		isProd()
+		(communityData.domain &&
+			whereQuery.subdomain &&
+			process.env.NODE_ENV === 'production' &&
+			isProd()) ||
+		(communityData.domain &&
+			communityData.domain === 'duqduqdomaintest.underlay.org' &&
+			whereQuery.subdomain &&
+			isDuqDuq())
 	) {
 		throw new Error(`UseCustomDomain:${communityData.domain}`);
 	}


### PR DESCRIPTION
Allows us to test custom domains on duqduq for a specific domain so we can test changes to the domain app and caching for the domain app.

## Issue(s) Resolved
n/a

## Test Plan
What I'm going for is that domain should load if and only if you are on duqduq. Gonna be pretty hard to test, I think, short of deploying to dev, but should isDuqDuq should be pretty protective.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
