### PR TITLE
Dev: cachebreaker for logout, cache cookie domain fix

### DIFF
--- a/client/components/GlobalControls/UserMenu.tsx
+++ b/client/components/GlobalControls/UserMenu.tsx
@@ -11,8 +11,9 @@ type Props = {
 };
 
 const handleLogout = () => {
+	const cacheBreaker = Math.round(new Date().getTime() / 1000);
 	apiFetch('/api/logout').then(() => {
-		window.location.href = '/';
+		window.location.href = `/?breakCache=${cacheBreaker}`;
 	});
 };
 

--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -115,8 +115,10 @@ app.post('/api/login', (req, res, next) => {
 					throw new Error(err);
 				}
 				res.cookie('pp-cache', 'pp-no-cache', {
-					...(isProd() && { domain: '.pubpub.org' }),
-					...(isDuqDuq() && { domain: '.duqduq.org' }),
+					...(isProd() &&
+						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.pubpub.org' }),
+					...(isDuqDuq() &&
+						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.duqduq.org' }),
 				});
 				return res.status(201).json('success');
 			});

--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -6,6 +6,7 @@ import { assert } from 'utils/assert';
 import * as types from 'types';
 import app from 'server/server';
 import { User } from 'server/models';
+import { isDuqDuq, isProd } from 'utils/environment';
 
 type SetPasswordData = { hash: string; salt: string };
 type Step1Result = [types.UserWithPrivateFields, null] | [null, types.UserWithPrivateFields];
@@ -114,8 +115,8 @@ app.post('/api/login', (req, res, next) => {
 					throw new Error(err);
 				}
 				res.cookie('pp-cache', 'pp-no-cache', {
-					...(req.get('hostname')?.includes('pubpub.org') && { domain: '.pubpub.org' }),
-					...(req.get('hostname')?.includes('duqduq.org') && { domain: '.duqduq.org' }),
+					...(isProd() && { domain: '.pubpub.org' }),
+					...(isDuqDuq() && { domain: '.duqduq.org' }),
 				});
 				return res.status(201).json('success');
 			});

--- a/server/logout/api.ts
+++ b/server/logout/api.ts
@@ -1,10 +1,12 @@
 import app from 'server/server';
 
+import { isDuqDuq, isProd } from 'utils/environment';
+
 app.get('/api/logout', (req, res) => {
 	res.cookie('gdpr-consent-survives-login', 'no');
 	res.cookie('pp-cache', 'pp-cache', {
-		...(req.get('hostname')?.includes('pubpub.org') && { domain: '.pubpub.org' }),
-		...(req.get('hostname')?.includes('duqduq.org') && { domain: '.duqduq.org' }),
+		...(isProd() && { domain: '.pubpub.org' }),
+		...(isDuqDuq() && { domain: '.duqduq.org' }),
 	});
 	// @ts-expect-error
 	req.logout();

--- a/server/logout/api.ts
+++ b/server/logout/api.ts
@@ -5,8 +5,8 @@ import { isDuqDuq, isProd } from 'utils/environment';
 app.get('/api/logout', (req, res) => {
 	res.cookie('gdpr-consent-survives-login', 'no');
 	res.cookie('pp-cache', 'pp-cache', {
-		...(isProd() && { domain: '.pubpub.org' }),
-		...(isDuqDuq() && { domain: '.duqduq.org' }),
+		...(isProd() && req.hostname.indexOf('pubpub.org') > -1 && { domain: '.pubpub.org' }),
+		...(isDuqDuq() && req.hostname.indexOf('pubpub.org') > -1 && { domain: '.duqduq.org' }),
 	});
 	// @ts-expect-error
 	req.logout();


### PR DESCRIPTION
- Adds a cachebreaker to the logout redirect.
- Uses env variables plus hostnames to set domains for cache cookies.

## Issue(s) Resolved
n/a

## Test Plan
***Will need to be smoke tested on duqduq***
- On the test app, clear cookies (or use incognito) and login
- Make sure `pp-cache=pp-no-cache` cookie appears, and the domain is the same as the test app
- Logout, make sure url has a cachebreaker query param is set on the URL and the `pp-cache=cache` cookie appears.

To smoke test on duqduq: cache cookie domain should be set to `.duqduq.org`, except for the duqduqtest.underlay.org custom domain

To smoke test on prod: cache cookie domain should be set to `.pubpub.org`, except for custom domains

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas
For some reason, we rewrite the request header to always be pubpub.org, so we can't use the request object to set the cache header. Instead, we'll use env variables. If it's prod and the hostname includes pubpub.org, we set the domain to .pubpub.org. If duqduq, we set to `.duqduq.org.` If the hostname doesn't include `pubpub.org`, it's a custom domain, so we just want to use the default hostname.

### Supporting Docs
