### PR TITLE
feat: add duplicate pubs option for page and collection layouts

### DIFF
--- a/client/components/LayoutEditor/LayoutEditor.tsx
+++ b/client/components/LayoutEditor/LayoutEditor.tsx
@@ -19,6 +19,7 @@ import LayoutEditorCollectionHeader from './LayoutEditorCollectionHeader';
 require('./layoutEditor.scss');
 
 type Props = {
+	allowDuplicatePubs: boolean;
 	onChange: (layout: LayoutBlock[]) => unknown;
 	initialLayout: LayoutBlock[];
 	initialLayoutPubsByBlock: LayoutPubsByBlock<Pub>;
@@ -49,7 +50,14 @@ const getTitleKindForBlock = (blockType: string) => {
 };
 
 const LayoutEditor = React.memo((props: Props) => {
-	const { initialLayout, initialLayoutPubsByBlock, collection, communityData, onChange } = props;
+	const {
+		allowDuplicatePubs,
+		initialLayout,
+		initialLayoutPubsByBlock,
+		collection,
+		communityData,
+		onChange,
+	} = props;
 	const {
 		layout,
 		changeLayout,
@@ -63,6 +71,7 @@ const LayoutEditor = React.memo((props: Props) => {
 		initialLayoutPubsByBlock,
 		layout,
 		collection && collection.id,
+		allowDuplicatePubs,
 	);
 
 	useEffect(() => {

--- a/client/containers/DashboardCollectionLayout/DashboardCollectionLayout.tsx
+++ b/client/containers/DashboardCollectionLayout/DashboardCollectionLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { useBeforeUnload, useUpdateEffect } from 'react-use';
-import { Button, ButtonGroup, RadioGroup, Radio } from '@blueprintjs/core';
+import { Button, ButtonGroup, RadioGroup, Radio, Switch } from '@blueprintjs/core';
 
 import {
 	DashboardFrame,
@@ -138,10 +138,21 @@ const DashboardCollectionLayout = (props: Props) => {
 						</ButtonGroup>
 					</InputField>
 				)}
+				<InputField label="Allow duplicate Pubs">
+					<Switch
+						checked={collection.layoutAllowsDuplicatePubs}
+						onClick={() =>
+							updateCollection({
+								layoutAllowsDuplicatePubs: !collection.layoutAllowsDuplicatePubs,
+							})
+						}
+					/>
+				</InputField>
 			</SettingsSection>
 			{isUsingBlocks && (
 				<SettingsSection title="Blocks">
 					<LayoutEditor
+						allowDuplicatePubs={collection.layoutAllowsDuplicatePubs}
 						initialLayout={layout.blocks}
 						initialLayoutPubsByBlock={props.layoutPubsByBlock}
 						collection={collection}

--- a/client/containers/DashboardPage/DashboardPage.tsx
+++ b/client/containers/DashboardPage/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react';
-import { AnchorButton, Button, Classes } from '@blueprintjs/core';
+import { AnchorButton, Button, Classes, Switch } from '@blueprintjs/core';
 import { useUpdateEffect } from 'react-use';
 
 import { communityUrl } from 'utils/canonicalUrls';
@@ -207,6 +207,16 @@ const DashboardPage = (props: Props) => {
 						</div>
 					</InputField>
 				)}
+				<InputField label="Allow duplicate Pubs">
+					<Switch
+						checked={pageData.layoutAllowsDuplicatePubs}
+						onClick={() =>
+							updatePageData({
+								layoutAllowsDuplicatePubs: !pageData.layoutAllowsDuplicatePubs,
+							})
+						}
+					/>
+				</InputField>
 			</SettingsSection>
 		);
 	};
@@ -215,6 +225,7 @@ const DashboardPage = (props: Props) => {
 		return (
 			<SettingsSection title="Layout">
 				<LayoutEditor
+					allowDuplicatePubs={pageData.layoutAllowsDuplicatePubs}
 					onChange={handleLayoutChange}
 					initialLayout={layout}
 					initialLayoutPubsByBlock={layoutPubsByBlock}

--- a/package-lock.json
+++ b/package-lock.json
@@ -258,6 +258,7 @@
 			}
 		},
 		"eslint": {
+			"name": "eslint-plugin-pubpub-rules",
 			"version": "1.0.0",
 			"dev": true
 		},

--- a/server/collection/model.ts
+++ b/server/collection/model.ts
@@ -28,6 +28,11 @@ export default (sequelize, dataTypes) => {
 				defaultValue: 'choose-best',
 			},
 			layout: { type: dataTypes.JSONB, allowNull: false, defaultValue: {} },
+			layoutAllowsDuplicatePubs: {
+				type: dataTypes.BOOLEAN,
+				defaultValue: false,
+				allowNull: false,
+			},
 			/* Set by Associations */
 			pageId: { type: dataTypes.UUID } /* Used to link a collection to a specific page */,
 			communityId: { type: dataTypes.UUID },

--- a/server/collection/permissions.ts
+++ b/server/collection/permissions.ts
@@ -22,6 +22,7 @@ export const getPermissions = async ({ userId, communityId, collectionId }) => {
 		'metadata',
 		'readNextPreviewSize',
 		'layout',
+		'layoutAllowsDuplicatePubs',
 		'avatar',
 	];
 	return {

--- a/server/layout/api.ts
+++ b/server/layout/api.ts
@@ -7,18 +7,21 @@ export type RequestIds = {
 	alreadyFetchedPubIds?: string[];
 	collectionId?: string;
 	blocks: LayoutBlockPubs[];
+	allowDuplicatePubs: boolean;
 };
 
 app.post(
 	'/api/layout',
 	wrap(async (req, res) => {
-		const { alreadyFetchedPubIds, collectionId, blocks } = req.body as RequestIds;
+		const { alreadyFetchedPubIds, collectionId, blocks, allowDuplicatePubs } =
+			req.body as RequestIds;
 		const initialData = await getInitialData(req);
 		const pubsForLayout = await getLayoutPubsByBlock({
 			initialData,
 			collectionId,
 			alreadyFetchedPubIds,
 			blocks,
+			allowDuplicatePubs,
 		});
 		return res.status(200).json(pubsForLayout);
 	}),

--- a/server/page/model.ts
+++ b/server/page/model.ts
@@ -11,6 +11,11 @@ export default (sequelize, dataTypes) => {
 			isNarrowWidth: { type: dataTypes.BOOLEAN },
 			viewHash: { type: dataTypes.TEXT },
 			layout: { type: dataTypes.JSONB, allowNull: false },
+			layoutAllowsDuplicatePubs: {
+				type: dataTypes.BOOLEAN,
+				defaultValue: false,
+				allowNull: false,
+			},
 
 			/* Set by Associations */
 			communityId: { type: dataTypes.UUID, allowNull: false },

--- a/server/page/permissions.ts
+++ b/server/page/permissions.ts
@@ -21,6 +21,7 @@ export const getPermissions = async ({ userId, communityId, pageId }) => {
 		'description',
 		'isPublic',
 		'layout',
+		'layoutAllowsDuplicatePubs',
 		'avatar',
 		'isNarrowWidth',
 	];

--- a/server/routes/collection.tsx
+++ b/server/routes/collection.tsx
@@ -102,6 +102,7 @@ app.get(['/collection/:collectionSlug', '/:collectionSlug'], async (req, res, ne
 			const layout = await getLayoutWithSubmissionWorkflowBlock(collection);
 			if (layout) {
 				const layoutPubsByBlock = await getLayoutPubsByBlock({
+					allowDuplicatePubs: collection.layoutAllowsDuplicatePubs,
 					blocks: layout.blocks,
 					initialData,
 					collectionId,

--- a/server/routes/dashboardCollectionLayout.tsx
+++ b/server/routes/dashboardCollectionLayout.tsx
@@ -23,6 +23,7 @@ app.get('/dash/collection/:collectionSlug/layout', async (req, res, next) => {
 				initialData={initialData}
 				viewData={{
 					layoutPubsByBlock: await getLayoutPubsByBlock({
+						allowDuplicatePubs: collection.layoutAllowsDuplicatePubs,
 						blocks: collection.layout && collection.layout.blocks,
 						initialData,
 						collectionId: collection.id,

--- a/server/utils/layouts/layoutPubs.ts
+++ b/server/utils/layouts/layoutPubs.ts
@@ -67,12 +67,14 @@ type GetPubsForLayoutOptions = {
 	initialData: InitialData;
 	collectionId?: string;
 	alreadyFetchedPubIds?: string[];
+	allowDuplicatePubs: boolean;
 };
 
 export const getPubIdsForLayout = async ({
 	blocks,
 	initialData,
 	collectionId,
+	allowDuplicatePubs,
 }: GetPubsForLayoutOptions): Promise<Record<string, string[]>> => {
 	const { id: communityId } = initialData.communityData;
 	const pubBlocks = blocks.filter((block): block is LayoutBlockPubs => block.type === 'pubs');
@@ -87,7 +89,9 @@ export const getPubIdsForLayout = async ({
 			Array.from(seenPubIds),
 			collectionId,
 		);
-		pubIdsForBlock.forEach((id) => seenPubIds.add(id));
+		if (!allowDuplicatePubs) {
+			pubIdsForBlock.forEach((id) => seenPubIds.add(id));
+		}
 		pubIdsByBlockId[block.id] = pubIdsForBlock;
 	}
 

--- a/server/utils/queryHelpers/pageGet.ts
+++ b/server/utils/queryHelpers/pageGet.ts
@@ -11,6 +11,7 @@ export default async ({ query, initialData }) => {
 	});
 
 	const layoutPubsByBlock = await getLayoutPubsByBlock({
+		allowDuplicatePubs: pageData.layoutAllowsDuplicatePubs,
 		blocks: pageData.layout || [],
 		initialData,
 	});

--- a/tools/migrations/2023_05_08_addLayoutAllowsDuplicatePubs.js
+++ b/tools/migrations/2023_05_08_addLayoutAllowsDuplicatePubs.js
@@ -1,0 +1,17 @@
+export const up = async ({ Sequelize, sequelize }) => {
+	await sequelize.queryInterface.addColumn('Pages', 'layoutAllowsDuplicatePubs', {
+		type: Sequelize.BOOLEAN,
+		allowNull: false,
+		defaultValue: false,
+	});
+	await sequelize.queryInterface.addColumn('Collections', 'layoutAllowsDuplicatePubs', {
+		type: Sequelize.BOOLEAN,
+		allowNull: false,
+		defaultValue: false,
+	});
+};
+
+export const down = async ({ sequelize }) => {
+	await sequelize.queryInterface.removeColumn('Pages', 'layoutAllowsDuplicatePubs');
+	await sequelize.queryInterface.removeColumn('Collections', 'layoutAllowsDuplicatePubs');
+};

--- a/types/collection.ts
+++ b/types/collection.ts
@@ -25,6 +25,7 @@ export type Collection = {
 	crossrefDepositRecord?: DepositRecord;
 	attributions?: CollectionAttribution[];
 	layout: CollectionLayout;
+	layoutAllowsDuplicatePubs: boolean;
 	createdAt: string;
 	updatedAt: string;
 	scopeSummaryId: null | string;

--- a/types/page.ts
+++ b/types/page.ts
@@ -11,4 +11,5 @@ export type Page = {
 	isNarrowWidth?: boolean;
 	viewHash?: string;
 	layout: LayoutBlock[];
+	layoutAllowsDuplicatePubs: boolean;
 };


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #2619

## Test Plan

1. Navigate to a Page layout in the dashboard (e.g. [Home zone](https://pubpub-pipel-feat-layou-fn9odf.herokuapp.com/dash/pages/home)) and flip on the _Allow duplicate Pubs_ option.
2. Confirm that Pubs are no longer de-duplicated between Pub blocks within the layout editor.
3. Click save changes.
4. Vistit the page and confirm that Pubs are no longer de-duplicated on the Page.
5. Repeat steps 1-4 for a Collection layout with Pub blocks.

## Screenshots (if applicable)

![image](https://github.com/pubpub/pubpub/assets/6402908/1eae6d91-5a73-4a83-aa05-cdb678ef2d2c)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
