### PR TITLE
fix: User bio profile editing

### DIFF
--- a/client/containers/User/UserEdit.tsx
+++ b/client/containers/User/UserEdit.tsx
@@ -52,7 +52,8 @@ const UserEdit = (props: Props) => {
 	};
 
 	const onBioChange = (e) => {
-		setBio(e.target.substring(0, 280).replace(/\n/g, ' '));
+		const { value } = e.target;
+		setBio(value.substring(0, 280).replace(/\n/g, ' '));
 	};
 
 	const onAvatarChange = (val) => {

--- a/client/containers/User/UserEdit.tsx
+++ b/client/containers/User/UserEdit.tsx
@@ -241,7 +241,7 @@ const UserEdit = (props: Props) => {
 								label={item.label}
 								value={item.value}
 								onChange={withHasChanged(item.onChange)}
-								onBlur={withHasChanged(item.onBlur)}
+								onBlur={item.onBlur && withHasChanged(item.onBlur)}
 								helperText={item.helperText}
 								error={
 									(item.label === 'Orcid' && isOrcidInvalid && 'Invalid Orcid') ||


### PR DESCRIPTION
## Issue(s) Resolved
Fixes #2663

Also fixes a console error where we were calling onblur on every field, even though only ORCID needs it for validation.

## Test Plan
- Make sure you can edit and save a user profile.
- Make sure the ORCID field validates correctly.
- Make sure you can edit and save all other user profile fields.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas
Somewhere along the line, react changed the handling of events for textarea fields so that the synthetic events they generate `onChange` are recycled unpredictably, meaning they can't be used as-is in asynchronous functions like useState hooks (see [this blog](https://medium.com/trabe/react-syntheticevent-reuse-889cd52981b6)). Instead, best practice is to pull values out into variables prior to using them in hooks.

### Supporting Docs
