### PR TITLE
Enhance/prevent release

### DIFF
--- a/client/components/Editor/plugins/suggestedEdits/resolve.ts
+++ b/client/components/Editor/plugins/suggestedEdits/resolve.ts
@@ -40,7 +40,7 @@ const removeSuggestionAttrs = (attrs: Attrs) => {
 	return newAttrs as Attrs;
 };
 
-const acceptSuggestions = (state: EditorState, from: number, to: number) => {
+export const acceptSuggestions = (state: EditorState, from: number, to: number) => {
 	const { tr, doc } = state;
 	tr.setMeta(suggestedEditsPluginKey, { resolving: true });
 	const suggestionMarkType = getSuggestionMarkTypeFromSchema(doc.type.schema);
@@ -72,7 +72,7 @@ const acceptSuggestions = (state: EditorState, from: number, to: number) => {
 	return tr;
 };
 
-const rejectSuggestions = (state: EditorState, from: number, to: number) => {
+export const rejectSuggestions = (state: EditorState, from: number, to: number) => {
 	const { tr, doc } = state;
 	const { schema } = doc.type;
 	tr.setMeta(suggestedEditsPluginKey, { resolving: true });

--- a/client/components/PubReleaseDialog/PubReleaseDialog.tsx
+++ b/client/components/PubReleaseDialog/PubReleaseDialog.tsx
@@ -47,7 +47,7 @@ const createRelease = ({ historyKey, pubId, communityId, noteContent, noteText }
 
 const PubReleaseDialog = (props: Props) => {
 	const { isOpen, onClose, historyKey, pub, onCreateRelease } = props;
-	const { communityData } = usePageContext();
+	const { communityData, featureFlags } = usePageContext();
 	const { collabData } = usePubContext();
 	const [noteData, setNoteData] = useState<{ content?: {}; text?: string }>({});
 	const [isCreatingRelease, setIsCreatingRelease] = useState(false);
@@ -215,12 +215,12 @@ const PubReleaseDialog = (props: Props) => {
 		suggestedEditsAction(rejectSuggestions);
 	};
 
-	const renderSuggestedEditsPreRealeaseButtons = () => {
+	const renderSuggestedEditsActionButtons = () => {
 		return (
 			<React.Fragment>
 				<Callout className="text-info" intent="warning">
 					You still have pending edits. Would you like to accept the suggested changes or
-					ignore them (
+					reject them (
 					<strong>this will remove any suggested changes from your doc</strong>)?
 				</Callout>
 				<div className={Classes.DIALOG_FOOTER_ACTIONS}>
@@ -228,8 +228,8 @@ const PubReleaseDialog = (props: Props) => {
 						Return to draft
 					</Button>
 					<Button
-						text="Ignore All"
-						intent="warning"
+						text="Reject All"
+						intent="danger"
 						onClick={handleSuggestedEditsReject}
 					/>
 					<Button
@@ -300,8 +300,8 @@ const PubReleaseDialog = (props: Props) => {
 				{renderReleaseResult()}
 			</div>
 			<div className={Classes.DIALOG_FOOTER}>
-				{hasSuggestions() ? (
-					<div>{renderSuggestedEditsPreRealeaseButtons()}</div>
+				{hasSuggestions() && featureFlags.suggestedEdits ? (
+					<div>{renderSuggestedEditsActionButtons()}</div>
 				) : (
 					<div className={Classes.DIALOG_FOOTER_ACTIONS}>
 						{createdRelease && renderPostReleaseButtons()}

--- a/client/components/PubReleaseDialog/PubReleaseDialog.tsx
+++ b/client/components/PubReleaseDialog/PubReleaseDialog.tsx
@@ -178,6 +178,43 @@ const PubReleaseDialog = (props: Props) => {
 		return null;
 	};
 
+	const handleSuggestedEditsResolve = (action: boolean) => {
+		if (action) {
+			// this block must iterate over the doc and apply all suggested edits
+			console.log('handle accpeting all changes');
+		} else {
+			// this block must iterate over the doc and remove all suggested edits
+			console.log('handle rmoving changes');
+		}
+	};
+
+	//  this will need to render on the prescence of suggested edits to make in the doc
+	const renderSuggestedEditsPreRealeaseButtons = () => {
+		return (
+			<React.Fragment>
+				<Callout className="text-info" intent="warning">
+					You still have pending edits. Would you like to accept the suggested changes or
+					ignore them (this will remove any suggested changes from your doc)?
+				</Callout>
+				<div className={Classes.DIALOG_FOOTER_ACTIONS}>
+					<Button disabled={isCreatingRelease} onClick={onClose}>
+						Return to draft
+					</Button>
+					<Button
+						text="Ignore All"
+						intent="warning"
+						onClick={() => handleSuggestedEditsResolve(false)}
+					/>
+					<Button
+						text="Accept All"
+						intent="primary"
+						onClick={() => handleSuggestedEditsResolve(true)}
+					/>
+				</div>
+			</React.Fragment>
+		);
+	};
+
 	const renderPreReleaseButtons = () => {
 		return (
 			<React.Fragment>
@@ -236,6 +273,7 @@ const PubReleaseDialog = (props: Props) => {
 				{renderReleaseResult()}
 			</div>
 			<div className={Classes.DIALOG_FOOTER}>
+				<div>{renderSuggestedEditsPreRealeaseButtons()}</div>
 				<div className={Classes.DIALOG_FOOTER_ACTIONS}>
 					{createdRelease && renderPostReleaseButtons()}
 					{!createdRelease && renderPreReleaseButtons()}

--- a/client/components/PubReleaseDialog/PubReleaseDialog.tsx
+++ b/client/components/PubReleaseDialog/PubReleaseDialog.tsx
@@ -10,6 +10,7 @@ import {
 	Icon,
 	InputGroup,
 } from '@blueprintjs/core';
+import { EditorState, Transaction } from 'prosemirror-state';
 
 import { pubUrl } from 'utils/canonicalUrls';
 import { formatDate, timeAgoBaseProps } from 'utils/dates';
@@ -195,25 +196,25 @@ const PubReleaseDialog = (props: Props) => {
 		return hasSugg;
 	};
 
-	const handleSuggestedEditsAccept = () => {
+	const suggestedEditsAction = (action: {
+		(state: EditorState, from: number, to: number): Transaction;
+	}) => {
 		if (!hasSuggestions()) return;
 		if (!editorChangeObject) return;
 		const editorState = editorChangeObject.view.state;
 		const size = editorChangeObject.view.state.doc.nodeSize;
-		const tr = acceptSuggestions(editorState, 0, size - 2);
+		const tr = action(editorState, 0, size - 2);
 		editorChangeObject.view.dispatch(tr);
+	};
+
+	const handleSuggestedEditsAccept = () => {
+		suggestedEditsAction(acceptSuggestions);
 	};
 
 	const handleSuggestedEditsReject = () => {
-		if (!hasSuggestions()) return;
-		if (!editorChangeObject) return;
-		const editorState = editorChangeObject.view.state;
-		const size = editorChangeObject.view.state.doc.nodeSize;
-		const tr = rejectSuggestions(editorState, 0, size - 2);
-		editorChangeObject.view.dispatch(tr);
+		suggestedEditsAction(rejectSuggestions);
 	};
 
-	//  this will need to render on the prescence of suggested edits to make in the doc
 	const renderSuggestedEditsPreRealeaseButtons = () => {
 		return (
 			<React.Fragment>

--- a/client/components/PubReleaseDialog/PubReleaseDialog.tsx
+++ b/client/components/PubReleaseDialog/PubReleaseDialog.tsx
@@ -181,7 +181,7 @@ const PubReleaseDialog = (props: Props) => {
 	const handleSuggestedEditsResolve = (action: boolean) => {
 		if (action) {
 			// this block must iterate over the doc and apply all suggested edits
-			console.log('handle accpeting all changes');
+			console.log('handle accepting all changes');
 		} else {
 			// this block must iterate over the doc and remove all suggested edits
 			console.log('handle rmoving changes');
@@ -194,7 +194,8 @@ const PubReleaseDialog = (props: Props) => {
 			<React.Fragment>
 				<Callout className="text-info" intent="warning">
 					You still have pending edits. Would you like to accept the suggested changes or
-					ignore them (this will remove any suggested changes from your doc)?
+					ignore them (
+					<strong>this will remove any suggested changes from your doc</strong>)?
 				</Callout>
 				<div className={Classes.DIALOG_FOOTER_ACTIONS}>
 					<Button disabled={isCreatingRelease} onClick={onClose}>
@@ -207,7 +208,7 @@ const PubReleaseDialog = (props: Props) => {
 					/>
 					<Button
 						text="Accept All"
-						intent="primary"
+						intent="success"
 						onClick={() => handleSuggestedEditsResolve(true)}
 					/>
 				</div>

--- a/client/components/PubReleaseDialog/PubReleaseDialog.tsx
+++ b/client/components/PubReleaseDialog/PubReleaseDialog.tsx
@@ -184,16 +184,15 @@ const PubReleaseDialog = (props: Props) => {
 	};
 
 	const hasSuggestions = (): boolean => {
-		if (!editorChangeObject) return false;
+		if (!editorChangeObject || !editorChangeObject.view) return false;
 		const doc = editorChangeObject.view.state.doc;
-		const presents: string[] = [];
+		let hasSugg = false;
 		doc.nodesBetween(0, doc.nodeSize - 2, (node) => {
+			if (hasSugg) return;
 			const present = getSuggestionAttrsForNode(node);
-			console.log(present);
-			if (present) presents.push('*');
+			if (present) hasSugg = true;
 		});
-		console.log(presents);
-		return presents.length > 0;
+		return hasSugg;
 	};
 
 	const handleSuggestedEditsAccept = () => {


### PR DESCRIPTION
## Issue(s) Resolved
#2589 

## Test Plan
1. Head to a pub 
2. Create some text and suggest edits
3. Try to release the pub
4. Be sure release button is hidden and the ignore / accept buttons are not
5. perform an action on suggested edits(accept or ignore)
6. Be sure the release button now appears
7. Try 2-6 with an opposite action

## Screenshots (if applicable)
![image](https://github.com/pubpub/pubpub/assets/34730449/11d6b74c-d341-48e5-980c-9729b158be39)


## Optional

### Notes/Context/Gotchas
this should only effect the pub release dialog component
### Supporting Docs
