### PR TITLE
fix: Set cache cookie expiry

### DIFF
--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -119,7 +119,7 @@ app.post('/api/login', (req, res, next) => {
 						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.pubpub.org' }),
 					...(isDuqDuq() &&
 						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.duqduq.org' }),
-					maxAge: 30 * 24 * 60 * 60 * 1000,
+					maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days to match login cookie
 				});
 				return res.status(201).json('success');
 			});

--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -119,6 +119,7 @@ app.post('/api/login', (req, res, next) => {
 						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.pubpub.org' }),
 					...(isDuqDuq() &&
 						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.duqduq.org' }),
+					maxAge: 30 * 24 * 60 * 60 * 1000,
 				});
 				return res.status(201).json('success');
 			});


### PR DESCRIPTION
Last thing I swear — adds an expiry to the cache cookie for 30 days, which is the same as the login cookie. 

By default, if you don't set an expiry the cookie will be a session cookie, meaning it clears when the user's session ends. Setting the expiry to match the login cookie prevents a rare scenario that could cause cache leakage where a user is logged in and has the no-cache cookie, then closes the browser and visits again the next day when the cookie has expired. This would mean the user is eligible to be served the page from cache, even though they're logged in. That's not the end of the world, but if the user visited when the cache for the page had become stale, their logged in page would then become the cached page, which would leak their profile photo.

## Issue(s) Resolved
n/a

## Test Plan
1. Visit the test app
2. Logout
3. Login
4. Make sure `pp-cache:pp-no-cache` cookie is set on domain `.duqduq.org` and has expiry ~30 days in the future

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
