### PR TITLE
Check for suggestions inside non-empty selections

### DIFF
--- a/client/components/Editor/plugins/suggestedEdits/resolve.ts
+++ b/client/components/Editor/plugins/suggestedEdits/resolve.ts
@@ -131,8 +131,8 @@ export const rejectSuggestions = (state: EditorState, from: number, to: number) 
 export const acceptSuggestedEdits = (state: EditorState, dispatch?: Dispatch): boolean => {
 	const range = getResolvableRangeForSelection(state);
 	if (range) {
-		const tr = acceptSuggestions(state, range.from, range.to);
 		if (dispatch) {
+			const tr = acceptSuggestions(state, range.from, range.to);
 			dispatch(tr);
 		}
 		return true;
@@ -143,8 +143,8 @@ export const acceptSuggestedEdits = (state: EditorState, dispatch?: Dispatch): b
 export const rejectSuggestedEdits = (state: EditorState, dispatch?: Dispatch): boolean => {
 	const range = getResolvableRangeForSelection(state);
 	if (range) {
-		const tr = rejectSuggestions(state, range.from, range.to);
 		if (dispatch) {
+			const tr = rejectSuggestions(state, range.from, range.to);
 			dispatch(tr);
 		}
 		return true;

--- a/client/components/Editor/plugins/suggestedEdits/resolve.ts
+++ b/client/components/Editor/plugins/suggestedEdits/resolve.ts
@@ -17,11 +17,7 @@ const getResolvableRangeForSelection = (
 	if (suggestedEditsState) {
 		const { suggestionRanges } = suggestedEditsState;
 		const suggestionRange = suggestionRanges.find((range) => {
-			const selectionStartIntersectsSuggestion =
-				range.from <= selection.from && selection.from <= range.to;
-			const selectionEndIntersectsSuggestion =
-				range.from <= selection.to && selection.to <= range.to;
-			return selectionStartIntersectsSuggestion || selectionEndIntersectsSuggestion;
+			return range.from <= selection.to && selection.from <= range.to;
 		});
 		if (suggestionRange) {
 			return selection.empty ? suggestionRange : selection;

--- a/client/components/Editor/plugins/suggestedEdits/resolve.ts
+++ b/client/components/Editor/plugins/suggestedEdits/resolve.ts
@@ -16,16 +16,16 @@ const getResolvableRangeForSelection = (
 	const suggestedEditsState = getSuggestedEditsState(state);
 	if (suggestedEditsState) {
 		const { suggestionRanges } = suggestedEditsState;
-		if (selection.from === selection.to) {
-			const suggestionRange = suggestionRanges.find(
-				(range) => range.from <= selection.from && selection.from <= range.to,
-			);
-			if (suggestionRange) {
-				return suggestionRange;
-			}
-			return null;
+		const suggestionRange = suggestionRanges.find((range) => {
+			const selectionStartIntersectsSuggestion =
+				range.from <= selection.from && selection.from <= range.to;
+			const selectionEndIntersectsSuggestion =
+				range.from <= selection.to && selection.to <= range.to;
+			return selectionStartIntersectsSuggestion || selectionEndIntersectsSuggestion;
+		});
+		if (suggestionRange) {
+			return selection.empty ? suggestionRange : selection;
 		}
-		return selection;
 	}
 	return null;
 };


### PR DESCRIPTION
- This fixes the suggestion buttons always showing as enabled when selecting a range of the document, even if it had no suggestions. 
- It also reduces the likelihood of any bugs causing editor crashes by modifying how the formatting bar checks if the accept/reject suggestions buttons should be enabled. Now those calls will no longer actually try resolving suggestions (and discarding the transaction) and will just check that the selection intersects with a suggestion
- This will be useful for other work we're doing, both on our UI and to make math blocks function properly.

## Test Plan
Try a few different selections (cursor, range, node) both with and without suggestions inside. Ensure the buttons are enabled or disabled as appropriate.