### PR TITLE
fix: correctly deduplicate repeating slashes in request url

### DIFF
--- a/server/middleware/deduplicateSlash.ts
+++ b/server/middleware/deduplicateSlash.ts
@@ -3,7 +3,7 @@
 import { parse, format } from 'url';
 import { expect } from 'utils/assert';
 
-const DUPLICATE_SLASH_PATTERN = /(\/+)\1/g;
+const DUPLICATE_SLASH_PATTERN = /\/\/+/g;
 
 export function deduplicateSlash() {
 	return function deduplicateSlashMiddleware(req: Request, res, next) {


### PR DESCRIPTION
## Issue(s) Resolved

N/A

## Test Plan

1. Visit the review app.
2. Visit some paths with duplicating slashes (see below) and ensure they redirect you to the "Page not found" screen, and not http://test.com:
  - /test.com
  - //test.com
  - ///////////test.com
  - /dash//test.com
  - //dash/////////////test.com
