### PR TITLE
feat: add vertical line divider for suggested edits controls

### DIFF
--- a/client/containers/Pub/PubDocument/PubHeaderFormatting.tsx
+++ b/client/containers/Pub/PubDocument/PubHeaderFormatting.tsx
@@ -1,3 +1,4 @@
+import { Divider } from '@blueprintjs/core';
 import React from 'react';
 import classNames from 'classnames';
 
@@ -52,15 +53,18 @@ const PubHeaderFormatting = (props: Props) => {
 			/>
 			<div className="right-content">
 				{featureFlags.suggestedEdits && (
-					<FormattingBar
-						buttons={buttons.suggestedEditsButtonSet}
-						editorChangeObject={editorChangeObject || ({} as any)}
-						showBlockTypes={false}
-						controlsConfiguration={{
-							container: editorWrapperRef.current!,
-							isAbsolutelyPositioned: true,
-						}}
-					/>
+					<>
+						<FormattingBar
+							buttons={buttons.suggestedEditsButtonSet}
+							editorChangeObject={editorChangeObject || ({} as any)}
+							showBlockTypes={false}
+							controlsConfiguration={{
+								container: editorWrapperRef.current!,
+								isAbsolutelyPositioned: true,
+							}}
+						/>
+						<Divider />
+					</>
 				)}
 				{state && <PubWordCountButton doc={state.doc} />}
 				<PubHeaderCollaborators collabData={collabData} />

--- a/client/containers/Pub/PubDocument/pubHeaderFormatting.scss
+++ b/client/containers/Pub/PubDocument/pubHeaderFormatting.scss
@@ -72,6 +72,10 @@ $bp: vendor.$bp-namespace;
 		user-select: none;
 		pointer-events: none;
 	}
+
+	.#{$bp}-divider {
+		height: 26px;
+	}
 }
 
 @media only screen and (max-width: 750px) {


### PR DESCRIPTION
## Issue(s) Resolved

#2681

## Test Plan

1. Open a draft and ensure there is a vertical divider between the suggested edits buttons and the Pub word count button in the formatting bar.

## Screenshots

![image](https://github.com/pubpub/pubpub/assets/6402908/5c06ee57-5c81-41a7-993c-2b7d7a461099)

