### PR TITLE
feat: add popover to suggested edits toggle button

### DIFF
--- a/client/components/FormattingBar/buttons.ts
+++ b/client/components/FormattingBar/buttons.ts
@@ -41,6 +41,7 @@ import {
 	FormattingBarButtonDataControls,
 	FormattingBarButtonPopoverCondition,
 } from './types';
+import { SuggestedEditsTogglePopover } from './controlComponents/SuggestedEditsTogglePopover';
 
 const triggerOnClick = (changeObject) => {
 	const { latestDomEvent } = changeObject;
@@ -315,6 +316,10 @@ export const suggestedEditsToggle: FormattingBarButtonData = {
 	icon: 'highlight',
 	isToggle: true,
 	command: toggleSuggestedEditsSpec,
+	popover: {
+		condition: FormattingBarButtonPopoverCondition.Always,
+		component: SuggestedEditsTogglePopover,
+	},
 };
 
 export const suggestedEditsReject: FormattingBarButtonData = {

--- a/client/components/FormattingBar/controlComponents/SuggestedEditsTogglePopover.tsx
+++ b/client/components/FormattingBar/controlComponents/SuggestedEditsTogglePopover.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { usePubContext } from 'client/containers/Pub/pubHooks';
+
+require('./suggestedEditsTogglePopover.scss');
+
+export const SuggestedEditsTogglePopover = () => {
+	const { inPub } = usePubContext();
+
+	if (!inPub) {
+		return null;
+	}
+
+	return (
+		<p className="suggested-edits-toggle-popover-component">
+			While active, edits will create suggestions that must be resolved before publication.
+		</p>
+	);
+};

--- a/client/components/FormattingBar/controlComponents/SuggestedEditsTogglePopover.tsx
+++ b/client/components/FormattingBar/controlComponents/SuggestedEditsTogglePopover.tsx
@@ -13,7 +13,7 @@ export const SuggestedEditsTogglePopover = () => {
 
 	return (
 		<p className="suggested-edits-toggle-popover-component">
-			While active, edits will create suggestions that must be resolved before publication.
+			Editing the document in this mode will create suggestions.
 		</p>
 	);
 };

--- a/client/components/FormattingBar/controlComponents/suggestedEditsTogglePopover.scss
+++ b/client/components/FormattingBar/controlComponents/suggestedEditsTogglePopover.scss
@@ -1,0 +1,5 @@
+.suggested-edits-toggle-popover-component {
+	max-width: 180px;
+	padding: 12px;
+	margin: 0;
+}

--- a/client/components/FormattingBar/utils.ts
+++ b/client/components/FormattingBar/utils.ts
@@ -3,7 +3,7 @@ import { FormattingBarButtonData, FormattingBarButtonPopoverCondition } from './
 export const getButtonPopoverComponent = (button: FormattingBarButtonData, isDisabled: boolean) =>
 	button.popover &&
 	Boolean(
-		FormattingBarButtonPopoverCondition.Always ||
+		button.popover.condition === FormattingBarButtonPopoverCondition.Always ||
 			(button.popover.condition === FormattingBarButtonPopoverCondition.Disabled &&
 				isDisabled),
 	)


### PR DESCRIPTION
## Issue(s) Resolved

#2593

## Test Plan

1. Hover the suggestion mode toggle button. You should see a popover with some text that describes its function.