### PR TITLE
Bh/sequelize model refactor

### DIFF
--- a/server/activityItem/__tests__/fetch.test.ts
+++ b/server/activityItem/__tests__/fetch.test.ts
@@ -51,6 +51,7 @@ const models = modelize`
 				Pub pub {
 					title: "Generic Pub"
 					Release release {
+						User {}
 						createdAt: "2021-01-01"
 						historyKey: 1
 					}

--- a/server/activityItem/model.ts
+++ b/server/activityItem/model.ts
@@ -14,12 +14,11 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'ActivityItems',
 			classMethods: {
-				associate: (models) => {
-					const { activityItem, pub, collection, community, user } = models;
-					activityItem.belongsTo(user, { as: 'actor' });
-					activityItem.belongsTo(pub);
-					activityItem.belongsTo(collection);
-					activityItem.belongsTo(community, { foreignKey: { allowNull: false } });
+				associate: ({ activityItem, ...models }) => {
+					activityItem.belongsTo(models.user, { as: 'actor' });
+					activityItem.belongsTo(models.pub);
+					activityItem.belongsTo(models.collection);
+					activityItem.belongsTo(models.community, { foreignKey: { allowNull: false } });
 				},
 			},
 			indexes: [

--- a/server/activityItem/model.ts
+++ b/server/activityItem/model.ts
@@ -1,21 +1,27 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'ActivityItem',
+		'activityItem',
 		{
 			id: sequelize.idType,
 			kind: { type: dataTypes.TEXT, allowNull: false },
-			pubId: { type: dataTypes.UUID },
-			payload: { type: dataTypes.JSONB },
+			payload: dataTypes.JSONB,
 			timestamp: {
 				type: dataTypes.DATE,
 				defaultValue: sequelize.Sequelize.NOW,
 				allowNull: false,
 			},
-			communityId: { type: dataTypes.UUID, allowNull: false },
-			actorId: { type: dataTypes.UUID },
-			collectionId: { type: dataTypes.UUID },
 		},
 		{
+			tableName: 'ActivityItems',
+			classMethods: {
+				associate: (models) => {
+					const { activityItem, pub, collection, community, user } = models;
+					activityItem.belongsTo(user, { as: 'actor' });
+					activityItem.belongsTo(pub);
+					activityItem.belongsTo(collection);
+					activityItem.belongsTo(community, { foreignKey: { allowNull: false } });
+				},
+			},
 			indexes: [
 				{ fields: ['communityId'], method: 'BTREE' },
 				{ fields: ['collectionId'], method: 'BTREE' },

--- a/server/collection/model.ts
+++ b/server/collection/model.ts
@@ -1,9 +1,9 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Collection',
+		'collection',
 		{
 			id: sequelize.idType,
-			title: { type: dataTypes.TEXT },
+			title: dataTypes.TEXT,
 			slug: {
 				type: dataTypes.TEXT,
 				allowNull: false,
@@ -13,16 +13,15 @@ export default (sequelize, dataTypes) => {
 					is: /^[a-zA-Z0-9-]+$/, // Must contain at least one letter, alphanumeric and underscores and hyphens
 				},
 			},
-			avatar: { type: dataTypes.TEXT },
-			isRestricted: {
-				type: dataTypes.BOOLEAN,
-			} /* Restricted collections can only be set by Community Admins */,
-			isPublic: { type: dataTypes.BOOLEAN } /* Only visible to community admins */,
-			viewHash: { type: dataTypes.STRING },
-			editHash: { type: dataTypes.STRING },
-			metadata: { type: dataTypes.JSONB },
-			kind: { type: dataTypes.TEXT },
-			doi: { type: dataTypes.TEXT },
+			avatar: dataTypes.TEXT,
+			isRestricted:
+				dataTypes.BOOLEAN /* Restricted collections can only be set by Community Admins */,
+			isPublic: dataTypes.BOOLEAN /* Only visible to community admins */,
+			viewHash: dataTypes.STRING,
+			editHash: dataTypes.STRING,
+			metadata: dataTypes.JSONB,
+			kind: dataTypes.TEXT,
+			doi: dataTypes.TEXT,
 			readNextPreviewSize: {
 				type: dataTypes.ENUM('none', 'minimal', 'medium', 'choose-best'),
 				defaultValue: 'choose-best',
@@ -33,55 +32,23 @@ export default (sequelize, dataTypes) => {
 				defaultValue: false,
 				allowNull: false,
 			},
-			/* Set by Associations */
-			pageId: { type: dataTypes.UUID } /* Used to link a collection to a specific page */,
-			communityId: { type: dataTypes.UUID },
-			scopeSummaryId: { type: dataTypes.UUID, allowNull: true },
 		},
 		{
+			tableName: 'Collections',
 			classMethods: {
 				associate: (models) => {
-					const {
-						Collection,
-						CollectionAttribution,
-						CollectionPub,
-						Community,
-						CrossrefDepositRecord,
-						SubmissionWorkflow,
-						Member,
-						Page,
-						ScopeSummary,
-					} = models;
-					Collection.hasMany(CollectionAttribution, {
+					const { collection } = models;
+					collection.hasMany(models.collectionAttribution, {
 						onDelete: 'CASCADE',
 						as: 'attributions',
 						foreignKey: 'collectionId',
 					});
-					Collection.hasOne(SubmissionWorkflow, {
-						as: 'submissionWorkflow',
-						foreignKey: 'collectionId',
-					});
-					Collection.hasMany(CollectionPub, {
-						as: 'collectionPubs',
-						foreignKey: 'collectionId',
-					});
-					Collection.hasMany(Member, {
-						as: 'members',
-						foreignKey: 'collectionId',
-					});
-					Collection.belongsTo(Page, { as: 'page', foreignKey: 'pageId' });
-					Collection.belongsTo(CrossrefDepositRecord, {
-						as: 'crossrefDepositRecord',
-						foreignKey: 'crossrefDepositRecordId',
-					});
-					Collection.belongsTo(ScopeSummary, {
-						as: 'scopeSummary',
-						foreignKey: 'scopeSummaryId',
-					});
-					Collection.belongsTo(Community, {
-						as: 'community',
-						foreignKey: 'communityId',
-					});
+					collection.hasOne(models.submissionWorkflow);
+					collection.hasMany(models.collectionPub);
+					collection.hasMany(models.member);
+					collection.belongsTo(models.page);
+					collection.belongsTo(models.crossrefDepositRecord);
+					collection.belongsTo(models.scopeSummary);
 				},
 			},
 		},

--- a/server/collection/model.ts
+++ b/server/collection/model.ts
@@ -35,30 +35,19 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Collections',
 			classMethods: {
-				associate: (models) => {
-					const {
-						activityItem,
-						collectionAttribution,
-						submissionWorkflow,
-						collectionPub,
-						member,
-						page,
-						crossrefDepositRecord,
-						scopeSummary,
-						collection,
-					} = models;
-					collection.hasMany(activityItem);
-					collection.hasMany(collectionPub);
-					collection.hasMany(collectionAttribution, {
+				associate: ({ collection, ...models }) => {
+					collection.hasMany(models.activityItem);
+					collection.hasMany(models.collectionPub);
+					collection.hasMany(models.collectionAttribution, {
 						onDelete: 'CASCADE',
 						as: 'attributions',
 						foreignKey: 'collectionId',
 					});
-					collection.belongsTo(crossrefDepositRecord);
-					collection.hasMany(member);
-					collection.belongsTo(page);
-					collection.hasOne(submissionWorkflow);
-					collection.belongsTo(scopeSummary);
+					collection.belongsTo(models.crossrefDepositRecord);
+					collection.hasMany(models.member);
+					collection.belongsTo(models.page);
+					collection.hasOne(models.submissionWorkflow);
+					collection.belongsTo(models.scopeSummary);
 				},
 			},
 		},

--- a/server/collection/model.ts
+++ b/server/collection/model.ts
@@ -44,6 +44,7 @@ export default (sequelize, dataTypes) => {
 						foreignKey: 'collectionId',
 					});
 					collection.belongsTo(models.crossrefDepositRecord);
+					collection.belongsTo(models.community);
 					collection.hasMany(models.member);
 					collection.belongsTo(models.page);
 					collection.hasOne(models.submissionWorkflow);

--- a/server/collection/model.ts
+++ b/server/collection/model.ts
@@ -14,9 +14,8 @@ export default (sequelize, dataTypes) => {
 				},
 			},
 			avatar: dataTypes.TEXT,
-			isRestricted:
-				dataTypes.BOOLEAN /* Restricted collections can only be set by Community Admins */,
-			isPublic: dataTypes.BOOLEAN /* Only visible to community admins */,
+			isRestricted: dataTypes.BOOLEAN, // Restricted collections can only be set by Community Admins
+			isPublic: dataTypes.BOOLEAN, // Only visible to community admins
 			viewHash: dataTypes.STRING,
 			editHash: dataTypes.STRING,
 			metadata: dataTypes.JSONB,
@@ -37,18 +36,29 @@ export default (sequelize, dataTypes) => {
 			tableName: 'Collections',
 			classMethods: {
 				associate: (models) => {
-					const { collection } = models;
-					collection.hasMany(models.collectionAttribution, {
+					const {
+						activityItem,
+						collectionAttribution,
+						submissionWorkflow,
+						collectionPub,
+						member,
+						page,
+						crossrefDepositRecord,
+						scopeSummary,
+						collection,
+					} = models;
+					collection.hasMany(activityItem);
+					collection.hasMany(collectionPub);
+					collection.hasMany(collectionAttribution, {
 						onDelete: 'CASCADE',
 						as: 'attributions',
 						foreignKey: 'collectionId',
 					});
-					collection.hasOne(models.submissionWorkflow);
-					collection.hasMany(models.collectionPub);
-					collection.hasMany(models.member);
-					collection.belongsTo(models.page);
-					collection.belongsTo(models.crossrefDepositRecord);
-					collection.belongsTo(models.scopeSummary);
+					collection.belongsTo(crossrefDepositRecord);
+					collection.hasMany(member);
+					collection.belongsTo(page);
+					collection.hasOne(submissionWorkflow);
+					collection.belongsTo(scopeSummary);
 				},
 			},
 		},

--- a/server/collectionAttribution/model.ts
+++ b/server/collectionAttribution/model.ts
@@ -1,33 +1,28 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'CollectionAttribution',
+		'collectionAttribution',
 		{
 			id: sequelize.idType,
-			name: { type: dataTypes.TEXT } /* Used for non-account attribution */,
-			avatar: { type: dataTypes.TEXT } /* Used for non-account attribution */,
-			title: { type: dataTypes.TEXT } /* Used for non-account attribution */,
-			order: { type: dataTypes.DOUBLE },
-			isAuthor: { type: dataTypes.BOOLEAN },
-			roles: { type: dataTypes.JSONB },
-			affiliation: { type: dataTypes.TEXT },
-			orcid: { type: dataTypes.STRING },
-			/* Set by Associations */
-			userId: { type: dataTypes.UUID },
-			collectionId: { type: dataTypes.UUID, allowNull: false },
+			name: dataTypes.TEXT /* Used for non-account attribution */,
+			avatar: dataTypes.TEXT /* Used for non-account attribution */,
+			title: dataTypes.TEXT /* Used for non-account attribution */,
+			order: dataTypes.DOUBLE,
+			isAuthor: dataTypes.BOOLEAN,
+			roles: dataTypes.JSONB,
+			affiliation: dataTypes.TEXT,
+			orcid: dataTypes.STRING,
 		},
 		{
+			tableName: 'CollectionAttributions',
 			classMethods: {
 				associate: (models) => {
-					const { Collection, CollectionAttribution, User } = models;
-					CollectionAttribution.belongsTo(User, {
+					const { collectionAttribution } = models;
+					collectionAttribution.belongsTo(models.user, {
+						foreignKey: { allowNull: false },
 						onDelete: 'CASCADE',
-						as: 'user',
-						foreignKey: 'userId',
 					});
-					CollectionAttribution.belongsTo(Collection, {
+					collectionAttribution.belongsTo(models.collection, {
 						onDelete: 'CASCADE',
-						as: 'collection',
-						foreignKey: 'collectionId',
 					});
 				},
 			},

--- a/server/collectionAttribution/model.ts
+++ b/server/collectionAttribution/model.ts
@@ -18,10 +18,10 @@ export default (sequelize, dataTypes) => {
 				associate: (models) => {
 					const { collectionAttribution } = models;
 					collectionAttribution.belongsTo(models.user, {
-						foreignKey: { allowNull: false },
 						onDelete: 'CASCADE',
 					});
 					collectionAttribution.belongsTo(models.collection, {
+						foreignKey: { allowNull: false },
 						onDelete: 'CASCADE',
 					});
 				},

--- a/server/collectionAttribution/model.ts
+++ b/server/collectionAttribution/model.ts
@@ -15,12 +15,11 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'CollectionAttributions',
 			classMethods: {
-				associate: (models) => {
-					const { collectionAttribution } = models;
-					collectionAttribution.belongsTo(models.user, {
+				associate: ({ collectionAttribution, ...models }) => {
+					collectionAttribution.belongsTo(models.models.user, {
 						onDelete: 'CASCADE',
 					});
-					collectionAttribution.belongsTo(models.collection, {
+					collectionAttribution.belongsTo(models.models.collection, {
 						foreignKey: { allowNull: false },
 						onDelete: 'CASCADE',
 					});

--- a/server/collectionPub/__tests__/api.test.ts
+++ b/server/collectionPub/__tests__/api.test.ts
@@ -50,13 +50,17 @@ const models = modelize`
 			CollectionPub {
 				rank: "a"
 				Pub pub1 {
-					Release {}
+					Release {
+						User {}
+					}
 				}
 			}
 			CollectionPub someCollectionPub {
 				rank: "b"
 				Pub pub2 {
-					Release {}
+					Release {
+						User {}
+					}
 					Member {
 						permissions: "manage"
 						User someMember {}

--- a/server/collectionPub/model.ts
+++ b/server/collectionPub/model.ts
@@ -17,13 +17,12 @@ export default (sequelize, dataTypes) => {
 				},
 			],
 			classMethods: {
-				associate: (models) => {
-					const { collectionPub, collection, pub } = models;
-					collectionPub.belongsTo(collection, {
+				associate: ({ collectionPub, ...models }) => {
+					collectionPub.belongsTo(models.collection, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});
-					collectionPub.belongsTo(pub, {
+					collectionPub.belongsTo(models.pub, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});

--- a/server/collectionPub/model.ts
+++ b/server/collectionPub/model.ts
@@ -1,15 +1,14 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'CollectionPub',
+		'collectionPub',
 		{
 			id: sequelize.idType,
-			pubId: { type: dataTypes.UUID, allowNull: false },
-			collectionId: { type: dataTypes.UUID, allowNull: false },
-			contextHint: { type: dataTypes.TEXT },
+			contextHint: dataTypes.TEXT,
 			rank: { type: dataTypes.TEXT, allowNull: false },
 			pubRank: { type: dataTypes.TEXT, allowNull: false },
 		},
 		{
+			tableName: 'CollectionPubs',
 			indexes: [
 				// Index to enforce that there is one CollectionPub per (collection, pub) pair
 				{
@@ -19,16 +18,14 @@ export default (sequelize, dataTypes) => {
 			],
 			classMethods: {
 				associate: (models) => {
-					const { CollectionPub, Collection, Pub } = models;
-					CollectionPub.belongsTo(Collection, {
+					const { collectionPub, collection, pub } = models;
+					collectionPub.belongsTo(collection, {
 						onDelete: 'CASCADE',
-						as: 'collection',
-						foreignKey: 'collectionId',
+						foreignKey: { allowNull: false },
 					});
-					CollectionPub.belongsTo(Pub, {
+					collectionPub.belongsTo(pub, {
 						onDelete: 'CASCADE',
-						as: 'pub',
-						foreignKey: 'pubId',
+						foreignKey: { allowNull: false },
 					});
 				},
 			},

--- a/server/commenter/model.ts
+++ b/server/commenter/model.ts
@@ -1,6 +1,18 @@
 export default (sequelize, dataTypes) => {
-	return sequelize.define('Commenter', {
-		id: sequelize.idType,
-		name: { type: dataTypes.TEXT },
-	});
+	return sequelize.define(
+		'commenter',
+		{
+			id: sequelize.idType,
+			name: dataTypes.TEXT,
+		},
+		{
+			tableName: 'Commenters',
+			classMethods: {
+				associate: (models) => {
+					const { commenter, discussion } = models;
+					commenter.hasMany(discussion, { onDelete: 'CASCADE' });
+				},
+			},
+		},
+	);
 };

--- a/server/commenter/model.ts
+++ b/server/commenter/model.ts
@@ -8,9 +8,8 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Commenters',
 			classMethods: {
-				associate: (models) => {
-					const { commenter, discussion } = models;
-					commenter.hasMany(discussion, { onDelete: 'CASCADE' });
+				associate: ({ commenter, ...models }) => {
+					commenter.hasMany(models.discussion, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/community/model.ts
+++ b/server/community/model.ts
@@ -75,28 +75,16 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Communities',
 			classMethods: {
-				associate: (models) => {
-					const {
-						activityItem,
-						community,
-						depositTarget,
-						organization,
-						collection,
-						page,
-						pub,
-						scopeSummary,
-						landingPageFeature,
-						spamTag,
-					} = models;
-					community.hasMany(activityItem, { foreignKey: { allowNull: false } });
-					community.hasMany(landingPageFeature, { onDelete: 'CASCADE' });
-					community.belongsTo(organization, { onDelete: 'CASCADE' });
-					community.hasMany(collection, { onDelete: 'CASCADE' });
-					community.hasMany(pub, { onDelete: 'CASCADE' });
-					community.hasMany(page, { onDelete: 'CASCADE' });
-					community.hasMany(depositTarget, { onDelete: 'CASCADE' });
-					community.belongsTo(scopeSummary);
-					community.belongsTo(spamTag);
+				associate: ({ community, ...models }) => {
+					community.hasMany(models.activityItem, { foreignKey: { allowNull: false } });
+					community.hasMany(models.landingPageFeature, { onDelete: 'CASCADE' });
+					community.belongsTo(models.organization, { onDelete: 'CASCADE' });
+					community.hasMany(models.collection, { onDelete: 'CASCADE' });
+					community.hasMany(models.pub, { onDelete: 'CASCADE' });
+					community.hasMany(models.page, { onDelete: 'CASCADE' });
+					community.hasMany(models.depositTarget, { onDelete: 'CASCADE' });
+					community.belongsTo(models.scopeSummary);
+					community.belongsTo(models.spamTag);
 				},
 			},
 		},

--- a/server/community/model.ts
+++ b/server/community/model.ts
@@ -77,6 +77,7 @@ export default (sequelize, dataTypes) => {
 			classMethods: {
 				associate: (models) => {
 					const {
+						activityItem,
 						community,
 						depositTarget,
 						organization,
@@ -87,6 +88,7 @@ export default (sequelize, dataTypes) => {
 						landingPageFeature,
 						spamTag,
 					} = models;
+					community.hasMany(activityItem, { foreignKey: { allowNull: false } });
 					community.hasMany(landingPageFeature, { onDelete: 'CASCADE' });
 					community.belongsTo(organization, { onDelete: 'CASCADE' });
 					community.hasMany(collection, { onDelete: 'CASCADE' });

--- a/server/community/model.ts
+++ b/server/community/model.ts
@@ -1,6 +1,6 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Community',
+		'community',
 		{
 			id: sequelize.idType,
 			subdomain: {
@@ -18,110 +18,83 @@ export default (sequelize, dataTypes) => {
 				unique: true,
 			},
 			title: { type: dataTypes.TEXT, allowNull: false },
-			citeAs: { type: dataTypes.TEXT },
-			publishAs: { type: dataTypes.TEXT },
+			citeAs: dataTypes.TEXT,
+			publishAs: dataTypes.TEXT,
 			description: {
 				type: dataTypes.TEXT,
 				validate: {
 					len: [0, 280],
 				},
 			},
-			avatar: { type: dataTypes.TEXT },
-			favicon: { type: dataTypes.TEXT },
-			accentColorLight: { type: dataTypes.STRING },
-			accentColorDark: { type: dataTypes.STRING },
-			hideCreatePubButton: { type: dataTypes.BOOLEAN },
-			headerLogo: { type: dataTypes.TEXT },
-			headerLinks: { type: dataTypes.JSONB },
+			avatar: dataTypes.TEXT,
+			favicon: dataTypes.TEXT,
+			accentColorLight: dataTypes.STRING,
+			accentColorDark: dataTypes.STRING,
+			hideCreatePubButton: dataTypes.BOOLEAN,
+			headerLogo: dataTypes.TEXT,
+			headerLinks: dataTypes.JSONB,
 			headerColorType: {
 				type: dataTypes.ENUM,
 				values: ['light', 'dark', 'custom'],
 				defaultValue: 'dark',
 			},
-			useHeaderTextAccent: { type: dataTypes.BOOLEAN },
-			hideHero: { type: dataTypes.BOOLEAN },
-			hideHeaderLogo: { type: dataTypes.BOOLEAN },
-			heroLogo: { type: dataTypes.TEXT },
-			heroBackgroundImage: { type: dataTypes.TEXT },
-			heroBackgroundColor: { type: dataTypes.TEXT },
-			heroTextColor: { type: dataTypes.TEXT },
-			useHeaderGradient: { type: dataTypes.BOOLEAN },
-			heroImage: { type: dataTypes.TEXT },
-			heroTitle: { type: dataTypes.TEXT },
-			heroText: { type: dataTypes.TEXT },
-			heroPrimaryButton: { type: dataTypes.JSONB },
-			heroSecondaryButton: { type: dataTypes.JSONB },
-			heroAlign: { type: dataTypes.TEXT },
-			navigation: { type: dataTypes.JSONB },
-			hideNav: { type: dataTypes.BOOLEAN },
+			useHeaderTextAccent: dataTypes.BOOLEAN,
+			hideHero: dataTypes.BOOLEAN,
+			hideHeaderLogo: dataTypes.BOOLEAN,
+			heroLogo: dataTypes.TEXT,
+			heroBackgroundImage: dataTypes.TEXT,
+			heroBackgroundColor: dataTypes.TEXT,
+			heroTextColor: dataTypes.TEXT,
+			useHeaderGradient: dataTypes.BOOLEAN,
+			heroImage: dataTypes.TEXT,
+			heroTitle: dataTypes.TEXT,
+			heroText: dataTypes.TEXT,
+			heroPrimaryButton: dataTypes.JSONB,
+			heroSecondaryButton: dataTypes.JSONB,
+			heroAlign: dataTypes.TEXT,
+			navigation: dataTypes.JSONB,
+			hideNav: dataTypes.BOOLEAN,
 
-			navLinks: { type: dataTypes.JSONB },
-			footerLinks: { type: dataTypes.JSONB },
-			footerLogoLink: { type: dataTypes.TEXT },
-			footerTitle: { type: dataTypes.TEXT },
-			footerImage: { type: dataTypes.TEXT },
+			navLinks: dataTypes.JSONB,
+			footerLinks: dataTypes.JSONB,
+			footerLogoLink: dataTypes.TEXT,
+			footerTitle: dataTypes.TEXT,
+			footerImage: dataTypes.TEXT,
 
-			website: { type: dataTypes.TEXT },
-			facebook: { type: dataTypes.TEXT },
-			twitter: { type: dataTypes.TEXT },
-			email: { type: dataTypes.TEXT },
-			issn: { type: dataTypes.TEXT },
-			isFeatured: { type: dataTypes.BOOLEAN },
-			viewHash: { type: dataTypes.STRING },
-			editHash: { type: dataTypes.STRING },
+			website: dataTypes.TEXT,
+			facebook: dataTypes.TEXT,
+			twitter: dataTypes.TEXT,
+			email: dataTypes.TEXT,
+			issn: dataTypes.TEXT,
+			isFeatured: dataTypes.BOOLEAN,
+			viewHash: dataTypes.STRING,
+			editHash: dataTypes.STRING,
 			premiumLicenseFlag: { type: dataTypes.BOOLEAN, defaultValue: false },
-			defaultPubCollections: { type: dataTypes.JSONB },
-			spamTagId: { type: dataTypes.UUID },
-
-			/* Set by Associations */
-			organizationId: { type: dataTypes.UUID },
+			defaultPubCollections: dataTypes.JSONB,
 		},
 		{
+			tableName: 'Communities',
 			classMethods: {
 				associate: (models) => {
 					const {
-						Community,
-						DepositTarget,
-						Organization,
-						Collection,
-						Page,
-						Pub,
-						ScopeSummary,
-						SpamTag,
+						community,
+						depositTarget,
+						organization,
+						collection,
+						page,
+						pub,
+						scopeSummary,
+						landingPageFeature,
+						spamTag,
 					} = models;
-					Community.belongsTo(Organization, {
-						onDelete: 'CASCADE',
-						as: 'organization',
-						foreignKey: 'organizationId',
-					});
-					Community.hasMany(Collection, {
-						onDelete: 'CASCADE',
-						as: 'collections',
-						foreignKey: 'communityId',
-					});
-					Community.hasMany(Pub, {
-						onDelete: 'CASCADE',
-						as: 'pubs',
-						foreignKey: 'communityId',
-					});
-					Community.hasMany(Page, {
-						onDelete: 'CASCADE',
-						as: 'pages',
-						foreignKey: 'communityId',
-					});
-					Community.hasMany(DepositTarget, {
-						onDelete: 'CASCADE',
-						as: 'depositTargets',
-						foreignKey: 'communityId',
-					});
-					Community.belongsTo(ScopeSummary, {
-						as: 'scopeSummary',
-						foreignKey: 'scopeSummaryId',
-					});
-					Community.belongsTo(SpamTag, {
-						as: 'spamTag',
-						foreignKey: 'spamTagId',
-					});
+					community.hasMany(landingPageFeature, { onDelete: 'CASCADE' });
+					community.belongsTo(organization, { onDelete: 'CASCADE' });
+					community.hasMany(collection, { onDelete: 'CASCADE' });
+					community.hasMany(pub, { onDelete: 'CASCADE' });
+					community.hasMany(page, { onDelete: 'CASCADE' });
+					community.hasMany(depositTarget, { onDelete: 'CASCADE' });
+					community.belongsTo(scopeSummary);
+					community.belongsTo(spamTag);
 				},
 			},
 		},

--- a/server/communityAdmin/model.ts
+++ b/server/communityAdmin/model.ts
@@ -1,9 +1,18 @@
-export default (sequelize, dataTypes) => {
-	return sequelize.define('CommunityAdmin', {
-		id: sequelize.idType,
-
-		/* Set by Associations */
-		userId: { type: dataTypes.UUID, allowNull: false },
-		communityId: { type: dataTypes.UUID, allowNull: false },
-	});
+export default (sequelize) => {
+	return sequelize.define(
+		'communityAdmin',
+		{
+			id: sequelize.idType,
+		},
+		{
+			tableName: 'CommunityAdmins',
+			classMethods: {
+				associate: (models) => {
+					const { communityAdmin, user, community } = models;
+					communityAdmin.belongsTo(user, { foreignKey: { allowNull: false } });
+					communityAdmin.belongsTo(community, { foreignKey: { allowNull: false } });
+				},
+			},
+		},
+	);
 };

--- a/server/communityAdmin/model.ts
+++ b/server/communityAdmin/model.ts
@@ -7,10 +7,11 @@ export default (sequelize) => {
 		{
 			tableName: 'CommunityAdmins',
 			classMethods: {
-				associate: (models) => {
-					const { communityAdmin, user, community } = models;
-					communityAdmin.belongsTo(user, { foreignKey: { allowNull: false } });
-					communityAdmin.belongsTo(community, { foreignKey: { allowNull: false } });
+				associate: ({ communityAdmin, ...models }) => {
+					communityAdmin.belongsTo(models.user, { foreignKey: { allowNull: false } });
+					communityAdmin.belongsTo(models.community, {
+						foreignKey: { allowNull: false },
+					});
 				},
 			},
 		},

--- a/server/crossrefDepositRecord/model.ts
+++ b/server/crossrefDepositRecord/model.ts
@@ -1,6 +1,10 @@
 export default (sequelize, dataTypes) => {
-	return sequelize.define('CrossrefDepositRecord', {
-		id: sequelize.idType,
-		depositJson: dataTypes.JSONB,
-	});
+	return sequelize.define(
+		'crossrefDepositRecord',
+		{
+			id: sequelize.idType,
+			depositJson: dataTypes.JSONB,
+		},
+		{ tableName: 'CrossrefDepositRecords' },
+	);
 };

--- a/server/customScript/model.ts
+++ b/server/customScript/model.ts
@@ -1,8 +1,19 @@
 export default (sequelize, dataTypes) => {
-	return sequelize.define('CustomScript', {
-		id: sequelize.idType,
-		communityId: dataTypes.UUID,
-		type: dataTypes.STRING,
-		content: dataTypes.TEXT,
-	});
+	return sequelize.define(
+		'customScript',
+		{
+			id: sequelize.idType,
+			type: dataTypes.STRING,
+			content: dataTypes.TEXT,
+		},
+		{
+			tableName: 'CustomScripts',
+			classMethods: {
+				associate: (models) => {
+					const { customScript, community } = models;
+					customScript.belongsTo(community);
+				},
+			},
+		},
+	);
 };

--- a/server/customScript/model.ts
+++ b/server/customScript/model.ts
@@ -9,9 +9,8 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'CustomScripts',
 			classMethods: {
-				associate: (models) => {
-					const { customScript, community } = models;
-					customScript.belongsTo(community);
+				associate: ({ customScript, ...models }) => {
+					customScript.belongsTo(models.community);
 				},
 			},
 		},

--- a/server/depositTarget/model.ts
+++ b/server/depositTarget/model.ts
@@ -1,15 +1,25 @@
 export default (sequelize, dataTypes) => {
-	return sequelize.define('DepositTarget', {
-		id: sequelize.idType,
-		communityId: { type: dataTypes.UUID },
-		doiPrefix: { type: dataTypes.STRING },
-		service: {
-			type: dataTypes.ENUM,
-			values: ['crossref', 'datacite'],
-			defaultValue: 'crossref',
+	return sequelize.define(
+		'depositTarget',
+		{
+			id: sequelize.idType,
+			doiPrefix: dataTypes.STRING,
+			service: {
+				type: dataTypes.ENUM,
+				values: ['crossref', 'datacite'],
+				defaultValue: 'crossref',
+			},
+			username: dataTypes.STRING,
+			password: dataTypes.STRING,
+			passwordInitVec: dataTypes.TEXT,
 		},
-		username: { type: dataTypes.STRING },
-		password: { type: dataTypes.STRING },
-		passwordInitVec: { type: dataTypes.TEXT },
-	});
+		{
+			tableName: 'DepositTargets',
+			classMethods: {
+				associate: (models) => {
+					models.depositTarget.belongsTo(models.community);
+				},
+			},
+		},
+	);
 };

--- a/server/depositTarget/model.ts
+++ b/server/depositTarget/model.ts
@@ -16,8 +16,8 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'DepositTargets',
 			classMethods: {
-				associate: (models) => {
-					models.depositTarget.belongsTo(models.community);
+				associate: ({ depositTarget, ...models }) => {
+					depositTarget.belongsTo(models.models.community);
 				},
 			},
 		},

--- a/server/discussion/model.ts
+++ b/server/discussion/model.ts
@@ -15,32 +15,23 @@ export default (sequelize, dataTypes) => {
 				{ fields: ['pubId'], method: 'BTREE' },
 			],
 			classMethods: {
-				associate: (models) => {
-					const {
-						discussion,
-						discussionAnchor,
-						visibility,
-						pub,
-						user,
-						thread,
-						commenter,
-					} = models;
-					discussion.belongsTo(thread, {
+				associate: ({ discussion, ...models }) => {
+					discussion.belongsTo(models.thread, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});
-					discussion.belongsTo(visibility, {
+					discussion.belongsTo(models.visibility, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});
-					discussion.belongsTo(user, {
+					discussion.belongsTo(models.user, {
 						onDelete: 'CASCADE',
 						as: 'author',
 						foreignKey: { name: 'userId' },
 					});
-					discussion.belongsTo(commenter, { onDelete: 'CASCADE' });
-					discussion.belongsTo(pub);
-					discussion.hasMany(discussionAnchor, {
+					discussion.belongsTo(models.commenter, { onDelete: 'CASCADE' });
+					discussion.belongsTo(models.pub);
+					discussion.hasMany(models.discussionAnchor, {
 						onDelete: 'CASCADE',
 						as: 'anchors',
 						foreignKey: 'discussionId',

--- a/server/discussion/model.ts
+++ b/server/discussion/model.ts
@@ -1,21 +1,15 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Discussion',
+		'discussion',
 		{
 			id: sequelize.idType,
-			title: { type: dataTypes.TEXT },
+			title: dataTypes.TEXT,
 			number: { type: dataTypes.INTEGER, allowNull: false },
-			isClosed: { type: dataTypes.BOOLEAN },
-			labels: { type: dataTypes.JSONB },
-			/* Set by Associations */
-			threadId: { type: dataTypes.UUID, allowNull: false },
-			visibilityId: { type: dataTypes.UUID, allowNull: false },
-			userId: { type: dataTypes.UUID, allowNull: true },
-			anchorId: { type: dataTypes.UUID },
-			pubId: { type: dataTypes.UUID },
-			commenterId: { type: dataTypes.UUID, allowNull: true },
+			isClosed: dataTypes.BOOLEAN,
+			labels: dataTypes.JSONB,
 		},
 		{
+			tableName: 'Discussions',
 			indexes: [
 				{ fields: ['userId'], method: 'BTREE' },
 				{ fields: ['pubId'], method: 'BTREE' },
@@ -23,40 +17,30 @@ export default (sequelize, dataTypes) => {
 			classMethods: {
 				associate: (models) => {
 					const {
-						Discussion,
-						DiscussionAnchor,
-						Visibility,
-						Pub,
-						User,
-						Thread,
-						Commenter,
+						discussion,
+						discussionAnchor,
+						visibility,
+						pub,
+						user,
+						thread,
+						commenter,
 					} = models;
-					Discussion.belongsTo(Thread, {
+					discussion.belongsTo(thread, {
 						onDelete: 'CASCADE',
-						as: 'thread',
-						foreignKey: 'threadId',
+						foreignKey: { allowNull: false },
 					});
-					Discussion.belongsTo(Visibility, {
+					discussion.belongsTo(visibility, {
 						onDelete: 'CASCADE',
-						as: 'visibility',
-						foreignKey: 'visibilityId',
+						foreignKey: { allowNull: false },
 					});
-					Discussion.belongsTo(User, {
+					discussion.belongsTo(user, {
 						onDelete: 'CASCADE',
 						as: 'author',
-						foreignKey: 'userId',
+						foreignKey: { name: 'userId' },
 					});
-					Discussion.belongsTo(Commenter, {
-						onDelete: 'CASCADE',
-						as: 'commenter',
-						foreignKey: 'commenterId',
-					});
-					Discussion.belongsTo(Pub, {
-						onDelete: 'CASCADE',
-						as: 'pub',
-						foreignKey: 'pubId',
-					});
-					Discussion.hasMany(DiscussionAnchor, {
+					discussion.belongsTo(commenter, { onDelete: 'CASCADE' });
+					discussion.belongsTo(pub);
+					discussion.hasMany(discussionAnchor, {
 						onDelete: 'CASCADE',
 						as: 'anchors',
 						foreignKey: 'discussionId',

--- a/server/discussionAnchor/model.ts
+++ b/server/discussionAnchor/model.ts
@@ -14,9 +14,10 @@ export default (sequelize, dataTypes) => {
 			tableName: 'DiscussionAnchors',
 			indexes: [{ fields: ['discussionId'], method: 'BTREE' }],
 			classMethods: {
-				associate: (models) => {
-					const { discussion, discussionAnchor } = models;
-					discussionAnchor.belongsTo(discussion, { foreignKey: { allowNull: false } });
+				associate: ({ discussionAnchor, ...models }) => {
+					discussionAnchor.belongsTo(models.discussion, {
+						foreignKey: { allowNull: false },
+					});
 				},
 			},
 		},

--- a/server/discussionAnchor/model.ts
+++ b/server/discussionAnchor/model.ts
@@ -1,10 +1,9 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'DiscussionAnchor',
+		'discussionAnchor',
 		{
 			id: sequelize.idType,
 			isOriginal: { type: dataTypes.BOOLEAN, allowNull: false },
-			discussionId: { type: dataTypes.UUID, allowNull: false },
 			historyKey: { type: dataTypes.INTEGER, allowNull: false },
 			selection: { type: dataTypes.JSONB, allowNull: true },
 			originalText: { type: dataTypes.TEXT, allowNull: false },
@@ -12,7 +11,14 @@ export default (sequelize, dataTypes) => {
 			originalTextSuffix: { type: dataTypes.TEXT, allowNull: false },
 		},
 		{
+			tableName: 'DiscussionAnchors',
 			indexes: [{ fields: ['discussionId'], method: 'BTREE' }],
+			classMethods: {
+				associate: (models) => {
+					const { discussion, discussionAnchor } = models;
+					discussionAnchor.belongsTo(discussion, { foreignKey: { allowNull: false } });
+				},
+			},
 		},
 	);
 };

--- a/server/doc/model.ts
+++ b/server/doc/model.ts
@@ -1,6 +1,10 @@
 export default (sequelize, dataTypes) => {
-	return sequelize.define('Doc', {
-		id: sequelize.idType,
-		content: { type: dataTypes.JSONB, allowNull: false },
-	});
+	return sequelize.define(
+		'doc',
+		{
+			id: sequelize.idType,
+			content: { type: dataTypes.JSONB, allowNull: false },
+		},
+		{ tableName: 'Docs' },
+	);
 };

--- a/server/doi/__tests__/api.test.ts
+++ b/server/doi/__tests__/api.test.ts
@@ -16,7 +16,9 @@ const models = modelize`
 			User communityManager {}
 		}
 		Pub pub {
-			Release {}
+			Release {
+				User {}
+			}
 			Member {
 				permissions: "admin"
 				User pubAdmin {}

--- a/server/draft/model.ts
+++ b/server/draft/model.ts
@@ -1,19 +1,17 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Draft',
+		'draft',
 		{
 			id: sequelize.idType,
-			latestKeyAt: { type: dataTypes.DATE },
+			latestKeyAt: dataTypes.DATE,
 			firebasePath: { type: dataTypes.STRING, allowNull: false },
 		},
 		{
+			tableName: 'Drafts',
 			classMethods: {
 				associate: (models) => {
-					const { Pub, Draft } = models;
-					Pub.belongsTo(Draft, {
-						as: 'draft',
-						foreignKey: 'draftId',
-					});
+					const { pub, draft } = models;
+					draft.hasOne(pub);
 				},
 			},
 		},

--- a/server/draft/model.ts
+++ b/server/draft/model.ts
@@ -9,9 +9,8 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Drafts',
 			classMethods: {
-				associate: (models) => {
-					const { pub, draft } = models;
-					draft.hasOne(pub);
+				associate: ({ draft, ...models }) => {
+					draft.hasOne(models.pub);
 				},
 			},
 		},

--- a/server/export/__tests__/api.test.ts
+++ b/server/export/__tests__/api.test.ts
@@ -11,9 +11,11 @@ const models = modelize`
 				User pubViewer {}
 			}
 			Release {
+				User {}
 				historyKey: 10
 			}
 			Release {
+				User {}
 				historyKey: 25
 			}
 		}

--- a/server/export/model.ts
+++ b/server/export/model.ts
@@ -1,23 +1,19 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Export',
+		'export',
 		{
 			id: sequelize.idType,
 			format: { type: dataTypes.STRING, allowNull: false },
 			url: { type: dataTypes.STRING, allowNull: true },
 			historyKey: { type: dataTypes.INTEGER, allowNull: false },
-			pubId: { type: dataTypes.UUID, allowNull: false },
-			workerTaskId: { type: dataTypes.UUID, allowNull: true },
 		},
 		{
+			tableName: 'Exports',
 			classMethods: {
 				associate: (models) => {
-					const { Export, WorkerTask } = models;
-					Export.belongsTo(WorkerTask, {
-						onDelete: 'SET NULL',
-						as: 'workerTask',
-						foreignKey: 'workerTaskId',
-					});
+					const { workerTask, pub } = models;
+					models.export.belongsTo(workerTask);
+					models.export.belongsTo(pub, { foreignKey: { allowNull: false } });
 				},
 			},
 		},

--- a/server/export/model.ts
+++ b/server/export/model.ts
@@ -10,10 +10,10 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Exports',
 			classMethods: {
-				associate: (models) => {
-					const { workerTask, pub } = models;
-					models.export.belongsTo(workerTask);
-					models.export.belongsTo(pub, { foreignKey: { allowNull: false } });
+				// alias to exportModel as export is a keyword
+				associate: ({ export: exportModel, ...models }) => {
+					exportModel.belongsTo(models.workerTask);
+					exportModel.belongsTo(models.pub, { foreignKey: { allowNull: false } });
 				},
 			},
 		},

--- a/server/externalPublication/model.ts
+++ b/server/externalPublication/model.ts
@@ -1,12 +1,16 @@
 export default (sequelize, dataTypes) => {
-	return sequelize.define('ExternalPublication', {
-		id: sequelize.idType,
-		title: { type: dataTypes.TEXT, allowNull: false },
-		url: { type: dataTypes.TEXT, allowNull: false },
-		contributors: { type: dataTypes.JSONB },
-		doi: { type: dataTypes.TEXT },
-		description: { type: dataTypes.TEXT },
-		avatar: { type: dataTypes.TEXT },
-		publicationDate: { type: dataTypes.DATE },
-	});
+	return sequelize.define(
+		'externalPublication',
+		{
+			id: sequelize.idType,
+			title: { type: dataTypes.TEXT, allowNull: false },
+			url: { type: dataTypes.TEXT, allowNull: false },
+			contributors: dataTypes.JSONB,
+			doi: dataTypes.TEXT,
+			description: dataTypes.TEXT,
+			avatar: dataTypes.TEXT,
+			publicationDate: dataTypes.DATE,
+		},
+		{ tableName: 'ExternalPublications' },
+	);
 };

--- a/server/facets/models/facetBinding.ts
+++ b/server/facets/models/facetBinding.ts
@@ -1,6 +1,6 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'FacetBinding',
+		'facetBinding',
 		{
 			id: sequelize.idType,
 			pubId: { type: dataTypes.UUID, allowNull: true },
@@ -8,6 +8,7 @@ export default (sequelize, dataTypes) => {
 			communityId: { type: dataTypes.UUID, allowNull: true },
 		},
 		{
+			tableName: 'FacetBindings',
 			indexes: [
 				{ fields: ['communityId'], method: 'BTREE' },
 				{ fields: ['collectionId'], method: 'BTREE' },

--- a/server/facets/models/facetBinding.ts
+++ b/server/facets/models/facetBinding.ts
@@ -12,15 +12,14 @@ export default (sequelize) => {
 				{ fields: ['pubId'], method: 'BTREE' },
 			],
 			classMethods: {
-				associate: (models) => {
-					const { facetBinding, community, collection, pub } = models;
-					facetBinding.belongsTo(community, {
+				associate: ({ facetBinding, ...models }) => {
+					facetBinding.belongsTo(models.community, {
 						onDelete: 'CASCADE',
 					});
-					facetBinding.belongsTo(collection, {
+					facetBinding.belongsTo(models.collection, {
 						onDelete: 'CASCADE',
 					});
-					facetBinding.belongsTo(pub, {
+					facetBinding.belongsTo(models.pub, {
 						onDelete: 'CASCADE',
 					});
 				},

--- a/server/facets/models/facetBinding.ts
+++ b/server/facets/models/facetBinding.ts
@@ -1,11 +1,8 @@
-export default (sequelize, dataTypes) => {
+export default (sequelize) => {
 	return sequelize.define(
 		'facetBinding',
 		{
 			id: sequelize.idType,
-			pubId: { type: dataTypes.UUID, allowNull: true },
-			collectionId: { type: dataTypes.UUID, allowNull: true },
-			communityId: { type: dataTypes.UUID, allowNull: true },
 		},
 		{
 			tableName: 'FacetBindings',
@@ -16,21 +13,15 @@ export default (sequelize, dataTypes) => {
 			],
 			classMethods: {
 				associate: (models) => {
-					const { FacetBinding, Community, Collection, Pub } = models;
-					FacetBinding.belongsTo(Community, {
+					const { facetBinding, community, collection, pub } = models;
+					facetBinding.belongsTo(community, {
 						onDelete: 'CASCADE',
-						as: 'community',
-						foreignKey: 'communityId',
 					});
-					FacetBinding.belongsTo(Collection, {
+					facetBinding.belongsTo(collection, {
 						onDelete: 'CASCADE',
-						as: 'collection',
-						foreignKey: 'collectionId',
 					});
-					FacetBinding.belongsTo(Pub, {
+					facetBinding.belongsTo(pub, {
 						onDelete: 'CASCADE',
-						as: 'pub',
-						foreignKey: 'pubId',
 					});
 				},
 			},

--- a/server/facets/models/facetDefinition.ts
+++ b/server/facets/models/facetDefinition.ts
@@ -1,16 +1,17 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'FacetDefinition',
+		'facetDefinition',
 		{
 			id: sequelize.idType,
 			name: { type: dataTypes.TEXT, allowNull: false },
 			structure: { typ: dataTypes.JSONB, allowNull: false },
 		},
 		{
+			tableName: 'FacetDefinitions',
 			classMethods: {
 				associate: (models) => {
-					const { FacetDefinition, FacetInstance } = models;
-					FacetDefinition.hasMany(FacetInstance, {
+					const { facetDefinition, facetInstance } = models;
+					facetDefinition.hasMany(facetInstance, {
 						onDelete: 'CASCADE',
 						as: 'instances',
 						foreignKey: 'facetDefinitionId',

--- a/server/facets/models/facetDefinition.ts
+++ b/server/facets/models/facetDefinition.ts
@@ -9,9 +9,8 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'FacetDefinitions',
 			classMethods: {
-				associate: (models) => {
-					const { facetDefinition, facetInstance } = models;
-					facetDefinition.hasMany(facetInstance, {
+				associate: ({ facetDefinition, ...models }) => {
+					facetDefinition.hasMany(models.facetInstance, {
 						onDelete: 'CASCADE',
 						as: 'instances',
 						foreignKey: 'facetDefinitionId',

--- a/server/featureFlag/model.ts
+++ b/server/featureFlag/model.ts
@@ -11,14 +11,13 @@ export default (sequelize, dataTypes) => {
 			tableName: 'FeatureFlags',
 			indexes: [{ unique: true, fields: ['name'] }],
 			classMethods: {
-				associate: (models) => {
-					const { featureFlag, featureFlagUser, featureFlagCommunity } = models;
-					featureFlag.hasMany(featureFlagUser, {
+				associate: ({ featureFlag, ...models }) => {
+					featureFlag.hasMany(models.featureFlagUser, {
 						onDelete: 'CASCADE',
 						as: 'users',
 						foreignKey: 'featureFlagId',
 					});
-					featureFlag.hasMany(featureFlagCommunity, {
+					featureFlag.hasMany(models.featureFlagCommunity, {
 						onDelete: 'CASCADE',
 						as: 'communities',
 						foreignKey: 'featureFlagId',

--- a/server/featureFlag/model.ts
+++ b/server/featureFlag/model.ts
@@ -1,23 +1,24 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'FeatureFlag',
+		'featureFlag',
 		{
 			id: sequelize.idType,
-			name: { type: dataTypes.STRING },
+			name: dataTypes.STRING,
 			enabledUsersFraction: { type: dataTypes.DOUBLE, defaultValue: 0 },
 			enabledCommunitiesFraction: { type: dataTypes.DOUBLE, defaultValue: 0 },
 		},
 		{
+			tableName: 'FeatureFlags',
 			indexes: [{ unique: true, fields: ['name'] }],
 			classMethods: {
 				associate: (models) => {
-					const { FeatureFlag, FeatureFlagUser, FeatureFlagCommunity } = models;
-					FeatureFlag.hasMany(FeatureFlagUser, {
+					const { featureFlag, featureFlagUser, featureFlagCommunity } = models;
+					featureFlag.hasMany(featureFlagUser, {
 						onDelete: 'CASCADE',
 						as: 'users',
 						foreignKey: 'featureFlagId',
 					});
-					FeatureFlag.hasMany(FeatureFlagCommunity, {
+					featureFlag.hasMany(featureFlagCommunity, {
 						onDelete: 'CASCADE',
 						as: 'communities',
 						foreignKey: 'featureFlagId',

--- a/server/featureFlagCommunity/model.ts
+++ b/server/featureFlagCommunity/model.ts
@@ -1,26 +1,17 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'FeatureFlagCommunity',
+		'featureFlagCommunity',
 		{
 			id: sequelize.idType,
-			featureFlagId: { type: dataTypes.UUID },
-			communityId: { type: dataTypes.UUID },
-			enabled: { type: dataTypes.BOOLEAN },
+			enabled: dataTypes.BOOLEAN,
 		},
 		{
+			tableName: 'FeatureFlagCommunities',
 			classMethods: {
 				associate: (models) => {
-					const { FeatureFlag, FeatureFlagCommunity, Community } = models;
-					FeatureFlagCommunity.belongsTo(Community, {
-						onDelete: 'CASCADE',
-						as: 'community',
-						foreignKey: 'communityId',
-					});
-					FeatureFlagCommunity.belongsTo(FeatureFlag, {
-						onDelete: 'CASCADE',
-						as: 'featureFlag',
-						foreignKey: 'featureFlagId',
-					});
+					const { featureFlag, featureFlagCommunity, community } = models;
+					featureFlagCommunity.belongsTo(community, { onDelete: 'CASCADE' });
+					featureFlagCommunity.belongsTo(featureFlag, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/featureFlagCommunity/model.ts
+++ b/server/featureFlagCommunity/model.ts
@@ -8,10 +8,9 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'FeatureFlagCommunities',
 			classMethods: {
-				associate: (models) => {
-					const { featureFlag, featureFlagCommunity, community } = models;
-					featureFlagCommunity.belongsTo(community, { onDelete: 'CASCADE' });
-					featureFlagCommunity.belongsTo(featureFlag, { onDelete: 'CASCADE' });
+				associate: ({ featureFlagCommunity, ...models }) => {
+					featureFlagCommunity.belongsTo(models.community, { onDelete: 'CASCADE' });
+					featureFlagCommunity.belongsTo(models.featureFlag, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/featureFlagUser/model.ts
+++ b/server/featureFlagUser/model.ts
@@ -8,10 +8,9 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'FeatureFlagUsers',
 			classMethods: {
-				associate: (models) => {
-					const { featureFlag, featureFlagUser, user } = models;
-					featureFlagUser.belongsTo(user, { onDelete: 'CASCADE' });
-					featureFlagUser.belongsTo(featureFlag, { onDelete: 'CASCADE' });
+				associate: ({ featureFlagUser, ...models }) => {
+					featureFlagUser.belongsTo(models.user, { onDelete: 'CASCADE' });
+					featureFlagUser.belongsTo(models.featureFlag, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/featureFlagUser/model.ts
+++ b/server/featureFlagUser/model.ts
@@ -1,26 +1,17 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'FeatureFlagUser',
+		'featureFlagUser',
 		{
 			id: sequelize.idType,
-			featureFlagId: { type: dataTypes.UUID },
-			userId: { type: dataTypes.UUID },
-			enabled: { type: dataTypes.BOOLEAN },
+			enabled: dataTypes.BOOLEAN,
 		},
 		{
+			tableName: 'FeatureFlagUsers',
 			classMethods: {
 				associate: (models) => {
-					const { FeatureFlag, FeatureFlagUser, User } = models;
-					FeatureFlagUser.belongsTo(User, {
-						onDelete: 'CASCADE',
-						as: 'user',
-						foreignKey: 'userId',
-					});
-					FeatureFlagUser.belongsTo(FeatureFlag, {
-						onDelete: 'CASCADE',
-						as: 'featureFlag',
-						foreignKey: 'featureFlagId',
-					});
+					const { featureFlag, featureFlagUser, user } = models;
+					featureFlagUser.belongsTo(user, { onDelete: 'CASCADE' });
+					featureFlagUser.belongsTo(featureFlag, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/integrationDataOAuth1/model.ts
+++ b/server/integrationDataOAuth1/model.ts
@@ -8,9 +8,8 @@ export default (sequelize, dataTypes) =>
 		{
 			tableName: 'IntegrationDataOAuth1',
 			classMethods: {
-				associate: (models) => {
-					const { integrationDataOAuth1, zoteroIntegration } = models;
-					integrationDataOAuth1.hasOne(zoteroIntegration, {
+				associate: ({ integrationDataOAuth1, ...models }) => {
+					integrationDataOAuth1.hasOne(models.zoteroIntegration, {
 						foreignKey: { allowNull: false },
 						onDelete: 'CASCADE',
 					});

--- a/server/landingPageFeature/__tests__/api.test.ts
+++ b/server/landingPageFeature/__tests__/api.test.ts
@@ -12,10 +12,14 @@ const models = modelize`
             User rando {}
         }
         Pub p1 {
-            Release {}
+            Release {
+							  User {}
+						}
         }
         Pub p2 {
-            Release {}
+            Release {
+							  User {}
+				    }
         }
         Pub p3 {}
     }

--- a/server/landingPageFeature/model.ts
+++ b/server/landingPageFeature/model.ts
@@ -1,14 +1,13 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'LandingPageFeature',
+		'landingPageFeature',
 		{
 			id: sequelize.idType,
-			communityId: { type: dataTypes.UUID, allowNull: true },
-			pubId: { type: dataTypes.UUID, allowNull: true },
 			rank: { type: dataTypes.TEXT, allowNull: false },
 			payload: { type: dataTypes.JSONB, allowNull: true },
 		},
 		{
+			tableName: 'LandingPageFeatures',
 			indexes: [
 				{
 					fields: ['communityId'],
@@ -21,17 +20,9 @@ export default (sequelize, dataTypes) => {
 			],
 			classMethods: {
 				associate: (models) => {
-					const { Pub, Community, LandingPageFeature } = models;
-					LandingPageFeature.belongsTo(Pub, {
-						onDelete: 'CASCADE',
-						as: 'pub',
-						foreignKey: 'pubId',
-					});
-					LandingPageFeature.belongsTo(Community, {
-						onDelete: 'CASCADE',
-						as: 'community',
-						foreignKey: 'communityId',
-					});
+					const { pub, community, landingPageFeature } = models;
+					landingPageFeature.belongsTo(pub, { onDelete: 'CASCADE' });
+					landingPageFeature.belongsTo(community, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/landingPageFeature/model.ts
+++ b/server/landingPageFeature/model.ts
@@ -19,10 +19,9 @@ export default (sequelize, dataTypes) => {
 				},
 			],
 			classMethods: {
-				associate: (models) => {
-					const { pub, community, landingPageFeature } = models;
-					landingPageFeature.belongsTo(pub, { onDelete: 'CASCADE' });
-					landingPageFeature.belongsTo(community, { onDelete: 'CASCADE' });
+				associate: ({ landingPageFeature, ...models }) => {
+					landingPageFeature.belongsTo(models.pub, { onDelete: 'CASCADE' });
+					landingPageFeature.belongsTo(models.community, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/member/model.ts
+++ b/server/member/model.ts
@@ -18,13 +18,12 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Members',
 			classMethods: {
-				associate: (models) => {
-					const { member, user, collection, community, pub, organization } = models;
-					member.belongsTo(user, { onDelete: 'CASCADE' });
-					member.belongsTo(community, { onDelete: 'CASCADE' });
-					member.belongsTo(pub, { onDelete: 'CASCADE' });
-					member.belongsTo(collection, { onDelete: 'CASCADE' });
-					member.belongsTo(organization);
+				associate: ({ member, ...models }) => {
+					member.belongsTo(models.user, { onDelete: 'CASCADE' });
+					member.belongsTo(models.community, { onDelete: 'CASCADE' });
+					member.belongsTo(models.pub, { onDelete: 'CASCADE' });
+					member.belongsTo(models.collection, { onDelete: 'CASCADE' });
+					member.belongsTo(models.organization);
 				},
 			},
 		},

--- a/server/member/model.ts
+++ b/server/member/model.ts
@@ -1,6 +1,6 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Member',
+		'member',
 		{
 			id: sequelize.idType,
 			permissions: {
@@ -8,44 +8,23 @@ export default (sequelize, dataTypes) => {
 				values: ['view', 'edit', 'manage', 'admin'],
 				defaultValue: 'view',
 			},
-			isOwner: { type: dataTypes.BOOLEAN },
+			isOwner: dataTypes.BOOLEAN,
 			subscribedToActivityDigest: {
 				type: dataTypes.BOOLEAN,
 				allowNull: false,
 				defaultValue: false,
 			},
-
-			/* Set by Associations */
-			userId: { type: dataTypes.UUID, allowNull: false },
-			pubId: { type: dataTypes.UUID },
-			collectionId: { type: dataTypes.UUID },
-			communityId: { type: dataTypes.UUID },
-			organizationId: { type: dataTypes.UUID },
 		},
 		{
+			tableName: 'Members',
 			classMethods: {
 				associate: (models) => {
-					const { Member, User, Collection, Community, Pub } = models;
-					Member.belongsTo(User, {
-						onDelete: 'CASCADE',
-						as: 'user',
-						foreignKey: 'userId',
-					});
-					Member.belongsTo(Community, {
-						onDelete: 'CASCADE',
-						as: 'community',
-						foreignKey: 'communityId',
-					});
-					Member.belongsTo(Pub, {
-						onDelete: 'CASCADE',
-						as: 'pub',
-						foreignKey: 'pubId',
-					});
-					Member.belongsTo(Collection, {
-						onDelete: 'CASCADE',
-						as: 'collection',
-						foreignKey: 'collectionId',
-					});
+					const { member, user, collection, community, pub, organization } = models;
+					member.belongsTo(user, { onDelete: 'CASCADE' });
+					member.belongsTo(community, { onDelete: 'CASCADE' });
+					member.belongsTo(pub, { onDelete: 'CASCADE' });
+					member.belongsTo(collection, { onDelete: 'CASCADE' });
+					member.belongsTo(organization);
 				},
 			},
 		},

--- a/server/merge/model.ts
+++ b/server/merge/model.ts
@@ -1,23 +1,18 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Merge',
+		'merge',
 		{
 			id: sequelize.idType,
-			noteContent: { type: dataTypes.JSONB },
-			noteText: { type: dataTypes.TEXT },
-			/* Set by Associations */
-			userId: { type: dataTypes.UUID, allowNull: false },
-			pubId: { type: dataTypes.UUID, allowNull: false },
+			noteContent: dataTypes.JSONB,
+			noteText: dataTypes.TEXT,
 		},
 		{
+			tableName: 'Merges',
 			classMethods: {
 				associate: (models) => {
-					const { User, Merge } = models;
-					Merge.belongsTo(User, {
-						onDelete: 'CASCADE',
-						as: 'user',
-						foreignKey: 'userId',
-					});
+					const { user, merge, pub } = models;
+					merge.belongsTo(user, { onDelete: 'CASCADE' });
+					merge.belongsTo(pub, { foreignKey: { allowNull: false } });
 				},
 			},
 		},

--- a/server/merge/model.ts
+++ b/server/merge/model.ts
@@ -9,10 +9,9 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Merges',
 			classMethods: {
-				associate: (models) => {
-					const { user, merge, pub } = models;
-					merge.belongsTo(user, { onDelete: 'CASCADE' });
-					merge.belongsTo(pub, { foreignKey: { allowNull: false } });
+				associate: ({ merge, ...models }) => {
+					merge.belongsTo(models.user, { onDelete: 'CASCADE' });
+					merge.belongsTo(models.pub, { foreignKey: { allowNull: false } });
 				},
 			},
 		},

--- a/server/organization/model.ts
+++ b/server/organization/model.ts
@@ -30,9 +30,8 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Organizations',
 			classMethods: {
-				associate: (models) => {
-					const { organization, community } = models;
-					organization.hasMany(community, { onDelete: 'CASCADE' });
+				associate: ({ organization, ...models }) => {
+					organization.hasMany(models.community, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/organization/model.ts
+++ b/server/organization/model.ts
@@ -1,6 +1,6 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Organization',
+		'organization',
 		{
 			id: sequelize.idType,
 			subdomain: {
@@ -24,18 +24,15 @@ export default (sequelize, dataTypes) => {
 					len: [0, 280],
 				},
 			},
-			avatar: { type: dataTypes.TEXT },
-			favicon: { type: dataTypes.TEXT },
+			avatar: dataTypes.TEXT,
+			favicon: dataTypes.TEXT,
 		},
 		{
+			tableName: 'Organizations',
 			classMethods: {
 				associate: (models) => {
-					const { Organization, Community } = models;
-					Organization.hasMany(Community, {
-						onDelete: 'CASCADE',
-						as: 'communities',
-						foreignKey: 'organizationId',
-					});
+					const { organization, community } = models;
+					organization.hasMany(community, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/page/model.ts
+++ b/server/page/model.ts
@@ -20,9 +20,8 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Pages',
 			classMethods: {
-				associate: (models) => {
-					const { page, community } = models;
-					page.belongsTo(community, { onDelete: 'CASCADE' });
+				associate: ({ page, ...models }) => {
+					page.belongsTo(models.community, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/page/model.ts
+++ b/server/page/model.ts
@@ -1,34 +1,28 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Page',
+		'page',
 		{
 			id: sequelize.idType,
 			title: { type: dataTypes.TEXT, allowNull: false },
 			slug: { type: dataTypes.TEXT, allowNull: false },
-			description: { type: dataTypes.TEXT },
-			avatar: { type: dataTypes.TEXT },
+			description: dataTypes.TEXT,
+			avatar: dataTypes.TEXT,
 			isPublic: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
-			isNarrowWidth: { type: dataTypes.BOOLEAN },
-			viewHash: { type: dataTypes.TEXT },
+			isNarrowWidth: dataTypes.BOOLEAN,
+			viewHash: dataTypes.TEXT,
 			layout: { type: dataTypes.JSONB, allowNull: false },
 			layoutAllowsDuplicatePubs: {
 				type: dataTypes.BOOLEAN,
 				defaultValue: false,
 				allowNull: false,
 			},
-
-			/* Set by Associations */
-			communityId: { type: dataTypes.UUID, allowNull: false },
 		},
 		{
+			tableName: 'Pages',
 			classMethods: {
 				associate: (models) => {
-					const { Page, Community } = models;
-					Page.belongsTo(Community, {
-						onDelete: 'CASCADE',
-						as: 'community',
-						foreignKey: 'communityId',
-					});
+					const { page, community } = models;
+					page.belongsTo(community, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/pub/__tests__/queryMany.test.ts
+++ b/server/pub/__tests__/queryMany.test.ts
@@ -77,9 +77,11 @@ const models = modelize`
                 c3
             }
             Release {
+							  User {}
                 createdAt: "2021-11-01"
             }
             Release {
+							  User {}
                 createdAt: "2021-12-02"
             }
             ReviewNew {
@@ -103,6 +105,7 @@ const models = modelize`
                 c3
             }
             Release {
+							  User {}
                 createdAt: "2021-10-01"
             }
 			Member {

--- a/server/pub/model.ts
+++ b/server/pub/model.ts
@@ -71,6 +71,7 @@ export default (sequelize, dataTypes) => {
 			classMethods: {
 				associate: (models) => {
 					const {
+						activityItem,
 						collectionPub,
 						community,
 						crossrefDepositRecord,
@@ -88,6 +89,7 @@ export default (sequelize, dataTypes) => {
 						submission,
 					} = models;
 					pub.belongsTo(draft, { foreignKey: { allowNull: false } });
+					pub.hasMany(activityItem);
 					pub.hasMany(pubAttribution, {
 						onDelete: 'CASCADE',
 						as: 'attributions',

--- a/server/pub/model.ts
+++ b/server/pub/model.ts
@@ -69,67 +69,49 @@ export default (sequelize, dataTypes) => {
 			tableName: 'Pubs',
 			indexes: [{ fields: ['communityId'], method: 'BTREE' }],
 			classMethods: {
-				associate: (models) => {
-					const {
-						activityItem,
-						collectionPub,
-						community,
-						crossrefDepositRecord,
-						draft,
-						discussion,
-						landingPageFeature,
-						member,
-						pub,
-						pubAttribution,
-						pubEdge,
-						pubVersion,
-						release,
-						reviewNew,
-						scopeSummary,
-						submission,
-					} = models;
-					pub.belongsTo(draft, { foreignKey: { allowNull: false } });
-					pub.hasMany(activityItem);
-					pub.hasMany(pubAttribution, {
+				associate: ({ pub, ...models }) => {
+					pub.belongsTo(models.draft, { foreignKey: { allowNull: false } });
+					pub.hasMany(models.activityItem);
+					pub.hasMany(models.pubAttribution, {
 						onDelete: 'CASCADE',
 						as: 'attributions',
 						foreignKey: 'pubId',
 					});
-					pub.hasMany(collectionPub, {
+					pub.hasMany(models.collectionPub, {
 						onDelete: 'CASCADE',
 						hooks: true,
 					});
-					pub.belongsTo(community, {
+					pub.belongsTo(models.community, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});
-					pub.hasMany(discussion, { onDelete: 'CASCADE' });
-					pub.hasMany(landingPageFeature, { onDelete: 'CASCADE' });
-					pub.hasMany(models.export);
-					pub.hasMany(reviewNew, {
+					pub.hasMany(models.discussion, { onDelete: 'CASCADE' });
+					pub.hasMany(models.landingPageFeature, { onDelete: 'CASCADE' });
+					pub.hasMany(models.models.export);
+					pub.hasMany(models.reviewNew, {
 						onDelete: 'CASCADE',
 						as: 'reviews',
 					});
-					pub.hasMany(member, {
+					pub.hasMany(models.member, {
 						onDelete: 'CASCADE',
 						as: 'members',
 						foreignKey: 'pubId',
 					});
-					pub.hasMany(release, { onDelete: 'CASCADE' });
-					pub.hasMany(pubVersion, { onDelete: 'CASCADE' });
-					pub.hasMany(pubEdge, {
+					pub.hasMany(models.release, { onDelete: 'CASCADE' });
+					pub.hasMany(models.pubVersion, { onDelete: 'CASCADE' });
+					pub.hasMany(models.pubEdge, {
 						onDelete: 'CASCADE',
 						as: 'outboundEdges',
 						foreignKey: 'pubId',
 					});
-					pub.hasMany(pubEdge, {
+					pub.hasMany(models.pubEdge, {
 						onDelete: 'CASCADE',
 						as: 'inboundEdges',
 						foreignKey: 'targetPubId',
 					});
-					pub.hasOne(submission);
-					pub.belongsTo(crossrefDepositRecord);
-					pub.belongsTo(scopeSummary);
+					pub.hasOne(models.submission);
+					pub.belongsTo(models.crossrefDepositRecord);
+					pub.belongsTo(models.scopeSummary);
 				},
 			},
 		},

--- a/server/pub/model.ts
+++ b/server/pub/model.ts
@@ -1,6 +1,6 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Pub',
+		'pub',
 		{
 			id: sequelize.idType,
 			slug: {
@@ -27,108 +27,107 @@ export default (sequelize, dataTypes) => {
 					len: [0, 280],
 				},
 			},
-			avatar: { type: dataTypes.TEXT },
-			customPublishedAt: { type: dataTypes.DATE },
-			doi: { type: dataTypes.TEXT },
-			labels: { type: dataTypes.JSONB },
-			downloads: { type: dataTypes.JSONB },
-			metadata: { type: dataTypes.JSONB },
-			viewHash: { type: dataTypes.STRING },
-			editHash: { type: dataTypes.STRING },
-			reviewHash: { type: dataTypes.STRING },
-			commentHash: { type: dataTypes.STRING },
-
-			/* Set by Associations */
-			draftId: { type: dataTypes.UUID, allowNull: false },
-			communityId: { type: dataTypes.UUID, allowNull: false },
+			avatar: dataTypes.TEXT,
+			headerStyle: {
+				type: dataTypes.ENUM,
+				values: ['white-blocks', 'black-blocks', 'dark', 'light'],
+				defaultValue: null,
+			},
+			headerBackgroundColor: dataTypes.STRING,
+			headerBackgroundImage: dataTypes.TEXT,
+			firstPublishedAt: dataTypes.DATE,
+			lastPublishedAt: dataTypes.DATE,
+			customPublishedAt: dataTypes.DATE,
+			doi: dataTypes.TEXT,
+			labels: dataTypes.JSONB,
+			downloads: dataTypes.JSONB,
+			metadata: dataTypes.JSONB,
+			licenseSlug: { type: dataTypes.TEXT, defaultValue: 'cc-by' },
+			citationStyle: { type: dataTypes.TEXT, defaultValue: 'apa-7' },
+			citationInlineStyle: { type: dataTypes.TEXT, defaultValue: 'count' },
+			viewHash: dataTypes.STRING,
+			editHash: dataTypes.STRING,
+			reviewHash: dataTypes.STRING,
+			commentHash: dataTypes.STRING,
+			nodeLabels: dataTypes.JSONB,
+			pubEdgeListingDefaultsToCarousel: {
+				type: dataTypes.BOOLEAN,
+				defaultValue: true,
+				allowNull: false,
+			},
+			pubEdgeDescriptionVisible: {
+				type: dataTypes.BOOLEAN,
+				defaultValue: true,
+				allowNull: false,
+			},
+			facetsMigratedAt: {
+				type: dataTypes.DATE,
+				allowNull: true,
+			},
 		},
 		{
+			tableName: 'Pubs',
 			indexes: [{ fields: ['communityId'], method: 'BTREE' }],
 			classMethods: {
 				associate: (models) => {
 					const {
-						CollectionPub,
-						Community,
-						CrossrefDepositRecord,
-						Discussion,
-						Export,
-						Member,
-						Pub,
-						PubAttribution,
-						PubEdge,
-						PubVersion,
-						Release,
-						ReviewNew,
-						ScopeSummary,
-						Submission,
+						collectionPub,
+						community,
+						crossrefDepositRecord,
+						draft,
+						discussion,
+						landingPageFeature,
+						member,
+						pub,
+						pubAttribution,
+						pubEdge,
+						pubVersion,
+						release,
+						reviewNew,
+						scopeSummary,
+						submission,
 					} = models;
-					Pub.hasMany(PubAttribution, {
+					pub.belongsTo(draft, { foreignKey: { allowNull: false } });
+					pub.hasMany(pubAttribution, {
 						onDelete: 'CASCADE',
 						as: 'attributions',
 						foreignKey: 'pubId',
 					});
-					Pub.hasMany(CollectionPub, {
+					pub.hasMany(collectionPub, {
 						onDelete: 'CASCADE',
 						hooks: true,
-						as: 'collectionPubs',
-						foreignKey: 'pubId',
 					});
-					Pub.belongsTo(Community, {
+					pub.belongsTo(community, {
 						onDelete: 'CASCADE',
-						as: 'community',
-						foreignKey: 'communityId',
+						foreignKey: { allowNull: false },
 					});
-					Pub.hasMany(Discussion, {
-						onDelete: 'CASCADE',
-						as: 'discussions',
-						foreignKey: 'pubId',
-					});
-					Pub.hasMany(Export, {
-						as: 'exports',
-						foreignKey: 'pubId',
-					});
-					Pub.hasMany(ReviewNew, {
+					pub.hasMany(discussion, { onDelete: 'CASCADE' });
+					pub.hasMany(landingPageFeature, { onDelete: 'CASCADE' });
+					pub.hasMany(models.export);
+					pub.hasMany(reviewNew, {
 						onDelete: 'CASCADE',
 						as: 'reviews',
-						foreignKey: 'pubId',
 					});
-					Pub.hasMany(Member, {
+					pub.hasMany(member, {
 						onDelete: 'CASCADE',
 						as: 'members',
 						foreignKey: 'pubId',
 					});
-					Pub.hasMany(Release, {
-						onDelete: 'CASCADE',
-						as: 'releases',
-						foreignKey: 'pubId',
-					});
-					Pub.hasMany(PubVersion, {
-						onDelete: 'CASCADE',
-						as: 'pubVersions',
-						foreignKey: 'pubId',
-					});
-					Pub.hasMany(PubEdge, {
+					pub.hasMany(release, { onDelete: 'CASCADE' });
+					pub.hasMany(pubVersion, { onDelete: 'CASCADE' });
+					pub.hasMany(pubEdge, {
 						onDelete: 'CASCADE',
 						as: 'outboundEdges',
 						foreignKey: 'pubId',
 					});
-					Pub.hasMany(PubEdge, {
+					pub.hasMany(pubEdge, {
 						onDelete: 'CASCADE',
 						as: 'inboundEdges',
 						foreignKey: 'targetPubId',
 					});
-					Pub.hasOne(Submission, {
-						as: 'submission',
-						foreignKey: 'pubId',
-					});
-					Pub.belongsTo(CrossrefDepositRecord, {
-						as: 'crossrefDepositRecord',
-						foreignKey: 'crossrefDepositRecordId',
-					});
-					Pub.belongsTo(ScopeSummary, {
-						as: 'scopeSummary',
-						foreignKey: 'scopeSummaryId',
-					});
+					pub.hasOne(submission);
+					pub.belongsTo(crossrefDepositRecord);
+					pub.belongsTo(scopeSummary);
 				},
 			},
 		},

--- a/server/pubAttribution/model.ts
+++ b/server/pubAttribution/model.ts
@@ -15,10 +15,9 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'PubAttributions',
 			classMethods: {
-				associate: (models) => {
-					const { user, pubAttribution, pub } = models;
-					pubAttribution.belongsTo(user, { onDelete: 'CASCADE' });
-					pubAttribution.belongsTo(pub, {
+				associate: ({ pubAttribution, ...models }) => {
+					pubAttribution.belongsTo(models.user, { onDelete: 'CASCADE' });
+					pubAttribution.belongsTo(models.pub, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});

--- a/server/pubAttribution/model.ts
+++ b/server/pubAttribution/model.ts
@@ -1,33 +1,26 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'PubAttribution',
+		'pubAttribution',
 		{
 			id: sequelize.idType,
-			name: { type: dataTypes.TEXT } /* Used for non-account attribution */,
-			avatar: { type: dataTypes.TEXT } /* Used for non-account attribution */,
-			title: { type: dataTypes.TEXT } /* Used for non-account attribution */,
-			order: { type: dataTypes.DOUBLE },
-			isAuthor: { type: dataTypes.BOOLEAN },
-			roles: { type: dataTypes.JSONB },
-			affiliation: { type: dataTypes.TEXT },
-			orcid: { type: dataTypes.STRING },
-			/* Set by Associations */
-			userId: { type: dataTypes.UUID },
-			pubId: { type: dataTypes.UUID, allowNull: false },
+			name: dataTypes.TEXT /* Used for non-account attribution */,
+			avatar: dataTypes.TEXT /* Used for non-account attribution */,
+			title: dataTypes.TEXT /* Used for non-account attribution */,
+			order: dataTypes.DOUBLE,
+			isAuthor: dataTypes.BOOLEAN,
+			roles: dataTypes.JSONB,
+			affiliation: dataTypes.TEXT,
+			orcid: dataTypes.STRING,
 		},
 		{
+			tableName: 'PubAttributions',
 			classMethods: {
 				associate: (models) => {
-					const { User, PubAttribution, Pub } = models;
-					PubAttribution.belongsTo(User, {
+					const { user, pubAttribution, pub } = models;
+					pubAttribution.belongsTo(user, { onDelete: 'CASCADE' });
+					pubAttribution.belongsTo(pub, {
 						onDelete: 'CASCADE',
-						as: 'user',
-						foreignKey: 'userId',
-					});
-					PubAttribution.belongsTo(Pub, {
-						onDelete: 'CASCADE',
-						as: 'pub',
-						foreignKey: 'pubId',
+						foreignKey: { allowNull: false },
 					});
 				},
 			},

--- a/server/pubEdge/model.ts
+++ b/server/pubEdge/model.ts
@@ -1,33 +1,28 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'PubEdge',
+		'pubEdge',
 		{
 			id: sequelize.idType,
-			pubId: { type: dataTypes.UUID, allowNull: false },
-			externalPublicationId: { type: dataTypes.UUID, allowNull: true },
-			targetPubId: { type: dataTypes.UUID, allowNull: true },
 			relationType: { type: dataTypes.STRING, allowNull: false },
 			rank: { type: dataTypes.TEXT, allowNull: false },
 			pubIsParent: { type: dataTypes.BOOLEAN, allowNull: false },
 			approvedByTarget: { type: dataTypes.BOOLEAN, allowNull: false },
 		},
 		{
+			tableName: 'PubEdges',
 			classMethods: {
-				associate: ({ PubEdge, Pub, ExternalPublication }) => {
-					PubEdge.belongsTo(Pub, {
+				associate: ({ pubEdge, pub, externalPublication }) => {
+					pubEdge.belongsTo(pub, {
 						onDelete: 'CASCADE',
-						as: 'pub',
-						foreignKey: 'pubId',
+						foreignKey: { allowNull: false },
 					});
-					PubEdge.belongsTo(Pub, {
+					pubEdge.belongsTo(pub, {
 						onDelete: 'CASCADE',
 						as: 'targetPub',
-						foreignKey: 'targetPubId',
 					});
-					PubEdge.belongsTo(ExternalPublication, {
+					pubEdge.belongsTo(externalPublication, {
 						onDelete: 'CASCADE',
 						as: 'externalPublication',
-						foreignKey: 'externalPublicationId',
 					});
 				},
 			},

--- a/server/pubHistory/__tests__/api.test.ts
+++ b/server/pubHistory/__tests__/api.test.ts
@@ -13,12 +13,13 @@ const models = modelize`
                 User collectionMember {}
             }
             CollectionPub {
-				rank: "h"
-                Pub pub {
-					viewHash: "blah-blah-blah"
+								rank: "h"
+								Pub pub {
+								viewHash: "blah-blah-blah"
                     Release {
-						historyKey: 10
-					}
+											User {}
+											historyKey: 10
+										}
                 }
             }
         }

--- a/server/pubManager/model.ts
+++ b/server/pubManager/model.ts
@@ -7,10 +7,9 @@ export default (sequelize) => {
 		{
 			tableName: 'PubManagers',
 			classMethods: {
-				associate: (models) => {
-					const { pubManager, user, pub } = models;
-					pubManager.belongsTo(pub, { foreignKey: { allowNull: false } });
-					pubManager.belongsTo(user, {
+				associate: ({ pubManager, ...models }) => {
+					pubManager.belongsTo(models.pub, { foreignKey: { allowNull: false } });
+					pubManager.belongsTo(models.user, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});

--- a/server/pubManager/model.ts
+++ b/server/pubManager/model.ts
@@ -1,21 +1,18 @@
-export default (sequelize, dataTypes) => {
+export default (sequelize) => {
 	return sequelize.define(
-		'PubManager',
+		'pubManager',
 		{
 			id: sequelize.idType,
-
-			/* Set by Associations */
-			userId: { type: dataTypes.UUID, allowNull: false },
-			pubId: { type: dataTypes.UUID, allowNull: false },
 		},
 		{
+			tableName: 'PubManagers',
 			classMethods: {
 				associate: (models) => {
-					const { PubManager, User } = models;
-					PubManager.belongsTo(User, {
+					const { pubManager, user, pub } = models;
+					pubManager.belongsTo(pub, { foreignKey: { allowNull: false } });
+					pubManager.belongsTo(user, {
 						onDelete: 'CASCADE',
-						as: 'user',
-						foreignKey: 'userId',
+						foreignKey: { allowNull: false },
 					});
 				},
 			},

--- a/server/pubVersion/model.ts
+++ b/server/pubVersion/model.ts
@@ -8,9 +8,8 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'PubVersions',
 			classMethods: {
-				associate: (models) => {
-					const { pubVersion, pub } = models;
-					pubVersion.belongsTo(pub, { onDelete: 'CASCADE' });
+				associate: ({ pubVersion, ...models }) => {
+					pubVersion.belongsTo(models.pub, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/pubVersion/model.ts
+++ b/server/pubVersion/model.ts
@@ -1,21 +1,16 @@
-export default (sequelize) => {
-	const { Sequelize } = sequelize;
+export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'PubVersion',
+		'pubVersion',
 		{
 			id: sequelize.idType,
-			historyKey: { type: Sequelize.INTEGER },
-			pubId: { type: Sequelize.UUID },
+			historyKey: dataTypes.INTEGER,
 		},
 		{
+			tableName: 'PubVersions',
 			classMethods: {
 				associate: (models) => {
-					const { PubVersion, Pub } = models;
-					PubVersion.belongsTo(Pub, {
-						onDelete: 'CASCADE',
-						as: 'pub',
-						foreignKey: 'pubId',
-					});
+					const { pubVersion, pub } = models;
+					pubVersion.belongsTo(pub, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/publicPermissions/model.ts
+++ b/server/publicPermissions/model.ts
@@ -1,28 +1,22 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'PublicPermissions',
+		'publicPermissions',
 		{
 			id: sequelize.idType,
-			canCreateReviews: { type: dataTypes.BOOLEAN },
-			canCreateDiscussions: { type: dataTypes.BOOLEAN },
-			canViewDraft: { type: dataTypes.BOOLEAN },
-			canEditDraft: { type: dataTypes.BOOLEAN },
-
-			/* Set by Associations */
-			pubId: { type: dataTypes.UUID },
-			collectionId: { type: dataTypes.UUID },
-			communityId: { type: dataTypes.UUID },
-			organizationId: { type: dataTypes.UUID },
+			canCreateReviews: dataTypes.BOOLEAN,
+			canCreateDiscussions: dataTypes.BOOLEAN,
+			canViewDraft: dataTypes.BOOLEAN,
+			canEditDraft: dataTypes.BOOLEAN,
 		},
 		{
+			tableName: 'PublicPermissions',
 			classMethods: {
 				associate: (models) => {
-					const { PublicPermissions, Pub } = models;
-					PublicPermissions.belongsTo(Pub, {
-						onDelete: 'CASCADE',
-						as: 'pub',
-						foreignKey: 'pubId',
-					});
+					const { publicPermissions, pub, collection, community, organization } = models;
+					publicPermissions.belongsTo(pub, { onDelete: 'CASCADE' });
+					publicPermissions.belongsTo(collection);
+					publicPermissions.belongsTo(community);
+					publicPermissions.belongsTo(organization);
 				},
 			},
 		},

--- a/server/publicPermissions/model.ts
+++ b/server/publicPermissions/model.ts
@@ -11,12 +11,11 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'PublicPermissions',
 			classMethods: {
-				associate: (models) => {
-					const { publicPermissions, pub, collection, community, organization } = models;
-					publicPermissions.belongsTo(pub, { onDelete: 'CASCADE' });
-					publicPermissions.belongsTo(collection);
-					publicPermissions.belongsTo(community);
-					publicPermissions.belongsTo(organization);
+				associate: ({ publicPermissions, ...models }) => {
+					publicPermissions.belongsTo(models.pub, { onDelete: 'CASCADE' });
+					publicPermissions.belongsTo(models.collection);
+					publicPermissions.belongsTo(models.community);
+					publicPermissions.belongsTo(models.organization);
 				},
 			},
 		},

--- a/server/release/model.ts
+++ b/server/release/model.ts
@@ -11,11 +11,10 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Releases',
 			classMethods: {
-				associate: (models) => {
-					const { doc, release, pub, user } = models;
-					release.belongsTo(doc, { foreignKey: { allowNull: false } });
-					release.belongsTo(user, { foreignKey: { allowNull: false } });
-					release.belongsTo(pub, { foreignKey: { allowNull: false } });
+				associate: ({ release, ...models }) => {
+					release.belongsTo(models.doc, { foreignKey: { allowNull: false } });
+					release.belongsTo(models.user, { foreignKey: { allowNull: false } });
+					release.belongsTo(models.pub, { foreignKey: { allowNull: false } });
 				},
 			},
 		},

--- a/server/release/model.ts
+++ b/server/release/model.ts
@@ -1,25 +1,21 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Release',
+		'release',
 		{
 			id: sequelize.idType,
-			noteContent: { type: dataTypes.JSONB },
-			noteText: { type: dataTypes.TEXT },
-			/* Set by Associations */
-			pubId: { type: dataTypes.UUID, allowNull: false },
-			userId: { type: dataTypes.UUID, allowNull: false },
-			docId: { type: dataTypes.UUID, allowNull: false },
+			noteContent: dataTypes.JSONB,
+			noteText: dataTypes.TEXT,
 			historyKey: { type: dataTypes.INTEGER, allowNull: false },
 			historyKeyMissing: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
 		},
 		{
+			tableName: 'Releases',
 			classMethods: {
 				associate: (models) => {
-					const { Doc, Release } = models;
-					Release.belongsTo(Doc, {
-						as: 'doc',
-						foreignKey: 'docId',
-					});
+					const { doc, release, pub, user } = models;
+					release.belongsTo(doc, { foreignKey: { allowNull: false } });
+					release.belongsTo(user, { foreignKey: { allowNull: false } });
+					release.belongsTo(pub, { foreignKey: { allowNull: false } });
 				},
 			},
 		},

--- a/server/review/model.ts
+++ b/server/review/model.ts
@@ -21,26 +21,25 @@ export default (sequelize, dataTypes) => {
 				{ fields: ['pubId'], method: 'BTREE' },
 			],
 			classMethods: {
-				associate: (models) => {
-					const { reviewNew, reviewer, visibility, pub, user, thread } = models;
-					reviewNew.belongsTo(thread, {
+				associate: ({ reviewNew, ...models }) => {
+					reviewNew.belongsTo(models.thread, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});
-					reviewNew.belongsTo(visibility, {
+					reviewNew.belongsTo(models.visibility, {
 						foreignKey: { allowNull: false },
 						onDelete: 'CASCADE',
 					});
-					reviewNew.belongsTo(user, {
+					reviewNew.belongsTo(models.user, {
 						onDelete: 'CASCADE',
 						as: 'author',
 						foreignKey: 'userId',
 						constraints: false,
 					});
-					reviewNew.belongsTo(pub, {
+					reviewNew.belongsTo(models.pub, {
 						onDelete: 'CASCADE',
 					});
-					reviewNew.hasMany(reviewer, {
+					reviewNew.hasMany(models.reviewer, {
 						as: 'reviewers',
 						onDelete: 'CASCADE',
 						foreignKey: 'reviewId',

--- a/server/review/model.ts
+++ b/server/review/model.ts
@@ -1,56 +1,48 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'ReviewNew',
+		'reviewNew',
 		{
 			id: sequelize.idType,
-			title: { type: dataTypes.TEXT },
+			title: dataTypes.TEXT,
 			number: { type: dataTypes.INTEGER, allowNull: false },
 			status: {
 				type: dataTypes.ENUM,
 				values: ['open', 'closed', 'completed'],
 				defaultValue: 'open',
 			},
-			releaseRequested: { type: dataTypes.BOOLEAN },
-			labels: { type: dataTypes.JSONB },
-			/* Set by Associations */
-			threadId: { type: dataTypes.UUID, allowNull: false },
-			visibilityId: { type: dataTypes.UUID, allowNull: false },
-			userId: { type: dataTypes.UUID },
-			pubId: { type: dataTypes.UUID },
+			releaseRequested: dataTypes.BOOLEAN,
+			labels: dataTypes.JSONB,
 			reviewContent: { type: dataTypes.JSONB, allowNull: true },
 		},
 		{
+			tableName: 'ReviewNews',
 			indexes: [
 				{ fields: ['userId'], method: 'BTREE' },
 				{ fields: ['pubId'], method: 'BTREE' },
 			],
 			classMethods: {
 				associate: (models) => {
-					const { ReviewNew, Reviewer, Visibility, Pub, User, Thread } = models;
-					ReviewNew.belongsTo(Thread, {
+					const { reviewNew, reviewer, visibility, pub, user, thread } = models;
+					reviewNew.belongsTo(thread, {
 						onDelete: 'CASCADE',
-						as: 'thread',
-						foreignKey: 'threadId',
+						foreignKey: { allowNull: false },
 					});
-					ReviewNew.belongsTo(Visibility, {
+					reviewNew.belongsTo(visibility, {
+						foreignKey: { allowNull: false },
 						onDelete: 'CASCADE',
-						as: 'visibility',
-						foreignKey: 'visibilityId',
 					});
-					ReviewNew.belongsTo(User, {
+					reviewNew.belongsTo(user, {
 						onDelete: 'CASCADE',
 						as: 'author',
 						foreignKey: 'userId',
 						constraints: false,
 					});
-					ReviewNew.belongsTo(Pub, {
+					reviewNew.belongsTo(pub, {
 						onDelete: 'CASCADE',
-						as: 'pub',
-						foreignKey: 'pubId',
 					});
-					ReviewNew.hasMany(Reviewer, {
-						onDelete: 'CASCADE',
+					reviewNew.hasMany(reviewer, {
 						as: 'reviewers',
+						onDelete: 'CASCADE',
 						foreignKey: 'reviewId',
 					});
 				},

--- a/server/reviewEvent/model.ts
+++ b/server/reviewEvent/model.ts
@@ -1,23 +1,27 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'ReviewEvent',
+		'reviewEvent',
 		{
 			id: sequelize.idType,
-			type: { type: dataTypes.STRING },
-			data: { type: dataTypes.JSONB },
-			/* Set by Associations */
-			userId: { type: dataTypes.UUID, allowNull: false },
-			pubId: { type: dataTypes.UUID, allowNull: false },
-			reviewId: { type: dataTypes.UUID, allowNull: false },
+			type: dataTypes.STRING,
+			data: dataTypes.JSONB,
 		},
 		{
+			tableName: 'ReviewEvents',
 			classMethods: {
 				associate: (models) => {
-					const { User, ReviewEvent } = models;
-					ReviewEvent.belongsTo(User, {
+					const { user, reviewEvent, reviewNew, pub } = models;
+					reviewEvent.belongsTo(user, {
 						onDelete: 'CASCADE',
-						as: 'user',
-						foreignKey: 'userId',
+						foreignKey: { allowNull: false },
+					});
+					reviewEvent.belongsTo(pub, {
+						onDelete: 'CASCADE',
+						foreignKey: { allowNull: false },
+					});
+					reviewEvent.belongsTo(reviewNew, {
+						onDelete: 'CASCADE',
+						foreignKey: { allowNull: false },
 					});
 				},
 			},

--- a/server/reviewEvent/model.ts
+++ b/server/reviewEvent/model.ts
@@ -9,17 +9,16 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'ReviewEvents',
 			classMethods: {
-				associate: (models) => {
-					const { user, reviewEvent, reviewNew, pub } = models;
-					reviewEvent.belongsTo(user, {
+				associate: ({ reviewEvent, ...models }) => {
+					reviewEvent.belongsTo(models.user, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});
-					reviewEvent.belongsTo(pub, {
+					reviewEvent.belongsTo(models.pub, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});
-					reviewEvent.belongsTo(reviewNew, {
+					reviewEvent.belongsTo(models.reviewNew, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});

--- a/server/reviewer/model.ts
+++ b/server/reviewer/model.ts
@@ -8,9 +8,8 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Reviewers',
 			classMethods: {
-				associate: (models) => {
-					const { reviewer, reviewNew } = models;
-					reviewer.belongsTo(reviewNew, {
+				associate: ({ reviewer, ...models }) => {
+					reviewer.belongsTo(models.reviewNew, {
 						as: 'review',
 						onDelete: 'CASCADE',
 						foreignKey: { name: 'reviewId', allowNull: false },

--- a/server/reviewer/model.ts
+++ b/server/reviewer/model.ts
@@ -1,19 +1,19 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Reviewer',
+		'reviewer',
 		{
 			id: sequelize.idType,
-			name: { type: dataTypes.TEXT },
-			reviewId: { type: dataTypes.UUID, allowNull: false },
+			name: dataTypes.TEXT,
 		},
 		{
+			tableName: 'Reviewers',
 			classMethods: {
 				associate: (models) => {
-					const { Reviewer, ReviewNew } = models;
-					Reviewer.belongsTo(ReviewNew, {
-						onDelete: 'CASCADE',
+					const { reviewer, reviewNew } = models;
+					reviewer.belongsTo(reviewNew, {
 						as: 'review',
-						foreignKey: 'reviewId',
+						onDelete: 'CASCADE',
+						foreignKey: { name: 'reviewId', allowNull: false },
 					});
 				},
 			},

--- a/server/routes/__tests__/pubRedirects.test.ts
+++ b/server/routes/__tests__/pubRedirects.test.ts
@@ -13,9 +13,15 @@ const models = modelize`
 			}
 		}
 		Pub releasePub {
-			Release {}
-			Release {}
-			Release {}
+			Release {
+				User {}
+			}
+			Release {
+				User {}
+			}
+			Release {
+				User {}
+			}
 		}
 	}
 `;

--- a/server/routes/collection.tsx
+++ b/server/routes/collection.tsx
@@ -25,7 +25,7 @@ import { LayoutBlockSubmissionBanner } from 'utils/layout';
 const findCollectionByPartialId = (maybePartialId: string) => {
 	return Collection.findOne({
 		where: [
-			sequelize.where(sequelize.cast(sequelize.col('Collection.id'), 'varchar'), {
+			sequelize.where(sequelize.cast(sequelize.col('collection.id'), 'varchar'), {
 				[Op.iLike]: `${maybePartialId}%`,
 			}),
 		],

--- a/server/rss/__tests__/data.ts
+++ b/server/rss/__tests__/data.ts
@@ -19,11 +19,13 @@ export const models = modelize`
         } 
         Pub p2 {
             Release {
+								User {}
                 createdAt: "2020-02-05"
             }
         }
         Pub p3 {
             Release {
+								User {}
                 createdAt: "2020-03-09"
             }
             outboundEdges: PubEdge {
@@ -37,6 +39,7 @@ export const models = modelize`
         Pub p4 {
             customPublishedAt: "2020-04-15"
             Release {
+								User {}
                 createdAt: "2020-08-15"
             }
             outboundEdges: PubEdge {
@@ -49,6 +52,7 @@ export const models = modelize`
         }
         Pub p5 {
             Release {
+								User {}
                 createdAt: "2020-05-26"
             }
             outboundEdges: PubEdge {

--- a/server/rss/__tests__/getFeedItemForPub.test.ts
+++ b/server/rss/__tests__/getFeedItemForPub.test.ts
@@ -9,6 +9,7 @@ const models = modelize`
             downloads: ${[{ type: 'formatted', url: 'formatted_download.pdf' }]}
             avatar: "avatar.png"
             Release {
+							  User {}
                 historyKey: 1
             }
             Export {

--- a/server/scopeSummary/model.ts
+++ b/server/scopeSummary/model.ts
@@ -1,10 +1,14 @@
 export default (sequelize, dataTypes) => {
-	return sequelize.define('ScopeSummary', {
-		id: sequelize.idType,
-		collections: { type: dataTypes.INTEGER, allowNull: false, defaultValue: 0 },
-		pubs: { type: dataTypes.INTEGER, allowNull: false, defaultValue: 0 },
-		discussions: { type: dataTypes.INTEGER, allowNull: false, defaultValue: 0 },
-		reviews: { type: dataTypes.INTEGER, allowNull: false, defaultValue: 0 },
-		submissions: { type: dataTypes.INTEGER, allowNull: false, defaultValue: 0 },
-	});
+	return sequelize.define(
+		'scopeSummary',
+		{
+			id: sequelize.idType,
+			collections: { type: dataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+			pubs: { type: dataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+			discussions: { type: dataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+			reviews: { type: dataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+			submissions: { type: dataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+		},
+		{ tableName: 'ScopeSummaries' },
+	);
 };

--- a/server/signup/model.ts
+++ b/server/signup/model.ts
@@ -1,18 +1,29 @@
 export default (sequelize, dataTypes) => {
-	return sequelize.define('Signup', {
-		id: sequelize.idType,
-		email: {
-			type: dataTypes.TEXT,
-			allowNull: false,
-			unique: true,
-			validate: {
-				isEmail: true,
-				isLowercase: true,
+	return sequelize.define(
+		'signup',
+		{
+			id: sequelize.idType,
+			email: {
+				type: dataTypes.TEXT,
+				allowNull: false,
+				unique: true,
+				validate: {
+					isEmail: true,
+					isLowercase: true,
+				},
+			},
+			hash: dataTypes.TEXT,
+			count: dataTypes.INTEGER,
+			completed: dataTypes.BOOLEAN,
+		},
+		{
+			tableName: 'Signups',
+			classMethods: {
+				associate: (models) => {
+					const { signup, community } = models;
+					signup.belongsTo(community);
+				},
 			},
 		},
-		hash: { type: dataTypes.TEXT },
-		count: { type: dataTypes.INTEGER },
-		completed: { type: dataTypes.BOOLEAN },
-		communityId: { type: dataTypes.UUID },
-	});
+	);
 };

--- a/server/signup/model.ts
+++ b/server/signup/model.ts
@@ -19,9 +19,8 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Signups',
 			classMethods: {
-				associate: (models) => {
-					const { signup, community } = models;
-					signup.belongsTo(community);
+				associate: ({ signup, ...models }) => {
+					signup.belongsTo(models.community);
 				},
 			},
 		},

--- a/server/spamTag/model.ts
+++ b/server/spamTag/model.ts
@@ -1,30 +1,34 @@
 export default (sequelize, dataTypes) => {
-	return sequelize.define('SpamTag', {
-		id: sequelize.idType,
-		status: {
-			type: dataTypes.STRING,
-			defaultValue: 'unreviewed',
-			allowNull: false,
+	return sequelize.define(
+		'spamTag',
+		{
+			id: sequelize.idType,
+			status: {
+				type: dataTypes.STRING,
+				defaultValue: 'unreviewed',
+				allowNull: false,
+			},
+			statusUpdatedAt: {
+				type: dataTypes.DATE,
+				allowNull: true,
+			},
+			fields: {
+				type: dataTypes.JSONB,
+				allowNull: false,
+			},
+			spamScore: {
+				type: dataTypes.DOUBLE,
+				allowNull: false,
+			},
+			spamScoreComputedAt: {
+				type: dataTypes.DATE,
+				allowNull: false,
+			},
+			spamScoreVersion: {
+				type: dataTypes.INTEGER,
+				defaultValue: 1,
+			},
 		},
-		statusUpdatedAt: {
-			type: dataTypes.DATE,
-			allowNull: true,
-		},
-		fields: {
-			type: dataTypes.JSONB,
-			allowNull: false,
-		},
-		spamScore: {
-			type: dataTypes.DOUBLE,
-			allowNull: false,
-		},
-		spamScoreComputedAt: {
-			type: dataTypes.DATE,
-			allowNull: false,
-		},
-		spamScoreVersion: {
-			type: dataTypes.INTEGER,
-			defaultValue: 1,
-		},
-	});
+		{ tableName: 'SpamTags' },
+	);
 };

--- a/server/submission/model.ts
+++ b/server/submission/model.ts
@@ -13,13 +13,12 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Submissions',
 			classMethods: {
-				associate: (models) => {
-					const { pub, submission, submissionWorkflow } = models;
-					submission.belongsTo(pub, {
+				associate: ({ submission, ...models }) => {
+					submission.belongsTo(models.pub, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});
-					submission.belongsTo(submissionWorkflow, {
+					submission.belongsTo(models.submissionWorkflow, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});

--- a/server/submission/model.ts
+++ b/server/submission/model.ts
@@ -1,30 +1,27 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Submission',
+		'submission',
 		{
 			id: sequelize.idType,
 			status: {
 				type: dataTypes.TEXT,
 				allowNull: false,
 			},
-			submittedAt: { type: dataTypes.DATE },
-			submissionWorkflowId: { type: dataTypes.UUID, allowNull: false },
-			pubId: { type: dataTypes.UUID, allowNull: false },
+			submittedAt: dataTypes.DATE,
 			abstract: { type: dataTypes.JSONB, allowNull: true },
 		},
 		{
+			tableName: 'Submissions',
 			classMethods: {
 				associate: (models) => {
-					const { Pub, Submission, SubmissionWorkflow } = models;
-					Submission.belongsTo(Pub, {
+					const { pub, submission, submissionWorkflow } = models;
+					submission.belongsTo(pub, {
 						onDelete: 'CASCADE',
-						as: 'pub',
-						foreignKey: 'pubId',
+						foreignKey: { allowNull: false },
 					});
-					Submission.belongsTo(SubmissionWorkflow, {
+					submission.belongsTo(submissionWorkflow, {
 						onDelete: 'CASCADE',
-						as: 'submissionWorkflow',
-						foreignKey: 'submissionWorkflowId',
+						foreignKey: { allowNull: false },
 					});
 				},
 			},

--- a/server/submissionWorkflow/model.ts
+++ b/server/submissionWorkflow/model.ts
@@ -17,10 +17,11 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'SubmissionWorkflows',
 			classMethods: {
-				associate: (models) => {
-					const { collection, submissionWorkflow, submission } = models;
-					submissionWorkflow.hasMany(submission);
-					submissionWorkflow.belongsTo(collection, { foreignKey: { allowNull: false } });
+				associate: ({ submissionWorkflow, ...models }) => {
+					submissionWorkflow.hasMany(models.submission);
+					submissionWorkflow.belongsTo(models.collection, {
+						foreignKey: { allowNull: false },
+					});
 				},
 			},
 		},

--- a/server/submissionWorkflow/model.ts
+++ b/server/submissionWorkflow/model.ts
@@ -1,10 +1,9 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'SubmissionWorkflow',
+		'submissionWorkflow',
 		{
 			id: sequelize.idType,
 			title: { type: dataTypes.TEXT, allowNull: false },
-			collectionId: { type: dataTypes.UUID },
 			enabled: { type: dataTypes.BOOLEAN, allowNull: false },
 			instructionsText: { type: dataTypes.JSONB, allowNull: false },
 			acceptedText: { type: dataTypes.JSONB, allowNull: false },
@@ -16,17 +15,12 @@ export default (sequelize, dataTypes) => {
 			requireDescription: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
 		},
 		{
+			tableName: 'SubmissionWorkflows',
 			classMethods: {
 				associate: (models) => {
-					const { Collection, SubmissionWorkflow, Submission } = models;
-					SubmissionWorkflow.hasMany(Submission, {
-						as: 'submissions',
-						foreignKey: 'submissionWorkflowId',
-					});
-					SubmissionWorkflow.belongsTo(Collection, {
-						as: 'collection',
-						foreignKey: 'collectionId',
-					});
+					const { collection, submissionWorkflow, submission } = models;
+					submissionWorkflow.hasMany(submission);
+					submissionWorkflow.belongsTo(collection, { foreignKey: { allowNull: false } });
 				},
 			},
 		},

--- a/server/thread/model.ts
+++ b/server/thread/model.ts
@@ -8,15 +8,14 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Threads',
 			classMethods: {
-				associate: (models) => {
-					const { discussion, thread, threadComment, threadEvent } = models;
-					thread.hasMany(discussion, { onDelete: 'CASCADE' });
-					thread.hasMany(threadComment, {
+				associate: ({ thread, ...models }) => {
+					thread.hasMany(models.discussion, { onDelete: 'CASCADE' });
+					thread.hasMany(models.threadComment, {
 						onDelete: 'CASCADE',
 						as: 'comments',
 						foreignKey: 'threadId',
 					});
-					thread.hasMany(threadEvent, {
+					thread.hasMany(models.threadEvent, {
 						onDelete: 'CASCADE',
 						as: 'events',
 						foreignKey: 'threadId',

--- a/server/thread/model.ts
+++ b/server/thread/model.ts
@@ -1,20 +1,22 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Thread',
+		'thread',
 		{
 			id: sequelize.idType,
-			isLocked: { type: dataTypes.BOOLEAN },
+			isLocked: dataTypes.BOOLEAN,
 		},
 		{
+			tableName: 'Threads',
 			classMethods: {
 				associate: (models) => {
-					const { Thread, ThreadComment, ThreadEvent } = models;
-					Thread.hasMany(ThreadComment, {
+					const { discussion, thread, threadComment, threadEvent } = models;
+					thread.hasMany(discussion, { onDelete: 'CASCADE' });
+					thread.hasMany(threadComment, {
 						onDelete: 'CASCADE',
 						as: 'comments',
 						foreignKey: 'threadId',
 					});
-					Thread.hasMany(ThreadEvent, {
+					thread.hasMany(threadEvent, {
 						onDelete: 'CASCADE',
 						as: 'events',
 						foreignKey: 'threadId',

--- a/server/threadComment/model.ts
+++ b/server/threadComment/model.ts
@@ -9,15 +9,14 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'ThreadComments',
 			classMethods: {
-				associate: (models) => {
-					const { commenter, threadComment, thread, user } = models;
-					threadComment.belongsTo(thread, { foreignKey: { allowNull: false } });
-					threadComment.belongsTo(user, {
+				associate: ({ threadComment, ...models }) => {
+					threadComment.belongsTo(models.thread, { foreignKey: { allowNull: false } });
+					threadComment.belongsTo(models.user, {
 						onDelete: 'CASCADE',
 						as: 'author',
 						foreignKey: 'userId',
 					});
-					threadComment.belongsTo(commenter, { onDelete: 'CASCADE' });
+					threadComment.belongsTo(models.commenter, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/threadComment/model.ts
+++ b/server/threadComment/model.ts
@@ -1,29 +1,23 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'ThreadComment',
+		'threadComment',
 		{
 			id: sequelize.idType,
-			text: { type: dataTypes.TEXT },
-			content: { type: dataTypes.JSONB },
-			/* Set by Associations */
-			userId: { type: dataTypes.UUID },
-			threadId: { type: dataTypes.UUID, allowNull: false },
-			commenterId: { type: dataTypes.UUID },
+			text: dataTypes.TEXT,
+			content: dataTypes.JSONB,
 		},
 		{
+			tableName: 'ThreadComments',
 			classMethods: {
 				associate: (models) => {
-					const { Commenter, ThreadComment, User } = models;
-					ThreadComment.belongsTo(User, {
+					const { commenter, threadComment, thread, user } = models;
+					threadComment.belongsTo(thread, { foreignKey: { allowNull: false } });
+					threadComment.belongsTo(user, {
 						onDelete: 'CASCADE',
 						as: 'author',
 						foreignKey: 'userId',
 					});
-					ThreadComment.belongsTo(Commenter, {
-						onDelete: 'CASCADE',
-						as: 'commenter',
-						foreignKey: 'commenterId',
-					});
+					threadComment.belongsTo(commenter, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/threadEvent/model.ts
+++ b/server/threadEvent/model.ts
@@ -9,10 +9,9 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'ThreadEvents',
 			classMethods: {
-				associate: (models) => {
-					const { user, threadEvent, thread } = models;
-					threadEvent.belongsTo(thread, { foreignKey: { allowNull: false } });
-					threadEvent.belongsTo(user, {
+				associate: ({ threadEvent, ...models }) => {
+					threadEvent.belongsTo(models.thread, { foreignKey: { allowNull: false } });
+					threadEvent.belongsTo(models.user, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});

--- a/server/threadEvent/model.ts
+++ b/server/threadEvent/model.ts
@@ -1,22 +1,20 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'ThreadEvent',
+		'threadEvent',
 		{
 			id: sequelize.idType,
-			type: { type: dataTypes.STRING },
-			data: { type: dataTypes.JSONB },
-			/* Set by Associations */
-			userId: { type: dataTypes.UUID, allowNull: false },
-			threadId: { type: dataTypes.UUID, allowNull: false },
+			type: dataTypes.STRING,
+			data: dataTypes.JSONB,
 		},
 		{
+			tableName: 'ThreadEvents',
 			classMethods: {
 				associate: (models) => {
-					const { User, ThreadEvent } = models;
-					ThreadEvent.belongsTo(User, {
+					const { user, threadEvent, thread } = models;
+					threadEvent.belongsTo(thread, { foreignKey: { allowNull: false } });
+					threadEvent.belongsTo(user, {
 						onDelete: 'CASCADE',
-						as: 'user',
-						foreignKey: 'userId',
+						foreignKey: { allowNull: false },
 					});
 				},
 			},

--- a/server/threadUser/model.ts
+++ b/server/threadUser/model.ts
@@ -1,6 +1,6 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'ThreadUser',
+		'threadUser',
 		{
 			id: sequelize.idType,
 			type: {
@@ -15,21 +15,15 @@ export default (sequelize, dataTypes) => {
 					isLowercase: true,
 				},
 			},
-			hash: { type: dataTypes.TEXT },
-
-			/* Set by Associations */
-			userId: { type: dataTypes.UUID },
-			threadId: { type: dataTypes.UUID, allowNull: false },
+			hash: dataTypes.TEXT,
 		},
 		{
+			tableName: 'ThreadUsers',
 			classMethods: {
 				associate: (models) => {
-					const { ThreadUser, User } = models;
-					ThreadUser.belongsTo(User, {
-						onDelete: 'CASCADE',
-						as: 'user',
-						foreignKey: 'userId',
-					});
+					const { threadUser, user, thread } = models;
+					threadUser.belongsTo(user, { onDelete: 'CASCADE' });
+					threadUser.belongsTo(thread, { foreignkey: { allowNull: false } });
 				},
 			},
 		},

--- a/server/threadUser/model.ts
+++ b/server/threadUser/model.ts
@@ -20,10 +20,9 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'ThreadUsers',
 			classMethods: {
-				associate: (models) => {
-					const { threadUser, user, thread } = models;
-					threadUser.belongsTo(user, { onDelete: 'CASCADE' });
-					threadUser.belongsTo(thread, { foreignkey: { allowNull: false } });
+				associate: ({ threadUser, ...models }) => {
+					threadUser.belongsTo(models.user, { onDelete: 'CASCADE' });
+					threadUser.belongsTo(models.thread, { foreignkey: { allowNull: false } });
 				},
 			},
 		},

--- a/server/user/model.ts
+++ b/server/user/model.ts
@@ -61,6 +61,7 @@ export default (sequelize, dataTypes) => {
 			classMethods: {
 				associate: (models) => {
 					const {
+						activityItem,
 						pubAttribution,
 						collectionAttribution,
 						discussion,
@@ -70,6 +71,7 @@ export default (sequelize, dataTypes) => {
 						zoteroIntegration,
 					} = models;
 					user.belongsToMany(visibility, { through: visibilityUser });
+					user.hasMany(activityItem, { as: 'actor' });
 					user.hasMany(collectionAttribution, {
 						onDelete: 'CASCADE',
 					});

--- a/server/user/model.ts
+++ b/server/user/model.ts
@@ -62,6 +62,7 @@ export default (sequelize, dataTypes) => {
 				associate: (models) => {
 					const {
 						pubAttribution,
+						collectionAttribution,
 						discussion,
 						userNotificationPreferences,
 						visibility,
@@ -69,6 +70,9 @@ export default (sequelize, dataTypes) => {
 						zoteroIntegration,
 					} = models;
 					user.belongsToMany(visibility, { through: visibilityUser });
+					user.hasMany(collectionAttribution, {
+						onDelete: 'CASCADE',
+					});
 					user.hasMany(pubAttribution, {
 						onDelete: 'CASCADE',
 						as: 'attributions',

--- a/server/user/model.ts
+++ b/server/user/model.ts
@@ -1,8 +1,8 @@
 const passportLocalSequelize = require('passport-local-sequelize');
 
 export default (sequelize, dataTypes) => {
-	const User = sequelize.define(
-		'User',
+	const user = sequelize.define(
+		'user',
 		{
 			id: sequelize.idType,
 			slug: {
@@ -19,9 +19,9 @@ export default (sequelize, dataTypes) => {
 			lastName: { type: dataTypes.TEXT, allowNull: false },
 			fullName: { type: dataTypes.TEXT, allowNull: false },
 			initials: { type: dataTypes.STRING, allowNull: false },
-			avatar: { type: dataTypes.TEXT },
-			bio: { type: dataTypes.TEXT },
-			title: { type: dataTypes.TEXT },
+			avatar: dataTypes.TEXT,
+			bio: dataTypes.TEXT,
+			title: dataTypes.TEXT,
 			email: {
 				type: dataTypes.TEXT,
 				allowNull: false,
@@ -38,57 +38,51 @@ export default (sequelize, dataTypes) => {
 					isLowercase: true,
 				},
 			},
-			authRedirectHost: { type: dataTypes.TEXT },
-			location: { type: dataTypes.TEXT },
-			website: { type: dataTypes.TEXT },
-			facebook: { type: dataTypes.TEXT },
-			twitter: { type: dataTypes.TEXT },
-			github: { type: dataTypes.TEXT },
-			orcid: { type: dataTypes.TEXT },
-			googleScholar: { type: dataTypes.TEXT },
-			resetHashExpiration: { type: dataTypes.DATE },
-			resetHash: { type: dataTypes.TEXT },
-			inactive: { type: dataTypes.BOOLEAN },
-			pubpubV3Id: { type: dataTypes.INTEGER },
-			passwordDigest: { type: dataTypes.TEXT },
+			authRedirectHost: dataTypes.TEXT,
+			location: dataTypes.TEXT,
+			website: dataTypes.TEXT,
+			facebook: dataTypes.TEXT,
+			twitter: dataTypes.TEXT,
+			github: dataTypes.TEXT,
+			orcid: dataTypes.TEXT,
+			googleScholar: dataTypes.TEXT,
+			resetHashExpiration: dataTypes.DATE,
+			resetHash: dataTypes.TEXT,
+			inactive: dataTypes.BOOLEAN,
+			pubpubV3Id: dataTypes.INTEGER,
+			passwordDigest: dataTypes.TEXT,
 			hash: { type: dataTypes.TEXT, allowNull: false },
 			salt: { type: dataTypes.TEXT, allowNull: false },
 			gdprConsent: { type: dataTypes.BOOLEAN, defaultValue: null },
 			isSuperAdmin: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
 		},
 		{
+			tableName: 'Users',
 			classMethods: {
 				associate: (models) => {
 					const {
-						PubAttribution,
-						Discussion,
-						UserNotificationPreferences,
+						pubAttribution,
+						discussion,
+						userNotificationPreferences,
+						visibility,
+						visibilityUser,
 						zoteroIntegration,
 					} = models;
-					User.hasMany(PubAttribution, {
+					user.belongsToMany(visibility, { through: visibilityUser });
+					user.hasMany(pubAttribution, {
 						onDelete: 'CASCADE',
 						as: 'attributions',
 						foreignKey: 'userId',
 					});
-					User.hasMany(Discussion, {
-						onDelete: 'CASCADE',
-						as: 'discussions',
-						foreignKey: 'userId',
-					});
-					User.hasOne(UserNotificationPreferences, {
-						onDelete: 'CASCADE',
-						as: 'userNotificationPreferences',
-						foreignKey: 'userId',
-					});
-					User.hasOne(zoteroIntegration, {
-						foreignKey: { name: 'userId', allowNull: false },
-					});
+					user.hasOne(zoteroIntegration, { allowNull: false });
+					user.hasMany(discussion, { onDelete: 'CASCADE' });
+					user.hasOne(userNotificationPreferences, { onDelete: 'CASCADE' });
 				},
 			},
 		},
 	);
 
-	passportLocalSequelize.attachToUser(User, {
+	passportLocalSequelize.attachToUser(user, {
 		usernameField: 'email',
 		hashField: 'hash',
 		saltField: 'salt',
@@ -96,5 +90,5 @@ export default (sequelize, dataTypes) => {
 		iterations: 25000,
 	});
 
-	return User;
+	return user;
 };

--- a/server/user/model.ts
+++ b/server/user/model.ts
@@ -60,29 +60,19 @@ export default (sequelize, dataTypes) => {
 			tableName: 'Users',
 			classMethods: {
 				associate: (models) => {
-					const {
-						activityItem,
-						pubAttribution,
-						collectionAttribution,
-						discussion,
-						userNotificationPreferences,
-						visibility,
-						visibilityUser,
-						zoteroIntegration,
-					} = models;
-					user.belongsToMany(visibility, { through: visibilityUser });
-					user.hasMany(activityItem, { as: 'actor' });
-					user.hasMany(collectionAttribution, {
+					user.belongsToMany(models.visibility, { through: models.visibilityUser });
+					user.hasMany(models.activityItem, { as: 'actor' });
+					user.hasMany(models.collectionAttribution, {
 						onDelete: 'CASCADE',
 					});
-					user.hasMany(pubAttribution, {
+					user.hasMany(models.pubAttribution, {
 						onDelete: 'CASCADE',
 						as: 'attributions',
 						foreignKey: 'userId',
 					});
-					user.hasOne(zoteroIntegration, { allowNull: false });
-					user.hasMany(discussion, { onDelete: 'CASCADE' });
-					user.hasOne(userNotificationPreferences, { onDelete: 'CASCADE' });
+					user.hasOne(models.zoteroIntegration, { allowNull: false });
+					user.hasMany(models.discussion, { onDelete: 'CASCADE' });
+					user.hasOne(models.userNotificationPreferences, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/userDismissable/model.ts
+++ b/server/userDismissable/model.ts
@@ -1,12 +1,18 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'UserDismissable',
+		'userDismissable',
 		{
 			id: sequelize.idType,
 			key: { type: dataTypes.STRING, allowNull: false },
-			userId: { type: dataTypes.UUID, allowNull: false },
 		},
 		{
+			tableName: 'UserDismissables',
+			classMethods: {
+				associate: (models) => {
+					const { user, userDismissable } = models;
+					userDismissable.belongsTo(user, { foreignKey: { allowNull: false } });
+				},
+			},
 			indexes: [{ fields: ['userId'], method: 'BTREE' }],
 		},
 	);

--- a/server/userDismissable/model.ts
+++ b/server/userDismissable/model.ts
@@ -8,9 +8,8 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'UserDismissables',
 			classMethods: {
-				associate: (models) => {
-					const { user, userDismissable } = models;
-					userDismissable.belongsTo(user, { foreignKey: { allowNull: false } });
+				associate: ({ userDismissable, ...models }) => {
+					userDismissable.belongsTo(models.user, { foreignKey: { allowNull: false } });
 				},
 			},
 			indexes: [{ fields: ['userId'], method: 'BTREE' }],

--- a/server/userNotification/__tests__/api.test.ts
+++ b/server/userNotification/__tests__/api.test.ts
@@ -46,7 +46,7 @@ const models = modelize`
     Community community {
 		id: ${communityId}
         Pub pub {
-			id: ${pubId}
+						id: ${pubId}
             Discussion {
                 number: 1
                 author: user
@@ -55,29 +55,19 @@ const models = modelize`
                     access: "public"
                 }
             }
+						ActivityItem activityItem1 {
+								kind: 'pub-discussion-comment-added'
+								payload: ${fakePayload}
+						}
+						ActivityItem activityItem2 {
+								kind: 'pub-discussion-comment-added'
+								payload: ${fakePayload}
+						}
+						ActivityItem activityItem3 {
+								kind: 'pub-discussion-comment-added'
+								payload: ${fakePayload}
+						}
         }
-    }
-
-    ActivityItem activityItem1 {
-        communityId: ${communityId}
-        pubId: ${pubId}
-        kind: 'pub-discussion-comment-added'
-		payload: ${fakePayload}
-    }
-
-    ActivityItem activityItem2 {
-        communityId: ${communityId}
-        pubId: ${pubId}
-        kind: 'pub-discussion-comment-added'
-		payload: ${fakePayload}
-
-    }
-
-    ActivityItem activityItem3 {
-        communityId: ${communityId}
-        pubId: ${pubId}
-        kind: 'pub-discussion-comment-added'
-		payload: ${fakePayload}
     }
 
     Thread thread {
@@ -87,17 +77,17 @@ const models = modelize`
             UserNotification n1 {
                 user: user
                 activityItem: activityItem1
-				createdAt: ${getTimestampForElapsedMinutes(0)}
+								createdAt: ${getTimestampForElapsedMinutes(0)}
             }
             UserNotification n2 {
                 user: user
                 activityItem: activityItem2
-				createdAt: ${getTimestampForElapsedMinutes(60)}
+								createdAt: ${getTimestampForElapsedMinutes(60)}
             }
             UserNotification n3 {
                 user: user
                 activityItem: activityItem3
-				createdAt: ${getTimestampForElapsedMinutes(75)}
+								createdAt: ${getTimestampForElapsedMinutes(75)}
             }
         }
     }
@@ -174,7 +164,7 @@ describe('/api/userNotifications', () => {
 		).toEqual(0);
 	});
 
-	it('Lets a user delete their own notificagtions', async () => {
+	it('Lets a user delete their own notifications', async () => {
 		const { user, n1, n2, n3 } = models;
 		const agent = await login(user);
 		await agent

--- a/server/userNotification/model.ts
+++ b/server/userNotification/model.ts
@@ -10,17 +10,16 @@ export default (sequelize, dataTypes) => {
 			tableName: 'UserNotifications',
 			indexes: [{ fields: ['userId'], method: 'BTREE' }],
 			classMethods: {
-				associate: (models) => {
-					const { activityItem, user, userNotification, userSubscription } = models;
-					userNotification.belongsTo(activityItem, {
+				associate: ({ userNotification, ...models }) => {
+					userNotification.belongsTo(models.activityItem, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});
-					userNotification.belongsTo(userSubscription, {
+					userNotification.belongsTo(models.userSubscription, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});
-					userNotification.belongsTo(user, {
+					userNotification.belongsTo(models.user, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});

--- a/server/userNotification/model.ts
+++ b/server/userNotification/model.ts
@@ -1,33 +1,28 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'UserNotification',
+		'userNotification',
 		{
 			id: sequelize.idType,
-			userId: { type: dataTypes.UUID, allowNull: false },
-			userSubscriptionId: { type: dataTypes.UUID, allowNull: false },
-			activityItemId: { type: dataTypes.UUID, allowNull: false },
 			isRead: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
 			manuallySetIsRead: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: false },
 		},
 		{
+			tableName: 'UserNotifications',
 			indexes: [{ fields: ['userId'], method: 'BTREE' }],
 			classMethods: {
 				associate: (models) => {
-					const { ActivityItem, User, UserNotification, UserSubscription } = models;
-					UserNotification.belongsTo(ActivityItem, {
+					const { activityItem, user, userNotification, userSubscription } = models;
+					userNotification.belongsTo(activityItem, {
 						onDelete: 'CASCADE',
-						as: 'activityItem',
-						foreignKey: 'activityItemId',
+						foreignKey: { allowNull: false },
 					});
-					UserNotification.belongsTo(UserSubscription, {
+					userNotification.belongsTo(userSubscription, {
 						onDelete: 'CASCADE',
-						as: 'userSubscription',
-						foreignKey: 'userSubscriptionId',
+						foreignKey: { allowNull: false },
 					});
-					UserNotification.belongsTo(User, {
+					userNotification.belongsTo(user, {
 						onDelete: 'CASCADE',
-						as: 'user',
-						foreignKey: 'userId',
+						foreignKey: { allowNull: false },
 					});
 				},
 			},

--- a/server/userNotificationPreferences/model.ts
+++ b/server/userNotificationPreferences/model.ts
@@ -32,7 +32,7 @@ export default (sequelize, dataTypes) => {
 			},
 		},
 		{
-			tableName: 'UserNoficationPreferences',
+			tableName: 'UserNotificationPreferences',
 			classMethods: {
 				associate: (models) => {
 					const { userNotificationPreferences, user } = models;

--- a/server/userNotificationPreferences/model.ts
+++ b/server/userNotificationPreferences/model.ts
@@ -34,9 +34,8 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'UserNotificationPreferences',
 			classMethods: {
-				associate: (models) => {
-					const { userNotificationPreferences, user } = models;
-					userNotificationPreferences.belongsTo(user, {
+				associate: ({ userNotificationPreferences, ...models }) => {
+					userNotificationPreferences.belongsTo(models.user, {
 						foreignKey: { allowNull: false },
 					});
 				},

--- a/server/userNotificationPreferences/model.ts
+++ b/server/userNotificationPreferences/model.ts
@@ -1,9 +1,8 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'UserNotificationPreferences',
+		'userNotificationPreferences',
 		{
 			id: sequelize.idType,
-			userId: { type: dataTypes.UUID, allowNull: false },
 			receiveNotifications: { type: dataTypes.BOOLEAN, allowNull: false, defaultValue: true },
 			lastReceivedNotificationsAt: { type: dataTypes.DATE, allowNull: true },
 			subscribeToThreadsAsCommenter: {
@@ -33,6 +32,15 @@ export default (sequelize, dataTypes) => {
 			},
 		},
 		{
+			tableName: 'UserNoficationPreferences',
+			classMethods: {
+				associate: (models) => {
+					const { userNotificationPreferences, user } = models;
+					userNotificationPreferences.belongsTo(user, {
+						foreignKey: { allowNull: false },
+					});
+				},
+			},
 			indexes: [{ fields: ['userId'], method: 'BTREE' }],
 		},
 	);

--- a/server/userScopeVisit/model.ts
+++ b/server/userScopeVisit/model.ts
@@ -7,12 +7,11 @@ export default (sequelize) => {
 		{
 			tableName: 'UserScopeVisits',
 			classMethods: {
-				associate: (models) => {
-					const { userScopeVisit, user, pub, collection, community } = models;
-					userScopeVisit.belongsTo(user);
-					userScopeVisit.belongsTo(pub);
-					userScopeVisit.belongsTo(collection);
-					userScopeVisit.belongsTo(community);
+				associate: ({ userScopeVisit, ...models }) => {
+					userScopeVisit.belongsTo(models.user);
+					userScopeVisit.belongsTo(models.pub);
+					userScopeVisit.belongsTo(models.collection);
+					userScopeVisit.belongsTo(models.community);
 				},
 			},
 			indexes: [

--- a/server/userScopeVisit/model.ts
+++ b/server/userScopeVisit/model.ts
@@ -1,14 +1,20 @@
-export default (sequelize, dataTypes) => {
+export default (sequelize) => {
 	return sequelize.define(
-		'UserScopeVisit',
+		'userScopeVisit',
 		{
 			id: sequelize.idType,
-			userId: { type: dataTypes.UUID, allowNull: true },
-			pubId: { type: dataTypes.UUID, allowNull: true },
-			collectionId: { type: dataTypes.UUID, allowNull: true },
-			communityId: { type: dataTypes.UUID, allowNull: true },
 		},
 		{
+			tableName: 'UserScopeVisits',
+			classMethods: {
+				associate: (models) => {
+					const { userScopeVisit, user, pub, collection, community } = models;
+					userScopeVisit.belongsTo(user);
+					userScopeVisit.belongsTo(pub);
+					userScopeVisit.belongsTo(collection);
+					userScopeVisit.belongsTo(community);
+				},
+			},
 			indexes: [
 				{
 					unique: true,

--- a/server/userSubscription/model.ts
+++ b/server/userSubscription/model.ts
@@ -1,15 +1,13 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'UserSubscription',
+		'userSubscription',
 		{
 			id: sequelize.idType,
 			setAutomatically: { type: dataTypes.BOOLEAN, allowNull: false },
 			status: { type: dataTypes.STRING, allowNull: false },
-			userId: { type: dataTypes.UUID, allowNull: false },
-			pubId: { type: dataTypes.UUID },
-			threadId: { type: dataTypes.UUID },
 		},
 		{
+			tableName: 'UserSubscriptions',
 			indexes: [
 				{ fields: ['userId'], method: 'BTREE' },
 				{ fields: ['pubId'], method: 'BTREE' },
@@ -17,21 +15,12 @@ export default (sequelize, dataTypes) => {
 			],
 			classMethods: {
 				associate: (models) => {
-					const { Pub, Thread, User, UserSubscription } = models;
-					UserSubscription.belongsTo(Pub, {
+					const { pub, thread, user, userSubscription } = models;
+					userSubscription.belongsTo(pub, { onDelete: 'CASCADE' });
+					userSubscription.belongsTo(thread, { onDelete: 'CASCADE' });
+					userSubscription.belongsTo(user, {
 						onDelete: 'CASCADE',
-						as: 'pub',
-						foreignKey: 'pubId',
-					});
-					UserSubscription.belongsTo(Thread, {
-						onDelete: 'CASCADE',
-						as: 'thread',
-						foreignKey: 'threadId',
-					});
-					UserSubscription.belongsTo(User, {
-						onDelete: 'CASCADE',
-						as: 'user',
-						foreignKey: 'userId',
+						foreignKey: { allowNull: false },
 					});
 				},
 			},

--- a/server/userSubscription/model.ts
+++ b/server/userSubscription/model.ts
@@ -14,11 +14,10 @@ export default (sequelize, dataTypes) => {
 				{ fields: ['threadId'], method: 'BTREE' },
 			],
 			classMethods: {
-				associate: (models) => {
-					const { pub, thread, user, userSubscription } = models;
-					userSubscription.belongsTo(pub, { onDelete: 'CASCADE' });
-					userSubscription.belongsTo(thread, { onDelete: 'CASCADE' });
-					userSubscription.belongsTo(user, {
+				associate: ({ userSubscription, ...models }) => {
+					userSubscription.belongsTo(models.pub, { onDelete: 'CASCADE' });
+					userSubscription.belongsTo(models.thread, { onDelete: 'CASCADE' });
+					userSubscription.belongsTo(models.user, {
 						onDelete: 'CASCADE',
 						foreignKey: { allowNull: false },
 					});

--- a/server/visibility/model.ts
+++ b/server/visibility/model.ts
@@ -12,10 +12,9 @@ export default (sequelize, dataTypes) => {
 		{
 			tableName: 'Visibilities',
 			classMethods: {
-				associate: (models) => {
-					const { visibility, visibilityUser, user, discussion } = models;
-					visibility.belongsToMany(user, { through: visibilityUser });
-					visibility.hasMany(discussion, { onDelete: 'CASCADE' });
+				associate: ({ visibility, ...models }) => {
+					visibility.belongsToMany(models.user, { through: models.visibilityUser });
+					visibility.hasMany(models.discussion, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/visibility/model.ts
+++ b/server/visibility/model.ts
@@ -1,6 +1,6 @@
 export default (sequelize, dataTypes) => {
 	return sequelize.define(
-		'Visibility',
+		'visibility',
 		{
 			id: sequelize.idType,
 			access: {
@@ -10,14 +10,12 @@ export default (sequelize, dataTypes) => {
 			},
 		},
 		{
+			tableName: 'Visibilities',
 			classMethods: {
 				associate: (models) => {
-					const { Visibility, User } = models;
-					Visibility.belongsToMany(User, {
-						as: 'users',
-						through: 'VisibilityUser',
-						foreignKey: 'visibilityId',
-					});
+					const { visibility, visibilityUser, user, discussion } = models;
+					visibility.belongsToMany(user, { through: visibilityUser });
+					visibility.hasMany(discussion, { onDelete: 'CASCADE' });
 				},
 			},
 		},

--- a/server/visibilityUser/model.ts
+++ b/server/visibilityUser/model.ts
@@ -1,9 +1,9 @@
-export default (sequelize, dataTypes) => {
-	return sequelize.define('VisibilityUser', {
-		id: sequelize.idType,
-
-		/* Set by Associations */
-		userId: { type: dataTypes.UUID, allowNull: false },
-		visibilityId: { type: dataTypes.UUID, allowNull: false },
-	});
+export default (sequelize) => {
+	return sequelize.define(
+		'visibilityUser',
+		{
+			id: sequelize.idType,
+		},
+		{ tableName: 'VisibilityUsers' },
+	);
 };

--- a/server/workerTask/model.ts
+++ b/server/workerTask/model.ts
@@ -1,12 +1,16 @@
 export default (sequelize, dataTypes) => {
-	return sequelize.define('WorkerTask', {
-		id: sequelize.idType,
-		type: { type: dataTypes.TEXT, allowNull: false },
-		input: { type: dataTypes.JSONB },
-		isProcessing: { type: dataTypes.BOOLEAN },
-		attemptCount: { type: dataTypes.INTEGER },
-		error: { type: dataTypes.JSONB },
-		output: { type: dataTypes.JSONB },
-		priority: { type: dataTypes.INTEGER },
-	});
+	return sequelize.define(
+		'workerTask',
+		{
+			id: sequelize.idType,
+			type: { type: dataTypes.TEXT, allowNull: false },
+			input: dataTypes.JSONB,
+			isProcessing: dataTypes.BOOLEAN,
+			attemptCount: dataTypes.INTEGER,
+			error: dataTypes.JSONB,
+			output: dataTypes.JSONB,
+			priority: dataTypes.INTEGER,
+		},
+		{ tableName: 'WorkerTasks' },
+	);
 };

--- a/server/zoteroIntegration/model.ts
+++ b/server/zoteroIntegration/model.ts
@@ -9,13 +9,12 @@ export default (sequelize, dataTypes) =>
 		{
 			tableName: 'ZoteroIntegrations',
 			classMethods: {
-				associate: (models) => {
-					const { User, zoteroIntegration, integrationDataOAuth1 } = models;
-					zoteroIntegration.belongsTo(User, {
+				associate: ({ zoteroIntegration, ...models }) => {
+					zoteroIntegration.belongsTo(models.User, {
 						as: 'user',
 						foreignKey: { allowNull: false },
 					});
-					zoteroIntegration.belongsTo(integrationDataOAuth1, {
+					zoteroIntegration.belongsTo(models.integrationDataOAuth1, {
 						foreignKey: { allowNull: false },
 						onDelete: 'CASCADE',
 					});

--- a/workers/utils/__tests__/searchUtils.test.ts
+++ b/workers/utils/__tests__/searchUtils.test.ts
@@ -51,6 +51,7 @@ const models = modelize`
                 }
             }
             Release {
+								User {}
                 createdAt: "2021-01-01"
                 historyKey: 1
                 Doc {
@@ -58,6 +59,7 @@ const models = modelize`
                 }
             }
             Release {
+								User {}
                 createdAt: "2020-01-02"
                 historyKey: 2
                 Doc {


### PR DESCRIPTION
rebased refresh of #2478, addresses #2477

Sweeping cleanup + trimming of model definitions.
does not yet guarantee implementation of both sides of associations

__test plan__
run api test script with `npm run test-dev`

__completed test__
together with @kalilsn I spun up a local database with current tables as created from `master`'s sequelize definitions, dumped that database, then created db again from this branch's definitions, dumped, and diffed the dump files. The table specifications were identical.