### PR TITLE
feat: make caption editor vertically resizable

### DIFF
--- a/client/components/FormattingBar/controlComponents/controls.scss
+++ b/client/components/FormattingBar/controlComponents/controls.scss
@@ -215,6 +215,7 @@ $bp: vendor.$bp-namespace;
 	@include controls-component();
 	@include controls-grid(minmax(300px, 1fr) 2fr);
 	max-width: 1200px;
+	height: auto !important;
 
 	.source-control {
 		.controls {

--- a/client/components/MinimalEditor/MinimalEditor.tsx
+++ b/client/components/MinimalEditor/MinimalEditor.tsx
@@ -17,6 +17,7 @@ type Props = {
 	initialContent?: any;
 	isReadOnly?: boolean;
 	isTranslucent?: boolean;
+	resizable?: boolean;
 	onEdit?: OnEditFn;
 	onContent?: ({ text: string, content: any }) => unknown;
 	placeholder?: string;
@@ -44,6 +45,7 @@ const MinimalEditor = (props: Props) => {
 		isReadOnly = false,
 		isTranslucent = false,
 		getButtons = defaultGetButtons,
+		resizable = false,
 	} = props;
 	const [changeObject, setChangeObject] = useState<EditorChangeObject | null>(null);
 	const [FormattingBar, setFormattingBar] = useState<any>(null as any);
@@ -98,6 +100,7 @@ const MinimalEditor = (props: Props) => {
 				isTranslucent && 'translucent',
 				useFormattingBar && 'has-formatting-bar',
 				noMinHeight && 'no-min-height',
+				resizable && 'resizable',
 			)}
 		>
 			{useFormattingBar && FormattingBar && (

--- a/client/components/MinimalEditor/minimalEditor.scss
+++ b/client/components/MinimalEditor/minimalEditor.scss
@@ -21,6 +21,10 @@ $border-style: 1px solid #ddd;
 		}
 	}
 
+	&.resizable {
+		resize: vertical;
+	}
+
 	&.constrain-height {
 		height: 100%;
 		overflow-y: hidden;

--- a/client/components/SimpleEditor/SimpleEditor.tsx
+++ b/client/components/SimpleEditor/SimpleEditor.tsx
@@ -48,9 +48,10 @@ const SimpleEditor = (props: Props) => {
 			onEdit={handleEdit}
 			placeholder={placeholder}
 			initialContent={initialDoc.current}
-			useFormattingBar={true}
-			isTranslucent={true}
-			constrainHeight={true}
+			useFormattingBar
+			isTranslucent
+			constrainHeight
+			resizable
 		/>
 	);
 };


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #2709

## Test Plan

1. Open a Pub draft and insert an image
2. Click on the image and add a caption. The caption editor should be resizable on its y-axis

## Screenshots (if applicable)
<img width="626" alt="Screenshot 2023-06-07 at 5 05 01 PM" src="https://github.com/pubpub/pubpub/assets/6402908/941f05ac-57eb-4c87-b516-615e65d2c051">
