### PR TITLE
Add cache cookie max-age

### DIFF
--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -119,7 +119,7 @@ app.post('/api/login', (req, res, next) => {
 						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.pubpub.org' }),
 					...(isDuqDuq() &&
 						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.duqduq.org' }),
-					maxAge: 30 * 24 * 60 * 60 * 1000,
+					maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days to match login cookie
 				});
 				return res.status(201).json('success');
 			});

--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -119,6 +119,7 @@ app.post('/api/login', (req, res, next) => {
 						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.pubpub.org' }),
 					...(isDuqDuq() &&
 						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.duqduq.org' }),
+					maxAge: 30 * 24 * 60 * 60 * 1000,
 				});
 				return res.status(201).json('success');
 			});

--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -119,6 +119,7 @@ app.post('/api/login', (req, res, next) => {
 						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.pubpub.org' }),
 					...(isDuqDuq() &&
 						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.duqduq.org' }),
+					maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days to match login cookie
 				});
 				return res.status(201).json('success');
 			});

--- a/server/login/api.ts
+++ b/server/login/api.ts
@@ -119,7 +119,6 @@ app.post('/api/login', (req, res, next) => {
 						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.pubpub.org' }),
 					...(isDuqDuq() &&
 						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.duqduq.org' }),
-					maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days to match login cookie
 				});
 				return res.status(201).json('success');
 			});

--- a/server/models.ts
+++ b/server/models.ts
@@ -15,8 +15,9 @@ export const sequelize = new Sequelize(database_url, {
 		max: process.env.SEQUELIZE_MAX_CONNECTIONS
 			? parseInt(process.env.SEQUELIZE_MAX_CONNECTIONS, 10)
 			: 5, // Some migrations require this number to be 150
-		// idle: 20000,
-		// acquire: 20000,
+		min: 0,
+		idle: 10000,
+		acquire: 60000,
 	},
 });
 


### PR DESCRIPTION
Adds the cookie max-age, which should have been present and has somehow been removed. Will avoid caching logged in pages and should help fix remaining cache login issues.