### PR TITLE
fix:return 404 on absent zotero integration

### DIFF
--- a/server/zoteroIntegration/api.ts
+++ b/server/zoteroIntegration/api.ts
@@ -6,7 +6,9 @@ app.get(
 	'/api/zoteroIntegration',
 	wrap((req, res) =>
 		getZoteroIntegration(req.user.id).then((integration) =>
-			integration ? res.status(201).json({ id: integration.id }) : res.status(404),
+			integration
+				? res.status(201).json({ id: integration.id })
+				: res.status(404).json({ message: 'no zotero integration present for user' }),
 		),
 	),
 );


### PR DESCRIPTION
## Issue(s) Resolved
#2728 

## Test Plan
perform same steps as in issue above:

1. Open a pub with an account that is not connected to Zotero and open dev console
2. Make a citation
3. Close citation
4. Re-open citation
6. Notice call to /api/zoteroIntegration, which eventually fails

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
