### PR TITLE
disallow bots in robots.txt if not prod

### DIFF
--- a/server/routes/robots.ts
+++ b/server/routes/robots.ts
@@ -4,8 +4,15 @@ import app, { wrap } from 'server/server';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { communityUrl } from 'utils/canonicalUrls';
+import { isProd } from 'utils/environment';
 
 const buildRobotsFile = (community) => {
+	if (!isProd()) {
+		return stripIndent(`
+			User-agent: *
+			Disallow: /
+		`).trim();
+	}
 	if (community) {
 		return stripIndent(`
 			User-agent: *


### PR DESCRIPTION
## Issue(s) Resolved
Resolves #2738 

## Test Plan
1. Visit any community's /robots.txt locally or on duqduq and make sure disallow is set to `/`. 
2. Run locally with prod env variable set, make sure robots.txt only disallows login, and the sitemap link is present.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
