### PR TITLE
fix: Impact iframe positioning

### DIFF
--- a/client/containers/DashboardImpact/dashboardImpact.scss
+++ b/client/containers/DashboardImpact/dashboardImpact.scss
@@ -15,12 +15,6 @@
 		width: 100%;
 		z-index: 1;
 		position: relative;
-		top: -75px;
-	}
-	@media only screen and (max-width: 1125px) {
-		iframe.metabase {
-			top: 0px;
-		}
 	}
 }
 


### PR DESCRIPTION
Metabase updated its embed styling to put the filter on the left instead of the right, which caused the header of the Impact tab to overlap it on some browser sizes. This fixes that.

![Screenshot 2023-06-29 at 22 03 18](https://github.com/pubpub/pubpub/assets/639110/6aa9eebb-da25-4c3f-bdee-38202457e002)

![Screenshot 2023-06-29 at 22 03 48](https://github.com/pubpub/pubpub/assets/639110/8277479b-a1e1-4da7-bd29-5af9264c4513)

_Test Plan_
Visit an impact tab at a few browser sizes and make sure it works ok?