### PR TITLE
dev: allow actorId as a parameter for sequelize.create etc, and fix activityHook related type errors

### DIFF
--- a/server/community/hooks.ts
+++ b/server/community/hooks.ts
@@ -13,5 +13,13 @@ createActivityHooks({
 	onModelUpdated: createCommunityUpdatedActivityItem,
 });
 
-Community.afterCreate((community) => defer(() => addSpamTagToCommunity(community.id)));
-Community.afterUpdate((community) => defer(() => addSpamTagToCommunity(community.id)));
+Community.afterCreate((community) =>
+	defer(async () => {
+		addSpamTagToCommunity(community.id);
+	}),
+);
+Community.afterUpdate((community) =>
+	defer(async () => {
+		addSpamTagToCommunity(community.id);
+	}),
+);

--- a/server/pub/model.ts
+++ b/server/pub/model.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import {
 	Model,
 	Table,
@@ -16,18 +15,7 @@ import {
 	BelongsTo,
 	HasOne,
 } from 'sequelize-typescript';
-import type {
-	InferAttributes,
-	InferCreationAttributes,
-	CreationOptional,
-	BuildOptions,
-	Logging,
-	Silent,
-	Transactionable,
-	Hookable,
-	TruncateOptions,
-	Paranoid,
-} from 'sequelize';
+import type { InferAttributes, InferCreationAttributes, CreationOptional } from 'sequelize';
 import {
 	PubAttribution,
 	CollectionPub,

--- a/server/pub/model.ts
+++ b/server/pub/model.ts
@@ -45,29 +45,6 @@ import {
 	ScopeSummary,
 } from '../models';
 
-// declare module 'sequelize' {
-// 	export interface CreateOptions<TAttributes = any>
-// 		extends BuildOptions,
-// 			Logging,
-// 			Silent,
-// 			Transactionable,
-// 			Hookable {
-// 		actorId?: string | null;
-// 	}
-
-// 	export interface DestroyOptions<TAttributes = any> extends TruncateOptions<TAttributes> {
-// 		actorId?: string | null;
-// 	}
-
-// 	export interface UpdateOptions<TAttributes = any>
-// 		extends Logging,
-// 			Transactionable,
-// 			Paranoid,
-// 			Hookable {
-// 		actorId?: string | null;
-// 	}
-// }
-
 @Table
 export class Pub extends Model<InferAttributes<Pub>, InferCreationAttributes<Pub>> {
 	@Default(DataType.UUIDV4)

--- a/server/scopeSummary/hooks.ts
+++ b/server/scopeSummary/hooks.ts
@@ -7,6 +7,7 @@ import {
 	Collection,
 	Community,
 } from 'server/models';
+import { expect } from 'utils/assert';
 import { summarizeCollection, summarizeCommunity, summarizePub } from './queries';
 
 let summarizeParentScopesOnPubCreation = true;
@@ -15,13 +16,17 @@ export const setSummarizeParentScopesOnPubCreation = (value: boolean) => {
 	summarizeParentScopesOnPubCreation = value;
 };
 
-[Discussion, ReviewNew].forEach((Model) => {
-	Model.afterCreate(async ({ pubId }) => {
-		await summarizePub(pubId);
-	});
-	Model.afterDestroy(async ({ pubId }) => {
-		await summarizePub(pubId);
-	});
+Discussion.afterCreate(async ({ pubId }) => {
+	await summarizePub(expect(pubId));
+});
+Discussion.afterDestroy(async ({ pubId }) => {
+	await summarizePub(expect(pubId));
+});
+ReviewNew.afterCreate(async ({ pubId }) => {
+	await summarizePub(expect(pubId));
+});
+ReviewNew.afterDestroy(async ({ pubId }) => {
+	await summarizePub(expect(pubId));
 });
 
 Pub.afterCreate(async ({ id }) => {

--- a/server/threadComment/hooks.ts
+++ b/server/threadComment/hooks.ts
@@ -46,5 +46,7 @@ ThreadComment.afterCreate(async (threadComment: types.ThreadComment) => {
 		}
 	}
 
-	defer(() => createActivityItem(threadComment));
+	defer(async () => {
+		createActivityItem(threadComment);
+	});
 });

--- a/types/sequelize-actorid-override.d.ts
+++ b/types/sequelize-actorid-override.d.ts
@@ -1,0 +1,37 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import {
+	BuildOptions,
+	Logging,
+	Silent,
+	Transactionable,
+	TruncateOptions,
+	Paranoid,
+	Hookable,
+} from 'sequelize';
+
+declare module 'sequelize' {
+	export interface CreateOptions<TAttributes = any>
+		extends BuildOptions,
+			Logging,
+			Silent,
+			Transactionable,
+			Hookable {
+		actorId?: string | null;
+	}
+
+	export interface DestroyOptions<TAttributes = any> extends TruncateOptions<TAttributes> {
+		actorId?: string | null;
+	}
+
+	export interface InstanceDestroyOptions extends Logging, Transactionable, Hookable {
+		actorId?: string | null;
+	}
+
+	export interface UpdateOptions<TAttributes = any>
+		extends Logging,
+			Transactionable,
+			Paranoid,
+			Hookable {
+		actorId?: string | null;
+	}
+}


### PR DESCRIPTION
This PR creates an override for a `sequelize` Model's options, such that e.g. these are typescript legal

```ts
Pub.create({...}, {actorId})
Pub.destory({actorId})
``` 

This patch affects every single model we use, even though not every model is able to use this actorId.
However, this was also the case before, and this is a much easier way of fixing this type issue.

This also fixes some other type errors related to activityHooks (where the `actorId` is used)


From 399 -> 343 errors in 99 files.

## Test Plan

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
