### PR TITLE
dev: make nullable sequelize fields `string | null` instead of `string | null | undefined`

### DIFF
--- a/server/activityItem/model.ts
+++ b/server/activityItem/model.ts
@@ -27,11 +27,11 @@ export class ActivityItem extends Model<
 
 	@Index({ using: 'BTREE' })
 	@Column(DataType.UUID)
-	pubId?: string | null;
+	pubId!: string | null;
 
 	// TODO: Add validation for payload
 	@Column(DataType.JSONB)
-	payload?: ActivityItemPayload | null;
+	payload!: ActivityItemPayload | null;
 
 	@AllowNull(false)
 	@Default(DataType.NOW)
@@ -45,9 +45,9 @@ export class ActivityItem extends Model<
 
 	@Index({ using: 'BTREE' })
 	@Column(DataType.UUID)
-	actorId?: string | null;
+	actorId!: string | null;
 
 	@Index({ using: 'BTREE' })
 	@Column(DataType.UUID)
-	collectionId?: string | null;
+	collectionId!: string | null;
 }

--- a/server/collection/model.ts
+++ b/server/collection/model.ts
@@ -38,7 +38,7 @@ export class Collection extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.TEXT)
-	title?: string | null;
+	title!: string | null;
 
 	@AllowNull(false)
 	@IsLowercase
@@ -48,34 +48,34 @@ export class Collection extends Model<
 	slug!: string;
 
 	@Column(DataType.TEXT)
-	avatar?: string | null;
+	avatar!: string | null;
 
 	@Column(DataType.BOOLEAN)
-	isRestricted?: boolean | null;
+	isRestricted!: boolean | null;
 
 	@Column(DataType.BOOLEAN)
-	isPublic?: boolean | null;
+	isPublic!: boolean | null;
 
 	@Column(DataType.STRING)
-	viewHash?: string | null;
+	viewHash!: string | null;
 
 	@Column(DataType.STRING)
-	editHash?: string | null;
+	editHash!: string | null;
 
 	// TODO: Add validation for this field
 	@Column(DataType.JSONB)
-	metadata?: Record<string, any> | null;
+	metadata!: Record<string, any> | null;
 
 	// TODO: Add validation for this field
 	@Column(DataType.TEXT)
-	kind?: CollectionKind | null;
+	kind!: CollectionKind | null;
 
 	@Column(DataType.TEXT)
-	doi?: string | null;
+	doi!: string | null;
 
 	@Default('choose-best')
 	@Column(DataType.ENUM('none', 'minimal', 'medium', 'choose-best'))
-	readNextPreviewSize?: CreationOptional<ReadNextPreviewSize | null>;
+	readNextPreviewSize!: CreationOptional<ReadNextPreviewSize | null>;
 
 	// TODO: Add validation for this field
 	@AllowNull(false)
@@ -89,16 +89,16 @@ export class Collection extends Model<
 	layoutAllowsDuplicatePubs!: CreationOptional<boolean>;
 
 	@Column(DataType.UUID)
-	pageId?: string | null;
+	pageId!: string | null;
 
 	@Column(DataType.UUID)
-	communityId?: string | null;
+	communityId!: string | null;
 
 	@Column(DataType.UUID)
-	scopeSummaryId?: string | null;
+	scopeSummaryId!: string | null;
 
 	@Column(DataType.UUID)
-	crossrefDepositRecordId?: string | null;
+	crossrefDepositRecordId!: string | null;
 
 	@HasMany(() => CollectionAttribution, {
 		onDelete: 'CASCADE',

--- a/server/collectionAttribution/model.ts
+++ b/server/collectionAttribution/model.ts
@@ -23,32 +23,32 @@ export class CollectionAttribution extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.TEXT)
-	name?: string | null;
+	name!: string | null;
 
 	@Column(DataType.TEXT)
-	avatar?: string | null;
+	avatar!: string | null;
 
 	@Column(DataType.TEXT)
-	title?: string | null;
+	title!: string | null;
 
 	@Column(DataType.DOUBLE)
-	order?: number | null;
+	order!: number | null;
 
 	@Column(DataType.BOOLEAN)
-	isAuthor?: boolean | null;
+	isAuthor!: boolean | null;
 
 	// TODO: Add validation for roles
 	@Column(DataType.JSONB)
-	roles?: string[] | null;
+	roles!: string[] | null;
 
 	@Column(DataType.TEXT)
-	affiliation?: string | null;
+	affiliation!: string | null;
 
 	@Column(DataType.STRING)
-	orcid?: string | null;
+	orcid!: string | null;
 
 	@Column(DataType.UUID)
-	userId?: string | null;
+	userId!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.UUID)

--- a/server/collectionPub/model.ts
+++ b/server/collectionPub/model.ts
@@ -33,7 +33,7 @@ export class CollectionPub extends Model<
 	collectionId!: string;
 
 	@Column(DataType.TEXT)
-	contextHint?: string | null;
+	contextHint!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.TEXT)

--- a/server/commenter/model.ts
+++ b/server/commenter/model.ts
@@ -12,5 +12,5 @@ export class Commenter extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.TEXT)
-	name?: string | null;
+	name!: string | null;
 }

--- a/server/community/model.ts
+++ b/server/community/model.ts
@@ -46,156 +46,156 @@ export class Community extends Model<
 
 	@Unique
 	@Column(DataType.TEXT)
-	domain?: string | null;
+	domain!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.TEXT)
 	title!: string;
 
 	@Column(DataType.TEXT)
-	citeAs?: string | null;
+	citeAs!: string | null;
 
 	@Column(DataType.TEXT)
-	publishAs?: string | null;
+	publishAs!: string | null;
 
 	@Length({ min: 0, max: 280 })
 	@Column(DataType.TEXT)
-	description?: string | null;
+	description!: string | null;
 
 	@Column(DataType.TEXT)
-	avatar?: string | null;
+	avatar!: string | null;
 
 	@Column(DataType.TEXT)
-	favicon?: string | null;
+	favicon!: string | null;
 
 	@Column(DataType.STRING)
-	accentColorLight?: string | null;
+	accentColorLight!: string | null;
 
 	@Column(DataType.STRING)
-	accentColorDark?: string | null;
+	accentColorDark!: string | null;
 
 	@Column(DataType.BOOLEAN)
-	hideCreatePubButton?: boolean | null;
+	hideCreatePubButton!: boolean | null;
 
 	@Column(DataType.TEXT)
-	headerLogo?: string | null;
+	headerLogo!: string | null;
 
 	// TODO: Add validation for headerLinks
 	@Column(DataType.JSONB)
-	headerLinks?: CommunityHeaderLink[] | null;
+	headerLinks!: CommunityHeaderLink[] | null;
 
 	@Default('dark')
 	@Column(DataType.ENUM('light', 'dark', 'custom'))
-	headerColorType?: CreationOptional<'light' | 'dark' | 'custom' | null>;
+	headerColorType!: CreationOptional<'light' | 'dark' | 'custom' | null>;
 
 	@Column(DataType.BOOLEAN)
-	useHeaderTextAccent?: boolean | null;
+	useHeaderTextAccent!: boolean | null;
 
 	@Column(DataType.BOOLEAN)
-	hideHero?: boolean | null;
+	hideHero!: boolean | null;
 
 	@Column(DataType.BOOLEAN)
-	hideHeaderLogo?: boolean | null;
+	hideHeaderLogo!: boolean | null;
 
 	@Column(DataType.TEXT)
-	heroLogo?: string | null;
+	heroLogo!: string | null;
 
 	@Column(DataType.TEXT)
-	heroBackgroundImage?: string | null;
+	heroBackgroundImage!: string | null;
 
 	@Column(DataType.TEXT)
-	heroBackgroundColor?: string | null;
+	heroBackgroundColor!: string | null;
 
 	@Column(DataType.TEXT)
-	heroTextColor?: string | null;
+	heroTextColor!: string | null;
 
 	@Column(DataType.BOOLEAN)
-	useHeaderGradient?: boolean | null;
+	useHeaderGradient!: boolean | null;
 
 	@Column(DataType.TEXT)
-	heroImage?: string | null;
+	heroImage!: string | null;
 
 	@Column(DataType.TEXT)
-	heroTitle?: string | null;
+	heroTitle!: string | null;
 
 	@Column(DataType.TEXT)
-	heroText?: string | null;
+	heroText!: string | null;
 
 	// TODO: Add validation for heroPrimaryButton
 	@Column(DataType.JSONB)
-	heroPrimaryButton?: CommunityHeroButton | null;
+	heroPrimaryButton!: CommunityHeroButton | null;
 
 	// TODO: Add validation for heroSecondaryButton
 	@Column(DataType.JSONB)
-	heroSecondaryButton?: CommunityHeroButton | null;
+	heroSecondaryButton!: CommunityHeroButton | null;
 
 	@Column(DataType.TEXT)
-	heroAlign?: string | null;
+	heroAlign!: string | null;
 
 	// TODO: Add validation for navigation
 	@Column(DataType.JSONB)
-	navigation?: CommunityNavigationEntry[] | null;
+	navigation!: CommunityNavigationEntry[] | null;
 
 	@Column(DataType.BOOLEAN)
-	hideNav?: boolean | null;
+	hideNav!: boolean | null;
 
 	// TODO: Add validation for navLinks
 	@Column(DataType.JSONB)
-	navLinks?: CommunityNavigationEntry[] | null;
+	navLinks!: CommunityNavigationEntry[] | null;
 
 	// TODO: Add validation for footerLinks
 	@Column(DataType.JSONB)
-	footerLinks?: CommunityNavigationEntry[] | null;
+	footerLinks!: CommunityNavigationEntry[] | null;
 
 	@Column(DataType.TEXT)
-	footerLogoLink?: string | null;
+	footerLogoLink!: string | null;
 
 	@Column(DataType.TEXT)
-	footerTitle?: string | null;
+	footerTitle!: string | null;
 
 	@Column(DataType.TEXT)
-	footerImage?: string | null;
+	footerImage!: string | null;
 
 	@Column(DataType.TEXT)
-	website?: string | null;
+	website!: string | null;
 
 	@Column(DataType.TEXT)
-	facebook?: string | null;
+	facebook!: string | null;
 
 	@Column(DataType.TEXT)
-	twitter?: string | null;
+	twitter!: string | null;
 
 	@Column(DataType.TEXT)
-	email?: string | null;
+	email!: string | null;
 
 	@Column(DataType.TEXT)
-	issn?: string | null;
+	issn!: string | null;
 
 	@Column(DataType.BOOLEAN)
-	isFeatured?: boolean | null;
+	isFeatured!: boolean | null;
 
 	@Column(DataType.STRING)
-	viewHash?: string | null;
+	viewHash!: string | null;
 
 	@Column(DataType.STRING)
-	editHash?: string | null;
+	editHash!: string | null;
 
 	@Default(false)
 	@Column(DataType.BOOLEAN)
-	premiumLicenseFlag?: CreationOptional<boolean | null>;
+	premiumLicenseFlag!: CreationOptional<boolean | null>;
 
 	// TODO: Add validation for defaultPubCollections
 	@Column(DataType.JSONB)
-	defaultPubCollections?: string[] | null;
+	defaultPubCollections!: string[] | null;
 
 	@Column(DataType.UUID)
-	spamTagId?: string | null;
+	spamTagId!: string | null;
 
 	@Column(DataType.UUID)
-	organizationId?: string | null;
+	organizationId!: string | null;
 
 	@Column(DataType.UUID)
-	scopeSummaryId?: string | null;
+	scopeSummaryId!: string | null;
 
 	@BelongsTo(() => Organization, {
 		onDelete: 'CASCADE',

--- a/server/crossrefDepositRecord/model.ts
+++ b/server/crossrefDepositRecord/model.ts
@@ -12,5 +12,5 @@ export class CrossrefDepositRecord extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.JSONB)
-	depositJson?: object | null;
+	depositJson!: object | null;
 }

--- a/server/customScript/model.ts
+++ b/server/customScript/model.ts
@@ -12,11 +12,11 @@ export class CustomScript extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.UUID)
-	communityId?: string | null;
+	communityId!: string | null;
 
 	@Column(DataType.STRING)
-	type?: string | null;
+	type!: string | null;
 
 	@Column(DataType.TEXT)
-	content?: string | null;
+	content!: string | null;
 }

--- a/server/depositTarget/model.ts
+++ b/server/depositTarget/model.ts
@@ -12,21 +12,21 @@ export class DepositTarget extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.UUID)
-	communityId?: string | null;
+	communityId!: string | null;
 
 	@Column(DataType.STRING)
-	doiPrefix?: string | null;
+	doiPrefix!: string | null;
 
 	@Default('crossref')
 	@Column(DataType.ENUM('crossref', 'datacite'))
-	service?: CreationOptional<'crossref' | 'datacite' | null>;
+	service!: CreationOptional<'crossref' | 'datacite' | null>;
 
 	@Column(DataType.STRING)
-	username?: string | null;
+	username!: string | null;
 
 	@Column(DataType.STRING)
-	password?: string | null;
+	password!: string | null;
 
 	@Column(DataType.TEXT)
-	passwordInitVec?: string | null;
+	passwordInitVec!: string | null;
 }

--- a/server/discussion/model.ts
+++ b/server/discussion/model.ts
@@ -24,17 +24,17 @@ export class Discussion extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.TEXT)
-	title?: string | null;
+	title!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.INTEGER)
 	number!: number;
 
 	@Column(DataType.BOOLEAN)
-	isClosed?: boolean | null;
+	isClosed!: boolean | null;
 
 	@Column(DataType.JSONB)
-	labels?: string[] | null;
+	labels!: string[] | null;
 
 	@AllowNull(false)
 	@Column(DataType.UUID)
@@ -46,17 +46,17 @@ export class Discussion extends Model<
 
 	@Index({ using: 'BTREE' })
 	@Column(DataType.UUID)
-	userId?: string | null;
+	userId!: string | null;
 
 	@Column(DataType.UUID)
-	anchorId?: string | null;
+	anchorId!: string | null;
 
 	@Index({ using: 'BTREE' })
 	@Column(DataType.UUID)
-	pubId?: string | null;
+	pubId!: string | null;
 
 	@Column(DataType.UUID)
-	commenterId?: string | null;
+	commenterId!: string | null;
 
 	@BelongsTo(() => Thread, { onDelete: 'CASCADE', as: 'thread', foreignKey: 'threadId' })
 	thread?: Thread;

--- a/server/discussionAnchor/model.ts
+++ b/server/discussionAnchor/model.ts
@@ -35,7 +35,7 @@ export class DiscussionAnchor extends Model<
 
 	// TODO: Add validation for selection
 	@Column(DataType.JSONB)
-	selection?: null | { type: 'text'; anchor: number; head: number };
+	selection!: null | { type: 'text'; anchor: number; head: number };
 
 	@AllowNull(false)
 	@Column(DataType.TEXT)

--- a/server/draft/model.ts
+++ b/server/draft/model.ts
@@ -19,7 +19,7 @@ export class Draft extends Model<InferAttributes<Draft>, InferCreationAttributes
 	id!: CreationOptional<string>;
 
 	@Column(DataType.DATE)
-	latestKeyAt?: Date | null;
+	latestKeyAt!: Date | null;
 
 	@AllowNull(false)
 	@Column(DataType.STRING)

--- a/server/export/model.ts
+++ b/server/export/model.ts
@@ -23,7 +23,7 @@ export class Export extends Model<InferAttributes<Export>, InferCreationAttribut
 	format!: string;
 
 	@Column(DataType.STRING)
-	url?: string | null;
+	url!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.INTEGER)
@@ -34,7 +34,7 @@ export class Export extends Model<InferAttributes<Export>, InferCreationAttribut
 	pubId!: string;
 
 	@Column(DataType.UUID)
-	workerTaskId?: string | null;
+	workerTaskId!: string | null;
 
 	@BelongsTo(() => WorkerTask, {
 		onDelete: 'SET NULL',

--- a/server/externalPublication/model.ts
+++ b/server/externalPublication/model.ts
@@ -29,17 +29,17 @@ export class ExternalPublication extends Model<
 
 	// TODO: add validation for contributors
 	@Column(DataType.JSONB)
-	contributors?: string[] | null;
+	contributors!: string[] | null;
 
 	@Column(DataType.TEXT)
-	doi?: string | null;
+	doi!: string | null;
 
 	@Column(DataType.TEXT)
-	description?: string | null;
+	description!: string | null;
 
 	@Column(DataType.TEXT)
-	avatar?: string | null;
+	avatar!: string | null;
 
 	@Column(DataType.DATE)
-	publicationDate?: Date | null;
+	publicationDate!: Date | null;
 }

--- a/server/facets/models/facetBinding.ts
+++ b/server/facets/models/facetBinding.ts
@@ -23,15 +23,15 @@ export class FacetBinding extends Model<
 
 	@Index({ using: 'BTREE' })
 	@Column(DataType.UUID)
-	pubId?: string | null;
+	pubId!: string | null;
 
 	@Index({ using: 'BTREE' })
 	@Column(DataType.UUID)
-	collectionId?: string | null;
+	collectionId!: string | null;
 
 	@Index({ using: 'BTREE' })
 	@Column(DataType.UUID)
-	communityId?: string | null;
+	communityId!: string | null;
 
 	@BelongsTo(() => Community, { onDelete: 'CASCADE', as: 'community', foreignKey: 'communityId' })
 	community?: Community;

--- a/server/featureFlag/model.ts
+++ b/server/featureFlag/model.ts
@@ -23,15 +23,15 @@ export class FeatureFlag extends Model<
 
 	@Index({ unique: true })
 	@Column(DataType.STRING)
-	name?: string | null;
+	name!: string | null;
 
 	@Default(0)
 	@Column(DataType.DOUBLE)
-	enabledUsersFraction?: CreationOptional<number | null>;
+	enabledUsersFraction!: CreationOptional<number | null>;
 
 	@Default(0)
 	@Column(DataType.DOUBLE)
-	enabledCommunitiesFraction?: CreationOptional<number | null>;
+	enabledCommunitiesFraction!: CreationOptional<number | null>;
 
 	@HasMany(() => FeatureFlagUser, {
 		onDelete: 'CASCADE',

--- a/server/featureFlagCommunity/model.ts
+++ b/server/featureFlagCommunity/model.ts
@@ -21,13 +21,13 @@ export class FeatureFlagCommunity extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.UUID)
-	featureFlagId?: string | null;
+	featureFlagId!: string | null;
 
 	@Column(DataType.UUID)
-	communityId?: string | null;
+	communityId!: string | null;
 
 	@Column(DataType.BOOLEAN)
-	enabled?: boolean | null;
+	enabled!: boolean | null;
 
 	@BelongsTo(() => Community, { onDelete: 'CASCADE', as: 'community', foreignKey: 'communityId' })
 	community?: Community;

--- a/server/featureFlagUser/model.ts
+++ b/server/featureFlagUser/model.ts
@@ -21,13 +21,13 @@ export class FeatureFlagUser extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.UUID)
-	featureFlagId?: string | null;
+	featureFlagId!: string | null;
 
 	@Column(DataType.UUID)
-	userId?: string | null;
+	userId!: string | null;
 
 	@Column(DataType.BOOLEAN)
-	enabled?: boolean | null;
+	enabled!: boolean | null;
 
 	@BelongsTo(() => User, { onDelete: 'CASCADE', as: 'user', foreignKey: 'userId' })
 	user?: User;

--- a/server/integrationDataOAuth1/model.ts
+++ b/server/integrationDataOAuth1/model.ts
@@ -15,7 +15,7 @@ export class IntegrationDataOAuth1 extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.TEXT)
-	accessToken?: string | null;
+	accessToken!: string | null;
 
 	@HasOne(() => ZoteroIntegration, {
 		foreignKey: { allowNull: false, name: 'integrationDataOAuth1Id' },

--- a/server/landingPageFeature/model.ts
+++ b/server/landingPageFeature/model.ts
@@ -24,11 +24,11 @@ export class LandingPageFeature extends Model<
 
 	@Index({ unique: true })
 	@Column(DataType.UUID)
-	communityId?: string | null;
+	communityId!: string | null;
 
 	@Index({ unique: true })
 	@Column(DataType.UUID)
-	pubId?: string | null;
+	pubId!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.TEXT)
@@ -36,7 +36,7 @@ export class LandingPageFeature extends Model<
 
 	// TODO: add validation for payload
 	@Column(DataType.JSONB)
-	payload?: Record<string, any> | null;
+	payload!: Record<string, any> | null;
 
 	@BelongsTo(() => Pub, { onDelete: 'CASCADE', as: 'pub', foreignKey: 'pubId' })
 	pub?: Pub;

--- a/server/member/model.ts
+++ b/server/member/model.ts
@@ -21,10 +21,10 @@ export class Member extends Model<InferAttributes<Member>, InferCreationAttribut
 
 	@Default('view')
 	@Column(DataType.ENUM('view', 'edit', 'manage', 'admin'))
-	permissions?: CreationOptional<MemberPermission | null>;
+	permissions!: CreationOptional<MemberPermission | null>;
 
 	@Column(DataType.BOOLEAN)
-	isOwner?: boolean | null;
+	isOwner!: boolean | null;
 
 	@AllowNull(false)
 	@Default(false)
@@ -36,16 +36,16 @@ export class Member extends Model<InferAttributes<Member>, InferCreationAttribut
 	userId!: string;
 
 	@Column(DataType.UUID)
-	pubId?: string | null;
+	pubId!: string | null;
 
 	@Column(DataType.UUID)
-	collectionId?: string | null;
+	collectionId!: string | null;
 
 	@Column(DataType.UUID)
-	communityId?: string | null;
+	communityId!: string | null;
 
 	@Column(DataType.UUID)
-	organizationId?: string | null;
+	organizationId!: string | null;
 
 	@BelongsTo(() => User, { onDelete: 'CASCADE', as: 'user', foreignKey: 'userId' })
 	user?: User;

--- a/server/merge/model.ts
+++ b/server/merge/model.ts
@@ -19,10 +19,10 @@ export class Merge extends Model<InferAttributes<Merge>, InferCreationAttributes
 	id!: CreationOptional<string>;
 
 	@Column(DataType.JSONB)
-	noteContent?: object | null;
+	noteContent!: object | null;
 
 	@Column(DataType.TEXT)
-	noteText?: string | null;
+	noteText!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.UUID)

--- a/server/organization/model.ts
+++ b/server/organization/model.ts
@@ -35,7 +35,7 @@ export class Organization extends Model<
 
 	@Unique
 	@Column(DataType.TEXT)
-	domain?: string | null;
+	domain!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.TEXT)
@@ -43,13 +43,13 @@ export class Organization extends Model<
 
 	@Length({ min: 0, max: 280 })
 	@Column(DataType.TEXT)
-	description?: string | null;
+	description!: string | null;
 
 	@Column(DataType.TEXT)
-	avatar?: string | null;
+	avatar!: string | null;
 
 	@Column(DataType.TEXT)
-	favicon?: string | null;
+	favicon!: string | null;
 
 	@HasMany(() => Community, {
 		onDelete: 'CASCADE',

--- a/server/page/model.ts
+++ b/server/page/model.ts
@@ -28,10 +28,10 @@ export class Page extends Model<InferAttributes<Page>, InferCreationAttributes<P
 	slug!: string;
 
 	@Column(DataType.TEXT)
-	description?: string | null;
+	description!: string | null;
 
 	@Column(DataType.TEXT)
-	avatar?: string | null;
+	avatar!: string | null;
 
 	@AllowNull(false)
 	@Default(false)
@@ -39,10 +39,10 @@ export class Page extends Model<InferAttributes<Page>, InferCreationAttributes<P
 	isPublic!: CreationOptional<boolean>;
 
 	@Column(DataType.BOOLEAN)
-	isNarrowWidth?: boolean | null;
+	isNarrowWidth!: boolean | null;
 
 	@Column(DataType.TEXT)
-	viewHash?: string | null;
+	viewHash!: string | null;
 
 	// TODO: Add @IsArray validation
 	@AllowNull(false)

--- a/server/pub/model.ts
+++ b/server/pub/model.ts
@@ -96,20 +96,20 @@ export class Pub extends Model<InferAttributes<Pub>, InferCreationAttributes<Pub
 
 	@Length({ min: 0, max: 280 })
 	@Column(DataType.TEXT)
-	htmlDescription?: string | null;
+	htmlDescription!: string | null;
 
 	@Column(DataType.TEXT)
-	avatar?: string | null;
+	avatar!: string | null;
 
 	@Column(DataType.DATE)
-	customPublishedAt?: Date | null;
+	customPublishedAt!: Date | null;
 
 	@Column(DataType.TEXT)
-	doi?: string | null;
+	doi!: string | null;
 
 	// TODO: add validation for labels
 	@Column(DataType.JSONB)
-	labels?: string[] | null;
+	labels!: string[] | null;
 
 	/**  TODO: add validation for downloads
 	// Should be something like
@@ -121,22 +121,22 @@ export class Pub extends Model<InferAttributes<Pub>, InferCreationAttributes<Pub
   }
  */
 	@Column(DataType.JSONB)
-	downloads?: any[] | null;
+	downloads!: any[] | null;
 
 	@Column(DataType.JSONB)
-	metadata?: object | null;
+	metadata!: object | null;
 
 	@Column(DataType.STRING)
-	viewHash?: string | null;
+	viewHash!: string | null;
 
 	@Column(DataType.STRING)
-	editHash?: string | null;
+	editHash!: string | null;
 
 	@Column(DataType.STRING)
-	reviewHash?: string | null;
+	reviewHash!: string | null;
 
 	@Column(DataType.STRING)
-	commentHash?: string | null;
+	commentHash!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.UUID)
@@ -148,10 +148,10 @@ export class Pub extends Model<InferAttributes<Pub>, InferCreationAttributes<Pub
 	communityId!: string;
 
 	@Column(DataType.UUID)
-	crossrefDepositRecordId?: string | null;
+	crossrefDepositRecordId!: string | null;
 
 	@Column(DataType.UUID)
-	scopeSummaryId?: string | null;
+	scopeSummaryId!: string | null;
 
 	@HasMany(() => PubAttribution, { onDelete: 'CASCADE', as: 'attributions', foreignKey: 'pubId' })
 	attributions?: PubAttribution[];

--- a/server/pubAttribution/model.ts
+++ b/server/pubAttribution/model.ts
@@ -22,32 +22,32 @@ export class PubAttribution extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.TEXT)
-	name?: string | null;
+	name!: string | null;
 
 	@Column(DataType.TEXT)
-	avatar?: string | null;
+	avatar!: string | null;
 
 	@Column(DataType.TEXT)
-	title?: string | null;
+	title!: string | null;
 
 	@Column(DataType.DOUBLE)
-	order?: number | null;
+	order!: number | null;
 
 	@Column(DataType.BOOLEAN)
-	isAuthor?: boolean | null;
+	isAuthor!: boolean | null;
 
 	// TODO: Add validation for roles
 	@Column(DataType.JSONB)
-	roles?: string[] | null;
+	roles!: string[] | null;
 
 	@Column(DataType.TEXT)
-	affiliation?: string | null;
+	affiliation!: string | null;
 
 	@Column(DataType.STRING)
-	orcid?: string | null;
+	orcid!: string | null;
 
 	@Column(DataType.UUID)
-	userId?: string | null;
+	userId!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.UUID)

--- a/server/pubEdge/model.ts
+++ b/server/pubEdge/model.ts
@@ -23,10 +23,10 @@ export class PubEdge extends Model<InferAttributes<PubEdge>, InferCreationAttrib
 	pubId!: string;
 
 	@Column(DataType.UUID)
-	externalPublicationId?: string | null;
+	externalPublicationId!: string | null;
 
 	@Column(DataType.UUID)
-	targetPubId?: string | null;
+	targetPubId!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.STRING)

--- a/server/pubVersion/model.ts
+++ b/server/pubVersion/model.ts
@@ -21,10 +21,10 @@ export class PubVersion extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.INTEGER)
-	historyKey?: number | null;
+	historyKey!: number | null;
 
 	@Column(DataType.UUID)
-	pubId?: string | null;
+	pubId!: string | null;
 
 	@BelongsTo(() => Pub, { onDelete: 'CASCADE', as: 'pub', foreignKey: 'pubId' })
 	pub?: Pub;

--- a/server/publicPermissions/model.ts
+++ b/server/publicPermissions/model.ts
@@ -21,28 +21,28 @@ export class PublicPermissions extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.BOOLEAN)
-	canCreateReviews?: boolean | null;
+	canCreateReviews!: boolean | null;
 
 	@Column(DataType.BOOLEAN)
-	canCreateDiscussions?: boolean | null;
+	canCreateDiscussions!: boolean | null;
 
 	@Column(DataType.BOOLEAN)
-	canViewDraft?: boolean | null;
+	canViewDraft!: boolean | null;
 
 	@Column(DataType.BOOLEAN)
-	canEditDraft?: boolean | null;
+	canEditDraft!: boolean | null;
 
 	@Column(DataType.UUID)
-	pubId?: string | null;
+	pubId!: string | null;
 
 	@Column(DataType.UUID)
-	collectionId?: string | null;
+	collectionId!: string | null;
 
 	@Column(DataType.UUID)
-	communityId?: string | null;
+	communityId!: string | null;
 
 	@Column(DataType.UUID)
-	organizationId?: string | null;
+	organizationId!: string | null;
 
 	@BelongsTo(() => Pub, { onDelete: 'CASCADE', as: 'pub', foreignKey: 'pubId' })
 	pub?: Pub;

--- a/server/release/model.ts
+++ b/server/release/model.ts
@@ -20,10 +20,10 @@ export class Release extends Model<InferAttributes<Release>, InferCreationAttrib
 
 	// TODO: add validation for noteContent
 	@Column(DataType.JSONB)
-	noteContent?: Record<string, any> | null;
+	noteContent!: Record<string, any> | null;
 
 	@Column(DataType.TEXT)
-	noteText?: string | null;
+	noteText!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.UUID)

--- a/server/review/model.ts
+++ b/server/review/model.ts
@@ -24,7 +24,7 @@ export class ReviewNew extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.TEXT)
-	title?: string | null;
+	title!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.INTEGER)
@@ -32,13 +32,13 @@ export class ReviewNew extends Model<
 
 	@Default('open')
 	@Column(DataType.ENUM('open', 'closed', 'completed'))
-	status?: CreationOptional<'open' | 'closed' | 'completed' | null>;
+	status!: CreationOptional<'open' | 'closed' | 'completed' | null>;
 
 	@Column(DataType.BOOLEAN)
-	releaseRequested?: boolean | null;
+	releaseRequested!: boolean | null;
 
 	@Column(DataType.JSONB)
-	labels?: object | null;
+	labels!: object | null;
 
 	@AllowNull(false)
 	@Column(DataType.UUID)
@@ -50,14 +50,14 @@ export class ReviewNew extends Model<
 
 	@Index({ using: 'BTREE' })
 	@Column(DataType.UUID)
-	userId?: string | null;
+	userId!: string | null;
 
 	@Index({ using: 'BTREE' })
 	@Column(DataType.UUID)
-	pubId?: string | null;
+	pubId!: string | null;
 
 	@Column(DataType.JSONB)
-	reviewContent?: object | null;
+	reviewContent!: object | null;
 
 	@BelongsTo(() => Thread, { onDelete: 'CASCADE', as: 'thread', foreignKey: 'threadId' })
 	thread?: Thread;

--- a/server/reviewEvent/model.ts
+++ b/server/reviewEvent/model.ts
@@ -22,10 +22,10 @@ export class ReviewEvent extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.STRING)
-	type?: string | null;
+	type!: string | null;
 
 	@Column(DataType.JSONB)
-	data?: object | null;
+	data!: object | null;
 
 	@AllowNull(false)
 	@Column(DataType.UUID)

--- a/server/reviewer/model.ts
+++ b/server/reviewer/model.ts
@@ -19,7 +19,7 @@ export class Reviewer extends Model<InferAttributes<Reviewer>, InferCreationAttr
 	id!: CreationOptional<string>;
 
 	@Column(DataType.TEXT)
-	name?: string | null;
+	name!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.UUID)

--- a/server/signup/model.ts
+++ b/server/signup/model.ts
@@ -27,14 +27,14 @@ export class Signup extends Model<InferAttributes<Signup>, InferCreationAttribut
 	email!: string;
 
 	@Column(DataType.TEXT)
-	hash?: string | null;
+	hash!: string | null;
 
 	@Column(DataType.INTEGER)
-	count?: number | null;
+	count!: number | null;
 
 	@Column(DataType.BOOLEAN)
-	completed?: boolean | null;
+	completed!: boolean | null;
 
 	@Column(DataType.UUID)
-	communityId?: string | null;
+	communityId!: string | null;
 }

--- a/server/spamTag/model.ts
+++ b/server/spamTag/model.ts
@@ -24,7 +24,7 @@ export class SpamTag extends Model<InferAttributes<SpamTag>, InferCreationAttrib
 	status!: CreationOptional<SpamStatus>;
 
 	@Column(DataType.DATE)
-	statusUpdatedAt?: Date | null;
+	statusUpdatedAt!: Date | null;
 
 	/**
 	 * TODO: add validation and better type for fields
@@ -63,5 +63,5 @@ export class SpamTag extends Model<InferAttributes<SpamTag>, InferCreationAttrib
 
 	@Default(1)
 	@Column(DataType.INTEGER)
-	spamScoreVersion?: CreationOptional<number | null>;
+	spamScoreVersion!: CreationOptional<number | null>;
 }

--- a/server/submission/model.ts
+++ b/server/submission/model.ts
@@ -28,7 +28,7 @@ export class Submission extends Model<
 	status!: SubmissionStatus;
 
 	@Column(DataType.DATE)
-	submittedAt?: Date | null;
+	submittedAt!: Date | null;
 
 	@AllowNull(false)
 	@Column(DataType.UUID)
@@ -43,7 +43,7 @@ export class Submission extends Model<
 	 * Should probably be DocJSON
 	 */
 	@Column(DataType.JSONB)
-	abstract?: object | null;
+	abstract!: object | null;
 
 	@BelongsTo(() => Pub, { onDelete: 'CASCADE', as: 'pub', foreignKey: 'pubId' })
 	pub?: Pub;

--- a/server/submissionWorkflow/model.ts
+++ b/server/submissionWorkflow/model.ts
@@ -28,7 +28,7 @@ export class SubmissionWorkflow extends Model<
 	title!: string;
 
 	@Column(DataType.UUID)
-	collectionId?: string | null;
+	collectionId!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.BOOLEAN)

--- a/server/thread/model.ts
+++ b/server/thread/model.ts
@@ -10,7 +10,7 @@ export class Thread extends Model<InferAttributes<Thread>, InferCreationAttribut
 	id!: CreationOptional<string>;
 
 	@Column(DataType.BOOLEAN)
-	isLocked?: boolean | null;
+	isLocked!: boolean | null;
 
 	@HasMany(() => ThreadComment, { onDelete: 'CASCADE', as: 'comments', foreignKey: 'threadId' })
 	comments?: ThreadComment[];

--- a/server/threadComment/model.ts
+++ b/server/threadComment/model.ts
@@ -23,21 +23,21 @@ export class ThreadComment extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.TEXT)
-	text?: string | null;
+	text!: string | null;
 
 	// TODO: Add validation for this
 	@Column(DataType.JSONB)
-	content?: DocJson | null;
+	content!: DocJson | null;
 
 	@Column(DataType.UUID)
-	userId?: string | null;
+	userId!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.UUID)
 	threadId!: string;
 
 	@Column(DataType.UUID)
-	commenterId?: string | null;
+	commenterId!: string | null;
 
 	@BelongsTo(() => User, { onDelete: 'CASCADE', as: 'author', foreignKey: 'userId' })
 	author?: User;

--- a/server/threadEvent/model.ts
+++ b/server/threadEvent/model.ts
@@ -22,11 +22,11 @@ export class ThreadEvent extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.STRING)
-	type?: string | null;
+	type!: string | null;
 
 	// TODO: Add validation for this
 	@Column(DataType.JSONB)
-	data?: Record<string, any> | null;
+	data!: Record<string, any> | null;
 
 	@AllowNull(false)
 	@Column(DataType.UUID)

--- a/server/threadUser/model.ts
+++ b/server/threadUser/model.ts
@@ -25,18 +25,18 @@ export class ThreadUser extends Model<
 
 	@Default('viewer')
 	@Column(DataType.ENUM('viewer', 'reviewer'))
-	type?: CreationOptional<string | null>;
+	type!: CreationOptional<string | null>;
 
 	@IsLowercase
 	@IsEmail
 	@Column(DataType.TEXT)
-	email?: string | null;
+	email!: string | null;
 
 	@Column(DataType.TEXT)
-	hash?: string | null;
+	hash!: string | null;
 
 	@Column(DataType.UUID)
-	userId?: string | null;
+	userId!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.UUID)

--- a/server/user/model.ts
+++ b/server/user/model.ts
@@ -54,13 +54,13 @@ export class User extends Model<InferAttributes<User>, InferCreationAttributes<U
 	initials!: string;
 
 	@Column(DataType.TEXT)
-	avatar?: string | null;
+	avatar!: string | null;
 
 	@Column(DataType.TEXT)
-	bio?: string | null;
+	bio!: string | null;
 
 	@Column(DataType.TEXT)
-	title?: string | null;
+	title!: string | null;
 
 	@AllowNull(false)
 	@IsLowercase
@@ -72,46 +72,46 @@ export class User extends Model<InferAttributes<User>, InferCreationAttributes<U
 	@IsLowercase
 	@IsEmail
 	@Column(DataType.TEXT)
-	publicEmail?: string | null;
+	publicEmail!: string | null;
 
 	@Column(DataType.TEXT)
-	authRedirectHost?: string | null;
+	authRedirectHost!: string | null;
 
 	@Column(DataType.TEXT)
-	location?: string | null;
+	location!: string | null;
 
 	@Column(DataType.TEXT)
-	website?: string | null;
+	website!: string | null;
 
 	@Column(DataType.TEXT)
-	facebook?: string | null;
+	facebook!: string | null;
 
 	@Column(DataType.TEXT)
-	twitter?: string | null;
+	twitter!: string | null;
 
 	@Column(DataType.TEXT)
-	github?: string | null;
+	github!: string | null;
 
 	@Column(DataType.TEXT)
-	orcid?: string | null;
+	orcid!: string | null;
 
 	@Column(DataType.TEXT)
-	googleScholar?: string | null;
+	googleScholar!: string | null;
 
 	@Column(DataType.DATE)
-	resetHashExpiration?: Date | null;
+	resetHashExpiration!: Date | null;
 
 	@Column(DataType.TEXT)
-	resetHash?: string | null;
+	resetHash!: string | null;
 
 	@Column(DataType.BOOLEAN)
-	inactive?: boolean | null;
+	inactive!: boolean | null;
 
 	@Column(DataType.INTEGER)
-	pubpubV3Id?: number | null;
+	pubpubV3Id!: number | null;
 
 	@Column(DataType.TEXT)
-	passwordDigest?: string | null;
+	passwordDigest!: string | null;
 
 	@AllowNull(false)
 	@Column(DataType.TEXT)
@@ -123,7 +123,7 @@ export class User extends Model<InferAttributes<User>, InferCreationAttributes<U
 
 	@Default(null)
 	@Column(DataType.BOOLEAN)
-	gdprConsent?: CreationOptional<boolean | null>;
+	gdprConsent!: CreationOptional<boolean | null>;
 
 	@AllowNull(false)
 	@Default(false)

--- a/server/userNotificationPreferences/model.ts
+++ b/server/userNotificationPreferences/model.ts
@@ -32,7 +32,7 @@ export class UserNotificationPreferences extends Model<
 	receiveNotifications!: CreationOptional<boolean>;
 
 	@Column(DataType.DATE)
-	lastReceivedNotificationsAt?: Date | null;
+	lastReceivedNotificationsAt!: Date | null;
 
 	@AllowNull(false)
 	@Default(true)

--- a/server/userScopeVisit/model.ts
+++ b/server/userScopeVisit/model.ts
@@ -14,16 +14,16 @@ export class UserScopeVisit extends Model<
 	@Index({ unique: true, name: 'user_scope_visits_user_id_collection_id' })
 	@Index({ unique: true, name: 'user_scope_visits_user_id_pub_id' })
 	@Column(DataType.UUID)
-	userId?: string | null;
+	userId!: string | null;
 
 	@Index({ unique: true, name: 'user_scope_visits_user_id_pub_id' })
 	@Column(DataType.UUID)
-	pubId?: string | null;
+	pubId!: string | null;
 
 	@Index({ unique: true, name: 'user_scope_visits_user_id_collection_id' })
 	@Column(DataType.UUID)
-	collectionId?: string | null;
+	collectionId!: string | null;
 
 	@Column(DataType.UUID)
-	communityId?: string | null;
+	communityId!: string | null;
 }

--- a/server/userSubscription/model.ts
+++ b/server/userSubscription/model.ts
@@ -38,11 +38,11 @@ export class UserSubscription extends Model<
 
 	@Index({ using: 'BTREE' })
 	@Column(DataType.UUID)
-	pubId?: string | null;
+	pubId!: string | null;
 
 	@Index({ using: 'BTREE' })
 	@Column(DataType.UUID)
-	threadId?: string | null;
+	threadId!: string | null;
 
 	@BelongsTo(() => Pub, { onDelete: 'CASCADE', as: 'pub', foreignKey: 'pubId' })
 	pub?: Pub;

--- a/server/visibility/model.ts
+++ b/server/visibility/model.ts
@@ -23,7 +23,7 @@ export class Visibility extends Model<
 
 	@Default('private')
 	@Column(DataType.ENUM('private', 'members', 'public'))
-	access?: CreationOptional<VisibilityAccess | null>;
+	access!: CreationOptional<VisibilityAccess | null>;
 
 	@BelongsToMany(() => User, {
 		as: 'users',

--- a/server/workerTask/model.ts
+++ b/server/workerTask/model.ts
@@ -25,22 +25,22 @@ export class WorkerTask extends Model<
 
 	// TODO: Add validation for input and enrich with type information
 	@Column(DataType.JSONB)
-	input?: object | null;
+	input!: object | null;
 
 	@Column(DataType.BOOLEAN)
-	isProcessing?: boolean | null;
+	isProcessing!: boolean | null;
 
 	@Column(DataType.INTEGER)
-	attemptCount?: number | null;
+	attemptCount!: number | null;
 
 	// TODO: Add validation for error and enrich with type information
 	@Column(DataType.JSONB)
-	error?: string | null;
+	error!: string | null;
 
 	// TODO: Add validation for output and enrich with type information
 	@Column(DataType.JSONB)
-	output?: object | null;
+	output!: object | null;
 
 	@Column(DataType.INTEGER)
-	priority?: number | null;
+	priority!: number | null;
 }

--- a/server/zoteroIntegration/model.ts
+++ b/server/zoteroIntegration/model.ts
@@ -21,16 +21,16 @@ export class ZoteroIntegration extends Model<
 	id!: CreationOptional<string>;
 
 	@Column(DataType.TEXT)
-	zoteroUsername?: string | null;
+	zoteroUsername!: string | null;
 
 	@Column(DataType.TEXT)
-	zoteroUserId?: string | null;
+	zoteroUserId!: string | null;
 
 	@Column(DataType.UUID)
-	userId?: string | null;
+	userId!: string | null;
 
 	@Column(DataType.UUID)
-	integrationDataOAuth1Id?: string | null;
+	integrationDataOAuth1Id!: string | null;
 
 	@BelongsTo(() => User, { as: 'user', foreignKey: { allowNull: false, name: 'userId' } })
 	user?: User;

--- a/tools/toSequelizeTypescript/diffs-rich.md
+++ b/tools/toSequelizeTypescript/diffs-rich.md
@@ -5,12 +5,12 @@
 {
   id: string
   kind: <del style="background:red">"community-created" | "community-updated" | "collection-created" | "collection-updated" | "collection-removed" | "collection-pub-created" | "collection-pub-removed" | "facet-instance-updated" | ... 16 more ... | "submission-status-updated"</del><ins style="background:green">ActivityItemKind</ins>
-  pubId?: string<ins style="background:green"> | null</ins>
-  payload<del style="background:red">:</del><ins style="background:green">?:</ins> any<ins style="background:green"> | null</ins>
+  pubId<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  payload: any<ins style="background:green"> | null</ins>
   timestamp: <del style="background:red">string</del><ins style="background:green">Date</ins>
   communityId: string
-  actorId<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
-  collectionId?: string<ins style="background:green"> | null</ins>
+  actorId: string | null
+  collectionId<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   createdAt<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">string</del><ins style="background:green">any</ins>
   updatedAt<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">string</del><ins style="background:green">any</ins>
   <ins style="background:green">deletedAt?: any</ins>
@@ -26,23 +26,23 @@
 <pre>
 {
   id: string
-  title<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
+  title: string<ins style="background:green"> | null</ins>
   slug: string
-  avatar?: string<ins style="background:green"> | null</ins>
-  isRestricted<del style="background:red">:</del><ins style="background:green">?:</ins> boolean<ins style="background:green"> | null</ins>
-  isPublic<del style="background:red">:</del><ins style="background:green">?:</ins> boolean<ins style="background:green"> | null</ins>
-  viewHash?: string<ins style="background:green"> | null</ins>
-  editHash?: string<ins style="background:green"> | null</ins>
-  metadata?: <del style="background:red">{</del><ins style="background:green">Record<string,</ins> <del style="background:red">[k:</del><ins style="background:green">any></ins> <del style="background:red">string]:</del><ins style="background:green">|</ins> <del style="background:red">any</del><ins style="background:green">null</ins>
-  kind<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">CollectionKind</del><ins style="background:green">any | null</ins>
-  doi?: string<ins style="background:green"> | null</ins>
-  readNextPreviewSize<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">ReadNextPreviewSize</del><ins style="background:green">any</ins>
+  avatar<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  isRestricted: boolean<ins style="background:green"> | null</ins>
+  isPublic: boolean<ins style="background:green"> | null</ins>
+  viewHash<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  editHash<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  metadata<del style="background:red">?: { [k</del>: <ins style="background:green">Record<</ins>string<del style="background:red">]:</del><ins style="background:green">,</ins> any<ins style="background:green">> | null</ins>
+  kind: <del style="background:red">CollectionKind</del><ins style="background:green">any | null</ins>
+  doi<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  readNextPreviewSize: <del style="background:red">ReadNextPreviewSize</del><ins style="background:green">any</ins>
   layout: <del style="background:red">CollectionLayout</del><ins style="background:green">any</ins>
   layoutAllowsDuplicatePubs: <ins style="background:green">CreationOptional<</ins>boolean<ins style="background:green">></ins>
-  pageId?: string | null
-  communityId<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  scopeSummaryId<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
-  crossrefDepositRecordId?: string | null
+  pageId<del style="background:red">?:</del><ins style="background:green">:</ins> string | null
+  communityId: string<ins style="background:green"> | null</ins>
+  scopeSummaryId: string | null
+  crossrefDepositRecordId<del style="background:red">?:</del><ins style="background:green">:</ins> string | null
   attributions?: CollectionAttribution[]
   <ins style="background:green">submissionWorkflow?: SubmissionWorkflow</ins>
   <ins style="background:green">collectionPubs?: CollectionPub[]</ins>
@@ -66,15 +66,15 @@
 <pre>
 {
   id: string
-  name<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  avatar?: string<ins style="background:green"> | null</ins>
-  title?: string<ins style="background:green"> | null</ins>
-  order<del style="background:red">:</del><ins style="background:green">?:</ins> number<ins style="background:green"> | null</ins>
-  isAuthor?: boolean<ins style="background:green"> | null</ins>
-  roles?: string[]<ins style="background:green"> | null</ins>
-  affiliation?: string<ins style="background:green"> | null</ins>
-  orcid?: string<ins style="background:green"> | null</ins>
-  userId?: string<ins style="background:green"> | null</ins>
+  name: string<ins style="background:green"> | null</ins>
+  avatar<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  title<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  order: number<ins style="background:green"> | null</ins>
+  isAuthor<del style="background:red">?:</del><ins style="background:green">:</ins> boolean<ins style="background:green"> | null</ins>
+  roles<del style="background:red">?:</del><ins style="background:green">:</ins> string[]<ins style="background:green"> | null</ins>
+  affiliation<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  orcid<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  userId<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   collectionId: string
   user?: MinimalUser
   <ins style="background:green">collection?: Collection</ins>
@@ -95,7 +95,7 @@
   id: string
   pubId: string
   collectionId: string
-  contextHint?: string | null
+  contextHint<del style="background:red">?:</del><ins style="background:green">:</ins> string | null
   rank: string
   pubRank: string
   collection?: Collection
@@ -115,7 +115,7 @@
 <pre>
 {
   id: string
-  name<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
+  name: string<ins style="background:green"> | null</ins>
   <ins style="background:green">createdAt?: any</ins>
   <ins style="background:green">updatedAt?: any</ins>
   <ins style="background:green">deletedAt?: any</ins>
@@ -132,53 +132,53 @@
 {
   id: string
   subdomain: string
-  domain?: string<ins style="background:green"> | null</ins>
+  domain<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   title: string
-  citeAs?: string<ins style="background:green"> | null</ins>
-  publishAs?: string<ins style="background:green"> | null</ins>
-  description?: string<ins style="background:green"> | null</ins>
-  avatar?: string<ins style="background:green"> | null</ins>
-  favicon?: string<ins style="background:green"> | null</ins>
-  accentColorLight<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  accentColorDark<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  hideCreatePubButton?: boolean<ins style="background:green"> | null</ins>
-  headerLogo?: string<ins style="background:green"> | null</ins>
-  headerLinks?: CommunityHeaderLink[]<ins style="background:green"> | null</ins>
-  headerColorType?: <ins style="background:green">CreationOptional<</ins>"light" | "dark" | "custom"<ins style="background:green">></ins>
-  useHeaderTextAccent?: boolean<ins style="background:green"> | null</ins>
-  hideHero?: boolean<ins style="background:green"> | null</ins>
-  hideHeaderLogo?: boolean<ins style="background:green"> | null</ins>
-  heroLogo?: string<ins style="background:green"> | null</ins>
-  heroBackgroundImage?: string<ins style="background:green"> | null</ins>
-  heroBackgroundColor?: string<ins style="background:green"> | null</ins>
-  heroTextColor?: string<ins style="background:green"> | null</ins>
-  useHeaderGradient?: boolean<ins style="background:green"> | null</ins>
-  heroImage?: string<ins style="background:green"> | null</ins>
-  heroTitle?: string<ins style="background:green"> | null</ins>
-  heroText?: string<ins style="background:green"> | null</ins>
-  heroPrimaryButton?: <del style="background:red">CommunityHeroButton</del><ins style="background:green">any | null</ins>
-  heroSecondaryButton?: <del style="background:red">CommunityHeroButton</del><ins style="background:green">any | null</ins>
-  heroAlign?: string<ins style="background:green"> | null</ins>
-  navigation<del style="background:red">:</del><ins style="background:green">?:</ins> CommunityNavigationEntry[]<ins style="background:green"> | null</ins>
-  hideNav?: boolean<ins style="background:green"> | null</ins>
-  <ins style="background:green">navLinks?: CommunityNavigationEntry[] | null</ins>
-  footerLinks?: CommunityNavigationEntry[]<ins style="background:green"> | null</ins>
-  footerLogoLink?: string<ins style="background:green"> | null</ins>
-  footerTitle?: string<ins style="background:green"> | null</ins>
-  footerImage?: string<ins style="background:green"> | null</ins>
-  website?: string<ins style="background:green"> | null</ins>
-  facebook?: string<ins style="background:green"> | null</ins>
-  twitter?: string<ins style="background:green"> | null</ins>
-  email?: string<ins style="background:green"> | null</ins>
-  issn?: string<ins style="background:green"> | null</ins>
-  isFeatured?: boolean<ins style="background:green"> | null</ins>
-  viewHash?: string<ins style="background:green"> | null</ins>
-  editHash?: string<ins style="background:green"> | null</ins>
-  premiumLicenseFlag?: <ins style="background:green">CreationOptional<</ins>boolean<ins style="background:green">></ins>
-  defaultPubCollections<del style="background:red">:</del><ins style="background:green">?:</ins> string[]<ins style="background:green"> | null</ins>
-  spamTagId<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
-  organizationId?: string<ins style="background:green"> | null</ins>
-  scopeSummaryId<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
+  citeAs<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  publishAs<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  description<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  avatar<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  favicon<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  accentColorLight: string<ins style="background:green"> | null</ins>
+  accentColorDark: string<ins style="background:green"> | null</ins>
+  hideCreatePubButton<del style="background:red">?:</del><ins style="background:green">:</ins> boolean<ins style="background:green"> | null</ins>
+  headerLogo<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  headerLinks<del style="background:red">?:</del><ins style="background:green">:</ins> CommunityHeaderLink[]<ins style="background:green"> | null</ins>
+  headerColorType<del style="background:red">?:</del><ins style="background:green">:</ins> <ins style="background:green">CreationOptional<</ins>"light" | "dark" | "custom"<ins style="background:green">></ins>
+  useHeaderTextAccent<del style="background:red">?:</del><ins style="background:green">:</ins> boolean<ins style="background:green"> | null</ins>
+  hideHero<del style="background:red">?:</del><ins style="background:green">:</ins> boolean<ins style="background:green"> | null</ins>
+  hideHeaderLogo<del style="background:red">?:</del><ins style="background:green">:</ins> boolean<ins style="background:green"> | null</ins>
+  heroLogo<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  heroBackgroundImage<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  heroBackgroundColor<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  heroTextColor<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  useHeaderGradient<del style="background:red">?:</del><ins style="background:green">:</ins> boolean<ins style="background:green"> | null</ins>
+  heroImage<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  heroTitle<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  heroText<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  heroPrimaryButton<del style="background:red">?:</del><ins style="background:green">:</ins> <del style="background:red">CommunityHeroButton</del><ins style="background:green">any | null</ins>
+  heroSecondaryButton<del style="background:red">?:</del><ins style="background:green">:</ins> <del style="background:red">CommunityHeroButton</del><ins style="background:green">any | null</ins>
+  heroAlign<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  navigation: CommunityNavigationEntry[]<ins style="background:green"> | null</ins>
+  hideNav<del style="background:red">?:</del><ins style="background:green">:</ins> boolean<ins style="background:green"> | null</ins>
+  <ins style="background:green">navLinks: CommunityNavigationEntry[] | null</ins>
+  footerLinks<del style="background:red">?:</del><ins style="background:green">:</ins> CommunityNavigationEntry[]<ins style="background:green"> | null</ins>
+  footerLogoLink<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  footerTitle<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  footerImage<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  website<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  facebook<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  twitter<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  email<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  issn<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  isFeatured<del style="background:red">?:</del><ins style="background:green">:</ins> boolean<ins style="background:green"> | null</ins>
+  viewHash<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  editHash<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  premiumLicenseFlag<del style="background:red">?:</del><ins style="background:green">:</ins> <ins style="background:green">CreationOptional<</ins>boolean<ins style="background:green">></ins>
+  defaultPubCollections: string[]<ins style="background:green"> | null</ins>
+  spamTagId: string | null
+  organizationId<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  scopeSummaryId: string | null
   <ins style="background:green">organization?: Organization</ins>
   collections?: Collection[]
   pubs?: Pub[]
@@ -202,7 +202,7 @@
 <pre>
 {
   id: string
-  depositJson?: <del style="background:red">any</del><ins style="background:green">object | null</ins>
+  depositJson<del style="background:red">?:</del><ins style="background:green">:</ins> <del style="background:red">any</del><ins style="background:green">object | null</ins>
   <ins style="background:green">createdAt?: any</ins>
   <ins style="background:green">updatedAt?: any</ins>
   <ins style="background:green">deletedAt?: any</ins>
@@ -218,16 +218,17 @@
 <pre>
 {
   id: string
-  communityId<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  doiPrefix<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  service<del style="background:red">:</del><ins style="background:green">?:</ins> <ins style="background:green">CreationOptional<</ins>"crossref" | "datacite"<ins style="background:green">></ins>
-  username<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  password<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  passwordInitVec<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
+  communityId: string<ins style="background:green"> | null</ins>
+  doiPrefix: string<ins style="background:green"> | null</ins>
+  service: <ins style="background:green">CreationOptional<</ins>"crossref" | "datacite"<ins style="background:green">></ins>
+  username: string<ins style="background:green"> | null</ins>
+  password: string<ins style="background:green"> | null</ins>
+  passwordInitVec: string<ins style="background:green"> | null</ins>
   <ins style="background:green">createdAt?: any</ins>
   <ins style="background:green">updatedAt?: any</ins>
   <ins style="background:green">deletedAt?: any</ins>
   <ins style="background:green">version?: any</ins>
+  <del style="background: red">isPubPubManaged?: boolean</del>
 }</pre>
 
 
@@ -239,16 +240,16 @@
 <pre>
 {
   id: string
-  title<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
+  title: string<ins style="background:green"> | null</ins>
   number: number
-  isClosed<del style="background:red">:</del><ins style="background:green">?:</ins> boolean<ins style="background:green"> | null</ins>
-  labels<del style="background:red">:</del><ins style="background:green">?:</ins> string[]<ins style="background:green"> | null</ins>
+  isClosed: boolean<ins style="background:green"> | null</ins>
+  labels: string[]<ins style="background:green"> | null</ins>
   threadId: string
   visibilityId: string
-  userId<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  <ins style="background:green">anchorId?: string | null</ins>
-  pubId<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  <ins style="background:green">commenterId?: string | null</ins>
+  userId: string<ins style="background:green"> | null</ins>
+  <ins style="background:green">anchorId: string | null</ins>
+  pubId: string<ins style="background:green"> | null</ins>
+  <ins style="background:green">commenterId: string | null</ins>
   thread?: Thread
   visibility<del style="background:red">:</del><ins style="background:green">?:</ins> Visibility
   <ins style="background:green">author?: User</ins>
@@ -273,7 +274,7 @@
   isOriginal: boolean
   discussionId: string
   historyKey: number
-  selection<del style="background:red">:</del><ins style="background:green">?:</ins> { type: "text"
+  selection: { type: "text"
   anchor: number
   head: number
   originalText: string
@@ -310,7 +311,7 @@
 <pre>
 {
   id: string
-  latestKeyAt?: <del style="background:red">string</del><ins style="background:green">Date | null</ins>
+  latestKeyAt<del style="background:red">?:</del><ins style="background:green">:</ins> <del style="background:red">string</del><ins style="background:green">Date | null</ins>
   firebasePath: string
   <ins style="background:green">createdAt?: any</ins>
   <ins style="background:green">updatedAt?: any</ins>
@@ -328,10 +329,10 @@
 {
   id: string
   format: string
-  url?: string<ins style="background:green"> | null</ins>
+  url<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   historyKey: number
   <ins style="background:green">pubId: string</ins>
-  workerTaskId?: string<ins style="background:green"> | null</ins>
+  workerTaskId<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   <ins style="background:green">workerTask?: WorkerTask</ins>
   <ins style="background:green">createdAt?: any</ins>
   <ins style="background:green">updatedAt?: any</ins>
@@ -350,11 +351,11 @@
   id: string
   title: string
   url: string
-  contributors?: string[]<ins style="background:green"> | null</ins>
-  doi?: string<ins style="background:green"> | null</ins>
-  description?: string<ins style="background:green"> | null</ins>
-  avatar?: string<ins style="background:green"> | null</ins>
-  publicationDate?: <del style="background:red">string</del><ins style="background:green">Date | null</ins>
+  contributors<del style="background:red">?:</del><ins style="background:green">:</ins> string[]<ins style="background:green"> | null</ins>
+  doi<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  description<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  avatar<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  publicationDate<del style="background:red">?:</del><ins style="background:green">:</ins> <del style="background:red">string</del><ins style="background:green">Date | null</ins>
   <ins style="background:green">createdAt?: any</ins>
   <ins style="background:green">updatedAt?: any</ins>
   <ins style="background:green">deletedAt?: any</ins>
@@ -370,9 +371,9 @@
 <pre>
 {
   id: string
-  name<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  enabledUsersFraction<del style="background:red">:</del><ins style="background:green">?:</ins> number
-  enabledCommunitiesFraction<del style="background:red">:</del><ins style="background:green">?:</ins> number
+  name: string<ins style="background:green"> | null</ins>
+  enabledUsersFraction: number
+  enabledCommunitiesFraction: number
   users?: FeatureFlagUser[]
   communities?: FeatureFlagCommunity[]
   <ins style="background:green">createdAt?: any</ins>
@@ -390,9 +391,9 @@
 <pre>
 {
   id: string
-  featureFlagId<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  userId<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  enabled<del style="background:red">:</del><ins style="background:green">?:</ins> boolean<ins style="background:green"> | null</ins>
+  featureFlagId: string<ins style="background:green"> | null</ins>
+  userId: string<ins style="background:green"> | null</ins>
+  enabled: boolean<ins style="background:green"> | null</ins>
   user?: User
   <ins style="background:green">featureFlag?: FeatureFlag</ins>
   <ins style="background:green">createdAt?: any</ins>
@@ -410,9 +411,9 @@
 <pre>
 {
   id: string
-  featureFlagId<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  communityId<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  enabled<del style="background:red">:</del><ins style="background:green">?:</ins> boolean<ins style="background:green"> | null</ins>
+  featureFlagId: string<ins style="background:green"> | null</ins>
+  communityId: string<ins style="background:green"> | null</ins>
+  enabled: boolean<ins style="background:green"> | null</ins>
   community?: Community
   <ins style="background:green">featureFlag?: FeatureFlag</ins>
   <ins style="background:green">createdAt?: any</ins>
@@ -430,10 +431,10 @@
 <pre>
 {
   id: string
-  zoteroUsername<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  zoteroUserId<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  userId<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  integrationDataOAuth1Id<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
+  zoteroUsername: string<ins style="background:green"> | null</ins>
+  zoteroUserId: string<ins style="background:green"> | null</ins>
+  userId: string<ins style="background:green"> | null</ins>
+  integrationDataOAuth1Id: string<ins style="background:green"> | null</ins>
   <ins style="background:green">user?: User</ins>
   <ins style="background:green">integrationDataOAuth1?: IntegrationDataOAuth1</ins>
   <ins style="background:green">createdAt?: any</ins>
@@ -451,7 +452,7 @@
 <pre>
 {
   id: string
-  accessToken<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
+  accessToken: string<ins style="background:green"> | null</ins>
   <ins style="background:green">zoteroIntegration?: ZoteroIntegration</ins>
   <ins style="background:green">createdAt?: any</ins>
   <ins style="background:green">updatedAt?: any</ins>
@@ -470,10 +471,10 @@
 <pre>
 {
   id: string
-  communityId<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
-  pubId<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
+  communityId: string | null
+  pubId: string | null
   rank: string
-  payload<del style="background:red">:</del><ins style="background:green">?:</ins> Record<string, any> | null
+  payload: Record<string, any> | null
   pub?: <del style="background:red">any | null</del><ins style="background:green">Pub</ins>
   community?: <del style="background:red">any | null</del><ins style="background:green">Community</ins>
   createdAt<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">string</del><ins style="background:green">any</ins>
@@ -491,14 +492,14 @@
 <pre>
 {
   id: string
-  permissions<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">MemberPermission</del><ins style="background:green">any</ins>
-  isOwner?: boolean<ins style="background:green"> | null</ins>
+  permissions: <del style="background:red">MemberPermission</del><ins style="background:green">any</ins>
+  isOwner<del style="background:red">?:</del><ins style="background:green">:</ins> boolean<ins style="background:green"> | null</ins>
   subscribedToActivityDigest: <ins style="background:green">CreationOptional<</ins>boolean<ins style="background:green">></ins>
   userId: string
-  pubId?: string<ins style="background:green"> | null</ins>
-  collectionId?: string<ins style="background:green"> | null</ins>
-  communityId?: string<ins style="background:green"> | null</ins>
-  organizationId?: string<ins style="background:green"> | null</ins>
+  pubId<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  collectionId<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  communityId<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  organizationId<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   user?: User
   <ins style="background:green">community?: Community</ins>
   <ins style="background:green">pub?: Pub</ins>
@@ -520,11 +521,11 @@
   id: string
   title: string
   slug: string
-  description<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
-  avatar?: string<ins style="background:green"> | null</ins>
+  description: string | null
+  avatar<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   isPublic: <ins style="background:green">CreationOptional<</ins>boolean<ins style="background:green">></ins>
-  isNarrowWidth?: boolean<ins style="background:green"> | null</ins>
-  viewHash?: string<ins style="background:green"> | null</ins>
+  isNarrowWidth<del style="background:red">?:</del><ins style="background:green">:</ins> boolean<ins style="background:green"> | null</ins>
+  viewHash<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   layout: LayoutBlock[]
   layoutAllowsDuplicatePubs: <ins style="background:green">CreationOptional<</ins>boolean<ins style="background:green">></ins>
   communityId: string
@@ -546,23 +547,23 @@
   id: string
   slug: string
   title: string
-  htmlTitle<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
-  description?: string<ins style="background:green"> | null</ins>
-  htmlDescription?: string<ins style="background:green"> | null</ins>
-  avatar?: string<ins style="background:green"> | null</ins>
-  customPublishedAt?: <del style="background:red">string</del><ins style="background:green">Date | null</ins>
-  doi<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
-  labels?: string[]<ins style="background:green"> | null</ins>
-  downloads?: any[]<ins style="background:green"> | null</ins>
-  metadata?: <del style="background:red">{}</del><ins style="background:green">object | null</ins>
-  viewHash?: string<ins style="background:green"> | null</ins>
-  editHash?: string<ins style="background:green"> | null</ins>
-  reviewHash?: string<ins style="background:green"> | null</ins>
-  commentHash?: string<ins style="background:green"> | null</ins>
+  htmlTitle: string | null
+  description<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  htmlDescription<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  avatar<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  customPublishedAt<del style="background:red">?:</del><ins style="background:green">:</ins> <del style="background:red">string</del><ins style="background:green">Date | null</ins>
+  doi: string | null
+  labels<del style="background:red">?:</del><ins style="background:green">:</ins> string[]<ins style="background:green"> | null</ins>
+  downloads<del style="background:red">?:</del><ins style="background:green">:</ins> any[]<ins style="background:green"> | null</ins>
+  metadata<del style="background:red">?:</del><ins style="background:green">:</ins> <del style="background:red">{}</del><ins style="background:green">object | null</ins>
+  viewHash<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  editHash<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  reviewHash<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  commentHash<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   draftId<del style="background:red">?:</del><ins style="background:green">:</ins> string
   communityId: string
-  crossrefDepositRecordId?: string<ins style="background:green"> | null</ins>
-  scopeSummaryId<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
+  crossrefDepositRecordId<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  scopeSummaryId: string | null
   attributions<del style="background:red">:</del><ins style="background:green">?:</ins> PubAttribution[]
   collectionPubs?: CollectionPub[]
   community?: Community
@@ -593,15 +594,15 @@
 <pre>
 {
   id: string
-  name<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  avatar?: string<ins style="background:green"> | null</ins>
-  title?: string<ins style="background:green"> | null</ins>
-  order<del style="background:red">:</del><ins style="background:green">?:</ins> number<ins style="background:green"> | null</ins>
-  isAuthor?: boolean<ins style="background:green"> | null</ins>
-  roles?: string[]<ins style="background:green"> | null</ins>
-  affiliation?: string<ins style="background:green"> | null</ins>
-  orcid?: string<ins style="background:green"> | null</ins>
-  userId?: string<ins style="background:green"> | null</ins>
+  name: string<ins style="background:green"> | null</ins>
+  avatar<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  title<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  order: number<ins style="background:green"> | null</ins>
+  isAuthor<del style="background:red">?:</del><ins style="background:green">:</ins> boolean<ins style="background:green"> | null</ins>
+  roles<del style="background:red">?:</del><ins style="background:green">:</ins> string[]<ins style="background:green"> | null</ins>
+  affiliation<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  orcid<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  userId<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   pubId: string
   user?: <del style="background:red">MinimalUser</del><ins style="background:green">User</ins>
   <ins style="background:green">pub?: Pub</ins>
@@ -621,8 +622,8 @@
 {
   id: string
   pubId: string
-  externalPublicationId?: <del style="background:red">number</del><ins style="background:green">string | null</ins>
-  targetPubId?: string<ins style="background:green"> | null</ins>
+  externalPublicationId<del style="background:red">?:</del><ins style="background:green">:</ins> <del style="background:red">number</del><ins style="background:green">string | null</ins>
+  targetPubId<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   relationType: string
   rank: string
   pubIsParent: boolean
@@ -645,8 +646,8 @@
 <pre>
 {
   id: string
-  historyKey?: number<ins style="background:green"> | null</ins>
-  pubId?: string<ins style="background:green"> | null</ins>
+  historyKey<del style="background:red">?:</del><ins style="background:green">:</ins> number<ins style="background:green"> | null</ins>
+  pubId<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   <ins style="background:green">pub?: Pub</ins>
   <ins style="background:green">createdAt?: any</ins>
   <ins style="background:green">updatedAt?: any</ins>
@@ -663,8 +664,8 @@
 <pre>
 {
   id: string
-  noteContent?: <del style="background:red">{}</del><ins style="background:green">Record<string, any> | null</ins>
-  noteText?: string<ins style="background:green"> | null</ins>
+  noteContent<del style="background:red">?:</del><ins style="background:green">:</ins> <del style="background:red">{}</del><ins style="background:green">Record<string, any> | null</ins>
+  noteText<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   pubId: string
   userId: string
   docId: string
@@ -707,10 +708,10 @@
 {
   id: string
   status: <del style="background:red">any</del><ins style="background:green">SubmissionStatus</ins>
-  submittedAt<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">string</del><ins style="background:green">Date</ins> | null
+  submittedAt: <del style="background:red">string</del><ins style="background:green">Date</ins> | null
   submissionWorkflowId: string
   pubId: string
-  abstract<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">any</del><ins style="background:green">object</ins> | null
+  abstract: <del style="background:red">any</del><ins style="background:green">object</ins> | null
   pub?: Pub
   submissionWorkflow?: SubmissionWorkflow
   <ins style="background:green">createdAt?: any</ins>
@@ -729,11 +730,11 @@
 {
   id: string
   status: <del style="background:red">SpamStatus</del><ins style="background:green">any</ins>
-  statusUpdatedAt<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">string</del><ins style="background:green">Date</ins> | null
+  statusUpdatedAt: <del style="background:red">string</del><ins style="background:green">Date</ins> | null
   fields: Record<string, <del style="background:red">string[]</del><ins style="background:green">any</ins>>
   spamScore: number
   spamScoreComputedAt: <del style="background:red">string</del><ins style="background:green">Date</ins>
-  spamScoreVersion<del style="background:red">:</del><ins style="background:green">?:</ins> number
+  spamScoreVersion: number
   <ins style="background:green">createdAt?: any</ins>
   <ins style="background:green">updatedAt?: any</ins>
   <ins style="background:green">deletedAt?: any</ins>
@@ -750,7 +751,7 @@
 {
   id: string
   title: string
-  collectionId<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
+  collectionId: string<ins style="background:green"> | null</ins>
   enabled: boolean
   instructionsText: <del style="background:red">DocJson</del><ins style="background:green">object</ins>
   acceptedText: DocJson
@@ -777,7 +778,7 @@
 <pre>
 {
   id: string
-  name<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
+  name: string<ins style="background:green"> | null</ins>
   <ins style="background:green">reviewId: string</ins>
   <ins style="background:green">review?: ReviewNew</ins>
   <ins style="background:green">createdAt?: any</ins>
@@ -795,7 +796,7 @@
 <pre>
 {
   id: string
-  <ins style="background:green">isLocked?: boolean | null</ins>
+  <ins style="background:green">isLocked: boolean | null</ins>
   comments<del style="background:red">:</del><ins style="background:green">?:</ins> ThreadComment[]
   events<del style="background:red">:</del><ins style="background:green">?:</ins> ThreadEvent[]
   createdAt<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">string</del><ins style="background:green">any</ins>
@@ -814,11 +815,11 @@
 <pre>
 {
   id: string
-  text<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  content<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">DocJson</del><ins style="background:green">any | null</ins>
-  userId<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
+  text: string<ins style="background:green"> | null</ins>
+  content: <del style="background:red">DocJson</del><ins style="background:green">any | null</ins>
+  userId: string | null
   threadId: string
-  commenterId<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
+  commenterId: string | null
   author?: User<del style="background:red"> | null</del>
   commenter?: Commenter<del style="background:red"> | null</del>
   createdAt<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">string</del><ins style="background:green">any</ins>
@@ -836,8 +837,8 @@
 <pre>
 {
   id: string
-  type?: string<ins style="background:green"> | null</ins>
-  data?: <del style="background:red">{}</del><ins style="background:green">Record<string, any> | null</ins>
+  type<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  data<del style="background:red">?:</del><ins style="background:green">:</ins> <del style="background:red">{}</del><ins style="background:green">Record<string, any> | null</ins>
   userId: string
   threadId: string
   <ins style="background:green">user?: User</ins>
@@ -861,27 +862,27 @@
   lastName: string
   fullName: string
   initials: string
-  avatar?: string<ins style="background:green"> | null</ins>
-  bio<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  title?: string<ins style="background:green"> | null</ins>
+  avatar<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  bio: string<ins style="background:green"> | null</ins>
+  title<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
   email: string
-  publicEmail?: string<ins style="background:green"> | null</ins>
-  authRedirectHost?: string<ins style="background:green"> | null</ins>
-  location<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  website<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  facebook<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  twitter<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  github<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  orcid?: string<ins style="background:green"> | null</ins>
-  googleScholar<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  resetHashExpiration<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">number</del><ins style="background:green">Date | null</ins>
-  resetHash<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  <ins style="background:green">inactive?: boolean | null</ins>
-  <ins style="background:green">pubpubV3Id?: number | null</ins>
-  passwordDigest<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
+  publicEmail<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  authRedirectHost<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  location: string<ins style="background:green"> | null</ins>
+  website: string<ins style="background:green"> | null</ins>
+  facebook: string<ins style="background:green"> | null</ins>
+  twitter: string<ins style="background:green"> | null</ins>
+  github: string<ins style="background:green"> | null</ins>
+  orcid<del style="background:red">?:</del><ins style="background:green">:</ins> string<ins style="background:green"> | null</ins>
+  googleScholar: string<ins style="background:green"> | null</ins>
+  resetHashExpiration: <del style="background:red">number</del><ins style="background:green">Date | null</ins>
+  resetHash: string<ins style="background:green"> | null</ins>
+  <ins style="background:green">inactive: boolean | null</ins>
+  <ins style="background:green">pubpubV3Id: number | null</ins>
+  passwordDigest: string<ins style="background:green"> | null</ins>
   hash: string
   salt: string
-  <ins style="background:green">gdprConsent?: CreationOptional<boolean></ins>
+  <ins style="background:green">gdprConsent: CreationOptional<boolean></ins>
   isSuperAdmin: <ins style="background:green">CreationOptional<</ins>boolean<ins style="background:green">></ins>
   isShadowUser?: boolean
   feedback?: string
@@ -930,7 +931,7 @@
   id: string
   userId: string
   receiveNotifications: <ins style="background:green">CreationOptional<</ins>boolean<ins style="background:green">></ins>
-  lastReceivedNotificationsAt<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">string</del><ins style="background:green">Date</ins> | null
+  lastReceivedNotificationsAt: <del style="background:red">string</del><ins style="background:green">Date</ins> | null
   subscribeToThreadsAsCommenter: <ins style="background:green">CreationOptional<</ins>boolean<ins style="background:green">></ins>
   subscribeToPubsAsMember: <ins style="background:green">CreationOptional<</ins>boolean<ins style="background:green">></ins>
   subscribeToPubsAsContributor: <ins style="background:green">CreationOptional<</ins>boolean<ins style="background:green">></ins>
@@ -951,10 +952,10 @@
 <pre>
 {
   id: string
-  userId<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
-  pubId<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
-  collectionId<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
-  communityId<del style="background:red">:</del><ins style="background:green">?:</ins> string<ins style="background:green"> | null</ins>
+  userId: string<ins style="background:green"> | null</ins>
+  pubId: string | null
+  collectionId: string | null
+  communityId: string<ins style="background:green"> | null</ins>
   <ins style="background:green">createdAt?: any</ins>
   updatedAt<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">string</del><ins style="background:green">any</ins>
   <ins style="background:green">deletedAt?: any</ins>
@@ -973,8 +974,8 @@
   setAutomatically: boolean
   status: UserSubscriptionStatus
   userId: string
-  pubId<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
-  threadId<del style="background:red">:</del><ins style="background:green">?:</ins> string | null
+  pubId: string | null
+  threadId: string | null
   <ins style="background:green">pub?: Pub</ins>
   <ins style="background:green">thread?: Thread</ins>
   <ins style="background:green">user?: User</ins>
@@ -993,7 +994,7 @@
 <pre>
 {
   id: string
-  access<del style="background:red">:</del><ins style="background:green">?:</ins> <del style="background:red">VisibilityAccess</del><ins style="background:green">any</ins>
+  access: <del style="background:red">VisibilityAccess</del><ins style="background:green">any</ins>
   users<del style="background:red">:</del><ins style="background:green">?:</ins> VisibilityUser[]
   <ins style="background:green">createdAt?: any</ins>
   <ins style="background:green">updatedAt?: any</ins>

--- a/tools/toSequelizeTypescript/diffs.md
+++ b/tools/toSequelizeTypescript/diffs.md
@@ -6,16 +6,15 @@ id: string
 - kind: "community-created" | "community-updated" | "collection-created" | "collection-updated" | "collection-removed" | "collection-pub-created" | "collection-pub-removed" | "facet-instance-updated" | ... 16 more ... | "submission-status-updated"
 + kind: ActivityItemKind
 - pubId?: string
-+ pubId?: string | null
++ pubId: string | null
 - payload: any
-+ payload?: any | null
++ payload: any | null
 - timestamp: string
 + timestamp: Date
 communityId: string
-- actorId: string | null
-+ actorId?: string | null
+actorId: string | null
 - collectionId?: string
-+ collectionId?: string | null
++ collectionId: string | null
 - createdAt: string
 + createdAt?: any
 - updatedAt: string
@@ -32,36 +31,37 @@ communityId: string
 ```diff
 id: string
 - title: string
-+ title?: string | null
++ title: string | null
 slug: string
 - avatar?: string
-+ avatar?: string | null
++ avatar: string | null
 - isRestricted: boolean
-+ isRestricted?: boolean | null
++ isRestricted: boolean | null
 - isPublic: boolean
-+ isPublic?: boolean | null
++ isPublic: boolean | null
 - viewHash?: string
-+ viewHash?: string | null
++ viewHash: string | null
 - editHash?: string
-+ editHash?: string | null
++ editHash: string | null
 - metadata?: { [k: string]: any
-+ metadata?: Record<string, any> | null
++ metadata: Record<string, any> | null
 - kind: CollectionKind
-+ kind?: any | null
++ kind: any | null
 - doi?: string
-+ doi?: string | null
++ doi: string | null
 - readNextPreviewSize: ReadNextPreviewSize
-+ readNextPreviewSize?: any
++ readNextPreviewSize: any
 - layout: CollectionLayout
 + layout: any
 - layoutAllowsDuplicatePubs: boolean
 + layoutAllowsDuplicatePubs: CreationOptional<boolean>
-pageId?: string | null
+- pageId?: string | null
++ pageId: string | null
 - communityId: string
-+ communityId?: string | null
-- scopeSummaryId: string | null
-+ scopeSummaryId?: string | null
-crossrefDepositRecordId?: string | null
++ communityId: string | null
+scopeSummaryId: string | null
+- crossrefDepositRecordId?: string | null
++ crossrefDepositRecordId: string | null
 attributions?: CollectionAttribution[]
 + submissionWorkflow?: SubmissionWorkflow
 + collectionPubs?: CollectionPub[]
@@ -87,23 +87,23 @@ community?: Community
 ```diff
 id: string
 - name: string
-+ name?: string | null
++ name: string | null
 - avatar?: string
-+ avatar?: string | null
++ avatar: string | null
 - title?: string
-+ title?: string | null
++ title: string | null
 - order: number
-+ order?: number | null
++ order: number | null
 - isAuthor?: boolean
-+ isAuthor?: boolean | null
++ isAuthor: boolean | null
 - roles?: string[]
-+ roles?: string[] | null
++ roles: string[] | null
 - affiliation?: string
-+ affiliation?: string | null
++ affiliation: string | null
 - orcid?: string
-+ orcid?: string | null
++ orcid: string | null
 - userId?: string
-+ userId?: string | null
++ userId: string | null
 collectionId: string
 user?: MinimalUser
 + collection?: Collection
@@ -123,7 +123,8 @@ user?: MinimalUser
 id: string
 pubId: string
 collectionId: string
-contextHint?: string | null
+- contextHint?: string | null
++ contextHint: string | null
 rank: string
 pubRank: string
 collection?: Collection
@@ -142,7 +143,7 @@ pub?: Pub
 ```diff
 id: string
 - name: string
-+ name?: string | null
++ name: string | null
 + createdAt?: any
 + updatedAt?: any
 + deletedAt?: any
@@ -158,97 +159,95 @@ id: string
 id: string
 subdomain: string
 - domain?: string
-+ domain?: string | null
++ domain: string | null
 title: string
 - citeAs?: string
-+ citeAs?: string | null
++ citeAs: string | null
 - publishAs?: string
-+ publishAs?: string | null
++ publishAs: string | null
 - description?: string
-+ description?: string | null
++ description: string | null
 - avatar?: string
-+ avatar?: string | null
++ avatar: string | null
 - favicon?: string
-+ favicon?: string | null
++ favicon: string | null
 - accentColorLight: string
-+ accentColorLight?: string | null
++ accentColorLight: string | null
 - accentColorDark: string
-+ accentColorDark?: string | null
++ accentColorDark: string | null
 - hideCreatePubButton?: boolean
-+ hideCreatePubButton?: boolean | null
++ hideCreatePubButton: boolean | null
 - headerLogo?: string
-+ headerLogo?: string | null
++ headerLogo: string | null
 - headerLinks?: CommunityHeaderLink[]
-+ headerLinks?: CommunityHeaderLink[] | null
++ headerLinks: CommunityHeaderLink[] | null
 - headerColorType?: "light" | "dark" | "custom"
-+ headerColorType?: CreationOptional<"light" | "dark" | "custom">
++ headerColorType: CreationOptional<"light" | "dark" | "custom">
 - useHeaderTextAccent?: boolean
-+ useHeaderTextAccent?: boolean | null
++ useHeaderTextAccent: boolean | null
 - hideHero?: boolean
-+ hideHero?: boolean | null
++ hideHero: boolean | null
 - hideHeaderLogo?: boolean
-+ hideHeaderLogo?: boolean | null
++ hideHeaderLogo: boolean | null
 - heroLogo?: string
-+ heroLogo?: string | null
++ heroLogo: string | null
 - heroBackgroundImage?: string
-+ heroBackgroundImage?: string | null
++ heroBackgroundImage: string | null
 - heroBackgroundColor?: string
-+ heroBackgroundColor?: string | null
++ heroBackgroundColor: string | null
 - heroTextColor?: string
-+ heroTextColor?: string | null
++ heroTextColor: string | null
 - useHeaderGradient?: boolean
-+ useHeaderGradient?: boolean | null
++ useHeaderGradient: boolean | null
 - heroImage?: string
-+ heroImage?: string | null
++ heroImage: string | null
 - heroTitle?: string
-+ heroTitle?: string | null
++ heroTitle: string | null
 - heroText?: string
-+ heroText?: string | null
++ heroText: string | null
 - heroPrimaryButton?: CommunityHeroButton
-+ heroPrimaryButton?: any | null
++ heroPrimaryButton: any | null
 - heroSecondaryButton?: CommunityHeroButton
-+ heroSecondaryButton?: any | null
++ heroSecondaryButton: any | null
 - heroAlign?: string
-+ heroAlign?: string | null
++ heroAlign: string | null
 - navigation: CommunityNavigationEntry[]
-+ navigation?: CommunityNavigationEntry[] | null
++ navigation: CommunityNavigationEntry[] | null
 - hideNav?: boolean
-+ hideNav?: boolean | null
-+ navLinks?: CommunityNavigationEntry[] | null
++ hideNav: boolean | null
++ navLinks: CommunityNavigationEntry[] | null
 - footerLinks?: CommunityNavigationEntry[]
-+ footerLinks?: CommunityNavigationEntry[] | null
++ footerLinks: CommunityNavigationEntry[] | null
 - footerLogoLink?: string
-+ footerLogoLink?: string | null
++ footerLogoLink: string | null
 - footerTitle?: string
-+ footerTitle?: string | null
++ footerTitle: string | null
 - footerImage?: string
-+ footerImage?: string | null
++ footerImage: string | null
 - website?: string
-+ website?: string | null
++ website: string | null
 - facebook?: string
-+ facebook?: string | null
++ facebook: string | null
 - twitter?: string
-+ twitter?: string | null
++ twitter: string | null
 - email?: string
-+ email?: string | null
++ email: string | null
 - issn?: string
-+ issn?: string | null
++ issn: string | null
 - isFeatured?: boolean
-+ isFeatured?: boolean | null
++ isFeatured: boolean | null
 - viewHash?: string
-+ viewHash?: string | null
++ viewHash: string | null
 - editHash?: string
-+ editHash?: string | null
++ editHash: string | null
 - premiumLicenseFlag?: boolean
-+ premiumLicenseFlag?: CreationOptional<boolean>
++ premiumLicenseFlag: CreationOptional<boolean>
 - defaultPubCollections: string[]
-+ defaultPubCollections?: string[] | null
-- spamTagId: string | null
-+ spamTagId?: string | null
++ defaultPubCollections: string[] | null
+spamTagId: string | null
 - organizationId?: string
-+ organizationId?: string | null
-- scopeSummaryId: string | null
-+ scopeSummaryId?: string | null
++ organizationId: string | null
+scopeSummaryId: string | null
 + organization?: Organization
 collections?: Collection[]
 pubs?: Pub[]
@@ -273,7 +272,7 @@ accentTextColor: string
 ```diff
 id: string
 - depositJson?: any
-+ depositJson?: object | null
++ depositJson: object | null
 + createdAt?: any
 + updatedAt?: any
 + deletedAt?: any
@@ -288,21 +287,22 @@ id: string
 ```diff
 id: string
 - communityId: string
-+ communityId?: string | null
++ communityId: string | null
 - doiPrefix: string
-+ doiPrefix?: string | null
++ doiPrefix: string | null
 - service: "crossref" | "datacite"
-+ service?: CreationOptional<"crossref" | "datacite">
++ service: CreationOptional<"crossref" | "datacite">
 - username: string
-+ username?: string | null
++ username: string | null
 - password: string
-+ password?: string | null
++ password: string | null
 - passwordInitVec: string
-+ passwordInitVec?: string | null
++ passwordInitVec: string | null
 + createdAt?: any
 + updatedAt?: any
 + deletedAt?: any
 + version?: any
+- isPubPubManaged?: boolean
 ```
 
 
@@ -313,20 +313,20 @@ id: string
 ```diff
 id: string
 - title: string
-+ title?: string | null
++ title: string | null
 number: number
 - isClosed: boolean
-+ isClosed?: boolean | null
++ isClosed: boolean | null
 - labels: string[]
-+ labels?: string[] | null
++ labels: string[] | null
 threadId: string
 visibilityId: string
 - userId: string
-+ userId?: string | null
-+ anchorId?: string | null
++ userId: string | null
++ anchorId: string | null
 - pubId: string
-+ pubId?: string | null
-+ commenterId?: string | null
++ pubId: string | null
++ commenterId: string | null
 thread?: Thread
 - visibility: Visibility
 + visibility?: Visibility
@@ -350,8 +350,7 @@ id: string
 isOriginal: boolean
 discussionId: string
 historyKey: number
-- selection: { type: "text"
-+ selection?: { type: "text"
+selection: { type: "text"
 anchor: number
 head: number
 originalText: string
@@ -387,7 +386,7 @@ content: DocJson
 ```diff
 id: string
 - latestKeyAt?: string
-+ latestKeyAt?: Date | null
++ latestKeyAt: Date | null
 firebasePath: string
 + createdAt?: any
 + updatedAt?: any
@@ -404,11 +403,11 @@ firebasePath: string
 id: string
 format: string
 - url?: string
-+ url?: string | null
++ url: string | null
 historyKey: number
 + pubId: string
 - workerTaskId?: string
-+ workerTaskId?: string | null
++ workerTaskId: string | null
 + workerTask?: WorkerTask
 + createdAt?: any
 + updatedAt?: any
@@ -426,15 +425,15 @@ id: string
 title: string
 url: string
 - contributors?: string[]
-+ contributors?: string[] | null
++ contributors: string[] | null
 - doi?: string
-+ doi?: string | null
++ doi: string | null
 - description?: string
-+ description?: string | null
++ description: string | null
 - avatar?: string
-+ avatar?: string | null
++ avatar: string | null
 - publicationDate?: string
-+ publicationDate?: Date | null
++ publicationDate: Date | null
 + createdAt?: any
 + updatedAt?: any
 + deletedAt?: any
@@ -449,11 +448,9 @@ url: string
 ```diff
 id: string
 - name: string
-+ name?: string | null
-- enabledUsersFraction: number
-+ enabledUsersFraction?: number
-- enabledCommunitiesFraction: number
-+ enabledCommunitiesFraction?: number
++ name: string | null
+enabledUsersFraction: number
+enabledCommunitiesFraction: number
 users?: FeatureFlagUser[]
 communities?: FeatureFlagCommunity[]
 + createdAt?: any
@@ -470,11 +467,11 @@ communities?: FeatureFlagCommunity[]
 ```diff
 id: string
 - featureFlagId: string
-+ featureFlagId?: string | null
++ featureFlagId: string | null
 - userId: string
-+ userId?: string | null
++ userId: string | null
 - enabled: boolean
-+ enabled?: boolean | null
++ enabled: boolean | null
 user?: User
 + featureFlag?: FeatureFlag
 + createdAt?: any
@@ -491,11 +488,11 @@ user?: User
 ```diff
 id: string
 - featureFlagId: string
-+ featureFlagId?: string | null
++ featureFlagId: string | null
 - communityId: string
-+ communityId?: string | null
++ communityId: string | null
 - enabled: boolean
-+ enabled?: boolean | null
++ enabled: boolean | null
 community?: Community
 + featureFlag?: FeatureFlag
 + createdAt?: any
@@ -512,13 +509,13 @@ community?: Community
 ```diff
 id: string
 - zoteroUsername: string
-+ zoteroUsername?: string | null
++ zoteroUsername: string | null
 - zoteroUserId: string
-+ zoteroUserId?: string | null
++ zoteroUserId: string | null
 - userId: string
-+ userId?: string | null
++ userId: string | null
 - integrationDataOAuth1Id: string
-+ integrationDataOAuth1Id?: string | null
++ integrationDataOAuth1Id: string | null
 + user?: User
 + integrationDataOAuth1?: IntegrationDataOAuth1
 + createdAt?: any
@@ -535,7 +532,7 @@ id: string
 ```diff
 id: string
 - accessToken: string
-+ accessToken?: string | null
++ accessToken: string | null
 + zoteroIntegration?: ZoteroIntegration
 + createdAt?: any
 + updatedAt?: any
@@ -552,13 +549,10 @@ id: string
 
 ```diff
 id: string
-- communityId: string | null
-+ communityId?: string | null
-- pubId: string | null
-+ pubId?: string | null
+communityId: string | null
+pubId: string | null
 rank: string
-- payload: Record<string, any> | null
-+ payload?: Record<string, any> | null
+payload: Record<string, any> | null
 - pub?: any | null
 + pub?: Pub
 - community?: any | null
@@ -579,20 +573,20 @@ rank: string
 ```diff
 id: string
 - permissions: MemberPermission
-+ permissions?: any
++ permissions: any
 - isOwner?: boolean
-+ isOwner?: boolean | null
++ isOwner: boolean | null
 - subscribedToActivityDigest: boolean
 + subscribedToActivityDigest: CreationOptional<boolean>
 userId: string
 - pubId?: string
-+ pubId?: string | null
++ pubId: string | null
 - collectionId?: string
-+ collectionId?: string | null
++ collectionId: string | null
 - communityId?: string
-+ communityId?: string | null
++ communityId: string | null
 - organizationId?: string
-+ organizationId?: string | null
++ organizationId: string | null
 user?: User
 + community?: Community
 + pub?: Pub
@@ -614,16 +608,15 @@ user?: User
 id: string
 title: string
 slug: string
-- description: string | null
-+ description?: string | null
+description: string | null
 - avatar?: string
-+ avatar?: string | null
++ avatar: string | null
 - isPublic: boolean
 + isPublic: CreationOptional<boolean>
 - isNarrowWidth?: boolean
-+ isNarrowWidth?: boolean | null
++ isNarrowWidth: boolean | null
 - viewHash?: string
-+ viewHash?: string | null
++ viewHash: string | null
 layout: LayoutBlock[]
 - layoutAllowsDuplicatePubs: boolean
 + layoutAllowsDuplicatePubs: CreationOptional<boolean>
@@ -644,39 +637,36 @@ communityId: string
 id: string
 slug: string
 title: string
-- htmlTitle: string | null
-+ htmlTitle?: string | null
+htmlTitle: string | null
 - description?: string
-+ description?: string | null
++ description: string | null
 - htmlDescription?: string
-+ htmlDescription?: string | null
++ htmlDescription: string | null
 - avatar?: string
-+ avatar?: string | null
++ avatar: string | null
 - customPublishedAt?: string
-+ customPublishedAt?: Date | null
-- doi: string | null
-+ doi?: string | null
++ customPublishedAt: Date | null
+doi: string | null
 - labels?: string[]
-+ labels?: string[] | null
++ labels: string[] | null
 - downloads?: any[]
-+ downloads?: any[] | null
++ downloads: any[] | null
 - metadata?: {}
-+ metadata?: object | null
++ metadata: object | null
 - viewHash?: string
-+ viewHash?: string | null
++ viewHash: string | null
 - editHash?: string
-+ editHash?: string | null
++ editHash: string | null
 - reviewHash?: string
-+ reviewHash?: string | null
++ reviewHash: string | null
 - commentHash?: string
-+ commentHash?: string | null
++ commentHash: string | null
 - draftId?: string
 + draftId: string
 communityId: string
 - crossrefDepositRecordId?: string
-+ crossrefDepositRecordId?: string | null
-- scopeSummaryId: string | null
-+ scopeSummaryId?: string | null
++ crossrefDepositRecordId: string | null
+scopeSummaryId: string | null
 - attributions: PubAttribution[]
 + attributions?: PubAttribution[]
 collectionPubs?: CollectionPub[]
@@ -715,23 +705,23 @@ submission?: Submission
 ```diff
 id: string
 - name: string
-+ name?: string | null
++ name: string | null
 - avatar?: string
-+ avatar?: string | null
++ avatar: string | null
 - title?: string
-+ title?: string | null
++ title: string | null
 - order: number
-+ order?: number | null
++ order: number | null
 - isAuthor?: boolean
-+ isAuthor?: boolean | null
++ isAuthor: boolean | null
 - roles?: string[]
-+ roles?: string[] | null
++ roles: string[] | null
 - affiliation?: string
-+ affiliation?: string | null
++ affiliation: string | null
 - orcid?: string
-+ orcid?: string | null
++ orcid: string | null
 - userId?: string
-+ userId?: string | null
++ userId: string | null
 pubId: string
 - user?: MinimalUser
 + user?: User
@@ -752,9 +742,9 @@ pubId: string
 id: string
 pubId: string
 - externalPublicationId?: number
-+ externalPublicationId?: string | null
++ externalPublicationId: string | null
 - targetPubId?: string
-+ targetPubId?: string | null
++ targetPubId: string | null
 relationType: string
 rank: string
 pubIsParent: boolean
@@ -776,9 +766,9 @@ externalPublication?: ExternalPublication
 ```diff
 id: string
 - historyKey?: number
-+ historyKey?: number | null
++ historyKey: number | null
 - pubId?: string
-+ pubId?: string | null
++ pubId: string | null
 + pub?: Pub
 + createdAt?: any
 + updatedAt?: any
@@ -794,9 +784,9 @@ id: string
 ```diff
 id: string
 - noteContent?: {}
-+ noteContent?: Record<string, any> | null
++ noteContent: Record<string, any> | null
 - noteText?: string
-+ noteText?: string | null
++ noteText: string | null
 pubId: string
 userId: string
 docId: string
@@ -839,11 +829,11 @@ id: string
 - status: any
 + status: SubmissionStatus
 - submittedAt: string | null
-+ submittedAt?: Date | null
++ submittedAt: Date | null
 submissionWorkflowId: string
 pubId: string
 - abstract: any | null
-+ abstract?: object | null
++ abstract: object | null
 pub?: Pub
 submissionWorkflow?: SubmissionWorkflow
 + createdAt?: any
@@ -862,14 +852,13 @@ id: string
 - status: SpamStatus
 + status: any
 - statusUpdatedAt: string | null
-+ statusUpdatedAt?: Date | null
++ statusUpdatedAt: Date | null
 - fields: Record<string, string[]>
 + fields: Record<string, any>
 spamScore: number
 - spamScoreComputedAt: string
 + spamScoreComputedAt: Date
-- spamScoreVersion: number
-+ spamScoreVersion?: number
+spamScoreVersion: number
 + createdAt?: any
 + updatedAt?: any
 + deletedAt?: any
@@ -885,7 +874,7 @@ spamScore: number
 id: string
 title: string
 - collectionId: string
-+ collectionId?: string | null
++ collectionId: string | null
 enabled: boolean
 - instructionsText: DocJson
 + instructionsText: object
@@ -916,7 +905,7 @@ collection?: Collection
 ```diff
 id: string
 - name: string
-+ name?: string | null
++ name: string | null
 + reviewId: string
 + review?: ReviewNew
 + createdAt?: any
@@ -932,7 +921,7 @@ id: string
 
 ```diff
 id: string
-+ isLocked?: boolean | null
++ isLocked: boolean | null
 - comments: ThreadComment[]
 + comments?: ThreadComment[]
 - events: ThreadEvent[]
@@ -954,14 +943,12 @@ id: string
 ```diff
 id: string
 - text: string
-+ text?: string | null
++ text: string | null
 - content: DocJson
-+ content?: any | null
-- userId: string | null
-+ userId?: string | null
++ content: any | null
+userId: string | null
 threadId: string
-- commenterId: string | null
-+ commenterId?: string | null
+commenterId: string | null
 - author?: User | null
 + author?: User
 - commenter?: Commenter | null
@@ -982,9 +969,9 @@ threadId: string
 ```diff
 id: string
 - type?: string
-+ type?: string | null
++ type: string | null
 - data?: {}
-+ data?: Record<string, any> | null
++ data: Record<string, any> | null
 userId: string
 threadId: string
 + user?: User
@@ -1008,41 +995,41 @@ lastName: string
 fullName: string
 initials: string
 - avatar?: string
-+ avatar?: string | null
++ avatar: string | null
 - bio: string
-+ bio?: string | null
++ bio: string | null
 - title?: string
-+ title?: string | null
++ title: string | null
 email: string
 - publicEmail?: string
-+ publicEmail?: string | null
++ publicEmail: string | null
 - authRedirectHost?: string
-+ authRedirectHost?: string | null
++ authRedirectHost: string | null
 - location: string
-+ location?: string | null
++ location: string | null
 - website: string
-+ website?: string | null
++ website: string | null
 - facebook: string
-+ facebook?: string | null
++ facebook: string | null
 - twitter: string
-+ twitter?: string | null
++ twitter: string | null
 - github: string
-+ github?: string | null
++ github: string | null
 - orcid?: string
-+ orcid?: string | null
++ orcid: string | null
 - googleScholar: string
-+ googleScholar?: string | null
++ googleScholar: string | null
 - resetHashExpiration: number
-+ resetHashExpiration?: Date | null
++ resetHashExpiration: Date | null
 - resetHash: string
-+ resetHash?: string | null
-+ inactive?: boolean | null
-+ pubpubV3Id?: number | null
++ resetHash: string | null
++ inactive: boolean | null
++ pubpubV3Id: number | null
 - passwordDigest: string
-+ passwordDigest?: string | null
++ passwordDigest: string | null
 hash: string
 salt: string
-+ gdprConsent?: CreationOptional<boolean>
++ gdprConsent: CreationOptional<boolean>
 - isSuperAdmin: boolean
 + isSuperAdmin: CreationOptional<boolean>
 isShadowUser?: boolean
@@ -1094,7 +1081,7 @@ userId: string
 - receiveNotifications: boolean
 + receiveNotifications: CreationOptional<boolean>
 - lastReceivedNotificationsAt: string | null
-+ lastReceivedNotificationsAt?: Date | null
++ lastReceivedNotificationsAt: Date | null
 - subscribeToThreadsAsCommenter: boolean
 + subscribeToThreadsAsCommenter: CreationOptional<boolean>
 - subscribeToPubsAsMember: boolean
@@ -1120,13 +1107,11 @@ notificationCadence: number
 ```diff
 id: string
 - userId: string
-+ userId?: string | null
-- pubId: string | null
-+ pubId?: string | null
-- collectionId: string | null
-+ collectionId?: string | null
++ userId: string | null
+pubId: string | null
+collectionId: string | null
 - communityId: string
-+ communityId?: string | null
++ communityId: string | null
 + createdAt?: any
 - updatedAt: string
 + updatedAt?: any
@@ -1144,10 +1129,8 @@ id: string
 setAutomatically: boolean
 status: UserSubscriptionStatus
 userId: string
-- pubId: string | null
-+ pubId?: string | null
-- threadId: string | null
-+ threadId?: string | null
+pubId: string | null
+threadId: string | null
 + pub?: Pub
 + thread?: Thread
 + user?: User
@@ -1167,7 +1150,7 @@ userId: string
 ```diff
 id: string
 - access: VisibilityAccess
-+ access?: any
++ access: any
 - users: VisibilityUser[]
 + users?: VisibilityUser[]
 + createdAt?: any


### PR DESCRIPTION
? -> !

More accurate to how sequelize actually works.

Instead of having nulable fields in sequelize model definitions be `field?: string | null`, make it `field!: string | null`.



From 399 -> 392 errors in 109 files.

## Test Plan

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
