### PR TITLE
dev: add types for `passport-local-sequelize`

### DIFF
--- a/server/passwordReset/queries.ts
+++ b/server/passwordReset/queries.ts
@@ -69,7 +69,7 @@ export const updatePasswordReset = (
 	return User.findOne({
 		where: whereQuery,
 	})
-		.then((userData: types.UserWithPrivateFields | null) => {
+		.then((userData) => {
 			if (!userData) {
 				throw new Error("User doesn't exist");
 			}
@@ -78,7 +78,7 @@ export const updatePasswordReset = (
 			}
 
 			/* Promisify the setPassword function, and use .update to match API convention */
-			const setPassword = promisify((userData as any).setPassword.bind(userData));
+			const setPassword = promisify(userData.setPassword.bind(userData));
 			return setPassword(inputValues.password);
 		})
 		.then((passwordResetData: PasswordResetData) => {

--- a/stubstub/modelize/builders.ts
+++ b/stubstub/modelize/builders.ts
@@ -76,7 +76,7 @@ export const builders = {
 		args?: WithOptional<UserType, 'firstName' | 'lastName' | 'email' | 'slug' | 'initials'> & {
 			password?: string;
 		},
-	): Promise<typeof User> => {
+	): Promise<User> => {
 		const uniqueness = uuid.v4();
 		const defaults = {
 			firstName: 'Test',
@@ -115,7 +115,7 @@ export const builders = {
 					passwordDigest: 'sha512',
 				},
 				sha3hashedPassword,
-				(err: any, user: typeof User) => {
+				(err, user) => {
 					if (err) {
 						return reject(err);
 					}


### PR DESCRIPTION
Types the User model with methods from `passport-local-sequelize`

From 399 -> 397 errors in 109 files.

## Test Plan

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
