### PR TITLE
Remove "You may reply to this email thread to reach us." 

### DIFF
--- a/client/components/SubmissionEmail/SubmissionEmail.tsx
+++ b/client/components/SubmissionEmail/SubmissionEmail.tsx
@@ -42,8 +42,7 @@ const SubmissionEmail = (props: Props) => {
 		if (kind === 'received') {
 			return (
 				<>
-					{submissionNounPhrase} has been received. You may reply to this email thread to
-					reach us.
+					{submissionNounPhrase} has been received.
 				</>
 			);
 		}


### PR DESCRIPTION
This isn't true, unless a CC: is set and the recipient uses reply-all, so might well result in lost messages.

It would be nicer if the reply-to was set rather than cc:, so replying would work, but perhaps this is a useful quick fix, as it just brings this email in line with the others.