### PR TITLE
fix: add next() in zotero middleware

### DIFF
--- a/server/routes/authenticate.tsx
+++ b/server/routes/authenticate.tsx
@@ -5,11 +5,14 @@ import { isDevelopment } from 'utils/environment';
 
 app.get(
 	'/auth/zotero',
-	wrap(async (req) => {
+	wrap(async (req, res, next) => {
 		if (req.user) {
 			const authRedirectHost = req.get('host');
 			await User.update({ authRedirectHost }, { where: { id: req.user.id } });
+		} else {
+			res.redirect('/');
 		}
+		next();
 	}),
 	passport.authenticate('zotero', { state: 'test' }),
 );


### PR DESCRIPTION
## Issue(s) Resolved
#2775 

## Test Plan

0. [optional, only if in dev] rather than `localhost` url, navigate to `lvh.me`
1. log in
2. navigate to user privacy settings
3. click 'activate'
4. if you are redirected to Zotero, the bug is addressed. Feel free to continue through the rest of the oauth flow for good feeling.


## Screenshots (if applicable)

## Optional
Also implements a redirect if a non-logged-in user attempts to visit `/auth/zotero`, where before it would route them through to Zotero for the usual oauth flow.

### Notes/Context/Gotchas

### Supporting Docs
