### PR TITLE
dev: add discussion email notification preference

### DIFF
--- a/client/components/UserNotifications/UserNotificationPreferences.tsx
+++ b/client/components/UserNotifications/UserNotificationPreferences.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { Classes, FormGroup, Switch, Button } from '@blueprintjs/core';
 
 import * as types from 'types';
@@ -9,8 +10,9 @@ require('./userNotificationPreferences.scss');
 
 type Props = {
 	preferences: types.UserNotificationPreferences;
+	minimal?: boolean;
 	onUpdatePreferences: (patch: Partial<types.UserNotificationPreferences>) => unknown;
-	onClose: () => unknown;
+	onClose?: () => unknown;
 };
 
 const notificationCadenceItems = [
@@ -44,8 +46,13 @@ const UserNotificationPreferences = (props: Props) => {
 	};
 
 	return (
-		<div className="user-notification-preferences-component">
-			<h4 className={Classes.HEADING}>Notification preferences</h4>
+		<div
+			className={classNames(
+				'user-notification-preferences-component',
+				props.minimal && 'minimal',
+			)}
+		>
+			{!props.minimal && <h4 className={Classes.HEADING}>Notification preferences</h4>}
 			<p>
 				<Switch
 					label="Receive notifications from PubPub"
@@ -98,9 +105,11 @@ const UserNotificationPreferences = (props: Props) => {
 					onSelectValue={(trigger) => onUpdatePreferences({ markReadTrigger: trigger })}
 				/>
 			</FormGroup>
-			<Button icon="tick" intent="primary" onClick={onClose}>
-				Done
-			</Button>
+			{!props.minimal && (
+				<Button icon="tick" intent="primary" onClick={onClose}>
+					Done
+				</Button>
+			)}
 		</div>
 	);
 };

--- a/client/components/UserNotifications/UserNotificationPreferences.tsx
+++ b/client/components/UserNotifications/UserNotificationPreferences.tsx
@@ -31,6 +31,7 @@ const UserNotificationPreferences = (props: Props) => {
 	const { preferences, onUpdatePreferences, onClose } = props;
 	const {
 		receiveNotifications,
+		receiveDiscussionThreadEmails,
 		subscribeToThreadsAsCommenter,
 		subscribeToPubsAsMember,
 		subscribeToPubsAsContributor,
@@ -50,6 +51,11 @@ const UserNotificationPreferences = (props: Props) => {
 					label="Receive notifications from PubPub"
 					checked={receiveNotifications}
 					onChange={() => toggle('receiveNotifications')}
+				/>
+				<Switch
+					label="Receive discussion thread emails from PubPub"
+					checked={receiveDiscussionThreadEmails}
+					onChange={() => toggle('receiveDiscussionThreadEmails')}
 				/>
 			</p>
 			<FormGroup label="Automatically subscribe me to..." disabled={!receiveNotifications}>

--- a/client/components/UserNotifications/userNotificationPreferences.scss
+++ b/client/components/UserNotifications/userNotificationPreferences.scss
@@ -1,3 +1,6 @@
 .user-notification-preferences-component {
 	padding: 24px;
+	&.minimal {
+		padding: 0;
+	}
 }

--- a/client/containers/Legal/Legal.tsx
+++ b/client/containers/Legal/Legal.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Menu, MenuItem } from '@blueprintjs/core';
 
-import { GridWrapper } from 'components';
+import { Integration, UserNotificationPreferences } from 'types';
 import { usePageContext } from 'utils/hooks';
-import { Integration } from 'types';
+import { GridWrapper } from 'components';
+import { apiFetch } from 'client/utils/apiFetch';
 
 import PrivacySettings from './PrivacySettings';
 import Terms from './Terms';
@@ -14,6 +15,7 @@ require('./legal.scss');
 
 type Props = {
 	integrations: Integration[];
+	userNotificationPreferences?: UserNotificationPreferences;
 };
 
 const Legal = (props: Props) => {
@@ -23,6 +25,20 @@ const Legal = (props: Props) => {
 		communityData: { accentColorDark },
 	} = usePageContext();
 	const { tab } = locationData.params;
+	const [userNotificationPreferences, setUserNotificationPreferences] = useState(
+		props.userNotificationPreferences,
+	);
+	const updateUserNotificationPreferences = async (
+		preferences: Partial<UserNotificationPreferences>,
+	) => {
+		setUserNotificationPreferences((state) => {
+			return {
+				...state,
+				...preferences,
+			} as UserNotificationPreferences;
+		});
+		await apiFetch.put('/api/userNotificationPreferences', { preferences });
+	};
 	return (
 		<>
 			<style>{`#legal-container .main-content p > a { color: ${accentColorDark}; }`}</style>
@@ -60,10 +76,14 @@ const Legal = (props: Props) => {
 						{tab === 'terms' && <Terms hostname={locationData.hostname} />}
 						{tab === 'privacy' && <PrivacyPolicy />}
 						{tab === 'aup' && <AUP />}
-						{tab === 'settings' && (
+						{tab === 'settings' && props.userNotificationPreferences && (
 							<PrivacySettings
 								isLoggedIn={!!loginData.id}
 								integrations={props.integrations}
+								userNotificationPreferences={userNotificationPreferences}
+								onUpdateUserNotificationPreferences={
+									updateUserNotificationPreferences
+								}
 							/>
 						)}
 					</div>

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -12,3 +12,4 @@ import './scopeSummary/hooks';
 import './submission/hooks';
 import './threadComment/hooks';
 import './visibility/hooks';
+import './userNotification/hooks';

--- a/server/userNotification/create.ts
+++ b/server/userNotification/create.ts
@@ -72,8 +72,10 @@ const createNotificationsForThreadComment = async (
 			.filter((userId) => !userIdsWhoDoNotWantNotifications.includes(userId)),
 	});
 
+	const deduplicatedUserIdsToNotify = [...new Set(userIdsToNotify)];
+
 	await UserNotification.bulkCreate(
-		userIdsToNotify.map((userId) => {
+		deduplicatedUserIdsToNotify.map((userId) => {
 			return {
 				userId,
 				userSubscriptionId: subscriptionsByUserId[userId].id,

--- a/server/userNotification/create.ts
+++ b/server/userNotification/create.ts
@@ -80,6 +80,7 @@ const createNotificationsForThreadComment = async (
 				activityItemId: item.id,
 			};
 		}),
+		{ individualHooks: true },
 	);
 };
 

--- a/server/userNotification/hooks.ts
+++ b/server/userNotification/hooks.ts
@@ -1,0 +1,63 @@
+import * as types from 'types';
+import mailgun from 'mailgun.js';
+import stripIndent from 'strip-indent';
+
+import {
+	ActivityItem,
+	Community,
+	Pub,
+	User,
+	UserNotification,
+	UserNotificationPreferences,
+} from 'server/models';
+import { defer } from 'server/utils/deferred';
+import * as urls from 'utils/canonicalUrls';
+
+const mg = mailgun.client({
+	username: 'api',
+	key: process.env.MAILGUN_API_KEY!,
+});
+
+const template = async (activityItem: types.PubDiscussionCommentAddedActivityItem) => {
+	const community = await Community.findByPk(activityItem.communityId);
+	const communityUrl = urls.communityUrl(community);
+	const pub = await Pub.findByPk(activityItem.pubId);
+	const pubUrl = urls.pubUrl(community, pub, {
+		discussionId: activityItem.payload.discussionId,
+	});
+	return stripIndent(`
+    <p>A comment was added to a discussion you are participating in on PubPub:</p>
+    <p>
+      <a href="${pubUrl}">View Discussion</a>
+    </p>
+    </p><a href="${communityUrl}/legal/settings#notifications">Unsubscribe</a></p>
+  `);
+};
+
+const createEmailForUserNotification = async (notification: types.UserNotification) => {
+	const userNotificationPreferences: types.UserNotificationPreferences =
+		await UserNotificationPreferences.findOne({
+			where: {
+				userId: notification.userId,
+			},
+		});
+	if (!userNotificationPreferences?.receiveNotifications) {
+		return;
+	}
+	const user: types.UserWithPrivateFields = await User.findByPk(notification.userId);
+	const activityItem: types.ActivityItem = await ActivityItem.findByPk(
+		notification.activityItemId,
+	);
+	if (activityItem?.kind === 'pub-discussion-comment-added') {
+		await mg.messages.create('mg.pubpub.org', {
+			from: 'PubPub Team <hello@mg.pubpub.org>',
+			to: [user.email],
+			subject: 'New reply to PubPub discussion',
+			html: await template(activityItem),
+		});
+	}
+};
+
+UserNotification.afterCreate((item: types.UserNotification) => {
+	defer(() => createEmailForUserNotification(item));
+});

--- a/server/userNotification/hooks.ts
+++ b/server/userNotification/hooks.ts
@@ -47,7 +47,7 @@ const template = async (activityItem: types.PubDiscussionCommentAddedActivityIte
 			${actor.fullName} added <a href="${href}">${title}</a> to <a href="${pubUrl}">${pubTitle}</a>.
 		</p>
     <p>
-			<a href="${communityUrl}/legal/settings#notifications">Unsubscribe</a>
+			<a href="${communityUrl}/legal/settings#notification-preferences">Unsubscribe</a>
 		</p>
   `);
 };

--- a/server/userNotificationPreferences/model.ts
+++ b/server/userNotificationPreferences/model.ts
@@ -31,6 +31,11 @@ class UserNotificationPreferences extends Model<
 	@Column(DataType.BOOLEAN)
 	receiveNotifications!: CreationOptional<boolean>;
 
+	@AllowNull(false)
+	@Default(false)
+	@Column(DataType.BOOLEAN)
+	receiveDiscussionThreadEmails!: CreationOptional<boolean>;
+
 	@Column(DataType.DATE)
 	// 	lastReceivedNotificationsAt?: Date | null;
 	lastReceivedNotificationsAt?: any;

--- a/server/userNotificationPreferences/queries.ts
+++ b/server/userNotificationPreferences/queries.ts
@@ -4,6 +4,7 @@ import { pickKeys } from 'utils/objects';
 
 const updatableFields = [
 	'receiveNotifications',
+	'receiveDiscussionThreadEmails',
 	'subscribeToThreadsAsCommenter',
 	'subscribeToPubsAsMember',
 	'subscribeToPubsAsContributor',

--- a/tools/migrations/2023_07_24_addDiscussionThreadEmailNotificationPreference.js
+++ b/tools/migrations/2023_07_24_addDiscussionThreadEmailNotificationPreference.js
@@ -1,0 +1,18 @@
+export const up = async ({ Sequelize, sequelize }) => {
+	await sequelize.queryInterface.addColumn(
+		'UserNotificationPreferences',
+		'receiveDiscussionThreadEmails',
+		{
+			type: Sequelize.BOOLEAN,
+			defaultValue: false,
+			allowNull: false,
+		},
+	);
+};
+
+export const down = async ({ sequelize }) => {
+	await sequelize.queryInterface.removeColumn(
+		'UserNotificationPreferences',
+		'receiveDiscussionThreadEmails',
+	);
+};

--- a/types/userNotification.ts
+++ b/types/userNotification.ts
@@ -30,6 +30,7 @@ export type UserNotificationPreferences = {
 	lastReceivedNotificationsAt: null | string;
 	userId: string;
 	receiveNotifications: boolean;
+	receiveDiscussionThreadEmails: boolean;
 	subscribeToThreadsAsCommenter: boolean;
 	subscribeToPubsAsMember: boolean;
 	subscribeToPubsAsContributor: boolean;


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #2745

This PR adds a new option to receive email notifications for discussions you are subscribed to. Existing notification preferences apply to these new emails, so if you opted out of receiving notifications for discussions threads, you will not get an email when threads receive a reply.

The email contains an Unsubscribe button that, when clicked, redirects to a new Notifications preferences section on the user privacy page.

## Test Plan

1. Log in to PubPub. Enable the "Receive discussion thread emails from PubPub" option using the user Privacy Settings page.
2. Create a Pub.
3. Log into another account in separate browser or private browsing window.
4. Visit the same Pub and create a few discussions/replies. The original user should receive an email with notifications for each new discussion/reply.
5. On the first account, disable the "Receive notifications from PubPub" option.
6. Add a new reply using the second account. The first account _should not_ receive another email notification.

## Screenshots (if applicable)

Email:
<img width="396" alt="Screenshot 2023-07-26 at 2 44 47 PM" src="https://github.com/pubpub/pubpub/assets/6402908/a7c29e39-18d3-471e-96fa-5c593f13fef7">

New setting:
<img width="407" alt="Screenshot 2023-07-26 at 2 34 43 PM" src="https://github.com/pubpub/pubpub/assets/6402908/28f6d6ad-28b4-4be0-805c-9757ead3a306">
