### PR TITLE
dev: revert worker idle to default

### DIFF
--- a/server/sequelize.ts
+++ b/server/sequelize.ts
@@ -23,7 +23,6 @@ const poolOptions = process.env.WORKER
 	? {
 			max: 2,
 			min: 0,
-			idle: 0,
 			acquire: 10000,
 	  }
 	: {


### PR DESCRIPTION
Reverts worker idle to default to try to avoid timeouts when lots of async queries are initiated during a job. The theory is that what's happening is workers are launching a lot of queries, and the second any of them ends the connection is closed and another started. After a few queries, this causes a sequelizeconnectionerror.

To be smoke tested locally and on duqduq prior to release.