### PR TITLE
fix: make `/password-reset` not crash

### DIFF
--- a/server/routes/passwordReset.tsx
+++ b/server/routes/passwordReset.tsx
@@ -9,7 +9,7 @@ import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
 
 app.get(['/password-reset', '/password-reset/:resetHash/:slug'], (req, res, next) => {
 	const findUser = User.findOne({
-		where: { slug: req.params.slug },
+		where: { slug: req.params.slug ?? null },
 	});
 
 	return Promise.all([getInitialData(req), findUser])


### PR DESCRIPTION
Seems to be a semi-common regression in sequelize https://github.com/sequelize/sequelize/issues/15702

## Issue(s) Resolved
https://kfg.sentry.io/issues/4397182310/?project=1505439&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+my_teams%2C+none%5D&referrer=issue-stream&sort=inbox&stream_index=1


## Test Plan

1. Go to /password-reset
2. See it work agian

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
