### PR TITLE
Run all queries in transaction to avoid connection errors

### DIFF
--- a/server/release/queries.ts
+++ b/server/release/queries.ts
@@ -51,12 +51,14 @@ const createDiscussionAnchorsForRelease = async (
 		const discussions = await Discussion.findAll({
 			where: { pubId },
 			attributes: ['id'],
+			transaction: sequelizeTransaction,
 		});
 		const existingAnchors = await DiscussionAnchor.findAll({
 			where: {
 				discussionId: { [Op.in]: discussions.map((d) => d.id) },
 				historyKey: previousRelease.historyKey,
 			},
+			transaction: sequelizeTransaction,
 		});
 		await Promise.all(
 			existingAnchors.map((anchor) =>

--- a/server/release/queries.ts
+++ b/server/release/queries.ts
@@ -44,7 +44,7 @@ const createDiscussionAnchorsForRelease = async (
 	currentHistoryKey: number,
 	sequelizeTransaction: any,
 ) => {
-	const draftRef = await getPubDraftRef(pubId);
+	const draftRef = await getPubDraftRef(pubId, sequelizeTransaction);
 	if (previousRelease) {
 		const steps = await getStepsSinceLastRelease(draftRef, previousRelease, currentHistoryKey);
 		const flatSteps = steps.reduce((a, b) => [...a, ...b], []);

--- a/server/utils/firebaseAdmin.ts
+++ b/server/utils/firebaseAdmin.ts
@@ -46,11 +46,12 @@ export const getDatabaseRef = (key: string): firebase.database.Reference => {
 	return database?.ref(key) as unknown as firebase.database.Reference;
 };
 
-export const getPubDraftRef = async (pubId: string) => {
+export const getPubDraftRef = async (pubId: string, sequelizeTransaction: any = null) => {
 	const pub = expect(
 		await Pub.findOne({
 			where: { id: pubId },
 			include: [{ model: Draft, as: 'draft' }],
+			transaction: sequelizeTransaction,
 		}),
 	);
 	return getDatabaseRef(expect(pub.draft).firebasePath);


### PR DESCRIPTION
~Right now on duqduq, creating a release times out every time with this error: https://kfg.sentry.io/issues/4380557716/events/bc6079257f1e4ee39336b67ff82fbdb0/~ Update: That was fixed by increasing the max connections on dev from 1 to 12. But this still seems like a good idea

According to [this comment](https://github.com/sequelize/sequelize/issues/10858\#issuecomment-549817032) this can happen when queries inside a transaction callback aren't passed the transaction (and are therefore run outside the transaction). 

Sequelize docs: https://sequelize.org/docs/v6/other-topics/transactions/#managed-transactions

## Test Plan
Try creating a release on the review instance

