### PR TITLE
Return 409 instead of 500 for duplicate emails

### DIFF
--- a/server/signup/api.ts
+++ b/server/signup/api.ts
@@ -1,6 +1,6 @@
 import app from 'server/server';
 
-import { createSignup } from './queries';
+import { DuplicateEmailError, createSignup } from './queries';
 
 app.post('/api/signup', (req, res) => {
 	return createSignup(req.body, req.hostname)
@@ -8,6 +8,9 @@ app.post('/api/signup', (req, res) => {
 			return res.status(201).json(true);
 		})
 		.catch((err) => {
+			if (err instanceof DuplicateEmailError) {
+				return res.status(409).json(err.message);
+			}
 			console.error('Error in postSignup: ', err);
 			return res.status(500).json(err.message);
 		});

--- a/server/signup/queries.ts
+++ b/server/signup/queries.ts
@@ -4,6 +4,8 @@ import { sequelize } from 'server/sequelize';
 import { sendSignupEmail } from 'server/utils/email';
 import { expect } from 'utils/assert';
 
+export class DuplicateEmailError extends Error {}
+
 export const createSignup = (inputValues, hostname) => {
 	const email = inputValues.email.toLowerCase().trim();
 	/* First, try to update the emailSentCount. */
@@ -14,7 +16,7 @@ export const createSignup = (inputValues, hostname) => {
 	})
 		.then((userData) => {
 			if (userData) {
-				throw new Error('Email already used');
+				throw new DuplicateEmailError('Email already used');
 			}
 
 			return Signup.update(


### PR DESCRIPTION
## Issue(s) Resolved
Resolves #2807
No real functionality change here, but we should stop seeing those extraneous log messages for something that's not actually an error

## Test Plan

Visit the signup page
Attempt to sign up again with your email address
Observe that the response code is 409 conflict and no log message is printed
