### PR TITLE
fix: throw not found error on /dash/.../impact for invalid collections/pubs instead of crashing

### DIFF
--- a/server/routes/dashboardActivity.tsx
+++ b/server/routes/dashboardActivity.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Html from 'server/Html';
 import app from 'server/server';
-import { ForbiddenError, handleErrors } from 'server/utils/errors';
+import { ForbiddenError, NotFoundError, handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
@@ -23,6 +23,10 @@ app.get(
 					activePermissions: { canView },
 				},
 			} = initialData;
+
+			if (!initialData.scopeData.elements.activeTarget) {
+				throw new NotFoundError();
+			}
 
 			if (!canView) {
 				throw new ForbiddenError();

--- a/server/routes/dashboardCustomScripts.tsx
+++ b/server/routes/dashboardCustomScripts.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Html from 'server/Html';
 import app from 'server/server';
-import { ForbiddenError, handleErrors } from 'server/utils/errors';
+import { ForbiddenError, NotFoundError, handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
@@ -15,6 +15,10 @@ app.get('/dash/scripts', async (req, res, next) => {
 		}
 		const initialData = await getInitialData(req, { isDashboard: true });
 		const { scopeData, communityData } = initialData;
+
+		if (!scopeData.elements.activeTarget) {
+			throw new NotFoundError();
+		}
 
 		if (!scopeData.activePermissions.canAdminCommunity) {
 			throw new ForbiddenError();

--- a/server/routes/dashboardDiscussions.tsx
+++ b/server/routes/dashboardDiscussions.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Html from 'server/Html';
 import app from 'server/server';
-import { handleErrors } from 'server/utils/errors';
+import { NotFoundError, handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
@@ -20,6 +20,9 @@ app.get(
 				return next();
 			}
 			const initialData = await getInitialData(req, { isDashboard: true });
+			if (!initialData.scopeData.elements.activeTarget) {
+				throw new NotFoundError();
+			}
 			// const discussionsData = await getDiscussions(initialData);
 			const discussionsData = {};
 			return renderToNodeStream(

--- a/server/routes/dashboardEdges.tsx
+++ b/server/routes/dashboardEdges.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import app, { wrap } from 'server/server';
 import Html from 'server/Html';
-import { handleErrors, ForbiddenError } from 'server/utils/errors';
+import { handleErrors, ForbiddenError, NotFoundError } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 
@@ -18,6 +18,9 @@ app.get(
 			}
 			const { pubSlug } = req.params;
 			const initialData = await getInitialData(req, { isDashboard: true });
+			if (!initialData.scopeData.elements.activeTarget) {
+				throw new NotFoundError();
+			}
 			const pubData = await getPubForRequest({
 				slug: pubSlug,
 				initialData,

--- a/server/routes/dashboardFacets.tsx
+++ b/server/routes/dashboardFacets.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Html from 'server/Html';
 import app from 'server/server';
-import { handleErrors, ForbiddenError } from 'server/utils/errors';
+import { handleErrors, ForbiddenError, NotFoundError } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
@@ -16,6 +16,9 @@ app.get(
 				return next();
 			}
 			const initialData = await getInitialData(req, { isDashboard: true });
+			if (!initialData.scopeData.elements.activeTarget) {
+				throw new NotFoundError();
+			}
 			const {
 				scopeData: { activePermissions, scope },
 			} = initialData;

--- a/server/routes/dashboardImpact.tsx
+++ b/server/routes/dashboardImpact.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Html from 'server/Html';
 import app from 'server/server';
-import { handleErrors } from 'server/utils/errors';
+import { NotFoundError, handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
@@ -16,6 +16,9 @@ app.get(
 				return next();
 			}
 			const initialData = await getInitialData(req, { isDashboard: true });
+			if (!initialData.scopeData.elements.activeTarget) {
+				throw new NotFoundError();
+			}
 			const { activeTargetType, activeTarget } = initialData.scopeData.elements;
 			const impactData = {
 				baseToken: generateMetabaseToken(activeTargetType, activeTarget.id, 'base'),

--- a/server/routes/dashboardMembers.tsx
+++ b/server/routes/dashboardMembers.tsx
@@ -16,6 +16,10 @@ app.get(
 				return next();
 			}
 			const initialData = await getInitialData(req, { isDashboard: true });
+			if (!initialData.scopeData.elements.activeTarget) {
+				throw new NotFoundError();
+			}
+
 			const membersData = await getMembers(initialData);
 
 			if (!initialData.scopeData.activePermissions.canView) {

--- a/server/routes/dashboardPage.tsx
+++ b/server/routes/dashboardPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Html from 'server/Html';
 import app from 'server/server';
-import { handleErrors, ForbiddenError } from 'server/utils/errors';
+import { handleErrors, ForbiddenError, NotFoundError } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
@@ -15,10 +15,7 @@ app.get(['/dash/pages/:subMode'], async (req, res, next) => {
 		}
 		const initialData = await getInitialData(req, { isDashboard: true });
 
-		if (
-			!initialData.scopeData.activePermissions.canView ||
-			!initialData.scopeData.elements.activeTarget
-		) {
+		if (!initialData.scopeData.activePermissions.canView) {
 			throw new ForbiddenError();
 		}
 
@@ -27,6 +24,11 @@ app.get(['/dash/pages/:subMode'], async (req, res, next) => {
 			query: { slug: pageSlug },
 			initialData,
 		});
+
+		if (!pageData.id) {
+			throw new NotFoundError();
+		}
+
 		return renderToNodeStream(
 			res,
 			<Html

--- a/server/routes/dashboardPage.tsx
+++ b/server/routes/dashboardPage.tsx
@@ -15,7 +15,10 @@ app.get(['/dash/pages/:subMode'], async (req, res, next) => {
 		}
 		const initialData = await getInitialData(req, { isDashboard: true });
 
-		if (!initialData.scopeData.activePermissions.canView) {
+		if (
+			!initialData.scopeData.activePermissions.canView ||
+			!initialData.scopeData.elements.activeTarget
+		) {
 			throw new ForbiddenError();
 		}
 

--- a/server/routes/dashboardPages.tsx
+++ b/server/routes/dashboardPages.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Html from 'server/Html';
 import app from 'server/server';
-import { NotFoundError, handleErrors } from 'server/utils/errors';
+import { handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
@@ -14,9 +14,6 @@ app.get(['/dash/pages'], async (req, res, next) => {
 			return next();
 		}
 		const initialData = await getInitialData(req, { isDashboard: true });
-		if (!initialData.scopeData.elements.activeTarget) {
-			throw new NotFoundError();
-		}
 		// const pagesData = await getPages(initialData);
 		return renderToNodeStream(
 			res,

--- a/server/routes/dashboardPages.tsx
+++ b/server/routes/dashboardPages.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Html from 'server/Html';
 import app from 'server/server';
-import { handleErrors } from 'server/utils/errors';
+import { NotFoundError, handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
@@ -14,6 +14,9 @@ app.get(['/dash/pages'], async (req, res, next) => {
 			return next();
 		}
 		const initialData = await getInitialData(req, { isDashboard: true });
+		if (!initialData.scopeData.elements.activeTarget) {
+			throw new NotFoundError();
+		}
 		// const pagesData = await getPages(initialData);
 		return renderToNodeStream(
 			res,

--- a/server/routes/dashboardReview.tsx
+++ b/server/routes/dashboardReview.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Html from 'server/Html';
 import app from 'server/server';
-import { handleErrors } from 'server/utils/errors';
+import { NotFoundError, handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
@@ -15,6 +15,9 @@ app.get(['/dash/pub/:pubSlug/reviews/:reviewNumber'], async (req, res, next) => 
 		}
 		const initialData = await getInitialData(req, { isDashboard: true });
 		const { scopeData, loginData } = initialData;
+		if (!initialData.scopeData.elements.activeTarget) {
+			throw new NotFoundError();
+		}
 		const { pubSlug, reviewNumber } = req.params;
 		const reviewData = await getReview(
 			pubSlug,
@@ -37,7 +40,7 @@ app.get(['/dash/pub/:pubSlug/reviews/:reviewNumber'], async (req, res, next) => 
 				viewData={{ reviewData: sanitizedReviewData }}
 				headerComponents={generateMetaComponents({
 					initialData,
-					title: `Review ${req.params.reviewNumber} · ${initialData.scopeData.elements.activeTarget.title}`,
+					title: `Review ${req.params.reviewNumber} · ${initialData.scopeData.elements.activeTarget?.title}`,
 					unlisted: true,
 				})}
 			/>,

--- a/server/routes/dashboardReviews.tsx
+++ b/server/routes/dashboardReviews.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Html from 'server/Html';
 import { getManyPubs } from 'server/pub/queryMany';
 import app from 'server/server';
-import { handleErrors } from 'server/utils/errors';
+import { NotFoundError, handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
@@ -37,6 +37,9 @@ app.get(
 				return next();
 			}
 			const initialData = await getInitialData(req, { isDashboard: true });
+			if (!initialData.scopeData.elements.activeTarget) {
+				throw new NotFoundError();
+			}
 			const pubsWithReviews = await getPubsWithReviews(initialData);
 			return renderToNodeStream(
 				res,

--- a/server/routes/dashboardSettings.tsx
+++ b/server/routes/dashboardSettings.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Html from 'server/Html';
 import app from 'server/server';
-import { handleErrors, ForbiddenError } from 'server/utils/errors';
+import { handleErrors, ForbiddenError, NotFoundError } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
@@ -41,6 +41,10 @@ app.get(
 				return next();
 			}
 			const initialData = await getInitialData(req, { isDashboard: true });
+			if (!initialData.scopeData.elements.activeTarget) {
+				throw new NotFoundError();
+			}
+
 			const settingsData = await getSettingsData(req.params.pubSlug, initialData);
 
 			if (!initialData.scopeData.activePermissions.canView) {

--- a/server/routes/dashboardSubmissions.tsx
+++ b/server/routes/dashboardSubmissions.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Html from 'server/Html';
 import app from 'server/server';
-import { ForbiddenError, handleErrors } from 'server/utils/errors';
+import { ForbiddenError, NotFoundError, handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { hostIsValid } from 'server/utils/routes';
 import { generateMetaComponents, renderToNodeStream } from 'server/utils/ssr';
@@ -51,6 +51,10 @@ app.get(
 			}
 
 			const initialData = await getInitialData(req, { isDashboard: true });
+			if (!initialData.scopeData.elements.activeTarget) {
+				throw new NotFoundError();
+			}
+
 			if (!initialData.featureFlags.submissions) {
 				return next();
 			}

--- a/server/utils/queryHelpers/pageGet.ts
+++ b/server/utils/queryHelpers/pageGet.ts
@@ -2,7 +2,6 @@ import { Page } from 'server/models';
 
 import { enrichLayoutBlocksWithPubTokens, getLayoutPubsByBlock } from 'server/utils/layouts';
 import { InitialData } from 'types';
-import { expect } from 'utils/assert';
 
 export default async ({ query, initialData }: { query: any; initialData: InitialData }) => {
 	const pageData = await Page.findOne({

--- a/server/utils/queryHelpers/pageGet.ts
+++ b/server/utils/queryHelpers/pageGet.ts
@@ -5,25 +5,23 @@ import { InitialData } from 'types';
 import { expect } from 'utils/assert';
 
 export default async ({ query, initialData }: { query: any; initialData: InitialData }) => {
-	const pageData = expect(
-		await Page.findOne({
-			where: {
-				...query,
-				communityId: initialData.communityData.id,
-			},
-		}),
-	);
+	const pageData = await Page.findOne({
+		where: {
+			...query,
+			communityId: initialData.communityData.id,
+		},
+	});
 
 	const layoutPubsByBlock = await getLayoutPubsByBlock({
-		allowDuplicatePubs: pageData.layoutAllowsDuplicatePubs,
-		blocks: pageData.layout || [],
+		allowDuplicatePubs: pageData?.layoutAllowsDuplicatePubs!,
+		blocks: pageData?.layout || [],
 		initialData,
 	});
 
 	return {
-		...pageData.toJSON(),
+		...pageData?.toJSON(),
 		layout: enrichLayoutBlocksWithPubTokens({
-			blocks: pageData.layout,
+			blocks: pageData?.layout,
 			initialData,
 		} as any),
 		layoutPubsByBlock,


### PR DESCRIPTION
Fixes errors like these: https://kfg.sentry.io/issues/4405829345/?project=1505439&query=is%3Aunresolved+cannot+read+properties+of+null&referrer=issue-stream&statsPeriod=14d&stream_index=0


## Issue(s) Resolved

## Test Plan
1. Go to random community
2. Go to /dash/collection/some-name/impact
3. See if you get "Not found"  instead of Application Error
4. Go to /dash/pub/some-name/impact
5. See if you get "Not found" instead of Application Error

Ideally also check for
/dash/.../some-name/settings
.../members
.../facets
.../submissions
.../reviews
.../activity

## Screenshots (if applicable)
### Before
<img width="889" alt="image" src="https://github.com/pubpub/pubpub/assets/21983833/fe823dfb-e35f-4ac0-a265-ef406e1f66b4">

### After
<img width="778" alt="image" src="https://github.com/pubpub/pubpub/assets/21983833/68f6a68e-d505-4475-93d6-7c9c154bc9d4">


## Optional

### Notes/Context/Gotchas

### Supporting Docs
