### PR TITLE
fix: add DOI and elocation to JATS even if no primary collection

### DIFF
--- a/workers/tasks/export/pandoc.ts
+++ b/workers/tasks/export/pandoc.ts
@@ -125,16 +125,16 @@ const createYamlMetadataFile = async (pubMetadata: PubMetadata, pandocTarget: Pa
 		},
 		affiliation: formattedAffiliations,
 		uri: pubUrl,
-		...(primaryCollectionMetadata && {
-			article: {
+		article: {
+			...(doi && { doi }),
+			'elocation-id': slug,
+			...(primaryCollectionMetadata && {
 				...(primaryCollectionMetadata.issue && { issue: primaryCollectionMetadata.issue }),
 				...(primaryCollectionMetadata.volume && {
 					volume: primaryCollectionMetadata.volume,
 				}),
-				...(doi && { doi }),
-				'elocation-id': slug,
-			},
-		}),
+			}),
+		},
 		'link-citations': true, // See https://github.com/jgm/pandoc/issues/6013#issuecomment-921409135
 		...(cslFile && { csl: cslFile }),
 	});


### PR DESCRIPTION
Fixes a small logic error where we were only including the DOI and elocation in JATS exports if the Pub was in a primary collection. This could cause Pubs with DOIs but without primary collections (e.g. https://baas.aas.org/pub/httpsbaasaasorgpub2023i025/release/1) to export JATS with no DOIs.

## Issue(s) Resolved
#2792 

## Test Plan
1. Visit a Pub with a DOI that is not in a primary collection (e.g. `/pub/httpsbaasaasorgpub2023i019`)
2. Clear its JATS exports in the DB (or create a new release)
3. Download JATS
4. Verify that elocation and DOI appear in the JATS
5. Visit a Pub with a DOI that is in a primary collection (e.g. `/pub/2022i091/release/1`)
6. Clear its JATS exports in the DB (or create a new release)
7. Download JATS
8. Verify that elocation, DOI and issue metadata (e.g. Volume and Issue) appear in the JATS
9. Visit or create a Pub without a DOI
10. Make sure JATS download succeeds and elocation is present in JATS
11. Add to a primary collection
12. Make sure JATS download succeeds and elocation (and any collection metadata) is present in JATS

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
