### PR TITLE
fix: Don't export pubs with historyKey > latest

### DIFF
--- a/server/export/queries.ts
+++ b/server/export/queries.ts
@@ -12,7 +12,7 @@ export const getOrStartExportTask = async ({ pubId, format, historyKey }) => {
 			pubId,
 			format,
 			historyKey: {
-				[Sequelize.Op.gte]: historyKey,
+				[Sequelize.Op.eq]: historyKey,
 			},
 		},
 		include: [{ model: WorkerTask, as: 'workerTask' }],

--- a/tools/exportCollection.js
+++ b/tools/exportCollection.js
@@ -4,7 +4,7 @@ import fetch from 'node-fetch';
 
 import { Collection, CollectionPub } from 'server/models';
 import { getBestDownloadUrl } from 'utils/pub/downloads';
-import { createLatestPubExports } from 'server/export/queries';
+import { createPubExportsForLatestRelease } from 'server/export/queries';
 import { getPubData } from 'server/rss/queries';
 
 import { promptOkay } from './utils/prompt';
@@ -31,7 +31,7 @@ const getPubExports = async (pubId, dest) => {
 		function.
 		*/
 		console.log('Missing:', pubData.slug);
-		await createLatestPubExports(pubId);
+		await createPubExportsForLatestRelease(pubId);
 		await getPubExports(pubId, dest);
 	} else {
 		fs.mkdirSync(finalDest);

--- a/tools/exportCollection.js
+++ b/tools/exportCollection.js
@@ -25,11 +25,6 @@ const getPubExports = async (pubId, dest) => {
 	const finalDest = `${dest}/${pubData.slug}`;
 
 	if (!pdfUrl || !jatsUrl) {
-		/* Note: for some very old pubs, this will fail for JATS becauseo of some historykey
-		mismatch issues. The workaround is to, for those pubs, go into the db and match the
-		historykey of the generated export to the one expected by the getPublicExport URL
-		function.
-		*/
 		console.log('Missing:', pubData.slug);
 		await createPubExportsForLatestRelease(pubId);
 		await getPubExports(pubId, dest);

--- a/utils/pub/downloads.js
+++ b/utils/pub/downloads.js
@@ -23,7 +23,7 @@ export const getPublicExportUrl = (pubData, format) => {
 		const latestHistoryKey = releases.map((r) => r.historyKey).reduce((a, b) => Math.max(a, b));
 		if (typeof latestHistoryKey === 'number') {
 			const validExport = exports.find(
-				(exp) => exp.historyKey === latestHistoryKey && exp.format === format,
+				(exp) => exp.historyKey >= latestHistoryKey && exp.format === format,
 			);
 			if (validExport) {
 				return validExport.url;

--- a/utils/pub/downloads.js
+++ b/utils/pub/downloads.js
@@ -23,7 +23,7 @@ export const getPublicExportUrl = (pubData, format) => {
 		const latestHistoryKey = releases.map((r) => r.historyKey).reduce((a, b) => Math.max(a, b));
 		if (typeof latestHistoryKey === 'number') {
 			const validExport = exports.find(
-				(exp) => exp.historyKey >= latestHistoryKey && exp.format === format,
+				(exp) => exp.historyKey === latestHistoryKey && exp.format === format,
 			);
 			if (validExport) {
 				return validExport.url;


### PR DESCRIPTION
This fixes what I think was a potentially problematic issue with download behavior. Previously, the `/api/export` query returned a valid download if the historyKey of the latest export was greater or equal than the historyKey sent to the query. Though rare, this could create the condition where, if a Pub's latest release exports failed, or was deleted prior to regeneration, and an export on a draft had subsequently been created, the API would effectively leak draft exports.

This fixes that gap by only returning matched exports if the historyKey sent to the query matches a historyKey in the database. I think this may also solve some of the sentry errors related to download routes, e.g. https://kfg.sentry.io/issues/3913456206/?project=1505439&query=is%3Aunresolved&referrer=issue-stream&stream_index=11)

It also fixes my exportCollection tool, which is how I found the issue. Previously, the tool created exports from the latest historyKey on the pub, not the latest release historyKey, which caused the issue of never being able to return exports for some releases (because the historyKey of the latest export was greater than the historyKey of the latest release, and there was a mismatch between the API query and the `getPublicExportUrl` function in `/utils/pub/downloads.ts` used in rss, and download routes that caused `getPublicExportUrl` to never resolve if the historyKey condition described above was true).

## Issue(s) Resolved

## Test Plan
- Verify that export behavior works as expected for existing Pubs with releases with drafts, and with download routes (e.g. /pub/download/pdf).
- Verify that RSS feeds contain expected downloads.
- Create a new release on a Pub that already has one and verify that a new export is created.
- Open the draft of a Pub that has a release in it. Change the draft in a noticeable way and download an export. Make sure the change is reflected.
- Return to the release of the Pub and download the same export type. Make sure the release export is returned.
- Visit the exports db table for this Pub and find the second-to-last history key export for the type of export you created. Delete it. Effectively, you have deleted the export for the release of the Pub, but left the export for the draft, which has a later historyKey.
- From the release of the Pub, download the same export type again. Make sure a new export is generated, and it matches the contents of the release.
- Visit the download route for the pub and format you exported (`pub/slug/download/format`) and make sure it returns the release export, not the draft export.
- Verify that the RSS feed contains the release download.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
