### PR TITLE
fix: move workflow target emails to cc; add Reply-To for first target address

### DIFF
--- a/server/submission/emails.tsx
+++ b/server/submission/emails.tsx
@@ -92,9 +92,11 @@ export const sendSubmissionEmail = async (options: SendEmailOptions) => {
 		);
 		await sendEmail({
 			from: { address: 'submissions@mg.pubpub.org', name: `PubPub Submissions` },
-			to: [...submitterEmails, ...submissionWorkflow.targetEmailAddresses],
+			to: submitterEmails,
+			cc: submissionWorkflow.targetEmailAddresses,
 			subject: `Your submission to ${community.title}`,
 			html,
+			replyTo: submissionWorkflow.targetEmailAddresses[0],
 		});
 	}
 };

--- a/server/utils/email/reset.ts
+++ b/server/utils/email/reset.ts
@@ -11,7 +11,9 @@ type Body = { text: string } | { html: string };
 
 type SendEmailOptions = {
 	from?: From;
+	replyTo?: string;
 	to: string[];
+	cc?: string[];
 	subject: string;
 } & Body;
 
@@ -27,6 +29,8 @@ export const sendEmail = (options: SendEmailOptions) => {
 		from: `${from.name} <${from.address}>`,
 		to,
 		subject,
+		...('replyTo' in options && { 'h:Reply-To': options.replyTo }),
+		...('cc' in options && { cc: options.cc }),
 		...body,
 	});
 };


### PR DESCRIPTION
## Issue(s) Resolved

Implements expected behavior addressed by #2776.

## Test Plan

1. Enable submissions for a collection.
2. Add a personal email address to the list of addresses to be CC'd when a Pub is submitted (target email addresses).
3. Submit a Pub to the collection.
4. Confirm the submitter's email address recieves a message with all target email addresses CC'd.
5. Reply to the email from the submitter's email address. The first target email address should receive this email.