### PR TITLE
Set release for frontend sourcemap uploads

### DIFF
--- a/client/webpack/webpackConfig.prod.js
+++ b/client/webpack/webpackConfig.prod.js
@@ -114,6 +114,9 @@ module.exports = {
 						errorHandler: (err) => {
 							console.warn(err);
 						},
+						release: {
+							name: process.env.SOURCE_VERSION,
+						},
 					}),
 			  ]),
 	],

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"tools": "NODE_PATH=./client:./ node -r ts-node/register/transpile-only -r esm --max-old-space-size=12000 ./tools",
 		"workers-dev": "NODE_PATH=./dist/server/client:./dist/server WORKER=true nodemon dist/server/workers/init --watch workers -e js",
 		"workers-prod": "NODE_PATH=./dist/server/client:./dist/server WORKER=true node --enable-source-maps dist/server/workers/init",
-		"upload-sentry-sourcemaps": "sentry-cli sourcemaps inject -p pubpub-v6 dist/server && sentry-cli releases files -p pubpub-v6 $SOURCE_VERSION upload-sourcemaps --url-prefix /app/dist --strip-common-prefix --wait dist/server",
+		"upload-sentry-sourcemaps": "sentry-cli sourcemaps inject -p pubpub-v6 dist/server && sentry-cli releases files -p pubpub-v6 $SOURCE_VERSION upload-sourcemaps --url-prefix /app --strip-common-prefix --wait dist/server",
 		"write-commit-version": "echo $SOURCE_VERSION > .app-commit"
 	},
 	"dependencies": {


### PR DESCRIPTION
Right now our stack traces are showing filenames just prefixed with `/app` rather than `/app/dist` as I thought before. This PR adjusts that path.

Example issue: https://kfg.sentry.io/issues/4443846320/events/053d757956f641f5a4c89a1892c87667/

It also explicitly sets a release for the frontend files because the plugin isn't detecting the heroku env vars.