### PR TITLE
hotfix: Add cache cookie and cachebuster to user signup

### DIFF
--- a/client/containers/UserCreate/UserCreate.tsx
+++ b/client/containers/UserCreate/UserCreate.tsx
@@ -69,7 +69,8 @@ const UserCreate = (props: Props) => {
 			}),
 		})
 			.then(() => {
-				window.location.href = '/';
+				const cacheBreaker = Math.round(new Date().getTime() / 1000);
+				window.location.href = `/?breakCache=${cacheBreaker}`;
 			})
 			.catch((err) => {
 				setPostUserIsLoading(false);

--- a/server/user/api.ts
+++ b/server/user/api.ts
@@ -3,6 +3,7 @@ import passport from 'passport';
 import app, { wrap } from 'server/server';
 import { ForbiddenError, NotFoundError } from 'server/utils/errors';
 
+import { isProd, isDuqDuq } from 'utils/environment';
 import { getPermissions } from './permissions';
 import { createUser, updateUser, getSuggestedEditsUserInfo } from './queries';
 
@@ -27,6 +28,13 @@ app.post('/api/users', (req, res) => {
 		})
 		.then((newUser) => {
 			passport.authenticate('local')(req, res, () => {
+				res.cookie('pp-cache', 'pp-no-cache', {
+					...(isProd() &&
+						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.pubpub.org' }),
+					...(isDuqDuq() &&
+						req.hostname.indexOf('pubpub.org') > -1 && { domain: '.duqduq.org' }),
+					maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days to match login cookies
+				});
 				return res.status(201).json(newUser);
 			});
 		})


### PR DESCRIPTION
## Issue(s) Resolved
Previously, newly created users were not receiving the cache cookie but were being logged in. When this coincided with a cache refresh, it meant logged in pages were sometimes cached and displayed to other users. This fixes that problem by adding the cache cookie on user signup and a cachebreaker to the redirect.

## Test Plan
1. Create new user locally.
2. Make sure the request to the users endpoint returns a `pp-no-cache` cookie.
3. Make sure the redirect request contains `pp-no-cache`
4. Repeat on duqduq, making sure that after new user creation, accessing duqduq from incognito doesn't load as if you are that new user.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
