### PR TITLE
hotfix: Get inlineCitationStyles from facets

### DIFF
--- a/workers/tasks/export/metadata.ts
+++ b/workers/tasks/export/metadata.ts
@@ -87,7 +87,6 @@ export const getPubMetadata = async (pubId: string): Promise<PubMetadata> => {
 	const updatedDateString = updatedDate && dateFormat(updatedDate, 'mmm dd, yyyy');
 	const primaryCollection = getPrimaryCollection(pubData.collectionPubs);
 	const attributions = getAllPubContributors(pubData, 'contributors', false, true);
-
 	return {
 		title: pubData.title,
 		slug: pubData.slug,
@@ -102,10 +101,8 @@ export const getPubMetadata = async (pubId: string): Promise<PubMetadata> => {
 		),
 		accentColor: pubData.community.accentColorDark,
 		attributions,
-		// @ts-expect-error: FIXME: Citationstyle is not in the model, its in the facets
-		citationStyle: pubData.citationStyle,
-		// @ts-expect-error: FIXME: CitationInlineStyle is not in the model, its in the facets
-		citationInlineStyle: pubData.citationInlineStyle,
+		citationStyle: facets.CitationStyle.value.citationStyle,
+		citationInlineStyle: facets.CitationStyle.value.inlineCitationStyle,
 		nodeLabels: facets.NodeLabels.value,
 		publisher: pubData.community.publishAs,
 		...getPrimaryCollectionMetadata(pubData.collectionPubs),


### PR DESCRIPTION
## Issue(s) Resolved
#2854 

Type changes introduced in #2793 caused styles to be undefined in exports, causing them to always export [1], etc. unless a custom style was set on the citation. This restores citation styles.

## Test Plan

- Create a pub and set a citation style.
- Export to word and pdf. Make sure citation style matches export.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
