### PR TITLE
Hotfix: allow multiple custom labels for the same reference in PDF exports

### DIFF
--- a/workers/tasks/export/html.tsx
+++ b/workers/tasks/export/html.tsx
@@ -94,7 +94,7 @@ const addAttrsToNodes = (newAttrs, matchNodeTypes, nodes) =>
 const getCitationLinkage = (unstructuredValue, structuredValue, nodeId = null) => {
 	const digest = digestCitation(unstructuredValue, structuredValue);
 	return {
-		inlineElementId: `citation-${digest}${nodeId && '-' + nodeId}-inline`,
+		inlineElementId: `citation-${digest}${nodeId ? '-' + nodeId : ''}-inline`,
 		bottomElementId: `citation-${digest}-bottom`,
 	};
 };

--- a/workers/tasks/export/html.tsx
+++ b/workers/tasks/export/html.tsx
@@ -91,10 +91,10 @@ const addAttrsToNodes = (newAttrs, matchNodeTypes, nodes) =>
 		return node;
 	});
 
-const getCitationLinkage = (unstructuredValue, structuredValue) => {
+const getCitationLinkage = (unstructuredValue, structuredValue, nodeId = null) => {
 	const digest = digestCitation(unstructuredValue, structuredValue);
 	return {
-		inlineElementId: `citation-${digest}-inline`,
+		inlineElementId: `citation-${digest}${nodeId && '-' + nodeId}-inline`,
 		bottomElementId: `citation-${digest}-bottom`,
 	};
 };
@@ -114,6 +114,7 @@ const addHrefsToNotes = (nodes) => {
 				const { inlineElementId, bottomElementId } = getCitationLinkage(
 					node.attrs.unstructuredValue,
 					node.attrs.value,
+					node.attrs.id,
 				);
 				return {
 					href: `#${bottomElementId}`,
@@ -322,7 +323,11 @@ export const renderStaticHtml = async (options: RenderStaticHtmlOptions) => {
 								title="References"
 								notes={renderedNotes.citations}
 								getLinkage={(note) =>
-									getCitationLinkage(note.unstructuredValue, note.structuredValue)
+									getCitationLinkage(
+										note.unstructuredValue,
+										note.structuredValue,
+										note.id,
+									)
 								}
 							/>
 						</div>


### PR DESCRIPTION
## Issue(s) Resolved

Currently, if you have two of the same references in a document with two different custom inline citation labels, and export to PDF/HTML, it will always export the PDF/HTML so that every inline citation label for that reference is the last custom label, rather than using the custom label for each one. 

The reason is that during the process of creating the HTML document which gets turned into a PDF, we are giving every inline citation with the same "fingerprint" -- e.g. the same reference -- the same ID, which when run through prosemirror-reactive, results in every node with that ID being replaced with the last version of the node. The result is a PDF/HTML export that deviates from the intent in the pub. Minimal example:

**Pub with multiple citations of the same reference with different custom labels**
<img width="327" alt="Screenshot 2023-10-09 at 16 18 48" src="https://github.com/pubpub/pubpub/assets/639110/bc01a712-3e9f-486d-86d3-af5a5614e0ec">

**Exported PDF version**
<img width="298" alt="Screenshot 2023-10-09 at 16 19 14" src="https://github.com/pubpub/pubpub/assets/639110/aa7e118a-78c8-44dd-9bd2-051e5ebc1ff0">

This PR fixes that by adding the original prosemirror node ID to the ID generated during the HTML/PDF conversion process. This means that if there are multiple citations in HTML/PDF, the "return" link in the footer reference list will always only go to the first such citation. Ideally, we'd probably list multiple return arrows? Maybe? But there's actually not a great UX solution for that, and this hotfix seems acceptable for now.

## Test Plan
1. Export a Pub with multiple citations with custom labels for the same reference to PDF/HTML. I have two examples below.
2. Make sure all the custom references show as expected in the PDF, e.g., match the Pub.
3. Make generated footer list is not duplicated (note: maximal example has two footer lists due to HDSR replicating footer list in text).

Minimal example (HDSR local/duqduq community): http://localhost:9876/pub/tlaq5hmc/draft

Maximal example (HDSR local/duqduq community): http://localhost:9876/pub/cuqeguoe/draft

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
