### PR TITLE
fix: make newer version of prosemirror-tables work by also using `esbuild-loader` in prod 

### DIFF
--- a/client/webpack/webpackConfig.prod.js
+++ b/client/webpack/webpackConfig.prod.js
@@ -54,8 +54,13 @@ module.exports = {
 					resolve(__dirname, '../../types'),
 					resolve(__dirname, '../../facets'),
 				],
-				loader: 'ts-loader',
-				options: { configFile: resolve(__dirname, '../../tsconfig.client.json') },
+				loader: 'esbuild-loader',
+				/**
+				 * @type {import('esbuild-loader').LoaderOptions}
+				 */
+				options: {
+					tsconfig: resolve(__dirname, '../../tsconfig.client.json'),
+				},
 			},
 			{
 				test: /\.scss$/,


### PR DESCRIPTION
## Issue(s) Resolved
Some tables could not be rendered in prod because of `prosemirror-tables` switching to ES6 Classes.
`ts-loader` transpiles our classes to functions, but not those of our dependencies, which causes an issue when we are extending external classes that use native ES6 classes.

Basically
```ts
import { TableView } from 'prosemirror-tables'

export class OurTableView extends TableView {
        constructor(){
              super()
        }
}
```

`OurTableView` gets transpiled to `es5` as per our `tsconfig.client.json`, but `TableView` isn't, which causes errors like

`Uncaught TypeError: Class constructor TableView cannot be invoked without 'new'`

because the transpiled `ES5` code is doing something like `TableView.call(null)`, which ya can't do.




## Test Plan

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
