### PR TITLE
fix: remove permission check for get user endpoint

### DIFF
--- a/client/containers/Pub/PubDocument/PubInlineSuggestedEdits.tsx
+++ b/client/containers/Pub/PubDocument/PubInlineSuggestedEdits.tsx
@@ -50,9 +50,7 @@ const PubInlineSuggestedEdits = () => {
 	const fetchSuggestedEditsUserInfo = useCallback(async () => {
 		if (selectedSuggestion) {
 			const suggestionUser: SuggestedEditsUser = await apiFetch.get(
-				`/api/users?suggestionUserId=${encodeURIComponent(
-					selectedSuggestion.suggestionUserId,
-				)}`,
+				`/api/users/${encodeURIComponent(selectedSuggestion.suggestionUserId)}`,
 			);
 			if (suggestionUser) {
 				setSuggestionAuthor(suggestionUser);

--- a/server/user/__tests__/api.test.ts
+++ b/server/user/__tests__/api.test.ts
@@ -46,7 +46,7 @@ describe('/api/users', () => {
 	it('allows an exisiting user to read another users profile info', async () => {
 		const { user, suggestionUser } = models;
 		const agent = await login(user);
-		const res = await agent.get(`/api/users/${suggestionUser.id}`).send({ userId: user.id });
+		const res = await agent.get(`/api/users/${suggestionUser.id}`);
 		const suggestedUserInfo = res.body;
 		expect(suggestedUserInfo).toEqual({
 			fullName: suggestionUser.fullName,

--- a/server/user/__tests__/api.test.ts
+++ b/server/user/__tests__/api.test.ts
@@ -46,9 +46,7 @@ describe('/api/users', () => {
 	it('allows an exisiting user to read another users profile info', async () => {
 		const { user, suggestionUser } = models;
 		const agent = await login(user);
-		const res = await agent
-			.get(`/api/users?suggestionUserId=${suggestionUser.id}`)
-			.send({ userId: user.id });
+		const res = await agent.get(`/api/users/${suggestionUser.id}`).send({ userId: user.id });
 		const suggestedUserInfo = res.body;
 		expect(suggestedUserInfo).toEqual({
 			fullName: suggestionUser.fullName,

--- a/server/user/api.ts
+++ b/server/user/api.ts
@@ -1,7 +1,7 @@
 import passport from 'passport';
 
 import app, { wrap } from 'server/server';
-import { ForbiddenError, NotFoundError } from 'server/utils/errors';
+import { NotFoundError } from 'server/utils/errors';
 
 import { isProd, isDuqDuq } from 'utils/environment';
 import { getPermissions } from './permissions';
@@ -47,22 +47,17 @@ app.post('/api/users', (req, res) => {
 app.get(
 	'/api/users',
 	wrap(async (req, res) => {
-		const requestIds = getRequestIds(req);
-		const permissions = await getPermissions(requestIds);
-		if (!permissions.read) {
-			throw new ForbiddenError();
-		}
 		const { suggestionUserId } = req.query;
 		if (!suggestionUserId) {
 			throw new NotFoundError();
 		}
 
 		const userInfo = await getSuggestedEditsUserInfo(suggestionUserId);
-		if (userInfo) {
-			return res.status(201).json(userInfo);
+		if (!userInfo) {
+			throw new NotFoundError();
 		}
 
-		throw new NotFoundError();
+		return res.status(201).json(userInfo);
 	}),
 );
 

--- a/server/user/api.ts
+++ b/server/user/api.ts
@@ -45,14 +45,14 @@ app.post('/api/users', (req, res) => {
 });
 
 app.get(
-	'/api/users',
+	'/api/users/:id',
 	wrap(async (req, res) => {
-		const { suggestionUserId } = req.query;
-		if (!suggestionUserId) {
+		const { id } = req.params;
+		if (!id) {
 			throw new NotFoundError();
 		}
 
-		const userInfo = await getSuggestedEditsUserInfo(suggestionUserId);
+		const userInfo = await getSuggestedEditsUserInfo(id);
 		if (!userInfo) {
 			throw new NotFoundError();
 		}


### PR DESCRIPTION
## Issue(s) Resolved
#2861 

## Test Plan
Modified existing test to work properly.

Otherwise:
1. Go to Draft with suggested edits enabled (to be disclosed URL) as a non-super admin user
2. Create some suggested edits
3. Hover over them checkmark
4. Should say "Approve edit suggested by <name>" instead of just "Approve edit"


## Notes/Context/Gotchas

This was caused by the permissions never returning `{ read: true}` except for superadmins, not even for looking at your own user information, because that data was never passed to the permissions.

The "user you are looking at" is supposed to be extracted by this `getRequestIdsFunction`, the `submittedUserId`
https://github.com/pubpub/pubpub/blob/bbf520c08d7e7ccc2908b7d38bc05dd35bb8b9b7/server/user/api.ts#L10C1-L18C3

However, it extracts that from the `body`, which a `GET` request isn't supposed to have, so no `submittedUserId` is used during the `GET` request.

Even if it did though, you would only have permission to read if the suggested user is you, or you are a superadmin.
https://github.com/pubpub/pubpub/blob/bbf520c08d7e7ccc2908b7d38bc05dd35bb8b9b7/server/user/permissions.ts#L45-L51

Since this is not really the behavior that is desired from this endpoint (you would only be able to see your own name), I changed it (consulting @kalilsn and @3mcd) to _remove_ the permissions check here.
This way, anyone is able to request the suggestedEdit user data.

This was deemed acceptable as we only expose the name and avatar, information which isn't private to begin with on PubPub as anyone can search users and get this information. The only change is that this can now be done if you know the user's id.

Hope that's okay with you @gabestein !

### Changing the path

I also changed the API route structure to match the new [GET routes](#2868), so from

```
GET /api/users?suggestedUserId=<userId>
```
to

```
GET /api/users/<userId>
```

and updated all the uses of this route to match that.

Not a super important change given that this route is only used for the suggested edits, but stillo

### Why did the test work before

There was a test that was supposed to check whether a user is able to get another user's info, however it sent a `GET` request with a body of `{userId: <the current user>}`, which would pass the check, as the requesting user is allowed to request their own info.
However, that probably isn't how the API is intended to be used, I didn't even know you could send `GET` requests with a body!

I changed the test to fit the new API route structure and to not send the `userId` in the body. 