### PR TITLE
Send less data to our monitoring services

### DIFF
--- a/init.js
+++ b/init.js
@@ -13,10 +13,6 @@ const main = async () => {
 		await setupLocalDatabase();
 	}
 
-	if (process.env.NODE_ENV === 'production') {
-		require('newrelic');
-	}
-
 	const loadServer = () => {
 		return require('./dist/server/server/server').startServer();
 	};

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,6 @@
 				"mailgun.js": "^2.0.1",
 				"mudder": "^1.0.4",
 				"mutationobserver-shim": "^0.3.3",
-				"newrelic": "^5.7.0",
 				"no-slash": "^1.2.15",
 				"node-fetch": "^2.6.7",
 				"passport": "^0.5.0",
@@ -6104,52 +6103,6 @@
 			"integrity": "sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==",
 			"dev": true
 		},
-		"node_modules/@newrelic/koa": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-1.0.8.tgz",
-			"integrity": "sha512-kY//FlLQkGdUIKEeGJlyY3dJRU63EG77YIa48ACMGZxQbWRd3WZMikyft33f8XScTq6WpCDo9xa0viNo8zeYkg==",
-			"dependencies": {
-				"methods": "^1.1.2"
-			},
-			"peerDependencies": {
-				"newrelic": ">=3.3.1"
-			}
-		},
-		"node_modules/@newrelic/native-metrics": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-4.1.0.tgz",
-			"integrity": "sha512-7CZlKMLuaYQW7mV9qVyo9b9HVe2xBnyn+kkETRJoZGs5P7gdfv9AAE3RPhtOBUopTfbmc8ju7njYadjui9J1XA==",
-			"hasInstallScript": true,
-			"optional": true,
-			"dependencies": {
-				"nan": "^2.12.1",
-				"semver": "^5.5.1"
-			},
-			"engines": {
-				"node": ">=6",
-				"npm": ">=3"
-			}
-		},
-		"node_modules/@newrelic/native-metrics/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"optional": true,
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
-		"node_modules/@newrelic/superagent": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-1.0.3.tgz",
-			"integrity": "sha512-lJbsqKa79qPLbHZsbiRaXl1jfzaXAN7zqqnLRqBY+zI/O5zcfyNngTmdi+9y+qIUq7xHYNaLsAxCXerrsoINKg==",
-			"dependencies": {
-				"methods": "^1.1.2"
-			},
-			"peerDependencies": {
-				"newrelic": ">=4.3.0"
-			}
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -11825,11 +11778,6 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@tyriar/fibonacci-heap": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.9.tgz",
-			"integrity": "sha512-bYuSNomfn4hu2tPiDN+JZtnzCpSpbJ/PNeulmocDy3xN2X5OkJL65zo6rPZp65cPPhLF9vfT/dgE+RtFRCSxOA=="
-		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -15264,60 +15212,6 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
-		"node_modules/concat-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-			"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-			"engines": [
-				"node >= 6.0"
-			],
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.0.2",
-				"typedarray": "^0.0.6"
-			}
-		},
-		"node_modules/concat-stream/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/concat-stream/node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/concat-stream/node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
 		"node_modules/concurrently": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-4.1.2.tgz",
@@ -18231,19 +18125,6 @@
 				"d": "1",
 				"es5-ext": "^0.10.35",
 				"es6-symbol": "^3.1.1"
-			}
-		},
-		"node_modules/es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-		},
-		"node_modules/es6-promisify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
-			"dependencies": {
-				"es6-promise": "^4.0.3"
 			}
 		},
 		"node_modules/es6-shim": {
@@ -27982,207 +27863,6 @@
 			"resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.1.tgz",
 			"integrity": "sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==",
 			"dev": true
-		},
-		"node_modules/newrelic": {
-			"version": "5.13.1",
-			"resolved": "https://registry.npmjs.org/newrelic/-/newrelic-5.13.1.tgz",
-			"integrity": "sha512-FRChTKLh29benj2r//8/q+nLX3oHYlaOkOAjCVkilbTpp8OwR84FFDZNWRVuocxWP+yPR6ayfPaNc0ueLp9R7g==",
-			"deprecated": "This version of the New Relic Node Agent has reached the end of life.",
-			"dependencies": {
-				"@newrelic/koa": "^1.0.8",
-				"@newrelic/superagent": "^1.0.2",
-				"@tyriar/fibonacci-heap": "^2.0.7",
-				"async": "^2.1.4",
-				"concat-stream": "^2.0.0",
-				"escodegen": "^1.11.1",
-				"esprima": "^4.0.1",
-				"https-proxy-agent": "^3.0.0",
-				"json-stringify-safe": "^5.0.0",
-				"readable-stream": "^3.1.1",
-				"semver": "^5.3.0"
-			},
-			"bin": {
-				"newrelic-naming-rules": "bin/test-naming-rules.js"
-			},
-			"engines": {
-				"node": ">=6.0.0 <13.0.0",
-				"npm": ">=3.0.0"
-			},
-			"optionalDependencies": {
-				"@newrelic/native-metrics": "^4.0.0"
-			}
-		},
-		"node_modules/newrelic/node_modules/agent-base": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-			"dependencies": {
-				"es6-promisify": "^5.0.0"
-			},
-			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
-		"node_modules/newrelic/node_modules/async": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-			"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-			"dependencies": {
-				"lodash": "^4.17.14"
-			}
-		},
-		"node_modules/newrelic/node_modules/debug": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-			"dependencies": {
-				"ms": "^2.1.1"
-			}
-		},
-		"node_modules/newrelic/node_modules/escodegen": {
-			"version": "1.14.3",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-			"integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-			"dependencies": {
-				"esprima": "^4.0.1",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1"
-			},
-			"bin": {
-				"escodegen": "bin/escodegen.js",
-				"esgenerate": "bin/esgenerate.js"
-			},
-			"engines": {
-				"node": ">=4.0"
-			},
-			"optionalDependencies": {
-				"source-map": "~0.6.1"
-			}
-		},
-		"node_modules/newrelic/node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/newrelic/node_modules/https-proxy-agent": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-			"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
-			"dependencies": {
-				"agent-base": "^4.3.0",
-				"debug": "^3.1.0"
-			},
-			"engines": {
-				"node": ">= 4.5.0"
-			}
-		},
-		"node_modules/newrelic/node_modules/levn": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-			"dependencies": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/newrelic/node_modules/optionator": {
-			"version": "0.8.3",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-			"dependencies": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.6",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"word-wrap": "~1.2.3"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/newrelic/node_modules/prelude-ls": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/newrelic/node_modules/readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/newrelic/node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/newrelic/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
-		"node_modules/newrelic/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"optional": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/newrelic/node_modules/string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dependencies": {
-				"safe-buffer": "~5.2.0"
-			}
-		},
-		"node_modules/newrelic/node_modules/type-check": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-			"dependencies": {
-				"prelude-ls": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
 		},
 		"node_modules/next-tick": {
 			"version": "1.1.0",
@@ -45121,40 +44801,6 @@
 				}
 			}
 		},
-		"@newrelic/koa": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-1.0.8.tgz",
-			"integrity": "sha512-kY//FlLQkGdUIKEeGJlyY3dJRU63EG77YIa48ACMGZxQbWRd3WZMikyft33f8XScTq6WpCDo9xa0viNo8zeYkg==",
-			"requires": {
-				"methods": "^1.1.2"
-			}
-		},
-		"@newrelic/native-metrics": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-4.1.0.tgz",
-			"integrity": "sha512-7CZlKMLuaYQW7mV9qVyo9b9HVe2xBnyn+kkETRJoZGs5P7gdfv9AAE3RPhtOBUopTfbmc8ju7njYadjui9J1XA==",
-			"optional": true,
-			"requires": {
-				"nan": "^2.12.1",
-				"semver": "^5.5.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-					"optional": true
-				}
-			}
-		},
-		"@newrelic/superagent": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-1.0.3.tgz",
-			"integrity": "sha512-lJbsqKa79qPLbHZsbiRaXl1jfzaXAN7zqqnLRqBY+zI/O5zcfyNngTmdi+9y+qIUq7xHYNaLsAxCXerrsoINKg==",
-			"requires": {
-				"methods": "^1.1.2"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -49592,11 +49238,6 @@
 				"eslint-visitor-keys": "^3.4.1"
 			}
 		},
-		"@tyriar/fibonacci-heap": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.9.tgz",
-			"integrity": "sha512-bYuSNomfn4hu2tPiDN+JZtnzCpSpbJ/PNeulmocDy3xN2X5OkJL65zo6rPZp65cPPhLF9vfT/dgE+RtFRCSxOA=="
-		},
 		"@webassemblyjs/ast": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -52295,42 +51936,6 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
-		"concat-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-			"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-			"requires": {
-				"buffer-from": "^1.0.0",
-				"inherits": "^2.0.3",
-				"readable-stream": "^3.0.2",
-				"typedarray": "^0.0.6"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.6.2",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-				},
-				"string_decoder": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-					"requires": {
-						"safe-buffer": "~5.2.0"
-					}
-				}
-			}
-		},
 		"concurrently": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-4.1.2.tgz",
@@ -54647,19 +54252,6 @@
 				"d": "1",
 				"es5-ext": "^0.10.35",
 				"es6-symbol": "^3.1.1"
-			}
-		},
-		"es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-		},
-		"es6-promisify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
-			"requires": {
-				"es6-promise": "^4.0.3"
 			}
 		},
 		"es6-shim": {
@@ -62152,146 +61744,6 @@
 			"resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.1.tgz",
 			"integrity": "sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==",
 			"dev": true
-		},
-		"newrelic": {
-			"version": "5.13.1",
-			"resolved": "https://registry.npmjs.org/newrelic/-/newrelic-5.13.1.tgz",
-			"integrity": "sha512-FRChTKLh29benj2r//8/q+nLX3oHYlaOkOAjCVkilbTpp8OwR84FFDZNWRVuocxWP+yPR6ayfPaNc0ueLp9R7g==",
-			"requires": {
-				"@newrelic/koa": "^1.0.8",
-				"@newrelic/native-metrics": "^4.0.0",
-				"@newrelic/superagent": "^1.0.2",
-				"@tyriar/fibonacci-heap": "^2.0.7",
-				"async": "^2.1.4",
-				"concat-stream": "^2.0.0",
-				"escodegen": "^1.11.1",
-				"esprima": "^4.0.1",
-				"https-proxy-agent": "^3.0.0",
-				"json-stringify-safe": "^5.0.0",
-				"readable-stream": "^3.1.1",
-				"semver": "^5.3.0"
-			},
-			"dependencies": {
-				"agent-base": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-					"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-					"requires": {
-						"es6-promisify": "^5.0.0"
-					}
-				},
-				"async": {
-					"version": "2.6.4",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-					"integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-					"requires": {
-						"lodash": "^4.17.14"
-					}
-				},
-				"debug": {
-					"version": "3.2.7",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"escodegen": {
-					"version": "1.14.3",
-					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-					"integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-					"requires": {
-						"esprima": "^4.0.1",
-						"estraverse": "^4.2.0",
-						"esutils": "^2.0.2",
-						"optionator": "^0.8.1",
-						"source-map": "~0.6.1"
-					}
-				},
-				"estraverse": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-					"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
-				},
-				"https-proxy-agent": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-					"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
-					"requires": {
-						"agent-base": "^4.3.0",
-						"debug": "^3.1.0"
-					}
-				},
-				"levn": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-					"integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-					"requires": {
-						"prelude-ls": "~1.1.2",
-						"type-check": "~0.3.2"
-					}
-				},
-				"optionator": {
-					"version": "0.8.3",
-					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-					"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-					"requires": {
-						"deep-is": "~0.1.3",
-						"fast-levenshtein": "~2.0.6",
-						"levn": "~0.3.0",
-						"prelude-ls": "~1.1.2",
-						"type-check": "~0.3.2",
-						"word-wrap": "~1.2.3"
-					}
-				},
-				"prelude-ls": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-					"integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
-				},
-				"readable-stream": {
-					"version": "3.6.2",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-					"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-				},
-				"semver": {
-					"version": "5.7.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"optional": true
-				},
-				"string_decoder": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-					"requires": {
-						"safe-buffer": "~5.2.0"
-					}
-				},
-				"type-check": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-					"integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-					"requires": {
-						"prelude-ls": "~1.1.2"
-					}
-				}
-			}
 		},
 		"next-tick": {
 			"version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -160,7 +160,6 @@
 		"mailgun.js": "^2.0.1",
 		"mudder": "^1.0.4",
 		"mutationobserver-shim": "^0.3.3",
-		"newrelic": "^5.7.0",
 		"no-slash": "^1.2.15",
 		"node-fetch": "^2.6.7",
 		"passport": "^0.5.0",

--- a/server/server.ts
+++ b/server/server.ts
@@ -94,7 +94,7 @@ if (process.env.NODE_ENV === 'production') {
 		dsn: 'https://abe1c84bbb3045bd982f9fea7407efaa@sentry.io/1505439',
 		environment: isProd() ? 'prod' : 'dev',
 		release: getAppCommit(),
-		tracesSampleRate: 1,
+		tracesSampleRate: 0.05,
 		integrations: [
 			new Sentry.Integrations.Http({ tracing: true }),
 			new Sentry.Integrations.Postgres(),


### PR DESCRIPTION
This PR does two things: remove the newrelic agent and lower the number of performance transactions we send to sentry from the backend. Both of these changes are intended to help keep us below our quotas:
- On Sentry we hit our performance limit and used all our dynamic spend in just 3 days of requests, so this will now capture 5% of our requests. In the future we may want to intentionally exclude some routes so that we can concentrate the tracing on the most useful ones
- On newrelic, the traces use about 3GB/day of our 100GB per month, so we usually exceed the quota by a small amount. Removing those should easily free up enough space for all of our logs