### PR TITLE
fix(#2903): fix connections not being able to be updated

### DIFF
--- a/server/pubEdge/__tests__/api.test.ts
+++ b/server/pubEdge/__tests__/api.test.ts
@@ -216,3 +216,30 @@ it('lets a Pub manager destroy a PubEdge', async () => {
 	const edgeNow = await PubEdge.findOne({ where: { id: existingEdge?.id } });
 	expect(edgeNow).toBeNull();
 });
+
+it('lets a Pub manager update the direction of a pubEdge', async () => {
+	const { anotherPub, sourcePub, sourcePubManager } = models;
+
+	const existingEdge = await createPubEdge({
+		pubId: sourcePub.id,
+		targetPubId: anotherPub.id,
+		relationType: 'comment',
+		pubIsParent: true,
+	});
+
+	expect(existingEdge.pubIsParent).toEqual(true);
+	const sourcePubAgent = await login(sourcePubManager);
+
+	const {
+		body: { pubIsParent },
+	} = await sourcePubAgent
+		.put('/api/pubEdges')
+		.send({
+			...existingEdge,
+			pubEdgeId: existingEdge.id,
+			pubIsParent: false,
+		})
+		.expect(200);
+
+	expect(pubIsParent).toEqual(false);
+});

--- a/utils/api/schemas/pubEdge.ts
+++ b/utils/api/schemas/pubEdge.ts
@@ -83,15 +83,15 @@ export const pubEdgeUpdateSchema = pubEdgeSchema
 		z.union([
 			z.object({
 				targetPubId: z.string().uuid(),
-				externalPublication: z.undefined().optional(),
+				externalPublication: z.null().optional(),
 			}),
 			z.object({
-				targetPubId: z.undefined().optional(),
-				externalPublication: externalPublicationCreateSchema.partial(),
+				targetPubId: z.null().optional(),
+				externalPublication: externalPublicationSchema.partial(),
 			}),
 			z.object({
-				targetPubId: z.undefined().optional(),
-				externalPublication: z.undefined().optional(),
+				targetPubId: z.null().optional(),
+				externalPublication: z.null().optional(),
 			}),
 		]),
 	);


### PR DESCRIPTION
## Issue(s) Resolved
#2903

## Test Plan
1. Create a pub
2. Add a connection
3. Try to update the connection

Also added a test to prevent regression

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

Cause was the connection schema not allowing for `null` values for the `targetPubId` or `externalPublication`, but the frontend sends that when updating.

### Supporting Docs
