### PR TITLE
fix(#2910): allow setting of default collectionIds for create pub banner

### DIFF
--- a/types/layout.ts
+++ b/types/layout.ts
@@ -87,6 +87,7 @@ export type LayoutBlockBanner = {
 		buttonUrl?: string;
 		showButton?: boolean;
 		text?: string;
+		defaultCollectionIds?: string[];
 	};
 };
 

--- a/utils/api/schemas/layout.ts
+++ b/utils/api/schemas/layout.ts
@@ -24,6 +24,7 @@ export const layoutBlockBannerSchema = z
 			buttonUrl: z.string().optional(),
 			showButton: z.boolean().optional(),
 			text: z.string().optional(),
+			defaultCollectionIds: z.array(z.string().uuid()).optional(),
 		}),
 	})
 	.openapi({


### PR DESCRIPTION
## Issue(s) Resolved
#2910 

## Test Plan
1. Create Page/Collection
2. Add "Create Pub" submission banner in Layout
3. Set a default collection, or multiple
4. Save
5. Reload page
6. Check that default collections are still there
7. Go to page/collection
8. Create Pub
9. Check that it has those collections

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
