### PR TITLE
fix: allow facets to revert to higher scope value

### DIFF
--- a/server/facets/__tests__/api.test.ts
+++ b/server/facets/__tests__/api.test.ts
@@ -151,7 +151,7 @@ describe('/api/facets', () => {
 				facetName: 'CitationStyle',
 				facetProps: {
 					citationStyle: {
-						from: 'apa-7',
+						from: null,
 						to: 'cell',
 					},
 				},

--- a/server/facets/__tests__/api.test.ts
+++ b/server/facets/__tests__/api.test.ts
@@ -69,6 +69,29 @@ describe('/api/facets', () => {
 		});
 	});
 
+	it('allows you to disable a facets prop for a certain scope by passing null', async () => {
+		const { userWhoCanManage, pub } = models;
+
+		const agent = await login(userWhoCanManage);
+
+		await agent
+			.post('/api/facets')
+			.send({
+				scope: { kind: 'pub', id: pub.id },
+				facets: {
+					CitationStyle: { citationStyle: null },
+				},
+			})
+			.expect(200);
+		expect(await fetchFacetsForScope({ pubId: pub.id }, ['CitationStyle'])).toMatchObject({
+			CitationStyle: {
+				value: {
+					citationStyle: 'apa', // the default
+				},
+			},
+		});
+	});
+
 	it('updates facets, and creates ActivityItems for each one', async () => {
 		const { userWhoCanManage, pub } = models;
 		const t0 = Date.now();

--- a/server/facets/__tests__/update.test.ts
+++ b/server/facets/__tests__/update.test.ts
@@ -73,11 +73,11 @@ describe('updateFacetsForScope', () => {
 				include: includeFacetBindingWhere({ pubId: pub.id }),
 			}),
 		]);
-		expect(citationStyleModel.toJSON()).toMatchObject({
+		expect(citationStyleModel?.toJSON()).toMatchObject({
 			citationStyle: 'cell',
 			inlineCitationStyle: 'authorYear',
 		});
-		expect(pubEdgeDisplayModel.toJSON()).toMatchObject({
+		expect(pubEdgeDisplayModel?.toJSON()).toMatchObject({
 			defaultsToCarousel: true,
 			descriptionIsVisible: null,
 		});

--- a/server/facets/create.ts
+++ b/server/facets/create.ts
@@ -1,8 +1,8 @@
 import { Sequelize, DataTypes } from 'sequelize';
+import type { Model, ModelCtor } from 'sequelize-typescript';
 import { FacetBinding } from './models/facetBinding';
 
 import { ALL_FACET_DEFINITIONS, FacetName, FacetProp, FacetProps } from '../../facets';
-import { Model, ModelCtor } from 'sequelize-typescript';
 
 type Column = {
 	type: (typeof DataTypes)[keyof typeof DataTypes];

--- a/server/facets/create.ts
+++ b/server/facets/create.ts
@@ -2,6 +2,7 @@ import { Sequelize, DataTypes } from 'sequelize';
 import { FacetBinding } from './models/facetBinding';
 
 import { ALL_FACET_DEFINITIONS, FacetName, FacetProp, FacetProps } from '../../facets';
+import { Model, ModelCtor } from 'sequelize-typescript';
 
 type Column = {
 	type: (typeof DataTypes)[keyof typeof DataTypes];
@@ -55,7 +56,11 @@ export const createSequelizeModelsFromFacetDefinitions = (sequelize: Sequelize) 
 		}
 	});
 	return {
-		facetModels: modelsByName as Record<FacetName, any>,
+		facetModels: modelsByName as {
+			[N in FacetName]: ModelCtor<
+				Model<FacetProps[N], Omit<FacetProps[N], '__facetProp' | 'propType'>>
+			>;
+		},
 		FacetBinding,
 	};
 };

--- a/utils/api/schemas/facets.ts
+++ b/utils/api/schemas/facets.ts
@@ -25,18 +25,15 @@ type FacetSchema = {
 const facetSchemas = Object.entries(ALL_FACET_DEFINITIONS).reduce((acc, [njame, facet]) => {
 	const name = njame as typeof facet extends FacetDefinition<infer N, any> ? N : never;
 
-	const rawShape = Object.entries(facet.props).reduce(
-		(accc, [propNjame, prop]) => {
-			const propName = propNjame as any;
-			// nullable bc that allows the facet to return to higher scope value
-			accc[propName] = prop.propType.schema.nullable().openapi({
-				description: prop.label,
-				example: prop.rootValue,
-			});
-			return accc;
-		},
-		{} as FacetSchema[typeof name] extends z.ZodObject<infer S extends ZodRawShape> ? S : never,
-	);
+	const rawShape = Object.entries(facet.props).reduce((accc, [propNjame, prop]) => {
+		const propName = propNjame as any;
+		// nullable bc that allows the facet to return to higher scope value
+		accc[propName] = prop.propType.schema.nullable().openapi({
+			description: prop.label,
+			example: prop.rootValue,
+		});
+		return accc;
+	}, {} as FacetSchema[typeof name] extends z.ZodObject<infer S extends ZodRawShape> ? S : never);
 
 	acc[name as any] = z.object(rawShape).partial().openapi({
 		description: facet.label,

--- a/utils/api/schemas/facets.ts
+++ b/utils/api/schemas/facets.ts
@@ -25,14 +25,18 @@ type FacetSchema = {
 const facetSchemas = Object.entries(ALL_FACET_DEFINITIONS).reduce((acc, [njame, facet]) => {
 	const name = njame as typeof facet extends FacetDefinition<infer N, any> ? N : never;
 
-	const rawShape = Object.entries(facet.props).reduce((accc, [propNjame, prop]) => {
-		const propName = propNjame as any;
-		accc[propName] = prop.propType.schema.openapi({
-			description: prop.label,
-			example: prop.rootValue,
-		});
-		return accc;
-	}, {} as FacetSchema[typeof name] extends z.ZodObject<infer S extends ZodRawShape> ? S : never);
+	const rawShape = Object.entries(facet.props).reduce(
+		(accc, [propNjame, prop]) => {
+			const propName = propNjame as any;
+			// nullable bc that allows the facet to return to higher scope value
+			accc[propName] = prop.propType.schema.nullable().openapi({
+				description: prop.label,
+				example: prop.rootValue,
+			});
+			return accc;
+		},
+		{} as FacetSchema[typeof name] extends z.ZodObject<infer S extends ZodRawShape> ? S : never,
+	);
 
 	acc[name as any] = z.object(rawShape).partial().openapi({
 		description: facet.label,
@@ -41,7 +45,11 @@ const facetSchemas = Object.entries(ALL_FACET_DEFINITIONS).reduce((acc, [njame, 
 }, {} as FacetSchema);
 
 export const facetSchema = z.object({
-	facets: z.object(facetSchemas).partial() satisfies z.ZodType<UpdateFacetsQuery>,
+	facets: z.object(facetSchemas).partial().default({}) satisfies z.ZodType<
+		UpdateFacetsQuery,
+		any,
+		any
+	>,
 	scope: z.object({
 		kind: z.enum(['community', 'collection', 'pub']),
 		id: z.string().uuid(),


### PR DESCRIPTION
## Issue(s) Resolved

Facets were not updating if you reverted to the higher facets setting.

## Test Plan

1. Go to a Pub
2. Change a facet setting (e.g. setting the labels for tables to "Strange Tables")
3. Save
4. Click "Revert to community/collection value"
5. Save
6. Reload
7. Change should be saved.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
