### PR TITLE
fix: math duplication

### DIFF
--- a/client/components/Editor/schemas/math.tsx
+++ b/client/components/Editor/schemas/math.tsx
@@ -12,6 +12,7 @@ const inlineMathSchema = {
 	atom: true,
 	parseDOM: [
 		{
+			contentElement: 'annotation',
 			tag: 'math-inline', // important!
 		},
 	],
@@ -24,6 +25,7 @@ const mathDisplaySchema = {
 	code: true,
 	parseDOM: [
 		{
+			contentElement: 'annotation',
 			tag: 'math-display',
 		},
 	],


### PR DESCRIPTION
## Issue(s) Resolved

Resolves #2925

## Test Plan

1. Add a math node (display or inline) to a caption.
2. Close the formatting bar controls and click on the captioned element again.
3. The math node should look the same as before, and not contain duplicates!