### PR TITLE
fix: prevent api route not returning by wrapping actually throwing in…

### DIFF
--- a/server/citation/__tests__/api.test.ts
+++ b/server/citation/__tests__/api.test.ts
@@ -1,0 +1,30 @@
+import { login, modelize, setup, teardown } from 'stubstub';
+
+const models = modelize`
+    Community community {
+        Member member {
+            User user {}
+        }
+    }
+    `;
+
+setup(beforeAll, async () => {
+	await models.resolve();
+});
+
+teardown(afterAll);
+
+describe('/api/citations/zotero', () => {
+	it('returns 403 if you are not logged in', async () => {
+		const agent = await login();
+
+		await agent.get('/api/citations/zotero').expect(403);
+	});
+
+	it('retruens 400 if no query is provided', async () => {
+		const { user } = models;
+		const agent = await login(user);
+
+		await agent.get('/api/citations/zotero').expect(400);
+	});
+});

--- a/server/citation/api.ts
+++ b/server/citation/api.ts
@@ -1,11 +1,13 @@
 import zoteroClient from 'zotero-api-client';
 
-import app from 'server/server';
+import app, { wrap } from 'server/server';
 import { CitationStyleKind } from 'utils/citations';
 
 import { ZoteroStyleKind } from 'types';
 
 import { expect } from 'utils/assert';
+import { ForbiddenError, BadRequestError, NotFoundError } from 'server/utils/errors';
+
 import { ZoteroIntegration, IntegrationDataOAuth1 } from '../models';
 
 // mapping our citation style keys to zotero's keys
@@ -27,29 +29,39 @@ const zoteroStyleKindMap: Record<CitationStyleKind, ZoteroStyleKind> = {
 
 // the parameters which can be passed to the get() method
 // can be found at https://www.zotero.org/support/dev/web_api/v3/basics
-app.get('/api/citations/zotero', (req, res) => {
-	const userId = req.user?.id;
-	const { q, include, style = 'apa' } = req.query;
-	const zoteroStyle = zoteroStyleKindMap[style as CitationStyleKind];
-	if (!userId) return new Error('Log in to request citations');
-	return ZoteroIntegration.findOne({
-		where: { userId },
-		include: { model: IntegrationDataOAuth1 },
-	})
-		.then((zoteroIntegration) => {
-			if (!zoteroIntegration) {
-				throw new Error('No zotero integration found');
-			}
-			const { integrationDataOAuth1 } = zoteroIntegration;
-			if (!integrationDataOAuth1) {
-				throw new Error('Zotero not authenticated');
-			}
-			const zoteroId = parseInt(expect(zoteroIntegration.zoteroUserId), 10);
-			const zoteroAPI = zoteroClient(integrationDataOAuth1.accessToken).library(
-				'user',
-				zoteroId,
-			);
-			return zoteroAPI.items().get({ q, include, style: zoteroStyle });
-		})
-		.then((results) => res.status(200).json({ items: results.raw }));
-});
+app.get(
+	'/api/citations/zotero',
+	wrap(async (req, res) => {
+		const userId = req.user?.id;
+		const { q, include, style = 'apa' } = req.query;
+		const zoteroStyle = zoteroStyleKindMap[style as CitationStyleKind];
+
+		if (!userId) {
+			throw new ForbiddenError(new Error('Log in to request citations'));
+		}
+
+		if (!q) {
+			throw new BadRequestError(new Error('No query provided'));
+		}
+
+		const zoteroIntegration = await ZoteroIntegration.findOne({
+			where: { userId },
+			include: { model: IntegrationDataOAuth1 },
+		});
+
+		if (!zoteroIntegration) {
+			throw new NotFoundError(Error('No zotero integration found'));
+		}
+
+		const { integrationDataOAuth1 } = zoteroIntegration;
+
+		if (!integrationDataOAuth1) {
+			throw new ForbiddenError(Error('Zotero not authenticated'));
+		}
+
+		const zoteroId = parseInt(expect(zoteroIntegration.zoteroUserId), 10);
+		const zoteroAPI = zoteroClient(integrationDataOAuth1.accessToken).library('user', zoteroId);
+		const results = zoteroAPI.items().get({ q, include, style: zoteroStyle });
+		return res.status(200).json({ items: results.raw });
+	}),
+);

--- a/server/citation/api.ts
+++ b/server/citation/api.ts
@@ -61,7 +61,8 @@ app.get(
 
 		const zoteroId = parseInt(expect(zoteroIntegration.zoteroUserId), 10);
 		const zoteroAPI = zoteroClient(integrationDataOAuth1.accessToken).library('user', zoteroId);
-		const results = zoteroAPI.items().get({ q, include, style: zoteroStyle });
+		const results = await zoteroAPI.items().get({ q, include, style: zoteroStyle });
+
 		return res.status(200).json({ items: results.raw });
 	}),
 );


### PR DESCRIPTION
## Issue(s) Resolved

#2951 

## Test Plan
Added tests

Make sure the api still works as expected otherwise (smoke test)

## Notes/Context/Gotchas

This fixes a weird issue where a bot was calling `/api/citations/zotero=q` a bunch, which lead to errors.

Reason why this was erroring out is because
a) the route was not wrapped in `wrap`
b) an error was returned instead of thrown.

Not sure this lead to actual downtime for the rest of the app (see screenshot), but good to fix anyway.

<img width="307" alt="image" src="https://github.com/pubpub/pubpub/assets/21983833/a1c888b7-31f6-4154-b59d-c835fb4350f5">
