### PR TITLE
Show user feedback when slug already exists, and make zod errors prettier

### DIFF
--- a/client/containers/DashboardOverview/CollectionOverview/collectionState.ts
+++ b/client/containers/DashboardOverview/CollectionOverview/collectionState.ts
@@ -143,7 +143,10 @@ export const useCollectionPubs = (options: UseCollectionPubsOptions) => {
 	};
 };
 
-const getSlugStatus = (error: Maybe<Record<string, any>>, currentSlug: string): SlugStatus => {
+export const getSlugStatus = (
+	error: Maybe<Record<string, any>>,
+	currentSlug: string,
+): SlugStatus => {
 	if (error && error.desiredSlug === currentSlug && error.type === 'forbidden-slug') {
 		return error.slugStatus;
 	}

--- a/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
+++ b/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
@@ -49,8 +49,10 @@ const PubSettings = (props: Props) => {
 		updatePersistedState: updatePersistedPubData,
 		persistedState: persistedPubData,
 		persist,
+		error,
 	} = usePersistableState<Pub>(settingsData.pubData, async (update) => {
 		await pendingPromise(apiFetch.put('/api/pubs', { pubId: pubData.id, ...update }));
+
 		if (update.slug && update.slug !== settingsData.pubData.slug) {
 			// The setTimeout() gives the usePersistableState hook a chance to disable its
 			// onBeforeUnload hook. which triggers a browser popup asking the user if they really
@@ -63,7 +65,22 @@ const PubSettings = (props: Props) => {
 			}, 0);
 		}
 	});
+	console.log({
+		pubData,
+		hasChanges,
+		updatePubData,
+		updatePersistedPubData,
+		persistedPubData,
+		persist,
+		error,
+	});
 	const headerBackgroundImage = useFacetsQuery((F) => F.PubHeaderTheme.backgroundImage);
+
+	const slugError = !pubData.slug
+		? 'Required'
+		: error?.slugStatus === 'used'
+		? 'This URL is not available because it is in use by another Pub.'
+		: null;
 
 	const renderDetails = () => {
 		return (
@@ -83,7 +100,7 @@ const PubSettings = (props: Props) => {
 						helperText={`Pub will be available at ${pubUrl(communityData, pubData)}`}
 						value={pubData.slug}
 						onChange={(evt) => updatePubData({ slug: slugifyString(evt.target.value) })}
-						error={!pubData.slug ? 'Required' : null}
+						error={slugError}
 					/>
 					<InputField
 						label="Custom publication date"

--- a/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
+++ b/client/containers/DashboardSettings/PubSettings/PubSettings.tsx
@@ -65,15 +65,6 @@ const PubSettings = (props: Props) => {
 			}, 0);
 		}
 	});
-	console.log({
-		pubData,
-		hasChanges,
-		updatePubData,
-		updatePersistedPubData,
-		persistedPubData,
-		persist,
-		error,
-	});
 	const headerBackgroundImage = useFacetsQuery((F) => F.PubHeaderTheme.backgroundImage);
 
 	const slugError = !pubData.slug

--- a/package-lock.json
+++ b/package-lock.json
@@ -203,6 +203,7 @@
 				"yargs": "^13.2.4",
 				"zod": "^3.22.4",
 				"zod-to-json-schema": "^3.17.0",
+				"zod-validation-error": "^2.1.0",
 				"zotero-api-client": "^0.40.0",
 				"zustand": "^4.0.0-rc.1"
 			},
@@ -40287,6 +40288,17 @@
 				"zod": "^3.21.4"
 			}
 		},
+		"node_modules/zod-validation-error": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-2.1.0.tgz",
+			"integrity": "sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==",
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"zod": "^3.18.0"
+			}
+		},
 		"node_modules/zotero-api-client": {
 			"version": "0.40.1",
 			"resolved": "https://registry.npmjs.org/zotero-api-client/-/zotero-api-client-0.40.1.tgz",
@@ -71646,6 +71658,12 @@
 			"version": "3.21.4",
 			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.21.4.tgz",
 			"integrity": "sha512-fjUZh4nQ1s6HMccgIeE0VP4QG/YRGPmyjO9sAh890aQKPEk3nqbfUXhMFaC+Dr5KvYBm8BCyvfpZf2jY9aGSsw==",
+			"requires": {}
+		},
+		"zod-validation-error": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-2.1.0.tgz",
+			"integrity": "sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==",
 			"requires": {}
 		},
 		"zotero-api-client": {

--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
 		"yargs": "^13.2.4",
 		"zod": "^3.22.4",
 		"zod-to-json-schema": "^3.17.0",
+		"zod-validation-error": "^2.1.0",
 		"zotero-api-client": "^0.40.0",
 		"zustand": "^4.0.0-rc.1"
 	},

--- a/server/pub/__tests__/api.test.ts
+++ b/server/pub/__tests__/api.test.ts
@@ -280,6 +280,24 @@ describe('/api/pubs', () => {
 		await agent.delete('/api/pubs').send({ pubId: destroyThisPub.id }).expect(403);
 	});
 
+	it('throws a clear 400 error if you try to change the slug to an already-taken slug', async () => {
+		const { ewPub, wowPub, admin } = models;
+		const agent = await login(admin);
+		await agent
+			.put('/api/pubs')
+			.send({ pubId: ewPub.id, slug: wowPub.slug })
+			.expect(400, { type: 'forbidden-slug', slugStatus: 'used', desiredSlug: 'wow' });
+	});
+
+	it('throws a clear 400 error if you try to create a pub with an already-taken slug', async () => {
+		const { wowPub, admin, community } = models;
+		const agent = await login(admin);
+		await agent
+			.post('/api/pubs')
+			.send({ communityId: community.id, slug: wowPub.slug })
+			.expect(400, { type: 'forbidden-slug', slugStatus: 'used', desiredSlug: 'wow' });
+	});
+
 	it('allows a Pub manager to delete a Pub', async () => {
 		const { destroyThisPub, destructivePubManager } = models;
 		const agent = await login(destructivePubManager);

--- a/server/pub/api.ts
+++ b/server/pub/api.ts
@@ -5,7 +5,7 @@ import { initServer } from '@ts-rest/express';
 
 import * as types from 'types';
 
-import { ForbiddenError, NotFoundError, PubPubError } from 'server/utils/errors';
+import { ForbiddenError, NotFoundError } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { indexByProperty } from 'utils/arrays';
 import { transformPubToResource } from 'deposit/transform/pub';
@@ -24,7 +24,6 @@ import { writeDocumentToPubDraft } from 'server/utils/firebaseTools';
 import { isDuqDuq, isProd } from 'utils/environment';
 import { ensureUserIsCommunityAdmin } from 'utils/ensureUserIsCommunityAdmin';
 import { omitKeys } from 'utils/objects';
-import { ValidationError } from 'sequelize';
 import { Pub } from './model';
 
 import { canCreatePub, canDestroyPub, getUpdatablePubFields } from './permissions';
@@ -105,27 +104,15 @@ export const pubServer = s.router(contract.pub, {
 			throw new ForbiddenError();
 		}
 		const createParams = omitKeys(body, ['communityId', 'collectionId', 'createPubToken']);
-		try {
-			const newPub = await createPub(
-				{ communityId: ids.communityId, collectionIds, ...createParams },
-				ids.userId,
-			);
-			const jsonedPub = newPub.toJSON();
-			return {
-				status: 201,
-				body: jsonedPub,
-			};
-		} catch (e: any) {
-			if (e instanceof ValidationError) {
-				e.errors.forEach((error) => {
-					if (error.message === 'slug must be unique') {
-						throw new PubPubError.ForbiddenSlugError(expect(error.value), 'used');
-					}
-				});
-			}
-
-			throw new Error(e);
-		}
+		const newPub = await createPub(
+			{ communityId: ids.communityId, collectionIds, ...createParams },
+			ids.userId,
+		);
+		const jsonedPub = newPub.toJSON();
+		return {
+			status: 201,
+			body: jsonedPub,
+		};
 	},
 	update: async ({ body, req }) => {
 		const { userId, pubId } = getRequestIds(body, req.user);
@@ -137,23 +124,11 @@ export const pubServer = s.router(contract.pub, {
 			throw new ForbiddenError();
 		}
 
-		try {
-			const updateResult = await updatePub(req.body, updatableFields, userId);
-			return {
-				status: 200,
-				body: updateResult,
-			};
-		} catch (e: any) {
-			if (e instanceof ValidationError) {
-				e.errors.forEach((error) => {
-					if (error.message === 'slug must be unique') {
-						throw new PubPubError.ForbiddenSlugError(expect(error.value), 'used');
-					}
-				});
-			}
-
-			throw new Error(e);
-		}
+		const updateResult = await updatePub(req.body, updatableFields, userId);
+		return {
+			status: 200,
+			body: updateResult,
+		};
 	},
 	remove: async ({ body, req }) => {
 		const { userId, pubId } = getRequestIds(body, req.user);

--- a/server/server.ts
+++ b/server/server.ts
@@ -227,7 +227,10 @@ createExpressEndpoints(contract, server, app, {
 			console.error(prettifiedError);
 		}
 
-		return res.status(400).json(prettifiedError);
+		return res.status(400).json({
+			...prettifiedError,
+			message: prettifiedError.message,
+		});
 	},
 	jsonQuery: true,
 });


### PR DESCRIPTION
- fix: show better error message for already used slugs for pubs
- fix: add tests and more readable zod errors

## Issue(s) Resolved
#2954

Someone was trying to update their Pub's slug to an already existing one for quite a while, see the Sentry events linked in the issue.


## Test Plan
1. Create new pub
2. Try to name the slug the same as an already existing one (for demo.pubpub.org you can use `oz6wzj9s` as an existing one)
3. see that you get an error message saying the slug is already in use

## Screenshots (if applicable)
How the error message looks
<img width="374" alt="image" src="https://github.com/pubpub/pubpub/assets/21983833/072e91a7-03fb-4b09-8b06-9edd552816cd">


## Optional

I also made Zod errors a bit more readable than before using a package `zod-validation-error`, since I was looking at the error handling anyway.

This will mostly be useful for the SDK, but could theoretically be used to build a more generic error display system on the client, although that's not very high priority.

So instead of getting
```json
{
    "issues": [
        {
            "validation": "regex",
            "code": "invalid_string",
            "message": "Invalid",
            "path": [
                "slug"
            ]
        },
        {
            "code": "too_small",
            "minimum": 1,
            "type": "string",
            "inclusive": true,
            "exact": false,
            "message": "String must contain at least 1 character(s)",
            "path": [
                "slug"
            ]
        }
    ],
    "name": "ZodError"
}
```

You get

```json
{
    "message": "Validation error: Invalid at \"slug\"; String must contain at least 1 character(s) at \"slug\"",
    "details": [
        {
            "validation": "regex",
            "code": "invalid_string",
            "message": "Invalid",
            "path": [
                "slug"
            ]
        },
        {
            "code": "too_small",
            "minimum": 1,
            "type": "string",
            "inclusive": true,
            "exact": false,
            "message": "String must contain at least 1 character(s)",
            "path": [
                "slug"
            ]
        }
    ],
    "name": "ZodValidationError"
}
```

### Notes/Context/Gotchas

### Supporting Docs
