### PR TITLE
feat(hooks.ts): add release hooks to create purge hooks for PubAttrib…

### DIFF
--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -13,4 +13,5 @@ import './scopeSummary/hooks';
 import './submission/hooks';
 import './threadComment/hooks';
 import './visibility/hooks';
+import './user/hooks';
 import './userNotification/hooks';

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -7,6 +7,7 @@ import './page/hooks';
 import './pub/hooks';
 import './pubAttribution/hooks';
 import './pubEdge/hooks';
+import './release/hooks';
 import './review/hooks';
 import './scopeSummary/hooks';
 import './submission/hooks';

--- a/server/release/hooks.ts
+++ b/server/release/hooks.ts
@@ -1,0 +1,24 @@
+import { createPurgeHooks } from 'utils/caching/createPurgeHooks';
+import { Op } from 'sequelize';
+import { PubAttribution, includeUserModel } from 'server/models';
+import { DefinitelyHas } from 'types';
+
+import { Release } from './model';
+
+const findAttributionsUserSlugsForPubId = async ({ pubId }: { pubId: string }) => {
+	const attributions = (await PubAttribution.findAll({
+		where: { userId: { [Op.ne]: null }, pubId },
+		include: [
+			includeUserModel({
+				as: 'user',
+			}),
+		],
+	})) as DefinitelyHas<PubAttribution, 'user'>[];
+
+	return attributions.map((attribution) => attribution.user.slug);
+};
+
+createPurgeHooks({
+	model: Release,
+	onModelCreated: findAttributionsUserSlugsForPubId,
+});

--- a/server/routes/user.tsx
+++ b/server/routes/user.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Html from 'server/Html';
 import app from 'server/server';
-import type { Response } from 'express';
+import type { Request, Response } from 'express';
 import { getUser } from 'server/utils/queryHelpers';
 import { handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
@@ -36,9 +36,13 @@ const getHostnames = (attributions: Awaited<ReturnType<typeof getUser>>['attribu
 	return Object.values(hostNames).join(' ');
 };
 
-const setSurrogateKeys = (res: Response, userData: Awaited<ReturnType<typeof getUser>>) => {
+const setSurrogateKeys = (
+	req: Request,
+	res: Response,
+	userData: Awaited<ReturnType<typeof getUser>>,
+) => {
 	const hostnames = getHostnames(userData.attributions);
-	const surrogateKeys = `${userData.id} ${hostnames}`;
+	const surrogateKeys = [userData.slug, hostnames, req.hostname].join(' ');
 
 	res.setHeader('Surrogate-Key', surrogateKeys);
 };
@@ -62,7 +66,7 @@ app.get(['/user/:slug', '/user/:slug/:mode'], async (req, res, next) => {
 			}
 		}
 
-		setSurrogateKeys(res, userData);
+		setSurrogateKeys(req, res, userData);
 
 		return renderToNodeStream(
 			res,

--- a/server/user/hooks.ts
+++ b/server/user/hooks.ts
@@ -1,0 +1,40 @@
+/* eslint-disable pubpub-rules/no-user-model */
+import { createPurgeHooks } from 'utils/caching/createPurgeHooks';
+
+import { sequelize } from 'server/models';
+import { uniqueCommunitiesFromMembersQuery } from 'utils/caching/uniqueCommunitiesFromMembersQuery';
+import { QueryTypes } from 'sequelize';
+import { getCorrectHostname } from 'utils/caching/getCorrectHostname';
+import { getPPLic } from 'utils/caching/getHashedUserId';
+import { User } from './model';
+
+const getUniqueHostnamesForUserId = async (userId: string) => {
+	const result = (await sequelize.query(uniqueCommunitiesFromMembersQuery, {
+		replacements: { userId },
+		type: QueryTypes.SELECT,
+	})) as { domain: string | null; subdomain: string }[];
+
+	const hostnames = result.map(({ domain, subdomain }) => getCorrectHostname(subdomain, domain));
+
+	return hostnames;
+};
+
+createPurgeHooks({
+	model: User,
+	onModelUpdated: async (user) => {
+		const hostnames = await getUniqueHostnamesForUserId(user.id);
+
+		const allPurges = [
+			// all the communities the user is a member of,
+			// either directly or through a pub/collection
+			// plus all the collection/pubs the user is attributed to
+			...hostnames,
+			// purge the cache for the logged in user
+			getPPLic(user),
+			// purge all the /user pages
+			user.slug,
+		];
+
+		return allPurges;
+	},
+});

--- a/server/user/queries.ts
+++ b/server/user/queries.ts
@@ -103,6 +103,7 @@ export const updateUser = (
 
 	return User.update(filteredValues, {
 		where: { id: inputValues.userId },
+		individualHooks: true,
 	}).then(() => {
 		if (req.user.fullName !== filteredValues.fullName) {
 			updateUserData(req.user.id);

--- a/utils/caching/caching_strategy.md
+++ b/utils/caching/caching_strategy.md
@@ -8,8 +8,8 @@ This document briefly describes the caching strategy employed on PubPub.
 
 PubPub caches pages on Fastly that follow the following rules:
 
--   Do not match `req.url ~ "(/login|/logout|/api|/auth|\?access=)"`
--   Do not match `req.http.Cookie ~ "pp-no-cache"`. The `pp-no-cache` cookie is set when you log in.
+-   Do not match `req.url ~ "(/login|/logout|/auth|\?access=)" || req.url ~ "^/api/(pubs/.+/text|logout|userNotifications|uploadPolicy|citations|users|search/users|zoteroIntegration|editor|generateDoi|pubEdgeProposal|pubEdges|pubHistory|workerTasks)"`
+-   Do not match `req.http.Cookie ~ "pp-lo"`. The `pp-lic = pp-lo` cookie is set when your'e logged out.
 
 This means that public facing pages for non-logged in users are cached, as those make up the majority of traffic.
 
@@ -46,7 +46,11 @@ While not very precise, this makes sure we do invalidate the cache when necessar
 
 Purging happens in four places
 
--   The purge middleware defined here: https://github.com/pubpub/pubpub/blob/master/utils/caching/purgeMiddleware.ts#L1-L100
+#### Purge middleware
+
+We have a middleware that is called on every request that checks if the request is a POST/PUT/PATCH/DELETE request and if so, purges the cache for the community the request is for.
+
+It is defined here: https://github.com/pubpub/pubpub/blob/master/utils/caching/purgeMiddleware.ts#L1-L100
 
 #### After workerTask completion
 
@@ -58,9 +62,17 @@ If we purged only after the `/api/release` or `/api/export` task had been called
 
 https://github.com/pubpub/pubpub/blob/master/workers/queue.ts#L84-L86
 
-#### After a PubAttribution is created
+#### Certain Model lifecycle hooks
 
-This is to counter a kind of niche situation.
+Sometimes you might want to purge the cache when a certain model is created, updated or destroyed.
+
+To do this you can use a very similar API as the activityHooks, called `createPurgeHooks`.
+
+Almost all the current uses of this are to update the `/user/*` pages, or other places where the user is shown.
+
+See https://github.com/pubpub/pubpub/blob/master/utils/caching/createPurgeHooks.ts
+
+##### After PubAttribution is created, or a Release is created
 
 Situation:
 
@@ -79,16 +91,34 @@ This does not need to happen when a PubAttribution is updated or destroyed, the 
 -   A PubAttribution is updated or destroyed on `demo.pubpub.org`, sending a purge request for that
 -   Barbara's user page is now uncached
 
-#### After PUT /api/users is called
+###### Even more specific case
 
-This is technically a subset of the middleware, but is kind of special.
+The above is valid when a user is added to an already published Pub, but we also need to purge when a Pub is published for the first time.
+
+Problem workflow:
+
+1. Add user which has no pubs in this community to a pub. This sends a purge request to the user page
+2. Go to www.pubpub.org/user/<user-slug>. Cache miss, but no pub, because it isn't released.
+3. Release Pub
+4. Go back to www.pubpub.org/user/<user-slug>. Still no Pub, because this page isn't purged on release.
+5. Remove and re-add user
+6. Go back to www.pubpub.org/user/<user-slug>. Now the pub shows up.
+
+##### User is modified
 
 When a user updates their profile, we expect this to reflected anywhere their profile is visible.
 E.g., imagine Barbara from before first did not have a profile picture, and now adds one.
 
-### Purge middleware
+This needs to be updated in the following places:
 
-We have a middleware that is called on every request that checks if the request is a POST/PUT/PATCH/DELETE request and if so, purges the cache for the community the request is for.
+1. On every /user/barbara page, as the profile picture is shown there.
+2. On every page where Barbara is shown as a member.
+3. On every pub where Barbara is shown as an author.
+4. On every logged-in page for Barbara themselves, they need to see their profile pic updated.
+
+#### User notifications
+
+TODO
 
 ### Debouncing
 

--- a/utils/caching/createPurgeHooks.ts
+++ b/utils/caching/createPurgeHooks.ts
@@ -1,0 +1,54 @@
+import type { Attributes, CreateOptions, DestroyOptions, UpdateOptions } from 'sequelize';
+import type { Model, ModelCtor } from 'sequelize-typescript';
+import { schedulePurge } from 'server/server';
+import { defer } from 'server/utils/deferred';
+
+const deferPurge =
+	<M extends Model<any, any>>(
+		func: (instance: M, options?: any) => Promise<string | string[] | null | undefined | void>,
+	) =>
+	(instance: any, options: any) => {
+		return defer(async () => {
+			const key = await func(instance, options);
+			if (!key) {
+				return;
+			}
+			if (Array.isArray(key)) {
+				await Promise.all(key.map((k) => schedulePurge(k)));
+				return;
+			}
+			await schedulePurge(key);
+		});
+	};
+
+type PurgeHook<
+	M extends ModelCtor,
+	T extends 'afterCreate' | 'afterDestroy' | 'afterUpdate',
+	I extends InstanceType<M> = InstanceType<M>,
+	A extends Attributes<I> = Attributes<I>,
+> = (
+	instance: InstanceType<M>,
+	options?: T extends 'afterCreate'
+		? CreateOptions<A>
+		: T extends 'afterUpdate'
+		? UpdateOptions<A>
+		: DestroyOptions<A>,
+) => Promise<string | string[] | null | undefined | void>;
+
+export const createPurgeHooks = <M extends ModelCtor>(options: {
+	model: M;
+	onModelCreated?: PurgeHook<M, 'afterCreate'>;
+	onModelUpdated?: PurgeHook<M, 'afterUpdate'>;
+	onModelDestroyed?: PurgeHook<M, 'afterDestroy'>;
+}) => {
+	const { model, onModelCreated, onModelUpdated, onModelDestroyed } = options;
+	if (onModelCreated) {
+		model.afterCreate(deferPurge(onModelCreated));
+	}
+	if (onModelUpdated) {
+		model.afterUpdate(deferPurge(onModelUpdated));
+	}
+	if (onModelDestroyed) {
+		model.afterDestroy(deferPurge(onModelDestroyed));
+	}
+};

--- a/utils/caching/createPurgeHooks.ts
+++ b/utils/caching/createPurgeHooks.ts
@@ -38,7 +38,17 @@ type PurgeHook<
 export const createPurgeHooks = <M extends ModelCtor>(options: {
 	model: M;
 	onModelCreated?: PurgeHook<M, 'afterCreate'>;
+	/**
+	 * Only runs by default on <instance>.update(), not on <Model>.update()
+	 *
+	 * If this isn't running, be sure to check that you have `{individualHooks: true}` in your `Model.update` call.
+	 */
 	onModelUpdated?: PurgeHook<M, 'afterUpdate'>;
+	/**
+	 * Only runs by default on <instance>.update(), not on <Model>.update()
+	 *
+	 * If this isn't running, be sure to check that you have `{individualHooks: true}` in your `Model.destroy` call.
+	 */
 	onModelDestroyed?: PurgeHook<M, 'afterDestroy'>;
 }) => {
 	const { model, onModelCreated, onModelUpdated, onModelDestroyed } = options;

--- a/utils/caching/purgeMiddleware.ts
+++ b/utils/caching/purgeMiddleware.ts
@@ -138,7 +138,7 @@ export const purgeMiddleware = (
 						// purge the cache for the logged in user
 						getPPLic(req.user),
 						// purge all the /user pages
-						req.user.id,
+						req.user.slug,
 					];
 
 					await Promise.all(allPurges.map(async (tag) => schedulePurge(tag)));


### PR DESCRIPTION
## Issue(s) Resolved
https://github.com/pubpub/pubpub/issues/2958

## Test Plan
Same as https://github.com/pubpub/pubpub/pull/2960, except do this also

### Added Pubs
We want to make sure a user's profile page updates if they are added to a Pub.

1. Login
2. Go to `www.duqduq.org/user/<your-user-slug>`
3. Confirm it is cached by checking for X-Cache: HIT on reload
4. Open new tab, go to a community you have no Pubs in.
5. Add yourself as an attribution to that Pub.
6. Refresh `wwww.duqduq.org/user/<your-user-slug>`, confirm X-Cache: HIT (nothing should have changed)
7. Release the Pub
8 Refresh `wwww.duqduq.org/user/<your-user-slug>`, confirm X-Cache: MISS (you should see the pub now)



## Notes/Context/Gotchas

Main changes are to make sure the comments mentioned here work: https://github.com/pubpub/pubpub/issues/2958#issuecomment-1865135864

The PR also introduces a somewhat more robust way to do purges outside of the standard middleware purge.

I define a `createPurgeHooks` function that works similarly to the `createActivityHooks` function, which works like shown here

https://github.com/pubpub/pubpub/blob/7d4774db96ef9e73bbb8ed023a48d7eb596a768c/server/pubAttribution/hooks.ts#L23-L37

Basically, you define a function that runs after a model is created/updated/destroyed, which returns either a string, and array of strings, or something nullish.
If given an array of strings or a string, it will schedule purges for those Surrogate Keys.

I moved the previously kind of haphazardly placed purges for `PUT /api/users` into such a hook, see comment below.

## Supporting Docs
