### PR TITLE
fix: handle pub downloads from base pubpub

### DIFF
--- a/server/routes/pubDownloads.ts
+++ b/server/routes/pubDownloads.ts
@@ -9,10 +9,14 @@ import { getPubForRequest } from 'server/utils/queryHelpers';
 import { getBestDownloadUrl } from 'utils/pub/downloads';
 import { defer } from 'server/utils/deferred';
 import { createPubExportsForLatestRelease } from 'server/export/queries';
+import { hostIsValid } from 'server/utils/routes';
 
 app.get(
 	['/pub/:pubSlug/download', '/pub/:pubSlug/download/:format'],
-	wrap(async (req, res) => {
+	wrap(async (req, res, next) => {
+		if (!hostIsValid(req, 'community')) {
+			return next();
+		}
 		const initialData = await getInitialData(req);
 		const { pubSlug, format = null } = req.params;
 


### PR DESCRIPTION
## Issue(s) Resolved
#2964 


## Test Plan
1. Go to \<base\>/pub/r2s2rfo7/download/pdf
2. See 404 instead of unhandled

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas
I decided to handle this the same way as releases are handled, i.e. check whether the community is valid and then just forward it

https://github.com/pubpub/pubpub/blob/c2c9d9b880892ac2068b29f0299a7eebfa8f4443/server/routes/pubDocument.tsx#L227-L230

### Supporting Docs
