### PR TITLE
perf: Add infinite scroll to collection dropdown/minimize calls to /api/collectionPubs

### DIFF
--- a/client/components/Menu/Menu.tsx
+++ b/client/components/Menu/Menu.tsx
@@ -52,6 +52,8 @@ export const Menu = React.forwardRef((props: MenuProps, ref) => {
 		unstable_fixed,
 	});
 
+	// RK doesn't provide a way to listen to visibility changes
+	// so we implement it ourselves here
 	useEffect(() => {
 		if (onVisibleChange) {
 			onVisibleChange(menu.visible);

--- a/client/components/Menu/Menu.tsx
+++ b/client/components/Menu/Menu.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import classNames from 'classnames';
 import { Classes } from '@blueprintjs/core';
 import * as RK from 'reakit/Menu';
@@ -15,6 +15,8 @@ export type MenuProps = {
 	onDismiss?: () => unknown;
 	placement?: RK.MenuProps['placement'];
 	unstable_fixed?: boolean;
+	menuListRef?: React.Ref<HTMLUListElement> | null;
+	onVisibleChange?: (visible: boolean) => void;
 };
 
 const renderDisclosure = (disclosure, disclosureProps) => {
@@ -34,7 +36,9 @@ export const Menu = React.forwardRef((props: MenuProps, ref) => {
 		onDismiss = () => {},
 		gutter,
 		unstable_fixed = false,
+		onVisibleChange,
 		menuStyle = {},
+		menuListRef,
 		...restProps
 	} = props;
 
@@ -47,6 +51,12 @@ export const Menu = React.forwardRef((props: MenuProps, ref) => {
 		unstable_flip: false,
 		unstable_fixed,
 	});
+
+	useEffect(() => {
+		if (onVisibleChange) {
+			onVisibleChange(menu.visible);
+		}
+	}, [menu.visible, onVisibleChange]);
 
 	const handleDismiss = () => {
 		menu.hide();
@@ -74,6 +84,7 @@ export const Menu = React.forwardRef((props: MenuProps, ref) => {
 				style={{ zIndex: 20, ...menuStyle }}
 				className={classNames(Classes.MENU, Classes.ELEVATION_1, className)}
 				unstable_portal={menuConfig.usePortal}
+				ref={menuListRef}
 				{...menu}
 			>
 				<MenuContext.Provider value={{ parentMenu: menu, dismissMenu: handleDismiss }}>

--- a/client/containers/Pub/PubDocument/PubBottom/ReadNextSection.tsx
+++ b/client/containers/Pub/PubDocument/PubBottom/ReadNextSection.tsx
@@ -1,30 +1,23 @@
 import React from 'react';
 
-import { Pub } from 'types';
+import { CollectionPub, DefinitelyHas, Pub } from 'types';
 import { pubUrl } from 'utils/canonicalUrls';
 import { usePageContext } from 'utils/hooks';
 import { PubTitle } from 'components';
-import {
-	chooseCollectionForPub,
-	createReadingParamUrl,
-	getNeighborsInCollectionPub,
-	useCollectionPubs,
-} from 'client/utils/collections';
-import { usePubContext } from '../../pubHooks';
+import { chooseCollectionForPub, createReadingParamUrl } from 'client/utils/collections';
 
 import PubBottomSection, { SectionBullets } from './PubBottomSection';
 
 type Props = {
-	pubData: Pub;
+	pubData: Pub & { nextCollectionPub?: DefinitelyHas<CollectionPub, 'pub'> };
 };
 
 const ReadNextSection = (props: Props) => {
 	const { pubData } = props;
 	const { locationData, communityData } = usePageContext();
-	const { updateLocalData } = usePubContext();
+	const nextPub = pubData.nextCollectionPub?.pub;
 	const currentCollection = chooseCollectionForPub(pubData, locationData);
-	const { pubs } = useCollectionPubs(updateLocalData, currentCollection);
-	const { nextPub } = getNeighborsInCollectionPub(pubs, pubData);
+
 	const { readNextPreviewSize = 'choose-best' } = currentCollection || {};
 
 	if (readNextPreviewSize === 'none' || !nextPub || !currentCollection) {

--- a/client/containers/Pub/PubHeader/collections/CollectionBrowser.tsx
+++ b/client/containers/Pub/PubHeader/collections/CollectionBrowser.tsx
@@ -7,11 +7,11 @@ import { usePageContext } from 'utils/hooks';
 import { createReadingParamUrl, useCollectionPubs } from 'client/utils/collections';
 import { pubUrl, collectionUrl } from 'utils/canonicalUrls';
 import { getSchemaForKind } from 'utils/collections/schemas';
+import { useInfiniteScroll } from 'client/utils/useInfiniteScroll';
 import { Collection, Pub } from 'types';
 
 import { usePubContext } from '../../pubHooks';
 import CollectionsBarButton from './CollectionsBarButton';
-import { useInfiniteScroll } from 'client/utils/useInfiniteScroll';
 
 require('./collectionBrowser.scss');
 

--- a/client/containers/Pub/PubHeader/collections/CollectionBrowser.tsx
+++ b/client/containers/Pub/PubHeader/collections/CollectionBrowser.tsx
@@ -31,12 +31,25 @@ const CollectionBrowser = (props: Props) => {
 	);
 	const [visible, setVisible] = React.useState(false);
 
+	const shouldFetchMoreCollectionPubs =
+		// the menu will have 0 height if it is invisible, which will
+		// make the check in useInfiniteScroll always return true
+		// so we only start fetching more pubs when the user clicks the menu
+		visible &&
+		// otherwise it'll fetch a whole bunch of pubs at once rather than 10 at a time
+		!isLoading &&
+		!hasLoadedAllPubs &&
+		// stop fetching more pubs if there's an error.
+		// possible improvement: retry once if there's an error
+		!error;
+
 	useInfiniteScroll({
-		enabled: !isLoading && !hasLoadedAllPubs && !error && visible,
+		enabled: shouldFetchMoreCollectionPubs,
 		element: menuRef.current,
 		onRequestMoreItems: requestMorePubs,
 		scrollTolerance: 0,
 	});
+
 	const { bpDisplayIcon } = getSchemaForKind(collection.kind)!;
 	const readingPubUrl = (pub) => createReadingParamUrl(pubUrl(communityData, pub), collection.id);
 

--- a/client/utils/collections.ts
+++ b/client/utils/collections.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { apiFetch } from 'client/utils/apiFetch';
 import { usePageContext } from 'utils/hooks';
 import { getPrimaryCollection } from 'utils/collections/primary';
@@ -11,8 +11,25 @@ const getCollectionFromReadingParam = (queryObj, collections) => {
 	);
 };
 
-const fetchCollectionPubs = ({ collectionId, communityId }) =>
-	apiFetch(`/api/collectionPubs?collectionId=${collectionId}&communityId=${communityId}`);
+const fetchCollectionPubs = ({
+	collectionId,
+	communityId,
+	offset = 0,
+	limit = 10,
+}: {
+	collectionId: string;
+	communityId: string;
+	offset?: number;
+	limit?: number;
+}) => {
+	const searchParams = new URLSearchParams();
+	searchParams.append('collectionId', collectionId);
+	searchParams.append('communityId', communityId);
+	searchParams.append('offset', offset.toString());
+	searchParams.append('limit', limit.toString());
+
+	return apiFetch(`/api/collectionPubs?${searchParams.toString()}`);
+};
 
 export const getNeighborsInCollectionPub = (pubs, currentPub) => {
 	if (!pubs) {
@@ -40,14 +57,18 @@ export const chooseCollectionForPub = (pubData, locationData) => {
 	);
 };
 
+const DEFAULT_LIMIT = 10 as const;
+
 export const useCollectionPubs = (updateLocalData, collection) => {
 	const [error, setError] = useState(false);
-	const [isLoading, setIsLoading] = useState(true);
-	const [pubs, setPubs] = useState(collection && collection.pubs);
+	const [isLoading, setIsLoading] = useState(false);
+	const [pubs, setPubs] = useState(collection?.pubs ?? []);
 	const { communityData } = usePageContext();
+	const [offset, setOffset] = useState(0);
+	const [hasLoadedAllPubs, setHasLoadedAllPubs] = useState(false);
 
 	const updatePubs = (nextPubs) => {
-		setPubs(nextPubs);
+		setPubs((currentPubs) => [...currentPubs, ...nextPubs]);
 		updateLocalData('pub', (pubData) => {
 			const collectionPubs = pubData.collectionPubs.map((cp) => {
 				if (cp.collection.id === collection.id) {
@@ -65,27 +86,36 @@ export const useCollectionPubs = (updateLocalData, collection) => {
 		});
 	};
 
-	useEffect(() => {
-		if (!collection) {
+	const requestMorePubs = () => {
+		if (hasLoadedAllPubs) {
 			return;
 		}
-		if (Array.isArray(collection.pubs)) {
-			setIsLoading(false);
-		}
-		fetchCollectionPubs({ collectionId: collection.id, communityId: communityData.id })
+		setIsLoading(true);
+
+		fetchCollectionPubs({
+			collectionId: collection.id,
+			communityId: communityData.id,
+			offset,
+		})
 			.then((res) => {
 				updatePubs(res);
 				setIsLoading(false);
+				setOffset((oldOffset) => oldOffset + DEFAULT_LIMIT);
+				if (res.length < DEFAULT_LIMIT) {
+					setHasLoadedAllPubs(true);
+				}
 			})
 			.catch((err) => {
 				setError(err);
 				setIsLoading(false);
 			});
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [collection && collection.id]);
+	};
+
 	return {
 		isLoading,
 		error,
 		pubs,
+		hasLoadedAllPubs,
+		requestMorePubs,
 	};
 };

--- a/server/collectionPub/api.ts
+++ b/server/collectionPub/api.ts
@@ -30,7 +30,10 @@ const s = initServer();
 
 export const collectionPubServer = s.router(contract.collectionPub, {
 	get: async ({ req, query }) => {
-		const pubsInCollection = await getPubsInCollection(getRequestIds(query, req.user));
+		const pubsInCollection = await getPubsInCollection({
+			...query,
+			userId: req.user?.id,
+		});
 		return {
 			status: 200,
 			body: pubsInCollection,

--- a/server/collectionPub/queries.ts
+++ b/server/collectionPub/queries.ts
@@ -12,16 +12,20 @@ import {
 import * as types from 'types';
 import { getCollectionPubsInCollection } from 'server/utils/collectionQueries';
 import { expect } from 'utils/assert';
+import { CollectionPubQueryInput } from './schemas';
 
 export const getPubsInCollection = async ({
-	communityId,
 	collectionId,
+	communityId,
 	userId,
-}: {
-	communityId: string;
-	collectionId: string;
-	userId?: string | null;
-}) => {
+	limit,
+	offset,
+	attributes,
+	include,
+	orderBy,
+	pubId,
+	sortBy,
+}: CollectionPubQueryInput & { userId?: string | null }) => {
 	const collectionPubsQuery = CollectionPub.findAll({
 		where: { collectionId: collectionId ?? null },
 		order: [['rank', 'ASC']],
@@ -57,6 +61,8 @@ export const getPubsInCollection = async ({
 				],
 			},
 		],
+		limit,
+		offset,
 	});
 	const membersQuery = userId ? Member.findAll({ where: { userId } }) : [];
 	const [collectionPubs, members] = await Promise.all([collectionPubsQuery, membersQuery]);

--- a/server/collectionPub/queries.ts
+++ b/server/collectionPub/queries.ts
@@ -20,11 +20,6 @@ export const getPubsInCollection = async ({
 	userId,
 	limit,
 	offset,
-	attributes,
-	include,
-	orderBy,
-	pubId,
-	sortBy,
 }: CollectionPubQueryInput & { userId?: string | null }) => {
 	const collectionPubsQuery = CollectionPub.findAll({
 		where: { collectionId: collectionId ?? null },

--- a/server/collectionPub/schemas.ts
+++ b/server/collectionPub/schemas.ts
@@ -19,10 +19,6 @@ export const collectionPubQuerySchema = z.object({
 	communityId: z.string().uuid(),
 	limit: z.number().int().min(1).default(10),
 	offset: z.number().int().min(0).default(0),
-	orderBy: z.enum(['asc', 'desc']).default('asc'),
-	sortBy: z.enum(['createdAt', 'updatedAt', 'pubRank']).default('pubRank'),
-	include: z.enum(['collection', 'pub']).array().default(['pub']),
-	attributes: collectionPubSchema.keyof().array().optional(),
 });
 
 export type CollectionPubQueryInput = (typeof collectionPubQuerySchema)['_input'];

--- a/server/collectionPub/schemas.ts
+++ b/server/collectionPub/schemas.ts
@@ -12,3 +12,17 @@ export const collectionPubSchema = z.object({
 	rank: z.string(),
 	pubRank: z.string(),
 }) satisfies z.ZodType<types.CollectionPub>;
+
+export const collectionPubQuerySchema = z.object({
+	pubId: z.string().uuid().optional(),
+	collectionId: z.string().uuid(),
+	communityId: z.string().uuid(),
+	limit: z.number().int().min(1).default(10),
+	offset: z.number().int().min(0).default(0),
+	orderBy: z.enum(['asc', 'desc']).default('asc'),
+	sortBy: z.enum(['createdAt', 'updatedAt', 'pubRank']).default('pubRank'),
+	include: z.enum(['collection', 'pub']).array().default(['pub']),
+	attributes: collectionPubSchema.keyof().array().optional(),
+});
+
+export type CollectionPubQueryInput = (typeof collectionPubQuerySchema)['_input'];

--- a/utils/api/contracts/collectionPub.ts
+++ b/utils/api/contracts/collectionPub.ts
@@ -1,6 +1,7 @@
 import { type AppRouter } from '@ts-rest/core';
 import { z } from 'zod';
 import { extendZodWithOpenApi } from '@anatine/zod-openapi';
+import { collectionPubQuerySchema } from 'server/collectionPub/schemas';
 import {
 	createCollectionPubSchema,
 	collectionPubSchema,
@@ -26,11 +27,7 @@ export const collectionPubRouter = {
 		method: 'GET',
 		summary: 'Get the pubs associated with a collection',
 		description: 'Get the pubs associated with a collection',
-		query: z.object({
-			pubId: z.string().uuid().optional(),
-			collectionId: z.string().uuid(),
-			communityId: z.string().uuid(),
-		}),
+		query: collectionPubQuerySchema,
 		responses: {
 			200: z.array(pubSchema),
 		},

--- a/utils/collections/getNextCollectionPub.ts
+++ b/utils/collections/getNextCollectionPub.ts
@@ -1,0 +1,31 @@
+import { Op } from 'sequelize';
+import { CollectionPub, Pub } from 'server/models';
+import * as types from 'types';
+
+/**
+ * Retrieves the next CollectionPub in a collection based on the current rank
+ *
+ * @param collectionPub - The current CollectionPub
+ * @returns The next CollectionPub, or null if there is no next publication.
+ */
+export const getNextCollectionPub = async (collectionPub: types.CollectionPub | CollectionPub) => {
+	const { rank: currentRank, collectionId } = collectionPub;
+
+	const nextCollectionPub = (await CollectionPub.findOne({
+		where: {
+			rank: {
+				[Op.gt]: currentRank,
+			},
+			collectionId,
+		},
+		order: [['rank', 'ASC']],
+		include: [
+			{
+				model: Pub,
+				as: 'pub',
+			},
+		],
+	})) as types.DefinitelyHas<CollectionPub, 'pub'> | null;
+
+	return nextCollectionPub;
+};


### PR DESCRIPTION
- feat: allow GET /api/collectionPubs to be paginated and make it slightly more efficient
- feat: find next pub to read on serverside
- feat: add infinite scroll to CollectionBrowser



## Issue(s) Resolved
#2979 

Previously, repeated fetching of very large collections over `/api/collectionPubs` through the Collection Dropdown could cause the DB to become overwhelmed.
This was especially problematic when crawlers crawled a ton of Pubs in very large collections at the same time, as the query would never succeed, therefore never cache, and would continue to bring too high of a load on the DB.

This PR changes the way that the Pubs in the Collection Dropdown are fetched. Instead of fetching everything all at once, now only 10 pubs are fetched at a time, the rest being loaded in on scroll.
Pubs will also only start being fetched on interaction, which will save a lot of requests, especially those due to both that aren't even interacting with the page in the first place.

The same fetching also happened at the "Read Next" section at the bottom of the page. This has been replaced by a much more efficient server side fetch.

## Test Plan

### Read next section
1. Go to `/pub/2021n1i101p01/release/1?readingCollection=27a4f9bb` (locally/duqduq)
2. Go to https://baas.aas.org/pub/2021n1i101p01/release/1?readingCollection=27a4f9bb
3. Check if Read Next section matches
4. Check a number of other Pubs against prod to see if the read next matches

### Dropdown
1. Go to `/pub/2021n1i101p01/release/1?readingCollection=27a4f9bb` (locally/duqduq) on BAAS
2. Click on the collection dropdown
3. Observe spinner
4. Scroll down
5. Observe loading

Ideally repeat with internet throttled to fast 3G to see if the loading speed is tolerable.

## Screenshots (if applicable)

## Optional

### Points of feedback
I'd like thoughts on the following

1. In the spec we wanted to keep the same client fetching mechanism for the Read Next section. I found it easier to just remove that fetch and pass this info through the server on load. Do you agree with this?
2. I chose to only fetch the collection pubs when the user interacts with the dropdown. This is possibly slightly worse UX, as you will always see a spinner when you click the dropdown. However it saves us a request as (most) users don't click the dropdown, especially bots. The query was also running twice every page load, possibly due to a rerendering bug, or possibly due to react strict mode running effects twice (i tried to investigate whether this was the case and am leaning towards this not being the case). Only running the query on open saves me from having to debug this duplicate fetching. 

### Supporting Docs
