### PR TITLE
fix: Remove annoying "0" when collectionPubs are loading

### DIFF
--- a/client/containers/Pub/PubHeader/collections/CollectionBrowser.tsx
+++ b/client/containers/Pub/PubHeader/collections/CollectionBrowser.tsx
@@ -82,25 +82,25 @@ const CollectionBrowser = (props: Props) => {
 				href={collectionUrl(communityData, collection)}
 			/>
 			<MenuItemDivider />
-			{pubs &&
-				pubs.length &&
-				pubs.map((pub) => (
-					<MenuItem
-						active={currentPub.id === pub.id}
-						href={readingPubUrl(pub)}
-						textClassName="menu-item-text"
-						icon="pubDoc"
-						key={pub.id}
-						text={
-							<>
-								<div className="title">
-									<PubTitle pubData={pub} />
-								</div>
-								<PubByline pubData={pub} linkToUsers={false} />
-							</>
-						}
-					/>
-				))}
+			{pubs?.length > 0
+				? pubs.map((pub) => (
+						<MenuItem
+							active={currentPub.id === pub.id}
+							href={readingPubUrl(pub)}
+							textClassName="menu-item-text"
+							icon="pubDoc"
+							key={pub.id}
+							text={
+								<>
+									<div className="title">
+										<PubTitle pubData={pub} />
+									</div>
+									<PubByline pubData={pub} linkToUsers={false} />
+								</>
+							}
+						/>
+				  ))
+				: null}
 			{isLoading && (
 				<MenuItem
 					disabled


### PR DESCRIPTION
## Issue(s) Resolved

After clicking the collection browser thingy, a small "0" shows up while the first collection pubs are loading.



## Test Plan

1. Go to `pub/2022n6i100p01/release/1?readingCollection=dee6a02a` on BAAS
2. Set throttling to `Slow 3G`
3. Click on Collection Browser
4. Observe no `0`

## Screenshots (if applicable)
### Before

https://github.com/pubpub/pubpub/assets/21983833/5bf2818b-3b01-4bae-b2fb-6c9f629bc7a8



### After 

https://github.com/pubpub/pubpub/assets/21983833/edc08f09-3c08-493c-b643-a13f7712f7ae



## Optional

This was because I added a check to see if the list of pubs was not empty, but did it in the lazy way, e.g.

```tsx
{pubs && pubs.length && pubs.map(...)}
```

I changed it to

```tsx
{ pubs?.length > 0 ? pubs.map(...) : null }
```


### Notes/Context/Gotchas

### Supporting Docs
