### PR TITLE
feat: lazy load analytics modules

### DIFF
--- a/client/components/Layout/Layout.tsx
+++ b/client/components/Layout/Layout.tsx
@@ -9,8 +9,8 @@ import {
 	resolveLayoutPubsByBlock,
 } from 'utils/layout';
 import { usePageContext } from 'utils/hooks';
-import { usePageOnce } from 'utils/analytics/useAnalytics';
 import { assert } from 'utils/assert';
+import { usePageOnce } from 'utils/analytics/usePageOnce';
 
 import LayoutPubs from './LayoutPubs';
 import LayoutHtml from './LayoutHtml';

--- a/client/containers/App/App.tsx
+++ b/client/containers/App/App.tsx
@@ -61,6 +61,7 @@ const App = (props: Props) => {
 		canUseCustomAnalyticsProvider: canUseCustomAnalyticsProvider(featureFlags),
 		analyticsSettings,
 		gdprConsent,
+		locationData,
 	});
 
 	const pathObject = getPaths(viewData, locationData, chunkName);

--- a/client/containers/App/App.tsx
+++ b/client/containers/App/App.tsx
@@ -1,10 +1,13 @@
-import React, { ReactNode, useEffect } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import { Provider as RKProvider } from 'reakit';
 import classNames from 'classnames';
 import { AnalyticsProvider } from 'use-analytics';
 
-import { createAnalyticsInstance } from 'utils/analytics/createAnalyticsInstance';
-import { canUseCustomAnalyticsProvider, shouldUseNewAnalytics } from 'utils/analytics/featureFlags';
+import {
+	createAnalyticsInstance,
+	createStubAnalyticsInstance,
+} from 'utils/analytics/createAnalyticsInstance';
+import { shouldUseNewAnalytics, canUseCustomAnalyticsProvider } from 'utils/analytics/featureFlags';
 
 import {
 	Header,
@@ -56,23 +59,18 @@ const App = (props: Props) => {
 
 	const { analyticsSettings } = communityData;
 
+	const [analyticsInstance, setAnalyticsInstance] = useState(createStubAnalyticsInstance());
+
 	useEffect(() => {
-		import(
-			// /* webpackChunkName: "dist/@analytics/google-analytics" */
-			'@analytics/google-analytics'
-		).then(({ default: googleAnalytics }) => {
-			console.log('Loaded Google Analytics plugin');
-			console.log(googleAnalytics);
+		createAnalyticsInstance({
+			shouldUseNewAnalytics: shouldUseNewAnalytics(featureFlags),
+			canUseCustomAnalyticsProvider: canUseCustomAnalyticsProvider(featureFlags),
+			analyticsSettings,
+			gdprConsent,
+		}).then((newAnalyticsInstance) => {
+			setAnalyticsInstance(newAnalyticsInstance);
 		});
 	}, []);
-
-	// TODO: figure out some way to lazy load plugins
-	const analyticsInstance = createAnalyticsInstance({
-		shouldUseNewAnalytics: shouldUseNewAnalytics(initialData.featureFlags),
-		canUseCustomAnalyticsProvider: canUseCustomAnalyticsProvider(initialData.featureFlags),
-		gdprConsent,
-		analyticsSettings,
-	});
 
 	const pathObject = getPaths(viewData, locationData, chunkName);
 	const { ActiveComponent, hideNav, hideFooter, hideHeader, isDashboard } = pathObject;

--- a/client/containers/App/App.tsx
+++ b/client/containers/App/App.tsx
@@ -1,13 +1,10 @@
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode } from 'react';
 import { Provider as RKProvider } from 'reakit';
 import classNames from 'classnames';
 import { AnalyticsProvider } from 'use-analytics';
 
-import {
-	createAnalyticsInstance,
-	createInitialAnalyticsInstance,
-} from 'utils/analytics/createAnalyticsInstance';
 import { shouldUseNewAnalytics, canUseCustomAnalyticsProvider } from 'utils/analytics/featureFlags';
+import { useLazyLoadedAnalyticsInstance } from 'utils/analytics/useLazyLoadedAnalyticsInstance';
 
 import {
 	Header,
@@ -41,7 +38,6 @@ import SpamBanner from './SpamBanner';
 
 import getPaths from './paths';
 import { usePageState } from './usePageState';
-import { useLazyLoadedAnalyticsInstance } from 'utils/analytics/useLazyLoadedAnalyticsInstance';
 
 require('../../styles/base.scss');
 require('./app.scss');

--- a/client/containers/App/App.tsx
+++ b/client/containers/App/App.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import { Provider as RKProvider } from 'reakit';
 import classNames from 'classnames';
 import { AnalyticsProvider } from 'use-analytics';
@@ -55,6 +55,16 @@ const App = (props: Props) => {
 		pageContextProps;
 
 	const { analyticsSettings } = communityData;
+
+	useEffect(() => {
+		import(
+			// /* webpackChunkName: "dist/@analytics/google-analytics" */
+			'@analytics/google-analytics'
+		).then(({ default: googleAnalytics }) => {
+			console.log('Loaded Google Analytics plugin');
+			console.log(googleAnalytics);
+		});
+	}, []);
 
 	// TODO: figure out some way to lazy load plugins
 	const analyticsInstance = createAnalyticsInstance({

--- a/client/containers/App/App.tsx
+++ b/client/containers/App/App.tsx
@@ -5,7 +5,7 @@ import { AnalyticsProvider } from 'use-analytics';
 
 import {
 	createAnalyticsInstance,
-	createStubAnalyticsInstance,
+	createInitialAnalyticsInstance,
 } from 'utils/analytics/createAnalyticsInstance';
 import { shouldUseNewAnalytics, canUseCustomAnalyticsProvider } from 'utils/analytics/featureFlags';
 
@@ -41,6 +41,7 @@ import SpamBanner from './SpamBanner';
 
 import getPaths from './paths';
 import { usePageState } from './usePageState';
+import { useLazyLoadedAnalyticsInstance } from 'utils/analytics/useLazyLoadedAnalyticsInstance';
 
 require('../../styles/base.scss');
 require('./app.scss');
@@ -59,18 +60,12 @@ const App = (props: Props) => {
 
 	const { analyticsSettings } = communityData;
 
-	const [analyticsInstance, setAnalyticsInstance] = useState(createStubAnalyticsInstance());
-
-	useEffect(() => {
-		createAnalyticsInstance({
-			shouldUseNewAnalytics: shouldUseNewAnalytics(featureFlags),
-			canUseCustomAnalyticsProvider: canUseCustomAnalyticsProvider(featureFlags),
-			analyticsSettings,
-			gdprConsent,
-		}).then((newAnalyticsInstance) => {
-			setAnalyticsInstance(newAnalyticsInstance);
-		});
-	}, []);
+	const analyticsInstance = useLazyLoadedAnalyticsInstance({
+		shouldUseNewAnalytics: shouldUseNewAnalytics(featureFlags),
+		canUseCustomAnalyticsProvider: canUseCustomAnalyticsProvider(featureFlags),
+		analyticsSettings,
+		gdprConsent,
+	});
 
 	const pathObject = getPaths(viewData, locationData, chunkName);
 	const { ActiveComponent, hideNav, hideFooter, hideHeader, isDashboard } = pathObject;

--- a/client/containers/DashboardCustomScripts/DashboardCustomScripts.tsx
+++ b/client/containers/DashboardCustomScripts/DashboardCustomScripts.tsx
@@ -20,9 +20,10 @@ const DashboardCustomScripts = (props: Props) => {
 	const { featureFlags } = usePageContext();
 	const [Editor, setEditor] = useState<null | EditorComponentType>(null);
 	useEffect(() => {
-		import('@monaco-editor/react').then(({ default: EditorComponent }) =>
-			setEditor(EditorComponent),
-		);
+		import(
+			/* webpackChunkName: "@monaco-editor/react" */
+			'@monaco-editor/react'
+		).then(({ default: EditorComponent }) => setEditor(EditorComponent));
 	}, []);
 
 	const renderLoading = () => {

--- a/client/containers/Pub/PubDocument/PubDocument.tsx
+++ b/client/containers/Pub/PubDocument/PubDocument.tsx
@@ -8,9 +8,9 @@ import {
 	Mode as PubEdgeMode,
 } from 'components/PubEdgeListing';
 import { useFacetsQuery } from 'client/utils/useFacets';
-import { usePageOnce } from 'utils/analytics/useAnalytics';
 import { chooseCollectionForPub } from 'client/utils/collections';
 import { getPrimaryCollection } from 'utils/collections/primary';
+import { usePageOnce } from 'utils/analytics/usePageOnce';
 
 import { usePubContext } from '../pubHooks';
 import { usePermalinkOnMount } from '../usePermalinkOnMount';

--- a/client/webpack/lazyLoadedModules.js
+++ b/client/webpack/lazyLoadedModules.js
@@ -1,0 +1,9 @@
+/** Modules that are lazy loaded and should be excluded from the vendor bundle */
+const lazyLoadedModules = ['@analytics/google-analytics', '@analytics/simple-analytics'];
+
+const lazyModuleRegExp = new RegExp(`node_modules[\\\\/](${lazyLoadedModules.join('|')})`);
+
+module.exports = {
+	lazyLoadedModules,
+	lazyModuleRegExp,
+};

--- a/client/webpack/webpackConfig.dev.js
+++ b/client/webpack/webpackConfig.dev.js
@@ -10,7 +10,6 @@ const crypto = require('crypto');
 const cryptoCreateHash = crypto.createHash;
 crypto.createHash = (algorithm) => cryptoCreateHash(algorithm === 'md4' ? 'sha256' : algorithm);
 
-/** @type {import('webpack').Configuration} */
 module.exports = {
 	mode: 'development',
 	entry: {
@@ -45,9 +44,9 @@ module.exports = {
 		assets: false,
 		children: false,
 		timings: true,
-		chunks: false,
-		chunkModules: false,
-		entrypoints: false,
+		chunks: true,
+		chunkModules: true,
+		entrypoints: true,
 		modules: false,
 	},
 	module: {

--- a/client/webpack/webpackConfig.dev.js
+++ b/client/webpack/webpackConfig.dev.js
@@ -10,6 +10,7 @@ const crypto = require('crypto');
 const cryptoCreateHash = crypto.createHash;
 crypto.createHash = (algorithm) => cryptoCreateHash(algorithm === 'md4' ? 'sha256' : algorithm);
 
+/** @type {import('webpack').Configuration} */
 module.exports = {
 	mode: 'development',
 	entry: {
@@ -34,8 +35,9 @@ module.exports = {
 	output: {
 		filename: '[name].js',
 		path: resolve(__dirname, '../../dist/client'),
-		publicPath: '/',
+		publicPath: '/dist/',
 		hashFunction: 'sha256',
+		chunkFilename: '[name].bundle.js',
 	},
 	stats: {
 		colors: true,
@@ -111,20 +113,20 @@ module.exports = {
 		// Allow shared utils to import the sentry/node package by replacing it in the webpack build
 		new webpack.NormalModuleReplacementPlugin(/@sentry\/node/, '@sentry/react'),
 	],
-	optimization: {
-		splitChunks: {
-			cacheGroups: {
-				vendors: {
-					// TODO: bundle components into vendor, I think...
-					// test: /([\\/]node_modules[\\/]|[\\/]components[\\/])/,
-					test: /([\\/]node_modules[\\/])/,
-					name: 'vendor',
-					chunks: 'all',
-					// minChunks: 2,
-				},
-			},
-		},
-	},
+	// optimization: {
+	// 	splitChunks: {
+	// 		cacheGroups: {
+	// 			vendors: {
+	// 				// TODO: bundle components into vendor, I think...
+	// 				// test: /([\\/]node_modules[\\/]|[\\/]components[\\/])/,
+	// 				test: /([\\/]node_modules[\\/])/,
+	// 				name: 'vendor',
+	// 				chunks: 'all',
+	// 				// minChunks: 2,
+	// 			},
+	// 		},
+	// 	},
+	// },
 	node: {
 		net: 'empty',
 		tls: 'empty',

--- a/server/Html.tsx
+++ b/server/Html.tsx
@@ -87,7 +87,7 @@ const Html = (props: Props) => {
 					name="google-site-verification"
 					content="jmmJFnkSOeIEuS54adOzGMwc0kwpsa8wQ-L4GyPpPDg"
 				/>
-				<link rel="stylesheet" type="text/css" href={getPath('vendor', 'css')} />
+				{/* <link rel="stylesheet" type="text/css" href={getPath('vendor', 'css')} /> */}
 				<link rel="stylesheet" type="text/css" href={getPath('main', 'css')} />
 				{customScripts?.css && (
 					<style

--- a/utils/analytics/createAnalyticsInstance.ts
+++ b/utils/analytics/createAnalyticsInstance.ts
@@ -1,7 +1,7 @@
 // @ts-expect-error FIXME: types from @analytics/core are not bundled properly
 import { Analytics } from '@analytics/core';
 import type { AnalyticsInstance } from 'analytics';
-import googleAnalyticsPlugin from '@analytics/google-analytics';
+// import googleAnalyticsPlugin from '@analytics/google-analytics';
 import simpleAnalyticsPlugin from '@analytics/simple-analytics';
 import type { AnalyticsSettings } from 'types';
 import { analyticsPlugin, stubPlugin } from './plugin';
@@ -37,17 +37,17 @@ const getPluginsForType = ({
 			);
 			break;
 		}
-		case 'google-analytics': {
-			if (googleAnalyticsRefused) {
-				break;
-			}
-			analyticsPlugins.push(
-				googleAnalyticsPlugin({
-					measurementIds: [analyticsSettings.credentials],
-				}),
-			);
-			break;
-		}
+		// case 'google-analytics': {
+		// 	if (googleAnalyticsRefused) {
+		// 		break;
+		// 	}
+		// 	analyticsPlugins.push(
+		// 		googleAnalyticsPlugin({
+		// 			measurementIds: [analyticsSettings.credentials],
+		// 		}),
+		// 	);
+		// 	break;
+		// }
 		default:
 			break;
 	}

--- a/utils/analytics/createAnalyticsInstance.ts
+++ b/utils/analytics/createAnalyticsInstance.ts
@@ -1,21 +1,24 @@
+// we use @analytics/core instead of analytics to avoid setting cookies
 // @ts-expect-error FIXME: types from @analytics/core are not bundled properly
 import { Analytics } from '@analytics/core';
 import type { AnalyticsInstance } from 'analytics';
 import type { AnalyticsSettings } from 'types';
 import { analyticsPlugin, stubPlugin } from './plugin';
+import { thirdPartyPlugins, thirdPartyPluginsThatNeedGdprConsent } from './thirdPartyPlugins';
 
-// TODO: lazy load the plugins. Might be hard as they are needed when the page first loads, forcing a lot of rerenders
-const getPluginsForType = async ({
+const loadAnalyticsPlugins = async ({
 	shouldStub,
 	canUseCustomAnalyticsProvider,
-	googleAnalyticsRefused,
+	gdprConsent,
 	analyticsSettings,
 }: {
 	shouldStub?: boolean;
-	googleAnalyticsRefused?: boolean;
+	gdprConsent?: boolean | null;
 	canUseCustomAnalyticsProvider?: boolean;
 	analyticsSettings: AnalyticsSettings;
 }) => {
+	const { type = null, credentials = null } = analyticsSettings ?? {};
+
 	if (shouldStub) {
 		return [stubPlugin()];
 	}
@@ -26,42 +29,42 @@ const getPluginsForType = async ({
 		return analyticsPlugins;
 	}
 
-	switch (analyticsSettings?.type) {
-		case 'simple-analytics': {
-			const { default: simpleAnalyticsPlugin } = await import(
-				/* webpackChunkName: "@analytics/simple-analytics" */
-				'@analytics/simple-analytics'
-			);
-
-			analyticsPlugins.push(
-				simpleAnalyticsPlugin({
-					autoCollect: false,
-				}),
-			);
-			break;
-		}
-		case 'google-analytics': {
-			if (googleAnalyticsRefused) {
-				break;
-			}
-
-			const { default: googleAnalyticsPlugin } = await import(
-				/* webpackChunkName: "@analytics/google-analytics" */
-				'@analytics/google-analytics'
-			);
-
-			analyticsPlugins.push(
-				googleAnalyticsPlugin({
-					measurementIds: [analyticsSettings.credentials],
-				}),
-			);
-			break;
-		}
-		default:
-			break;
+	if (!type) {
+		return analyticsPlugins;
 	}
 
-	return analyticsPlugins;
+	const provider = thirdPartyPlugins[type];
+	if (!provider) {
+		throw new Error(`Unknown analytics provider: ${type}`);
+	}
+
+	if (provider.needsGdprConsent && !gdprConsent) {
+		return analyticsPlugins;
+	}
+
+	const loadedPlugin = await provider.load(credentials);
+
+	return [...analyticsPlugins, loadedPlugin];
+};
+
+export const setGdprSensitivePlugins = async (
+	analytics: AnalyticsInstance,
+	gdprConsent?: boolean | null,
+) => {
+	const { plugins } = analytics.getState();
+
+	if (!thirdPartyPluginsThatNeedGdprConsent.some((plugin) => plugin in plugins)) {
+		return;
+	}
+
+	await Promise.all(
+		thirdPartyPluginsThatNeedGdprConsent.map((pluginName) => {
+			if (gdprConsent) {
+				return analytics.plugins.enable(pluginName);
+			}
+			return analytics.plugins.disable(pluginName, () => {});
+		}),
+	);
 };
 
 export const createAnalyticsInstance = async ({
@@ -77,28 +80,34 @@ export const createAnalyticsInstance = async ({
 	gdprConsent?: boolean | null;
 	analyticsSettings: AnalyticsSettings;
 }) => {
-	const googleAnalyticsRefused = analyticsSettings?.type === 'google-analytics' && !gdprConsent;
-
-	const plugins = await getPluginsForType({
+	const plugins = await loadAnalyticsPlugins({
 		shouldStub: !shouldUseNewAnalytics,
 		canUseCustomAnalyticsProvider,
-		googleAnalyticsRefused,
 		analyticsSettings,
+		gdprConsent,
 	});
 
 	const analytics = Analytics({
 		app: appname,
 		debug: true,
 		plugins,
-	});
+	}) as AnalyticsInstance;
 
-	return analytics as AnalyticsInstance;
+	await setGdprSensitivePlugins(analytics, gdprConsent);
+
+	return analytics;
 };
 
-export const createStubAnalyticsInstance = () => {
-	return Analytics({
+export const createInitialAnalyticsInstance = (shouldUseNewAnalytics = true) => {
+	const initialAnalyticsPluginToUse = shouldUseNewAnalytics ? analyticsPlugin() : stubPlugin();
+
+	const stubInstance = Analytics({
 		app: 'pubpub',
 		debug: true,
-		plugins: [stubPlugin()],
+		plugins: [initialAnalyticsPluginToUse],
 	});
+
+	stubInstance.isStub = true;
+
+	return stubInstance as AnalyticsInstance & { isStub: true };
 };

--- a/utils/analytics/ignoredPaths.ts
+++ b/utils/analytics/ignoredPaths.ts
@@ -1,0 +1,8 @@
+/** Paths for which analytics should not be loaded */
+export const ingoredPaths = [
+	/^\/dash\/.*/,
+	/^\/login/,
+	/^\/signup/,
+	/^\/password-reset/,
+	/^\/superadmin/,
+] as const;

--- a/utils/analytics/thirdPartyPlugins.ts
+++ b/utils/analytics/thirdPartyPlugins.ts
@@ -30,7 +30,7 @@ export const thirdPartyPlugins = {
 		key: 'simple-analytics',
 		name: 'Simple Analytics',
 		needsGdprConsent: false,
-		load: (_credentials) =>
+		load: () =>
 			import(
 				/* webpackChunkName: "@analytics/simple-analytics" */
 				'@analytics/simple-analytics'

--- a/utils/analytics/thirdPartyPlugins.ts
+++ b/utils/analytics/thirdPartyPlugins.ts
@@ -1,0 +1,83 @@
+// eslint-disable-next-line import/no-unresolved
+import { AnalyticsPlugin } from 'analytics';
+import { AnalyticsSettings, AnalyticsType } from 'types/analyticsSettings';
+
+export type ThirdPartyPluginsShape = {
+	[K in AnalyticsType]?: {
+		key: K;
+		name: string;
+		needsGdprConsent: boolean;
+		load: (
+			credentials: (AnalyticsSettings & { key: K })['credentials'],
+		) => Promise<AnalyticsPlugin>;
+	};
+};
+
+export const thirdPartyPlugins = {
+	'google-analytics': {
+		key: 'google-analytics',
+		name: 'Google Analytics',
+		needsGdprConsent: true,
+		load: (credentials) =>
+			import(
+				/* webpackChunkName: "@analytics/google-analytics" */
+				'@analytics/google-analytics'
+			).then(({ default: googleAnalyticsPlugin }) =>
+				googleAnalyticsPlugin({ measurementIds: [credentials] }),
+			),
+	},
+	'simple-analytics': {
+		key: 'simple-analytics',
+		name: 'Simple Analytics',
+		needsGdprConsent: false,
+		load: (_credentials) =>
+			import(
+				/* webpackChunkName: "@analytics/simple-analytics" */
+				'@analytics/simple-analytics'
+			).then(({ default: simpleAnalyticsPlugin }) =>
+				simpleAnalyticsPlugin({ autoCollect: false }),
+			),
+	},
+} as const satisfies ThirdPartyPluginsShape;
+
+export type ThirdPartyPlugins = typeof thirdPartyPlugins;
+
+export type ThirdPartyPlugin = ThirdPartyPlugins[keyof ThirdPartyPlugins];
+
+export const thirdPartyPluginsThatNeedGdprConsent = Object.values(thirdPartyPlugins)
+	.filter(
+		(plugin): plugin is Extract<ThirdPartyPlugin, { needsGdprConsent: true }> =>
+			plugin.needsGdprConsent,
+	)
+	.map((provider) => provider.key);
+
+export const getThirdPartyPluginsObjectWithGdprConsent = (
+	gdprConsent: boolean | null,
+	plugins: {
+		[K in AnalyticsType | 'analytics-plugin']?: {
+			enabled: boolean;
+			loaded: boolean;
+			initialized: boolean;
+			config: Record<string, any>;
+		};
+	},
+) => {
+	return Object.entries(plugins).reduce(
+		(acc, [pluginName, plugin]) => {
+			if (plugins && !plugin?.enabled) {
+				return acc;
+			}
+
+			if (!thirdPartyPlugins[pluginName]) {
+				return acc;
+			}
+
+			const isEnabledAndHasConsent =
+				plugin.enabled && (gdprConsent || !thirdPartyPlugins[pluginName]?.needsGdprConsent);
+
+			acc[pluginName] = isEnabledAndHasConsent;
+			return acc;
+		},
+		{} as Record<AnalyticsType, boolean>,
+	);
+};

--- a/utils/analytics/useLazyLoadedAnalyticsInstance.ts
+++ b/utils/analytics/useLazyLoadedAnalyticsInstance.ts
@@ -1,7 +1,8 @@
 import type { AnalyticsInstance } from 'analytics';
 import { useEffect, useState } from 'react';
-import { AnalyticsSettings } from 'types';
+import { AnalyticsSettings, LocationData } from 'types';
 import { createAnalyticsInstance, createInitialAnalyticsInstance } from './createAnalyticsInstance';
+import { ingoredPaths } from './ignoredPaths';
 
 export const useLazyLoadedAnalyticsInstance = ({
 	appname = 'pubpub',
@@ -9,27 +10,28 @@ export const useLazyLoadedAnalyticsInstance = ({
 	canUseCustomAnalyticsProvider,
 	gdprConsent,
 	analyticsSettings,
+	locationData,
 }: {
 	appname?: string;
 	shouldUseNewAnalytics?: boolean;
 	canUseCustomAnalyticsProvider?: boolean;
 	gdprConsent?: boolean | null;
 	analyticsSettings: AnalyticsSettings;
+	locationData: LocationData;
 }) => {
 	const [analytics, setAnalytics] = useState<AnalyticsInstance>(
 		createInitialAnalyticsInstance(shouldUseNewAnalytics),
 	);
 
+	const isIgnoredPath = ingoredPaths.some((path) => path.test(locationData.path));
+
 	const needsCustomPlugin =
-		shouldUseNewAnalytics && canUseCustomAnalyticsProvider && analyticsSettings !== null;
+		shouldUseNewAnalytics &&
+		canUseCustomAnalyticsProvider &&
+		analyticsSettings !== null &&
+		!isIgnoredPath;
 
 	useEffect(() => {
-		console.log({
-			shouldUseNewAnalytics,
-			canUseCustomAnalyticsProvider,
-			analyticsSettings,
-			needsCustomPlugin,
-		});
 		if (!needsCustomPlugin) {
 			return;
 		}

--- a/utils/analytics/useLazyLoadedAnalyticsInstance.ts
+++ b/utils/analytics/useLazyLoadedAnalyticsInstance.ts
@@ -1,0 +1,47 @@
+import type { AnalyticsInstance } from 'analytics';
+import { useEffect, useState } from 'react';
+import { AnalyticsSettings } from 'types';
+import { createAnalyticsInstance, createInitialAnalyticsInstance } from './createAnalyticsInstance';
+
+export const useLazyLoadedAnalyticsInstance = ({
+	appname = 'pubpub',
+	shouldUseNewAnalytics,
+	canUseCustomAnalyticsProvider,
+	gdprConsent,
+	analyticsSettings,
+}: {
+	appname?: string;
+	shouldUseNewAnalytics?: boolean;
+	canUseCustomAnalyticsProvider?: boolean;
+	gdprConsent?: boolean | null;
+	analyticsSettings: AnalyticsSettings;
+}) => {
+	const [analytics, setAnalytics] = useState<AnalyticsInstance>(
+		createInitialAnalyticsInstance(shouldUseNewAnalytics),
+	);
+
+	const needsCustomPlugin =
+		shouldUseNewAnalytics && canUseCustomAnalyticsProvider && analyticsSettings !== null;
+
+	useEffect(() => {
+		console.log({
+			shouldUseNewAnalytics,
+			canUseCustomAnalyticsProvider,
+			analyticsSettings,
+			needsCustomPlugin,
+		});
+		if (!needsCustomPlugin) {
+			return;
+		}
+
+		createAnalyticsInstance({
+			appname,
+			shouldUseNewAnalytics,
+			canUseCustomAnalyticsProvider,
+			gdprConsent,
+			analyticsSettings,
+		}).then(setAnalytics);
+	}, [Boolean(gdprConsent && needsCustomPlugin)]);
+
+	return analytics;
+};

--- a/utils/analytics/usePageOnce.ts
+++ b/utils/analytics/usePageOnce.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useState } from 'react';
+import { PageViewPayload, useAnalytics } from './useAnalytics';
+import { getThirdPartyPluginsObjectWithGdprConsent } from './thirdPartyPlugins';
+
+/**
+ * Custom hook that sends a page view event to the analytics services only once.
+ *
+ * Also handles rerender logic for GDPR consent when using Google Analytics.
+ *
+ * # Base Flow f
+ *
+ * 1. Page loads with our analytics enabled
+ * 2. Page view event is sent to only our analytics service
+ *
+ * This always happens, regardless of consent.
+ *
+ * ## Flow for privacy friendly 3rd party analytics provider, or Google Analytics + consent given
+ *
+ * 3. Other analytics provider is loaded in dynamically
+ * 4. Page view event is sent to other analytics provider
+ *
+ * ## Flow for Google Analytics + consent not yet given
+ *
+ * 3. User gives consent by e.g. clicking "Accept" on the cookie banner
+ * 4. Google Analytics is loaded in dynamically
+ * 5. Page view event is sent to Google Analytics
+ *
+ * ## Flow for Google Analytics + consent refused
+ *
+ * Nothing happens on top of the base flow, Google Analytics is never loaded.
+ *
+ * @param payload - The payload containing the page view data or a function that returns the
+ *   payload.
+ * @param gdprConsent - Optional boolean indicating whether GDPR consent has been given.
+ */
+export const usePageOnce = (
+	payload: PageViewPayload | (() => PageViewPayload | null),
+	gdprConsent?: boolean | null,
+) => {
+	const { page, getState } = useAnalytics();
+	const [hasFiredInitialEvent, setHasFiredInitialEvent] = useState(false);
+	const [hasFiredLazyPlugin, setHasFiredLazyPlugin] = useState(false);
+
+	// Function to get the payload
+	const getPayload = useCallback(
+		() => (typeof payload === 'function' ? payload() : payload),
+		[payload],
+	);
+
+	const { plugins } = getState();
+
+	const pluginLength = Object.keys(plugins).length;
+
+	useEffect(() => {
+		const allEventsHaveFired = hasFiredInitialEvent && hasFiredLazyPlugin;
+		if (allEventsHaveFired) {
+			return;
+		}
+
+		const toBeSentPayload = getPayload();
+		if (!toBeSentPayload) {
+			return;
+		}
+
+		// Initial event firing with our custom plugin (only once), before other plugins are loaded
+		if (!hasFiredInitialEvent) {
+			page(toBeSentPayload, {
+				plugins: {
+					all: false,
+					'analytics-plugin': true,
+				},
+			});
+			setHasFiredInitialEvent(true);
+			return;
+		}
+
+		const enabledGdprPlugins = getThirdPartyPluginsObjectWithGdprConsent(
+			Boolean(gdprConsent),
+			plugins,
+		);
+		page(toBeSentPayload, {
+			plugins: {
+				all: false,
+				...enabledGdprPlugins,
+			},
+		});
+		setHasFiredLazyPlugin(true);
+		/**
+		 * The only change we need to track is whether the custom analytics get loaded afterwards or
+		 * not
+		 */
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [pluginLength]);
+};


### PR DESCRIPTION
This PR allows for the following flow

1. At page load, our analytics plugin is loaded, and a pageview event is sent
2. If the user has some third party analytics enabled, that plugin is lazy loaded immediately afterwards OR after accepting the GDPR cookie banner if using a plugin which requires setting cookies (for now only GA)

Additionally, it improves how 3rd party plugins are defined, and cleans up the analytics code a bit.

## Issue(s) Resolved

#2998 

<details>
<summary> 
<h2>Test Plan</h2>
<hr/>
 </summary>

The current setup for features per community is

- `demo`: uses new analytics, does not use 3rd party plugins
- `jtrialerror`: uses new analytics, uses google analytics
- `eric`: uses custom analytics, uses simple analytics

For each of these tests, open inspector and clear cookies, and disable adblock for good measure

### `demo`/just custom analytics

1. Open page
4. Check that event is sent to `/api/analytics/track`
5. Check that no cookies are set, and no additional modules are loaded


### `jtrialerror`/ google analytics

1. Open page
2. Check that you see cookie banner popup, do not accept yet
3. Check that event is sent to `/api/analytics/track`
6. Check that no cookies are set, and no additional modules are loaded

Then, check the following

7. Click "Accept"
8. Check that Google Analytics Module is loaded (from `dist/@analytics/google-analytics.[hash].bundle.js`, analytics script is loaded from google
9. Wait 10ish seconds, check that `collect` event is sent to google

Also check

5. Click "Disable"
6. Check that google analytics is not loaded, no events are sent to google


Also check

5. Click "Accept"
6. Reload page
7. Check that google analytics module is loaded, analytics script is loaded from google, and `collect` event is sent to google


Also check

1. Go to `/dash/overview` or anything `/dash`
2. Check that Google Analytics is not loaded (we don't want to load it there)

### `eric`/ simple analytics

1. Open page
3. Check that no cookie banner pops up
4. Check that module is loaded from `dist/@analytics/simple-analytics.[hash].bundle.js`
5. Check that script is loaded from simple
6. Check that event is sent to simple (looks like a request to `simple.gif`, very clever)


Also check

1. Go to `/dash/overview`
2. Check that Simple analytics is not loaded
</details>


## Supporting Docs

### Lazy loading

In order to allow for lazy loading, some small changes needed to be made to the `webpack` settings.

I basically needed to prevent certain modules from being bundled in `vendor.js`, seen here:

https://github.com/pubpub/pubpub/blob/4b01739c8723829e65a82e078d0579b54db3023b/client/webpack/webpackConfig.dev.js#L124-L131

At the moment the only modules that are lazy loaded are the analytics modules.

https://github.com/pubpub/pubpub/blob/4b01739c8723829e65a82e078d0579b54db3023b/client/webpack/lazyLoadedModules.js#L1-L2
This could be expanded to e.g. the language modules for code blocks in the pub editor in a future pr.


### General flow

First, the `useLazyLoadedAnalyticsInstance` hook is called in `<App>`

https://github.com/pubpub/pubpub/blob/e42c9f2ff3aafb9b05f898c84138e09960d01ea4/client/containers/App/App.tsx#L59-L65

This creates the initial analytics instance, which is a stub if the community does not have access to the new analytics suite, and an analytics instance with our analytics plugin otherwise

https://github.com/pubpub/pubpub/blob/e42c9f2ff3aafb9b05f898c84138e09960d01ea4/client/containers/App/App.tsx#L59-L65

Then, in this `useEffect`, the other plugins are loaded IF we are on a path that requires plugins (e.g. not `/dash/*`, `/login` etc. I did not think we needed to send that to e.g. google analytics or simple. This is mostly for `simple`, as we cannot control when a pageview event is sent, it does this automatically on load.), the community has access to 3rd party analytics providers, and the community has a third party analytics provider set.

https://github.com/pubpub/pubpub/blob/e42c9f2ff3aafb9b05f898c84138e09960d01ea4/utils/analytics/useLazyLoadedAnalyticsInstance.ts#L26-L46


Elsewhere, page views can be tracked using the `usePageOnce` hook, which is used in the `Layout` component, and in the `PubDocument` component, to capture pageviews for pages, collections, and pubs.
This might not be the best place for it, we could theoretically also do this higher up, but this way it was easier to feed page specific data to the hook, e.g. `pubId`s for Pubs and `collectionId`s for Collections.

https://github.com/pubpub/pubpub/blob/1d7c715a9009a398ab864e78827e3afb761f043f/client/components/Layout/Layout.tsx#L37-L63

https://github.com/pubpub/pubpub/blob/1d7c715a9009a398ab864e78827e3afb761f043f/client/containers/Pub/PubDocument/PubDocument.tsx#L58-L74


In `usePageOnce`, the flow is as follows

1. Send pageview event to our analytics if that has not happened yet
https://github.com/pubpub/pubpub/blob/1d7c715a9009a398ab864e78827e3afb761f043f/utils/analytics/usePageOnce.ts#L65-L75
2. Send a pageview event to the other analytics once the other analytics plugin has loaded and, if necessary, GDPR consent has been given 
https://github.com/pubpub/pubpub/blob/1d7c715a9009a398ab864e78827e3afb761f043f/utils/analytics/usePageOnce.ts#L77-L87

We only need to listen for changes in the number of plugins, as plugins are loaded either after initial load or after the GDPR cookies have been accepted. This way we don't need to separately listen for cookie-banner-accept-events, as done previously.

https://github.com/pubpub/pubpub/blob/1d7c715a9009a398ab864e78827e3afb761f043f/client/containers/Pub/PubDocument/PubDocument.tsx#L58-L74



