### PR TITLE
feat: add additional fields to the analytics schema

### DIFF
--- a/client/components/Layout/Layout.tsx
+++ b/client/components/Layout/Layout.tsx
@@ -41,16 +41,21 @@ const Layout = (props: Props) => {
 			return null;
 		}
 
+		const base = {
+			communityId: communityData.id,
+			communityName: communityData.title,
+			communitySubdomain: communityData.subdomain,
+		};
+
 		if (collection) {
 			return {
 				event: 'collection' as const,
-				communityId: collection.communityId,
 				title: collection.title,
 				collectionId: collection.id,
 				collectionTitle: collection.title,
 				collectionSlug: collection.slug,
 				collectionKind: expect(collection.kind),
-				communityName: communityData.title,
+				...base,
 			};
 		}
 
@@ -58,11 +63,10 @@ const Layout = (props: Props) => {
 
 		return {
 			event: 'page' as const,
-			communityId: communityData.id,
-			communityName: communityData.title,
 			pageSlug: pageData.slug,
 			pageTitle: pageData.title,
 			pageId: pageData.id,
+			...base,
 		};
 	}, gdprConsent);
 

--- a/client/components/Layout/Layout.tsx
+++ b/client/components/Layout/Layout.tsx
@@ -45,6 +45,7 @@ const Layout = (props: Props) => {
 			communityId: communityData.id,
 			communityName: communityData.title,
 			communitySubdomain: communityData.subdomain,
+			isProd: locationData.isProd,
 		};
 
 		if (collection) {

--- a/client/containers/Pub/PubDocument/PubDocument.tsx
+++ b/client/containers/Pub/PubDocument/PubDocument.tsx
@@ -70,6 +70,7 @@ const PubDocument = () => {
 			communityId: pubData.communityId,
 			communityName: communityData.title,
 			communitySubdomain: communityData.subdomain,
+			isProd: locationData.isProd,
 		},
 		gdprConsent,
 	);

--- a/client/containers/Pub/PubDocument/PubDocument.tsx
+++ b/client/containers/Pub/PubDocument/PubDocument.tsx
@@ -58,8 +58,6 @@ const PubDocument = () => {
 	usePageOnce(
 		{
 			event: 'pub',
-			communityId: pubData.communityId,
-			communityName: communityData.title,
 			pubSlug: pubData.slug,
 			pubId: pubData.id,
 			pubTitle: pubData.title,
@@ -69,6 +67,9 @@ const PubDocument = () => {
 			collectionSlug: collection?.slug,
 			primaryCollectionId: getPrimaryCollection(pubData?.collectionPubs)?.id,
 			collectionKind: collection?.kind,
+			communityId: pubData.communityId,
+			communityName: communityData.title,
+			communitySubdomain: communityData.subdomain,
 		},
 		gdprConsent,
 	);

--- a/client/containers/Pub/PubHeader/Download.tsx
+++ b/client/containers/Pub/PubHeader/Download.tsx
@@ -64,6 +64,7 @@ const Download = (props: Props) => {
 			communitySubdomain: communityData.subdomain,
 			format: type.format,
 			pubId: pubData.id,
+			isProd: locationData.isProd,
 		});
 		if (type.format === 'formatted') {
 			return download(formattedDownload.url);

--- a/client/containers/Pub/PubHeader/Download.tsx
+++ b/client/containers/Pub/PubHeader/Download.tsx
@@ -59,6 +59,9 @@ const Download = (props: Props) => {
 	// eslint-disable-next-line consistent-return
 	const handleStartDownload = (type) => {
 		track('download', {
+			communityId: communityData.id,
+			communityName: communityData.title,
+			communitySubdomain: communityData.subdomain,
 			format: type.format,
 			pubId: pubData.id,
 		});

--- a/server/analytics/api.ts
+++ b/server/analytics/api.ts
@@ -9,7 +9,9 @@ import type { AnalyticsEvent } from 'utils/api/schemas/analytics';
 
 const s = initServer();
 
-const sendToStitch = async (payload: AnalyticsEvent & { country: string | null }) => {
+const sendToStitch = async (
+	payload: AnalyticsEvent & { country: string | null; countryCode: string | null },
+) => {
 	if (!process.env.STITCH_WEBHOOK_URL) {
 		throw new Error('Missing STITCH_WEBHOOK_URL');
 	}
@@ -45,9 +47,9 @@ export const analyticsServer = s.router(contract.analytics, {
 		handler: async ({ body: payload }) => {
 			const { timezone } = payload;
 
-			const { name: country = null } = getCountryForTimezone(timezone) || {};
+			const { name: country = null, id = null } = getCountryForTimezone(timezone) || {};
 
-			await sendToStitch({ country, ...payload });
+			await sendToStitch({ country, countryCode: id, ...payload });
 
 			return {
 				status: 204,

--- a/utils/analytics/useAnalytics.ts
+++ b/utils/analytics/useAnalytics.ts
@@ -1,11 +1,11 @@
 import type { AnalyticsType } from 'types';
-import type { PageViewPayload, Track } from 'utils/api/schemas/analytics';
+import type { PageViewPayload, TrackPayload, TrackEvent } from 'utils/api/schemas/analytics';
 import { useAnalytics as useOldAnalytics } from 'use-analytics';
 import type { AnalyticsInstance } from 'analytics';
 import { stubPlugin } from './plugin';
 
 type Analytics = {
-	track: <T extends Track>(event: T['event'], data: Omit<T, 'type' | 'event'>) => void;
+	track: <T extends TrackEvent>(event: T, data: TrackPayload<T>) => void;
 	page: <Payload extends PageViewPayload>(
 		payload?: Payload,
 		options?: {

--- a/utils/api/schemas/analytics.ts
+++ b/utils/api/schemas/analytics.ts
@@ -25,6 +25,7 @@ export const sharedEventPayloadSchema = z.object({
 	communityId: z.string().uuid(),
 	communitySubdomain: z.string(),
 	communityName: z.string(),
+	isProd: z.boolean(),
 });
 
 export const basePageViewSchema = baseSchema.merge(

--- a/utils/api/schemas/analytics.ts
+++ b/utils/api/schemas/analytics.ts
@@ -20,6 +20,13 @@ export const baseSchema = z.object({
 	os: z.string(),
 });
 
+/** Information that should always be included in any event payload */
+export const sharedEventPayloadSchema = z.object({
+	communityId: z.string().uuid(),
+	communitySubdomain: z.string(),
+	communityName: z.string(),
+});
+
 export const basePageViewSchema = baseSchema.merge(
 	z.object({
 		type: z.literal('page'),
@@ -32,11 +39,11 @@ export const basePageViewSchema = baseSchema.merge(
 	}),
 );
 
-export const sharedPageViewPayloadSchema = z.object({
-	communityId: z.string().uuid(),
-	communityName: z.string(),
-	event: z.enum(['page', 'collection', 'pub']),
-});
+export const sharedPageViewPayloadSchema = sharedEventPayloadSchema.merge(
+	z.object({
+		event: z.enum(['page', 'collection', 'pub']),
+	}),
+);
 
 export const pagePageViewPayloadSchema = sharedPageViewPayloadSchema.merge(
 	z.object({
@@ -78,29 +85,44 @@ export const pageViewPayloadSchema = z.discriminatedUnion('event', [
 
 export const pageViewSchema = pageViewPayloadSchema.and(basePageViewSchema);
 
-export const pubDownloadTrackPayloadSchema = z.object({
-	format: z.string(),
-	pubId: z.string().uuid(),
-});
+export const baseTrackSchema = baseSchema.merge(
+	z.object({
+		type: z.literal('track'),
+	}),
+);
 
-export const pubDownloadTrackSchema = pubDownloadTrackPayloadSchema.extend({
-	type: z.literal('track'),
-	event: z.literal('download'),
-});
+export const sharedTrackPayloadSchema = sharedEventPayloadSchema;
+
+export const pubDownloadTrackPayloadSchema = sharedTrackPayloadSchema.merge(
+	z.object({
+		format: z.string(),
+		pubId: z.string().uuid(),
+	}),
+);
+
+export const pubDownloadTrackSchema = pubDownloadTrackPayloadSchema.merge(
+	z.object({
+		event: z.literal('download'),
+	}),
+);
 
 // this is just here to set up the discriminated union, can't have a union of one
-export const stubTrackPayloadSchema = z.object({});
+export const stubTrackPayloadSchema = sharedTrackPayloadSchema.merge(z.object({}));
 
-export const stubTrackSchema = z.object({
-	type: z.literal('track'),
-	event: z.literal('stub'),
-});
+export const stubTrackSchema = stubTrackPayloadSchema.merge(
+	z.object({
+		event: z.literal('stub'),
+	}),
+);
 
-export const trackSchema = z.discriminatedUnion('event', [pubDownloadTrackSchema, stubTrackSchema]);
+export const trackSchemaPayloadSchemaWithEvent = z.discriminatedUnion('event', [
+	pubDownloadTrackSchema,
+	stubTrackSchema,
+]);
 
-export const trackSchemaFull = baseSchema.and(trackSchema);
+export const trackSchema = trackSchemaPayloadSchemaWithEvent.and(baseTrackSchema);
 
-export const analyticsEventSchema = z.union([trackSchemaFull, pageViewSchema]);
+export const analyticsEventSchema = z.union([trackSchema, pageViewSchema]);
 
 export type AnalyticsEvent = z.infer<typeof analyticsEventSchema>;
 
@@ -112,6 +134,10 @@ export type PubDownloadPayload = z.infer<typeof pubDownloadTrackPayloadSchema>;
 
 export type Track = z.infer<typeof trackSchema>;
 
-export type TrackPayload<T extends Track = Track> = T extends any
-	? Prettify<Omit<T, 'event' | 'type'>>
+export type TrackPayloadWithEvent = z.infer<typeof trackSchemaPayloadSchemaWithEvent>;
+
+export type TrackEvent = TrackPayloadWithEvent['event'];
+
+export type TrackPayload<T extends TrackEvent = TrackEvent> = T extends any
+	? Prettify<Omit<TrackPayloadWithEvent & { event: T }, 'event'>>
 	: never;


### PR DESCRIPTION
- refactor: require community name/subdomain for track events
- feat: add country code to data
- feat: add isProd flag to analytics event payload

## Issue(s) Resolved

This semi-finalizes the schema for analytics.

Explanation of the extra flags

### Community name/id/subdomain for every event

This makes grouping events easier in metabase.
Before I only required this info for pageviews, but I now also do for track events.


### Country code

This allows us to use a different map in metabase that is slightly nicer.
Specifically, this map has much easier to see/click countries. To pick a completely random and non-biased example, the Netherlands is quite hard to see on the default one.



### isProd

I decided that it would be much easier to store Prod and Dev analytics in the same db. 

The way metabase works means we basically have to duplicate every view/model/dashboard if we use two different databases, making it very hard to keep things in sync. 

By using the same database, we only have to create two versions of every dashboard, which is much easier to do.

The downside is that schema experimentation in dev is slightly more risky, as it will also affect the prod db.
I do not think this is a significant issue though, since most schema changes moving forward would probably be additive.

## Test Plan

1. Go to `demo`
2. Check whether analytics event sent to `/api/analytics/track` contains the `isProd` flag. It should be false

You could also try to do this locally

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
