### PR TITLE
fix: add client and server side validation for orcids

### DIFF
--- a/client/components/AttributionEditor/AttributionDetailControls.tsx
+++ b/client/components/AttributionEditor/AttributionDetailControls.tsx
@@ -3,8 +3,10 @@ import { Checkbox, Classes, InputGroup, MenuItem, Position, Tag } from '@bluepri
 import { MultiSelect } from '@blueprintjs/select';
 
 import { AttributionWithUser } from 'types';
+import { ORCID_ID_PATTERN } from 'utils/orcid';
 
 import { getFilteredRoles } from './roles';
+import InputField from '../InputField/InputField';
 
 type Props = {
 	attribution: AttributionWithUser;
@@ -18,6 +20,8 @@ const AttributionDetailControls = (props: Props) => {
 	const { attribution, isShadowAttribution, listOnBylineText, onAttributionUpdate, roles } =
 		props;
 	const { affiliation, id, isAuthor, orcid } = attribution;
+
+	const isOrcidInvalid = Boolean(orcid && !orcid.match(ORCID_ID_PATTERN));
 
 	return (
 		<div className="detail-controls">
@@ -112,7 +116,7 @@ const AttributionDetailControls = (props: Props) => {
 					}
 				/>
 				{isShadowAttribution && (
-					<InputGroup
+					<InputField
 						// @ts-expect-error ts-migrate(2322) FIXME: Type '"" | Element | undefined' is not assignable ... Remove this comment to see the full error message
 						rightElement={orcid && <Tag minimal>ORCID</Tag>}
 						placeholder="ORCID"
@@ -127,6 +131,11 @@ const AttributionDetailControls = (props: Props) => {
 								id,
 								orcid: evt.target.value.trim(),
 							})
+						}
+						error={
+							isOrcidInvalid
+								? 'Invalid ORCID. Please enter a valid ORCID or leave the field blank.'
+								: undefined
 						}
 					/>
 				)}

--- a/client/components/AttributionEditor/AttributionDetailControls.tsx
+++ b/client/components/AttributionEditor/AttributionDetailControls.tsx
@@ -3,7 +3,7 @@ import { Checkbox, Classes, InputGroup, MenuItem, Position, Tag } from '@bluepri
 import { MultiSelect } from '@blueprintjs/select';
 
 import { AttributionWithUser } from 'types';
-import { ORCID_ID_PATTERN } from 'utils/orcid';
+import { ORCID_ID_OR_URL_PATTERN } from 'utils/orcid';
 
 import { getFilteredRoles } from './roles';
 import InputField from '../InputField/InputField';
@@ -21,7 +21,7 @@ const AttributionDetailControls = (props: Props) => {
 		props;
 	const { affiliation, id, isAuthor, orcid } = attribution;
 
-	const isOrcidInvalid = Boolean(orcid && !orcid.match(ORCID_ID_PATTERN));
+	const isOrcidInvalid = Boolean(orcid && !orcid.match(ORCID_ID_OR_URL_PATTERN));
 
 	return (
 		<div className="detail-controls">

--- a/package-lock.json
+++ b/package-lock.json
@@ -311,7 +311,7 @@
 				"ts-loader": "^8.0.11",
 				"ts-morph": "^21.0.1",
 				"ts-node": "^10.9.1",
-				"typescript": "^5.2.2",
+				"typescript": "^5.3.3",
 				"webpack": "^4.41.5",
 				"webpack-bundle-analyzer": "^3.1.0",
 				"webpack-cli": "^3.3.1",
@@ -38418,9 +38418,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -71122,9 +71122,9 @@
 			}
 		},
 		"typescript": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw=="
 		},
 		"uglify-js": {
 			"version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -349,7 +349,7 @@
 		"ts-loader": "^8.0.11",
 		"ts-morph": "^21.0.1",
 		"ts-node": "^10.9.1",
-		"typescript": "^5.2.2",
+		"typescript": "^5.3.3",
 		"webpack": "^4.41.5",
 		"webpack-bundle-analyzer": "^3.1.0",
 		"webpack-cli": "^3.3.1",

--- a/server/pubAttribution/__tests__/pubAttribution.test.ts
+++ b/server/pubAttribution/__tests__/pubAttribution.test.ts
@@ -361,3 +361,100 @@ describe('GET /api/pubAttributions', () => {
 		expect(sortedOrder).toEqual(structuredClone(unsortedOrder).sort());
 	});
 });
+
+describe('orcid update tests', () => {
+	it('should allow you to create attributions with orcid ids, empty strings, nulls, and orcid urls', async () => {
+		const { pubManager, community, pub } = models;
+
+		const agent = await login(pubManager);
+
+		const { body: attr } = await agent
+			.post('/api/pubAttributions')
+			.send({
+				order: 0,
+				name: 'Test Person',
+				communityId: community.id,
+				pubId: pub.id,
+				orcid: '0000-0000-0000-0000',
+			})
+			.expect(201);
+
+		expect(attr.orcid).toEqual('0000-0000-0000-0000');
+
+		const { body: attr2 } = await agent
+			.post('/api/pubAttributions')
+			.send({
+				order: 0,
+				name: 'Test Person',
+				communityId: community.id,
+				pubId: pub.id,
+				orcid: '',
+			})
+			.expect(201);
+
+		expect(attr2.orcid).toEqual('');
+
+		const { body: attr3 } = await agent
+			.post('/api/pubAttributions')
+			.send({
+				order: 0,
+				name: 'Test Person',
+				communityId: community.id,
+				pubId: pub.id,
+				orcid: null,
+			})
+			.expect(201);
+
+		expect(attr3.orcid).toEqual(null);
+
+		const { body: attr4 } = await agent
+			.post('/api/pubAttributions')
+			.send({
+				order: 0,
+				name: 'Test Person',
+				communityId: community.id,
+				pubId: pub.id,
+				orcid: 'https://orcid.org/0000-0000-0000-0000',
+			})
+			.expect(201);
+
+		expect(attr4.orcid).toEqual('0000-0000-0000-0000');
+	});
+
+	it('should not allow you to update attributions with invalid orcids', async () => {
+		const { pubManager, community, pub } = models;
+
+		const agent = await login(pubManager);
+
+		const { body: attr } = await agent
+			.post('/api/pubAttributions')
+			.send({
+				order: 0,
+				name: 'Test Person',
+				communityId: community.id,
+				pubId: pub.id,
+				orcid: '0000-0000-0000-0000',
+			})
+			.expect(201);
+
+		await agent
+			.put('/api/pubAttributions')
+			.send({
+				orcid: 'random string',
+				communityId: community.id,
+				pubId: pub.id,
+				id: attr.id,
+			})
+			.expect(400);
+
+		await agent
+			.put('/api/pubAttributions')
+			.send({
+				orcid: '0000',
+				communityId: community.id,
+				pubId: pub.id,
+				id: attr.id,
+			})
+			.expect(400);
+	});
+});

--- a/server/pubAttribution/api.ts
+++ b/server/pubAttribution/api.ts
@@ -2,9 +2,6 @@ import { ForbiddenError } from 'server/utils/errors';
 
 import { expect } from 'utils/assert';
 import { createGetRequestIds } from 'utils/getRequestIds';
-import { z } from 'zod';
-import * as types from 'types';
-import { extendZodWithOpenApi } from '@anatine/zod-openapi';
 import { contract } from 'utils/api/contract';
 import { initServer } from '@ts-rest/express';
 import { queryMany } from 'utils/query/queryMany';
@@ -24,58 +21,6 @@ const getRequestIds = createGetRequestIds<{
 	pubId?: string;
 	id?: string;
 }>();
-
-extendZodWithOpenApi(z);
-
-export const attributionSchema = z.object({
-	id: z.string().uuid(),
-	order: z.number().max(1).min(0),
-	roles: z.array(z.string()).openapi({ example: types.DEFAULT_ROLES }).nullable(),
-	affiliation: z.string().nullable(),
-	isAuthor: z.boolean().nullable(),
-	userId: z.string().uuid().nullable(),
-	name: z.string().nullable(),
-	orcid: z.string().nullable(),
-	avatar: z.string().url().nullable(),
-	title: z.string().nullable().openapi({
-		deprecated: true,
-		description: 'Legacy field, do not use.',
-	}),
-}) satisfies z.ZodType<Omit<types.PubAttribution, 'pubId'>>;
-
-export const pubAttributionSchema = attributionSchema.merge(
-	z.object({
-		pubId: z.string().uuid(),
-	}),
-);
-
-export const attributionCreationSchema = attributionSchema
-	.omit({ id: true, pubId: true, userId: true, name: true, orcid: true })
-	.partial()
-	.merge(
-		z.object({
-			order: attributionSchema.shape.order.default(0.5),
-			roles: attributionSchema.shape.roles.default([]),
-			affiliation: attributionSchema.shape.affiliation.optional(),
-			isAuthor: attributionSchema.shape.isAuthor.optional(),
-		}),
-	)
-	.and(
-		z.union([
-			z.object({
-				userId: attributionSchema.shape.userId.unwrap(),
-				name: z.undefined().optional(),
-				orcid: z.undefined().optional(),
-			}),
-			z.object({
-				userId: z.undefined().optional(),
-				name: attributionSchema.shape.name.unwrap(),
-				orcid: attributionSchema.shape.orcid.unwrap().optional(),
-			}),
-		]),
-	) satisfies z.ZodType<
-	Omit<types.PubAttributionCreationParams, 'order' | 'pubId'> & { order?: number }
->;
 
 const s = initServer();
 

--- a/utils/api/schemas/attribution.ts
+++ b/utils/api/schemas/attribution.ts
@@ -43,7 +43,7 @@ export const attributionCreationSchema = attributionSchema
 			z.object({
 				userId: z.undefined().nullish(),
 				name: attributionSchema.shape.name.unwrap(),
-				orcid: attributionSchema.shape.orcid.optional(),
+				orcid: attributionSchema.shape.orcid.nullish(),
 			}),
 		]),
 	) satisfies z.ZodType<

--- a/utils/api/schemas/attribution.ts
+++ b/utils/api/schemas/attribution.ts
@@ -3,6 +3,7 @@ import { extendZodWithOpenApi } from '@anatine/zod-openapi';
 import { PubAttribution } from 'server/models';
 import * as types from 'types';
 import { DEFAULT_ROLES } from 'types/attribution';
+import { ORCID_ID_OR_URL_PATTERN, ORCID_PATTERN } from 'utils/orcid';
 import { baseSchema } from '../utils/baseSchema';
 
 extendZodWithOpenApi(z);
@@ -14,7 +15,15 @@ export const attributionSchema = baseSchema.extend({
 	isAuthor: z.boolean().nullable(),
 	userId: z.string().uuid().nullable(),
 	name: z.string().nullable(),
-	orcid: z.string().nullable(),
+	orcid: z
+		.string()
+		// allow both url or id to be submitted
+		.regex(ORCID_ID_OR_URL_PATTERN)
+		// grab just the id part of the pattern
+		.transform((orcid) => orcid.match(ORCID_PATTERN)?.[0]!)
+		.nullable()
+		// for historical reasons, we allow empty strings to be submitted
+		.or(z.literal('')),
 	avatar: z.string().url().nullable(),
 	title: z.string().nullable().openapi({
 		deprecated: true,

--- a/utils/orcid.ts
+++ b/utils/orcid.ts
@@ -1,4 +1,4 @@
 export const ORCID_PATTERN = /(\d{4}-){3}\d{3}(\d|X)/g;
 
 export const ORCID_ID_OR_URL_PATTERN =
-	/^(?:https?:\/\/(?:www\.)?orcid\.org\/)?(\d{4}-){3}\d{3}(\d|X)$/g;
+	/^(?:(?:https?:\/\/)?(?:www\.)?orcid\.org\/)?(\d{4}-){3}\d{3}(\d|X)$/g;

--- a/utils/orcid.ts
+++ b/utils/orcid.ts
@@ -1,1 +1,4 @@
 export const ORCID_PATTERN = /(\d{4}-){3}\d{3}(\d|X)/g;
+
+/** Same as the ORCID_PATTERN, but with ^ and $ to match the entire string. */
+export const ORCID_ID_PATTERN = /^(\d{4}-){3}\d{3}(\d|X)$/g;

--- a/utils/orcid.ts
+++ b/utils/orcid.ts
@@ -1,4 +1,4 @@
 export const ORCID_PATTERN = /(\d{4}-){3}\d{3}(\d|X)/g;
 
-/** Same as the ORCID_PATTERN, but with ^ and $ to match the entire string. */
-export const ORCID_ID_PATTERN = /^(\d{4}-){3}\d{3}(\d|X)$/g;
+export const ORCID_ID_OR_URL_PATTERN =
+	/^(?:https?:\/\/(?:www\.)?orcid\.org\/)?(\d{4}-){3}\d{3}(\d|X)$/g;


### PR DESCRIPTION
## Issue(s) Resolved

Closes #3014 

## Test Plan

1. Run tests

1. Open network tab
2. Create new attribution for a pub
3. Try to add the following orcids:
	- 0000-0000-0000
	- https://orcid.org/0000-0000-0000-0000
	- http://orcid.org/0000-0000-0000-0000
	- https://www.orcid.org/0000-0000-0000-0000
	- orcid.org/0000-0000-0000-0000
	- www.orcid.org/0000-0000-0000-0000
4. Observe that the response of all of these is `{"orcid": "0000-0000-0000-0000"}`
5. Also do this for collection attributions
6. Check that when creating an orcid with `https://orcid.org`, this is gone when reloading 
7. Try to create some invalid orcids and observe an error message popping up, AND that the API response 404s.


## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

I decided to allow `https://orcid.org/ID` to be filled in on the frontend and to be accepted by the backend, but have these be transformed into just the ID part with Zod.

https://github.com/pubpub/pubpub/blob/23258ba3bc4ee3b7c46daff500b99e411114e5e9/utils/api/schemas/attribution.ts#L18-L23

This makes the user experience slightly better i think.


Another change to note is when the change is submitted to the API, see the comments below for that.
TLDR: no more submission on Enter, instead autosubmission if correct orcid is sent.


### Supporting Docs
