### PR TITLE
PDF margin title fixes

### DIFF
--- a/workers/tasks/export/styles/printDocument.scss
+++ b/workers/tasks/export/styles/printDocument.scss
@@ -109,12 +109,20 @@ section.cover {
 			font-size: 10px;
 			font-family: $header-font;
 			content: string(top-heading-items);
+			vertical-align: top;
+			padding-top: 1cm;
 		}
 		@top-right {
 			color: #666;
 			font-size: 10px;
 			font-family: $header-font;
 			content: string(title);
+			vertical-align: top;
+			padding-top: 1cm;
+		}
+		@top-center {
+			content: '';
+			width: 1cm;
 		}
 		@bottom-center {
 			color: #666;


### PR DESCRIPTION
This PR:
- Adds small gap between top-left and top right margin titles
- Ensures the titles are top-aligned regardless of line breaks

## Issue(s) Resolved

Resolves #3024

## Test Plan

Export a PDF with a long title and a long community name + collection title. The titles in the margins should not bleed into each other, and should stay vertically aligned to the top of the page.

## Screenshots (if applicable)

Short top-left title:

![image](https://github.com/pubpub/pubpub/assets/6402908/4d8d234e-4de0-4717-9416-e97199055c7e)

Long top-left title:

<img width="1089" alt="Screenshot 2024-02-28 at 1 36 39 PM" src="https://github.com/pubpub/pubpub/assets/6402908/12ee1abc-a355-466f-b6ef-7ab4d57dba12">

## Optional

### Notes/Context/Gotchas

### Supporting Docs
