### PR TITLE
refactor: replace `polyfill.io`

### DIFF
--- a/server/Html.tsx
+++ b/server/Html.tsx
@@ -121,7 +121,7 @@ const Html = (props: Props) => {
 				</div>
 				<script
 					crossOrigin="anonymous"
-					src={`https://fastly-polyfill.io/v3/polyfill.min.js?features=${polyfills}`}
+					src={`https://polyfill-fastly.io/v3/polyfill.min.js?features=${polyfills}`}
 				/>
 				<script
 					id="initial-data"

--- a/server/Html.tsx
+++ b/server/Html.tsx
@@ -121,7 +121,7 @@ const Html = (props: Props) => {
 				</div>
 				<script
 					crossOrigin="anonymous"
-					src={`https://polyfill.io/v3/polyfill.min.js?features=${polyfills}`}
+					src={`https://fastly-polyfill.io/v3/polyfill.min.js?features=${polyfills}`}
 				/>
 				<script
 					id="initial-data"


### PR DESCRIPTION
## Issue(s) Resolved

N/A

## Test Plan

N/A

## Screenshots (if applicable)

N/A

## Optional

### Notes/Context/Gotchas

`polyfill.io` was acquired by **a China-based CDN company** "Funnull", see [the announcement from the `polyfill.io` domain owner's Twitter](https://x.com/JakeDChampion/status/1761315227008643367) and https://github.com/polyfillpolyfill/polyfill-service/issues/2834. Despite Funnull's claims of operating in the United States, the predominance of Simplified Chinese on its website suggests otherwise, and it turns out that **"Funnull" is notorious for providing service for the betting and pornography industries**.

[The original creator of the `polyfill.io` has voiced his concern on Twitter](https://twitter.com/triblondon/status/1761852117579427975). And since the acquisition, numerous issues have emerged (https://github.com/polyfillpolyfill/polyfill-service/issues/2835, https://github.com/polyfillpolyfill/polyfill-service/issues/2838, https://github.com/alist-org/alist/issues/6100), rendering the `polyfill.io` service **extremely unstable**. Since then, Fastly ([Announcement](https://community.fastly.com/t/new-options-for-polyfill-io-users/2540)) and Cloudflare ([Announcement](https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk)) has hosted their own instances of `polyfill.io` service.

### Supporting Docs

N/A
