### PR TITLE
feat: allow heap and new analytics to be used simultaneously, and add AWS endpoint instead of local one

### DIFF
--- a/client/utils/hydrateWrapper.tsx
+++ b/client/utils/hydrateWrapper.tsx
@@ -3,7 +3,6 @@ import * as Sentry from '@sentry/react';
 import { hydrate } from 'react-dom';
 import { FocusStyleManager } from '@blueprintjs/core';
 
-import { shouldUseNewAnalytics } from 'utils/analytics/featureFlags';
 import { setEnvironment, setAppCommit } from 'utils/environment';
 
 import { getClientInitialData } from './initialData';
@@ -39,9 +38,7 @@ export const hydrateWrapper = (Component) => {
 			document.getElementById('chunk-name').getAttribute('data-json'),
 		);
 		if (!isLocalEnv(window)) {
-			if (!shouldUseNewAnalytics(initialData)) {
-				setupHeap(initialData);
-			}
+			setupHeap(initialData);
 			// @ts-expect-error ts-migrate(2339) FIXME: Property 'sentryIsActive' does not exist on type '... Remove this comment to see the full error message
 			window.sentryIsActive = true;
 			Sentry.init({

--- a/utils/analytics/plugin.ts
+++ b/utils/analytics/plugin.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-undef, import/no-unresolved */
 import { AnalyticsInstance, type AnalyticsPlugin } from 'analytics';
 
-const ANALYTICS_ENDPOINT = '/api/analytics/track' as const;
+const ANALYTICS_ENDPOINT =
+	'https://yhzkpvgmsji7wkkmeplrtgoj5y0qbzpp.lambda-url.us-east-1.on.aws' as const;
 
 /**
  * Retrieves the referrer URL and determines if the visit is from a unique visitor If there is no
@@ -60,21 +61,20 @@ const sendData = (data: { payload: any; instance: AnalyticsInstance }) => {
 
 	// we use navigator.sendBeacon to make sure the request is sent even if the user navigates away from the page
 	// and doesn't block the rest of the page
-	navigator.sendBeacon(
-		ANALYTICS_ENDPOINT,
-		JSON.stringify({
-			event,
-			type,
-			timestamp: ts,
-			timezone,
-			locale,
-			userAgent,
-			os,
-			...properties,
-			...getReferrerAndUnique(),
-			...utmCampaign,
-		}),
-	);
+	const payloadToSend = {
+		event,
+		type,
+		timestamp: ts,
+		timezone,
+		locale,
+		userAgent,
+		os,
+		...properties,
+		...getReferrerAndUnique(),
+		...utmCampaign,
+	};
+
+	navigator.sendBeacon(ANALYTICS_ENDPOINT, JSON.stringify(payloadToSend));
 };
 
 export const analyticsPlugin = () => {

--- a/utils/analytics/plugin.ts
+++ b/utils/analytics/plugin.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-undef, import/no-unresolved */
 import { AnalyticsInstance, type AnalyticsPlugin } from 'analytics';
 
-const ANALYTICS_ENDPOINT =
-	'https://yhzkpvgmsji7wkkmeplrtgoj5y0qbzpp.lambda-url.us-east-1.on.aws' as const;
+// this gets rewritten to the AWS lambda on fastly
+const ANALYTICS_ENDPOINT = '/api/analytics/track' as const;
 
 /**
  * Retrieves the referrer URL and determines if the visit is from a unique visitor If there is no


### PR DESCRIPTION
- fix: allow stitch even with new analytics
- chore: add analytics lambda endpoint

## Issue(s) Resolved
Currently Heap and New analytics cannot both be turned on at the same time. Specifically, heap would not get initialized when new analytics is turned on. This PR gets rid of that flag.

It also sends the events to the new AWS endpoint instead of the old /api/analytics/track endpoint.

## Test Plan
(on demo, on either qubqub or duqduq)
1. Open network tab
2. Go to home
3. See event to `https://yhzkpvgmsji7wkkmeplrtgoj5y0qbzpp.lambda-url.us-east-1.on.aws` with a payload and `event: 'page'` and an event to `heap.io`
4. Go to a collection
5. See event to AWS endpoint with `event: 'collection'` and an event to `heap.io`
6. Go to a pub
7. See event to AWS endpoint with `event: 'pub'` and an event to `heap.io`


## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas
I hardcoded the URL to AWS, as I don't know how to pass environment variables to the client.

### Follow ups
After this PR is merged, a `shouldUseNewAnalytics` feature flag should be created in prod and turned on for everyone. 

### Supporting Docs
