### PR TITLE
fix: get rid of some 500s

### DIFF
--- a/client/components/FormattingBar/controlComponents/ControlsFootnoteCitation/CitationBuilder.tsx
+++ b/client/components/FormattingBar/controlComponents/ControlsFootnoteCitation/CitationBuilder.tsx
@@ -37,9 +37,15 @@ const CitationBuilder = (props: Props) => {
 	const [hasZoteroIntegration, setHasZoteroIntegration] = useState(false);
 
 	useEffect(() => {
-		apiFetch('/api/zoteroIntegration').then((res) => {
-			setHasZoteroIntegration(res.id);
-		});
+		apiFetch('/api/zoteroIntegration')
+			.then((res) => {
+				setHasZoteroIntegration(res.id);
+			})
+			.catch((e) => {
+				if (e.message !== 'no zotero integration present for user') {
+					console.error(e);
+				}
+			});
 	}, []);
 
 	useEffect(

--- a/server/collectionPub/__tests__/api.test.ts
+++ b/server/collectionPub/__tests__/api.test.ts
@@ -307,4 +307,30 @@ it('lets a user destroy a collectionPub for their Pub in an unrestricted Collect
 	expect(deletedCollectionPub).toEqual(null);
 });
 
+describe('what to do if pub is missing', () => {
+	it('403s if trying to delete a pub that does not exits', async () => {
+		const { admin, community } = models;
+		const agent = await login(admin);
+		await agent
+			.delete('/api/collectionPubs')
+			.send({
+				id: '51cdd239-2cf4-483d-8c25-2a1b90a153df',
+				communityId: community.id,
+			})
+			.expect(403);
+	});
+
+	it('403s if trying to update a pub that does not exits', async () => {
+		const { admin, community } = models;
+		const agent = await login(admin);
+		await agent
+			.put('/api/collectionPubs')
+			.send({
+				id: '51cdd239-2cf4-483d-8c25-2a1b90a153df',
+				communityId: community.id,
+			})
+			.expect(403);
+	});
+});
+
 teardown(afterAll);

--- a/server/collectionPub/permissions.ts
+++ b/server/collectionPub/permissions.ts
@@ -61,9 +61,14 @@ export const getUpdatableFieldsForCollectionPub = async ({
 	if (!userId) {
 		return null;
 	}
-	const { pubId, collectionId } = expect(
-		await CollectionPub.findOne({ where: { id: collectionPubId } }),
-	);
+	const collectionPub = await CollectionPub.findOne({ where: { id: collectionPubId } });
+	if (!collectionPub) {
+		// we pretend the user doesn't have permission to update the collectionPub
+		return null;
+	}
+
+	const { pubId, collectionId } = collectionPub;
+
 	const {
 		elements: { activeCollection },
 		activePermissions,
@@ -98,9 +103,14 @@ export const canDestroyCollectionPub = async ({
 	if (!userId) {
 		return false;
 	}
-	const { collectionId, pubId } = expect(
-		await CollectionPub.findOne({ where: { id: collectionPubId } }),
-	);
+	const collectionPub = await CollectionPub.findOne({ where: { id: collectionPubId } });
+	if (!collectionPub) {
+		// we pretend the user doesn't have permission to delete the collectionPub
+		return null;
+	}
+
+	const { pubId, collectionId } = collectionPub;
+
 	const {
 		activePermissions: { canManage },
 		elements: { activeCollection },

--- a/server/routes/__tests__/pubDownloads.test.ts
+++ b/server/routes/__tests__/pubDownloads.test.ts
@@ -1,0 +1,38 @@
+import { setup, teardown, stubFirebaseAdmin, login, modelize } from 'stubstub';
+
+const models = modelize`
+	Community community {
+		Pub pub {
+        }
+	}
+`;
+
+stubFirebaseAdmin();
+
+setup(beforeAll, async () => {
+	await models.resolve();
+});
+
+teardown(afterAll);
+
+const getHost = (community) => `${community.subdomain}.pubpub.org`;
+
+describe('/pub/download/pdf', () => {
+	it('404s for undefined community', async () => {
+		const { pub } = models;
+
+		const agent = await login();
+		const host = 'something.pubpub.org';
+
+		await agent.get(`/pub/${pub.slug}/download/pdf`).set('Host', host).expect(404);
+	});
+
+	it('404s for missing pub', async () => {
+		const { community } = models;
+
+		const agent = await login();
+		const host = getHost(community);
+
+		await agent.get(`/pub/fakeSlug/download/pdf`).set('Host', host).expect(404);
+	});
+});

--- a/server/routes/pubDownloads.ts
+++ b/server/routes/pubDownloads.ts
@@ -3,7 +3,7 @@ import { pipeline } from 'stream';
 import { promisify } from 'util';
 
 import app, { wrap } from 'server/server';
-import { ForbiddenError, NotFoundError } from 'server/utils/errors';
+import { ForbiddenError, NotFoundError, handleErrors } from 'server/utils/errors';
 import { getInitialData } from 'server/utils/initData';
 import { getPubForRequest } from 'server/utils/queryHelpers';
 import { getBestDownloadUrl } from 'utils/pub/downloads';
@@ -17,31 +17,35 @@ app.get(
 		if (!hostIsValid(req, 'community')) {
 			return next();
 		}
-		const initialData = await getInitialData(req);
-		const { pubSlug, format = null } = req.params;
+		try {
+			const initialData = await getInitialData(req);
+			const { pubSlug, format = null } = req.params;
 
-		const pubData = await getPubForRequest({ slug: pubSlug, initialData });
-		const bestPubDownloadUrl = getBestDownloadUrl(pubData, format);
+			const pubData = await getPubForRequest({ slug: pubSlug, initialData });
+			const bestPubDownloadUrl = getBestDownloadUrl(pubData, format);
 
-		if (!pubData || pubData.releases.length === 0) {
-			throw new ForbiddenError();
-		}
-
-		if (bestPubDownloadUrl) {
-			res.attachment(bestPubDownloadUrl);
-			const downloadResponse = await fetch(bestPubDownloadUrl);
-			if (downloadResponse.ok) {
-				return promisify(pipeline)(downloadResponse.body, res);
+			if (!pubData || pubData.releases.length === 0) {
+				throw new ForbiddenError();
 			}
+
+			if (bestPubDownloadUrl) {
+				res.attachment(bestPubDownloadUrl);
+				const downloadResponse = await fetch(bestPubDownloadUrl);
+				if (downloadResponse.ok) {
+					return promisify(pipeline)(downloadResponse.body, res);
+				}
+			}
+
+			// If there's no download URL then we'll want to regenerate the Pub's exports to produce
+			// an auto-generated PDF. We generally shouldn't get into this state, since those are
+			// generated when a Pub is released -- and this route only works for released Pubs.
+			defer(async () => {
+				await createPubExportsForLatestRelease(pubData.id);
+			});
+
+			throw new NotFoundError();
+		} catch (err) {
+			return handleErrors(req, res, next)(err);
 		}
-
-		// If there's no download URL then we'll want to regenerate the Pub's exports to produce
-		// an auto-generated PDF. We generally shouldn't get into this state, since those are
-		// generated when a Pub is released -- and this route only works for released Pubs.
-		defer(async () => {
-			await createPubExportsForLatestRelease(pubData.id);
-		});
-
-		throw new NotFoundError();
 	}),
 );

--- a/server/user/__tests__/api.test.ts
+++ b/server/user/__tests__/api.test.ts
@@ -54,4 +54,13 @@ describe('/api/users', () => {
 			avatar: suggestionUser.avatar,
 		});
 	});
+
+	it('returns 400 for /api/users/:id if its not a valid uuid', async () => {
+		const { user } = models;
+		const agent = await login(user);
+		await Promise.all([
+			agent.get('/api/users/not-a-uuid').expect(400),
+			agent.get('/api/users/null').expect(400),
+		]);
+	});
 });

--- a/server/user/api.ts
+++ b/server/user/api.ts
@@ -7,6 +7,7 @@ import { isProd, isDuqDuq } from 'utils/environment';
 import { getHashedUserId } from 'utils/caching/getHashedUserId';
 import { getPermissions } from './permissions';
 import { createUser, updateUser, getSuggestedEditsUserInfo } from './queries';
+import { z } from 'zod';
 
 const getRequestIds = (req) => {
 	const user = req.user || {};
@@ -47,11 +48,13 @@ app.post('/api/users', (req, res) => {
 		});
 });
 
+const uuidParser = z.string().uuid();
+
 app.get(
 	'/api/users/:id',
 	wrap(async (req, res) => {
 		const { id } = req.params;
-		if (!id) {
+		if (!id || !uuidParser.safeParse(id).success) {
 			throw new NotFoundError();
 		}
 

--- a/server/user/api.ts
+++ b/server/user/api.ts
@@ -1,13 +1,13 @@
 import passport from 'passport';
+import { z } from 'zod';
 
 import app, { wrap } from 'server/server';
-import { NotFoundError } from 'server/utils/errors';
+import { BadRequestError, NotFoundError } from 'server/utils/errors';
 
 import { isProd, isDuqDuq } from 'utils/environment';
 import { getHashedUserId } from 'utils/caching/getHashedUserId';
 import { getPermissions } from './permissions';
 import { createUser, updateUser, getSuggestedEditsUserInfo } from './queries';
-import { z } from 'zod';
 
 const getRequestIds = (req) => {
 	const user = req.user || {};
@@ -55,7 +55,7 @@ app.get(
 	wrap(async (req, res) => {
 		const { id } = req.params;
 		if (!id || !uuidParser.safeParse(id).success) {
-			throw new NotFoundError();
+			throw new BadRequestError();
 		}
 
 		const userInfo = await getSuggestedEditsUserInfo(id);

--- a/server/zoteroIntegration/__tests__/api.test.ts
+++ b/server/zoteroIntegration/__tests__/api.test.ts
@@ -1,0 +1,23 @@
+import { login, modelize, setup, teardown } from 'stubstub';
+
+const models = modelize`
+    Community community {
+        Member member {
+            User user {}
+        }
+    }
+`;
+
+setup(beforeAll, async () => {
+	await models.resolve();
+});
+
+teardown(afterAll);
+
+describe('/api/zoteroIntegration', () => {
+	it('returns 403 if you are not logged in', async () => {
+		const agent = await login();
+
+		await agent.get('/api/citations/zotero').expect(403);
+	});
+});

--- a/server/zoteroIntegration/api.ts
+++ b/server/zoteroIntegration/api.ts
@@ -1,14 +1,19 @@
 import app, { wrap } from 'server/server';
+import { ForbiddenError } from 'server/utils/errors';
 
 import { getZoteroIntegration } from './queries';
 
 app.get(
 	'/api/zoteroIntegration',
-	wrap((req, res) =>
-		getZoteroIntegration(req.user.id).then((integration) =>
+	wrap((req, res) => {
+		if (!req.user?.id) {
+			throw new ForbiddenError(new Error('User is not logged in'));
+		}
+
+		return getZoteroIntegration(req.user.id).then((integration) =>
 			integration
-				? res.status(201).json({ id: integration.id })
+				? res.status(200).json({ id: integration.id })
 				: res.status(404).json({ message: 'no zotero integration present for user' }),
-		),
-	),
+		);
+	}),
 );


### PR DESCRIPTION
- fix: wrap it before you get it
- feat: add tests for 404s
- fix: fix assertion errors, just 403 if collection pub is missing
- fix: add tests for collectionpub case

## Issue(s) Resolved

Lots of 500s that clog up my inbox.

Tried to fix the most common ones I see in sentry.

### `pub/slug/donwload/pdf` 
At least two kinds of errors.

Both fixed by wrapping it in this error handler also used in `/pub/slug`

#### Sentry issues

##### Pub does not exist
https://kfg.sentry.io/issues/4444264955/?project=1505439&query=&referrer=issue-stream&statsPeriod=7d&stream_index=4


##### Community does not exist
https://kfg.sentry.io/issues/4444036431/?project=1505439&query=&referrer=issue-stream&statsPeriod=7d&stream_index=5


#### Implementation
https://github.com/pubpub/pubpub/blob/e4def7d6ade7734b8f30dd1fc050e211ff0680d7/server/routes/pubDownloads.ts#L14-L20

https://github.com/pubpub/pubpub/blob/e4def7d6ade7734b8f30dd1fc050e211ff0680d7/server/routes/pubDownloads.ts#L47-L51

##### Tests
https://github.com/pubpub/pubpub/blob/7dcac283d68b05101c4df23aa82b9fc2bada5757/server/routes/__tests__/pubDownloads.test.ts#L20-L38


### `api/collectionPub`.

#### Sentry issue
https://kfg.sentry.io/issues/4513413810/?project=1505439&query=collectionpub&referrer=issue-stream&statsPeriod=7d&stream_index=1

Bad use of `assert`, very reasonable expectation that someone might want to try and update a pub that no longer exists.

#### Implementation
https://github.com/pubpub/pubpub/blob/eae77edf417d44ef299f8897a45afa1bed9e0873/server/collectionPub/permissions.ts#L64-L68

#### Test
https://github.com/pubpub/pubpub/blob/63a6c600704efe8446949eeb980dde54b05f8f1b/server/collectionPub/__tests__/api.test.ts#L310-L334

### `/api/user/:id`
When getting `api/user/:id`, sometimes `api/user/null` is called (don't know why)
https://kfg.sentry.io/issues/4486870216/?project=1505439&query=&referrer=issue-stream&statsPeriod=7d&stream_index=1

We now parse the id to check if it is actually a uuid first, return a 400 if not.

#### Implementation
https://github.com/pubpub/pubpub/blob/073188e3f03b4bf1f3ee9627e3700181e80fae3c/server/user/api.ts#L51-L59

#### Test
https://github.com/pubpub/pubpub/blob/620354d5674642ae03aa51eb5ccbc67ebf6dbf04/server/user/__tests__/api.test.ts#L58-L65

### `/api/zoterointegration`

#### Sentry issue
https://kfg.sentry.io/issues/5060789852/?project=1505439&query=zoterointegration&referrer=issue-stream&statsPeriod=7d&stream_index=0

If called as not a user, would cause a 500. Added check to make sure that does not happen.

I also changed slightly how the response is handled on the frontend. Atm when you do not have a zoteroIntegration setup, the response would come back as 404, but this would just get thrown on the client, not ideal.

I added a manual check for this case here:
https://github.com/pubpub/pubpub/blob/c4778ce301f8a7b00ae061b8991661a229cf4dd6/client/components/FormattingBar/controlComponents/ControlsFootnoteCitation/CitationBuilder.tsx#L44-L48

#### Implementation
https://github.com/pubpub/pubpub/blob/c4778ce301f8a7b00ae061b8991661a229cf4dd6/server/zoteroIntegration/api.ts#L9-L11

#### Test
https://github.com/pubpub/pubpub/blob/d677ab7c1e7ee4a03afe5553b09ac2b6283d1da8/server/zoteroIntegration/__tests__/api.test.ts#L17-L23

## Test Plan

1. Run tests.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
