### PR TITLE
fix: fix blank screen on settings pages and www.pubpub.org not loading 

### DIFF
--- a/utils/analytics/createAnalyticsInstance.ts
+++ b/utils/analytics/createAnalyticsInstance.ts
@@ -95,9 +95,9 @@ export const createAnalyticsInstance = async ({
 	return analytics;
 };
 
-export const createInitialAnalyticsInstance = () =>
+export const createInitialAnalyticsInstance = ({ stub }: { stub?: boolean } = { stub: false }) =>
 	Analytics({
 		app: 'pubpub',
 		debug: true,
-		plugins: [analyticsPlugin()],
+		plugins: [stub ? stubPlugin() : analyticsPlugin()],
 	}) as AnalyticsInstance;

--- a/utils/analytics/ignoredPaths.ts
+++ b/utils/analytics/ignoredPaths.ts
@@ -6,3 +6,11 @@ export const ignoredPaths = [
 	/^\/password-reset/,
 	/^\/superadmin/,
 ] as const;
+
+export const shouldPathBeIgnored = (path?: string) => {
+	if (!path) {
+		return false;
+	}
+
+	return ignoredPaths.some((ignoredPath) => ignoredPath.test(path));
+};

--- a/utils/analytics/useLazyLoadedAnalyticsInstance.ts
+++ b/utils/analytics/useLazyLoadedAnalyticsInstance.ts
@@ -17,16 +17,20 @@ export const useLazyLoadedAnalyticsInstance = ({
 	analyticsSettings: AnalyticsSettings;
 	locationData: LocationData;
 }) => {
-	// first we load the initial instance without any third party plugins
-	const [analytics, setAnalytics] = useState<AnalyticsInstance>(createInitialAnalyticsInstance());
-
 	const isIgnoredPath = ignoredPaths.some((path) => path.test(locationData.path));
 
-	const needsCustomPlugin =
-		canUseCustomAnalyticsProvider && analyticsSettings !== null && !isIgnoredPath;
+	// first we load the initial instance without any third party plugins
+	const [analytics, setAnalytics] = useState<AnalyticsInstance>(
+		createInitialAnalyticsInstance({
+			// we don't want the analytics plugin to load on ignored paths
+			stub: isIgnoredPath,
+		}),
+	);
+
+	const needsCustomPlugin = canUseCustomAnalyticsProvider && analyticsSettings !== null;
 
 	useEffect(() => {
-		if (!needsCustomPlugin) {
+		if (!needsCustomPlugin || isIgnoredPath) {
 			return;
 		}
 

--- a/utils/analytics/usePageOnce.ts
+++ b/utils/analytics/usePageOnce.ts
@@ -95,6 +95,9 @@ const determinePayload = (
 		return {
 			event: 'other' as const,
 			...base,
+			communityId: communityData.id ?? null,
+			communityName: communityData.title ?? 'pubpub',
+			communitySubdomain: communityData.subdomain ?? 'www',
 		};
 	}
 
@@ -176,7 +179,8 @@ export const usePageOnce = (
 			return;
 		}
 
-		// we don't want to track 404 pages
+		// we don't want to track 404 pages. not really a path per se
+		// hence we don't include it in the above
 		if (/^Not Found ·/.test(window.document?.title)) {
 			return;
 		}

--- a/utils/api/schemas/analytics.ts
+++ b/utils/api/schemas/analytics.ts
@@ -23,6 +23,7 @@ export const baseSchema = z.object({
 /** Information that should always be included in any event payload */
 export const sharedEventPayloadSchema = z.object({
 	communityId: z.string().uuid(),
+	// if it's null, it 'www.pubpub.org'
 	communitySubdomain: z.string(),
 	communityName: z.string(),
 	isProd: z.boolean(),
@@ -42,6 +43,10 @@ export const basePageViewSchema = baseSchema.merge(
 
 export const sharedPageViewPayloadSchema = sharedEventPayloadSchema.merge(
 	z.object({
+		communityId: z.string().uuid().nullable(),
+		// if it's null, it 'www.pubpub.org'
+		communitySubdomain: z.string().nullable().default('www'),
+		communityName: z.string().nullable().default('pubpub'),
 		event: z.enum(['page', 'collection', 'pub', 'other']),
 	}),
 );


### PR DESCRIPTION
- **fix: catch many cases where no analytics should be sent**
- **fix: allow for base pubpub events to be tracked**

## Issue(s) Resolved

Resolves #3050 

## Test Plan

1. Go to the most common pages on `www`, e.g. `/`, `/explore`.
2. See a working page


___

1. Go to `/dash/pub/<existing slug>/settings`
2. See working page


___

(optional check)
1. Go to `/pub/\<fake slug\>`
2. Observe no data being sent to `/api/analytics/track`

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

This was due to naive relying on the `initialData` types. For some pages, such as dashboard pages, 404s, and base PubPub, these do not reflect the actual initial data.

Dashboard pages and 404s are now more explicitly ignored, and additional access checks have been put in place.

### Supporting Docs
