### PR TITLE
Feat: condensed body contributor

### DIFF
--- a/client/components/ContributorsListCondensed/ContributorCondensed.tsx
+++ b/client/components/ContributorsListCondensed/ContributorCondensed.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Avatar, Icon } from 'components';
+
+require('./contributorCondensed.scss');
+
+const propTypes = {
+	attribution: PropTypes.object.isRequired,
+};
+
+const ContributorCondensed = function (props) {
+	const { attribution } = props;
+	const { user } = attribution;
+	const avatarElement = user.slug ? (
+		<a href={`/user/${user.slug}`}>
+			<Avatar initials={user.initials} avatar={user.avatar} width={30} />
+		</a>
+	) : (
+		<Avatar initials={user.initials} avatar={user.avatar} width={30} />
+	);
+
+	const nameElement = user.slug ? (
+		<a href={`/user/${user.slug}`} className="hoverline">
+			{user.fullName}
+		</a>
+	) : (
+		<span>{user.fullName}</span>
+	);
+
+	const affiliation = attribution.affiliation || user.title;
+
+	const rolesString = (attribution.roles || []).reduce((prev, curr) => {
+		if (prev) {
+			return `${prev}, ${curr}`;
+		}
+		return curr;
+	}, '');
+
+	return (
+		<div className="contributors-list_contributor-component">
+			<div className="avatar-wrapper">{avatarElement}</div>
+			<div className="details-wrapper">
+				<div className="name">{nameElement}</div>
+				{user.orcid && (
+					<div className="pub-header-themed-secondary orcid">
+						<Icon icon="orcid" />
+						<a
+							href={`https://orcid.org/${user.orcid}`}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{user.orcid}
+						</a>
+					</div>
+				)}
+				{affiliation && (
+					<div className="affiliation pub-header-themed-secondary">{affiliation}</div>
+				)}
+				{!!rolesString && (
+					<div className="roles pub-header-themed-secondary">Roles: {rolesString}</div>
+				)}
+			</div>
+		</div>
+	);
+};
+
+ContributorCondensed.propTypes = propTypes;
+export default ContributorCondensed;

--- a/client/components/ContributorsListCondensed/ContributorCondensed.tsx
+++ b/client/components/ContributorsListCondensed/ContributorCondensed.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Avatar, Icon } from 'components';
+import { Avatar } from 'components';
 
 require('./contributorCondensed.scss');
 
@@ -14,10 +14,10 @@ const ContributorCondensed = function (props) {
 	const { user } = attribution;
 	const avatarElement = user.slug ? (
 		<a href={`/user/${user.slug}`}>
-			<Avatar initials={user.initials} avatar={user.avatar} width={30} />
+			<Avatar initials={user.initials} avatar={user.avatar} width={20} />
 		</a>
 	) : (
-		<Avatar initials={user.initials} avatar={user.avatar} width={30} />
+		<Avatar initials={user.initials} avatar={user.avatar} width={20} />
 	);
 
 	const nameElement = user.slug ? (
@@ -28,8 +28,6 @@ const ContributorCondensed = function (props) {
 		<span>{user.fullName}</span>
 	);
 
-	const affiliation = attribution.affiliation || user.title;
-
 	const rolesString = (attribution.roles || []).reduce((prev, curr) => {
 		if (prev) {
 			return `${prev}, ${curr}`;
@@ -38,29 +36,15 @@ const ContributorCondensed = function (props) {
 	}, '');
 
 	return (
-		<div className="contributors-list_contributor-component">
-			<div className="avatar-wrapper">{avatarElement}</div>
+		<div className="contributors-list-condensed_contributor-component">
+			<div className="avatar-wrapper">{avatarElement}</div>{' '}
 			<div className="details-wrapper">
 				<div className="name">{nameElement}</div>
-				{user.orcid && (
-					<div className="pub-header-themed-secondary orcid">
-						<Icon icon="orcid" />
-						<a
-							href={`https://orcid.org/${user.orcid}`}
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							{user.orcid}
-						</a>
-					</div>
-				)}
-				{affiliation && (
-					<div className="affiliation pub-header-themed-secondary">{affiliation}</div>
-				)}
-				{!!rolesString && (
-					<div className="roles pub-header-themed-secondary">Roles: {rolesString}</div>
-				)}
 			</div>
+			<div className="separator">{' • '}</div>
+			{!!rolesString && (
+				<div className="roles pub-header-themed-secondary">{rolesString}</div>
+			)}
 		</div>
 	);
 };

--- a/client/components/ContributorsListCondensed/ContributorsListCondensed.tsx
+++ b/client/components/ContributorsListCondensed/ContributorsListCondensed.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ContributorCondensed from './ContributorCondensed';
+
+const propTypes = {
+	attributions: PropTypes.array.isRequired,
+};
+
+const ContributorsListCondensed = function (props) {
+	const { attributions } = props;
+	return (
+		<div className="contributors-list-condensed-component">
+			{attributions.map((item) => {
+				return <ContributorCondensed attribution={item} key={item.id} />;
+			})}
+		</div>
+	);
+};
+
+ContributorsListCondensed.propTypes = propTypes;
+export default ContributorsListCondensed;

--- a/client/components/ContributorsListCondensed/contributorCondensed.scss
+++ b/client/components/ContributorsListCondensed/contributorCondensed.scss
@@ -2,6 +2,14 @@
 
 $bp: vendor.$bp-namespace;
 
+.body-contributors {
+	display: flex;
+	gap: 92px;
+	.body-contributors-header {
+		line-height: 24px;
+	}
+}
+
 .contributors-list-condensed_contributor-component {
 	display: flex;
 	margin-bottom: 8px;
@@ -20,10 +28,9 @@ $bp: vendor.$bp-namespace;
 	}
 
 	.details-wrapper {
-		flex-grow: 1;
 		padding-left: 7px;
-		width: calc(100% - 40px);
 		.name {
+			font-size: 16px;
 			font-weight: 600;
 			width: 100%;
 			white-space: nowrap;
@@ -35,32 +42,58 @@ $bp: vendor.$bp-namespace;
 				color: inherit;
 			}
 			&:first-child:last-child {
-				line-height: 30px; // Center w.r.t. avatar
+				line-height: 26px; // Center w.r.t. avatar
 			}
 		}
 	}
 
-	.orcid {
-		display: flex;
-		align-items: center;
-		margin-top: 3px;
-		font-size: 12px;
-		.#{$bp}-icon {
-			margin-right: 3px;
-		}
+	.avatar-component {
+		margin-bottom: 2px;
 	}
 
-	.affiliation {
-		font-style: italic;
-		margin-top: 3px;
-		font-size: 12px;
+	.separator {
+		color: #ffa35c;
+		margin-left: 12px;
+		margin-right: 12px;
 	}
 
 	.roles {
-		font-size: 11px;
-		text-transform: uppercase;
-		letter-spacing: 0.03em;
+		font-size: 16px;
 		margin-top: 3px;
-		font-size: 11px;
+	}
+}
+
+@media screen and (max-width: 1024px) {
+	.contributors-list-condensed_contributor-component {
+		.body-contributors {
+			display: block;
+		}
+	}
+	.pub-document-component {
+		.body-contributors {
+			display: block;
+		}
+	}
+}
+
+@media screen and (max-width: 720px) {
+	.contributors-list-condensed_contributor-component {
+		display: block;
+		.avatar-wrapper {
+			float: left;
+		}
+		.details-wrapper {
+			display: inline-block;
+		}
+		.avatar-component {
+			margin-top: 3px;
+		}
+		.roles {
+			margin-top: 0;
+			margin-bottom: 16px;
+		}
+	}
+	.separator {
+		display: none;
 	}
 }

--- a/client/components/ContributorsListCondensed/contributorCondensed.scss
+++ b/client/components/ContributorsListCondensed/contributorCondensed.scss
@@ -1,0 +1,66 @@
+@use 'styles/vendor.scss';
+
+$bp: vendor.$bp-namespace;
+
+.contributors-list-condensed_contributor-component {
+	display: flex;
+	margin-bottom: 8px;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+
+	.avatar-wrapper {
+		flex-shrink: 0;
+		z-index: 0;
+		a {
+			text-decoration: none;
+			display: block;
+		}
+	}
+
+	.details-wrapper {
+		flex-grow: 1;
+		padding-left: 7px;
+		width: calc(100% - 40px);
+		.name {
+			font-weight: 600;
+			width: 100%;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			a,
+			a:hover,
+			a:visited {
+				color: inherit;
+			}
+			&:first-child:last-child {
+				line-height: 30px; // Center w.r.t. avatar
+			}
+		}
+	}
+
+	.orcid {
+		display: flex;
+		align-items: center;
+		margin-top: 3px;
+		font-size: 12px;
+		.#{$bp}-icon {
+			margin-right: 3px;
+		}
+	}
+
+	.affiliation {
+		font-style: italic;
+		margin-top: 3px;
+		font-size: 12px;
+	}
+
+	.roles {
+		font-size: 11px;
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
+		margin-top: 3px;
+		font-size: 11px;
+	}
+}

--- a/client/components/ContributorsListCondensed/contributorCondensed.scss
+++ b/client/components/ContributorsListCondensed/contributorCondensed.scss
@@ -7,6 +7,7 @@ $bp: vendor.$bp-namespace;
 	gap: 92px;
 	.body-contributors-header {
 		line-height: 24px;
+		color: #333;
 	}
 }
 

--- a/client/components/index.ts
+++ b/client/components/index.ts
@@ -14,6 +14,7 @@ export { default as CommunityPreview } from './CommunityPreview/CommunityPreview
 export { default as ConfirmDialog } from './ConfirmDialog/ConfirmDialog';
 export { default as ContributorAvatars } from './ContributorAvatars/ContributorAvatars';
 export { default as ContributorsList } from './ContributorsList/ContributorsList';
+export { default as ContributorsListCondensed } from './ContributorsListCondensed/ContributorsListCondensed';
 export { default as DashboardFrame } from './DashboardFrame/DashboardFrame';
 export { default as DashboardRow } from './DashboardRow/DashboardRow';
 export { default as DashboardRowListing } from './DashboardRow/DashboardRowListing';

--- a/client/containers/Pub/PubDocument/PubDocument.tsx
+++ b/client/containers/Pub/PubDocument/PubDocument.tsx
@@ -123,15 +123,16 @@ const PubDocument = () => {
 					{featureFlags.suggestedEdits && !isViewingHistory && (
 						<PubInlineSuggestedEdits />
 					)}
-					{/* TODO: FEATURE FLAG THIS */}
-					<div className="body-contributors">
-						<h5 className="body-contributors-header">
-							Contributors
-							<br />
-							(A-Z)
-						</h5>
-						<ContributorsListCondensed attributions={contributors} />
-					</div>
+					{featureFlags.bodyContributors && (
+						<div className="body-contributors">
+							<h5 className="body-contributors-header">
+								Contributors
+								<br />
+								(A-Z)
+							</h5>
+							<ContributorsListCondensed attributions={contributors} />
+						</div>
+					)}
 					<PubEdgeListing
 						className="bottom-pub-edges"
 						pubData={pubData}

--- a/client/containers/Pub/PubDocument/PubDocument.tsx
+++ b/client/containers/Pub/PubDocument/PubDocument.tsx
@@ -128,7 +128,7 @@ const PubDocument = () => {
 							<h5 className="body-contributors-header">
 								Contributors
 								<br />
-								(A-Z)
+								(A–Z)
 							</h5>
 							<ContributorsListCondensed attributions={contributors} />
 						</div>

--- a/client/containers/Pub/PubDocument/PubDocument.tsx
+++ b/client/containers/Pub/PubDocument/PubDocument.tsx
@@ -24,6 +24,8 @@ import PubInlineMenu from './PubInlineMenu';
 import PubInlineSuggestedEdits from './PubInlineSuggestedEdits';
 import PubLinkController from './PubLinkController';
 import PubMaintenanceNotice from './PubMaintenanceNotice';
+import ContributorsListCondensed from '../../../components/ContributorsListCondensed/ContributorsListCondensed';
+import { getAllPubContributors } from '../../../../utils/contributors';
 
 require('./pubDocument.scss');
 
@@ -44,6 +46,7 @@ const PubDocument = () => {
 	const mainContentRef = useRef<null | HTMLDivElement>(null);
 	const sideContentRef = useRef(null);
 	const editorWrapperRef = useRef(null);
+	const contributors = getAllPubContributors(pubData, 'contributors');
 
 	usePermalinkOnMount();
 	usePubHrefs({ enabled: !isReadOnly });
@@ -120,6 +123,15 @@ const PubDocument = () => {
 					{featureFlags.suggestedEdits && !isViewingHistory && (
 						<PubInlineSuggestedEdits />
 					)}
+					{/* TODO: FEATURE FLAG THIS */}
+					<div className="body-contributors">
+						<h5 className="body-contributors-header">
+							Contributors
+							<br />
+							(A-Z)
+						</h5>
+						<ContributorsListCondensed attributions={contributors} />
+					</div>
 					<PubEdgeListing
 						className="bottom-pub-edges"
 						pubData={pubData}


### PR DESCRIPTION
## Issue(s) Resolved
Adds a condensed contributor to the Pub body behind a feature flag to match Arcadia's current manual version.

## Test Plan
- Load arcadia-research locally or on dev, where feature flag is already set.
- Load an extent pub, e.g. http://localhost:9876/pub/idea-defining-actin/release/2?collectionSlug=functional-annotation
- Check that new section matches, with addition of avatar and links to profiles.
- Check that it breaks similarly on mobile (1024 and 728)

## Launch plan
Launching will require setting existing contributor section to display none.

After that's done, add `bodyContributors` feature flag and arcadia-research community to flag.

## Screenshots (if applicable)
<img width="1138" alt="Screenshot 2024-03-27 at 14 56 46" src="https://github.com/pubpub/pubpub/assets/639110/07947d90-9343-4fb7-9f5e-c2c64d04289a">


## Optional

### Notes/Context/Gotchas
- Could use community primary/secondary colors in the future rather than hard-coding
- Could be extended in the future to automate alphabetic sorting of contributor roles

### Supporting Docs
