### PR TITLE
Fix discussion email sending

### DIFF
--- a/server/userNotification/create.ts
+++ b/server/userNotification/create.ts
@@ -93,6 +93,7 @@ const createNotificationsForThreadComment = async (
 				activityItemId: item.id,
 			};
 		}),
+		{ individualHooks: true },
 	);
 
 	// purge cache for users who are receiving notifications

--- a/server/userNotification/hooks.ts
+++ b/server/userNotification/hooks.ts
@@ -16,7 +16,7 @@ import { discussionTitle } from 'utils/activity/titles/discussion';
 import { ActivityRenderContext } from 'client/utils/activity/types';
 import { expect } from 'utils/assert';
 
-const mg = mailgun.client({
+export const mg = mailgun.client({
 	username: 'api',
 	key: process.env.MAILGUN_API_KEY!,
 });


### PR DESCRIPTION
Discussion emails are sent by an `afterCreate` hook on `UserNotification` creation. However, these hooks don't run by default on bulk methods like `UserNotification.bulkCreate`.

https://sequelize.org/docs/v6/other-topics/hooks/#model-hooks:
>Note: methods like bulkCreate do not emit individual hooks by default - only the bulk hooks. However, if you want individual hooks to be emitted as well, you can pass the { individualHooks: true } option to the query call. However, this can drastically impact performance, depending on the number of records involved (since, among other things, all instances will be loaded into memory).


## Issue(s) Resolved
Resolves #3035

## Test Plan
Create a pub, comment on it, then reply from another account. You should receive an email.

## Optional

### Notes/Context/Gotchas
~I'm not quite sure how this ever worked, since it doesn't seem like sequelize changed the bulkCreate api recently (this behavior is in the v5 docs too).~ I see now that this was deleted in https://github.com/pubpub/pubpub/pull/2960/commits/06f99929a2b231d417eb3387f3019ca047e3cb15 hopefully just by mistake, though let me know if that's wrong and this is breaking something else.

I'm not sure how the activityDigest email script gets run, but if those aren't being sent it seems like a separate issue since they don't use hooks.
