### PR TITLE
Fix type error preventing activity digest email sending

### DIFF
--- a/server/community/queries.ts
+++ b/server/community/queries.ts
@@ -19,6 +19,7 @@ import { postToSlackAboutNewCommunity } from 'server/utils/slack';
 import { updateCommunityData } from 'server/utils/search';
 import { defer } from 'server/utils/deferred';
 import { getSpamTagForCommunity } from 'server/spamTag/queries';
+import * as types from 'types';
 
 export const getCommunity = (communityId: string) => {
 	return Community.findOne({
@@ -222,7 +223,7 @@ export const isUserAffiliatedWithCommunity = async (userId: string, communityId:
 	return isHere;
 };
 
-export const iterAllCommunities = async function* (limit = 10): AsyncGenerator<Community[]> {
+export const iterAllCommunities = async function* (limit = 10): AsyncGenerator<types.Community[]> {
 	let offset = 0;
 	while (true) {
 		const communities = await Community.findAll({
@@ -230,7 +231,7 @@ export const iterAllCommunities = async function* (limit = 10): AsyncGenerator<C
 			offset,
 			raw: true,
 		});
-		yield communities;
+		yield communities as types.Community[];
 		if (communities.length < limit) break;
 		offset += limit;
 	}

--- a/tools/emailActivityDigest.ts
+++ b/tools/emailActivityDigest.ts
@@ -3,6 +3,7 @@
 import { Op } from 'sequelize';
 import mailgun from 'mailgun.js';
 
+import * as Sentry from '@sentry/node';
 import { asyncMap } from 'utils/async';
 import { iterAllCommunities } from 'server/community/queries';
 import { Member, includeUserModel } from 'server/models';
@@ -58,6 +59,7 @@ async function main() {
 					} catch (err) {
 						// eslint-disable-next-line no-console
 						console.log(`sending email failed: ${err}`);
+						Sentry.captureException(err);
 					}
 				},
 				{ concurrency: 10 },

--- a/tools/emailActivityDigest.ts
+++ b/tools/emailActivityDigest.ts
@@ -46,7 +46,7 @@ async function main() {
 						console.log(`user ${user.id} ${email}`);
 						// Create an activity digest email
 						const scope = { communityId: community.id };
-						const digest = await renderDigestEmail(community.toJSON(), { scope, user });
+						const digest = await renderDigestEmail(community, { scope, user });
 						if (digest === null) return;
 						await mg.messages.create('mg.pubpub.org', {
 							from: 'PubPub Team <hello@mg.pubpub.org>',


### PR DESCRIPTION
#3035 
Fixes a new error in the activity digest script: https://my.papertrailapp.com/groups/14651822/events?q=program%3Aapp%2Fscheduler.3606&focus=1714219360833110031&selected=1714219360833110031

Also modifies the script to explicitly send these errors to sentry since they're being caught right now.

## Test Plan
Comment out the mailgun sending lines (L52-58) in `emailActivityDigest.ts`, then run `npm run tools -- emailActivityDigest` and it shouldn't error when rendering a digest email. Or just wait until this is merged and check that it succeeds via papertrail.