### PR TITLE
fix: prevent collectionpubs being fetched twice for smaller collections

### DIFF
--- a/client/utils/collections.ts
+++ b/client/utils/collections.ts
@@ -103,12 +103,13 @@ export const useCollectionPubs = (updateLocalData, collection) => {
 			offset,
 		})
 			.then((res) => {
-				updatePubs(res);
-				setIsLoading(false);
-				setOffset((oldOffset) => oldOffset + DEFAULT_LIMIT);
+				// for some reason this has to be done first, seems like the setstate updates don't get batched properly
 				if (res.length < DEFAULT_LIMIT) {
 					setHasLoadedAllPubs(true);
 				}
+				updatePubs(res);
+				setIsLoading(false);
+				setOffset((oldOffset) => oldOffset + DEFAULT_LIMIT);
 			})
 			.catch((err) => {
 				setError(err);


### PR DESCRIPTION
## Issue(s) Resolved
Resolves #3084

## Test Plan

1. Go to `pub/perspective-publishing-round-one/release/2?readingCollection=fe6424b5` on Arcadia
2. Click on the CollectionBrowser in the top right.
3. See only one entry

___

Regression prevention

1. Go to a pub in a large colllction e.g. `/pub/2022n8i101p01/release/1?readingCollection=15dae834` on BAAS
2. Click on the CollectionBrowser in the top right
3. Check that all entries are loading one by one, and that it doesn't stop after loading 10 or so.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
