### PR TITLE
fix: small type changes to get the sdk to compile master again

### DIFF
--- a/client/components/AttributionEditor/AttributionDetailControls.tsx
+++ b/client/components/AttributionEditor/AttributionDetailControls.tsx
@@ -129,8 +129,6 @@ const AttributionDetailControls = (props: Props) => {
 				/>
 				{isShadowAttribution && (
 					<InputField
-						// @ts-expect-error ts-migrate(2322) FIXME: Type '"" | Element | undefined' is not assignable ... Remove this comment to see the full error message
-						rightElement={orcid && <Tag minimal>ORCID</Tag>}
 						placeholder="ORCID"
 						defaultValue={orcid ?? undefined}
 						onChange={(evt) => {

--- a/client/components/AttributionEditor/AttributionDetailControls.tsx
+++ b/client/components/AttributionEditor/AttributionDetailControls.tsx
@@ -6,7 +6,6 @@ import { AttributionWithUser } from 'types';
 import { ORCID_ID_OR_URL_PATTERN } from 'utils/orcid';
 
 import { getFilteredRoles } from './roles';
-import InputField from '../InputField/InputField';
 
 type Props = {
 	attribution: AttributionWithUser;
@@ -128,34 +127,40 @@ const AttributionDetailControls = (props: Props) => {
 					}
 				/>
 				{isShadowAttribution && (
-					<InputField
-						placeholder="ORCID"
-						defaultValue={orcid ?? undefined}
-						onChange={(evt) => {
-							const input = evt.target.value;
-							const orcidInvalidity = isOrcidInvalid(input);
-							setInvalidOrcid(orcidInvalidity);
-
-							if (!orcidInvalidity) {
+					<div
+						className={`${invalidOrcid ? `${Classes.INTENT_DANGER} ` : ''}${
+							Classes.INPUT_GROUP
+						} ${Classes.FORM_GROUP}`}
+					>
+						<InputGroup
+							rightElement={orcid ? <Tag minimal>ORCID</Tag> : undefined}
+							placeholder="ORCID"
+							defaultValue={orcid ?? undefined}
+							onChange={(evt) => {
+								const input = evt.target.value;
+								const orcidInvalidity = isOrcidInvalid(input);
+								setInvalidOrcid(orcidInvalidity);
+								if (!orcidInvalidity) {
+									onAttributionUpdateWithValidation({
+										id,
+										orcid: input.trim(),
+									});
+								}
+							}}
+							onBlur={(evt) => {
+								setInvalidOrcid(isOrcidInvalid(evt.target.value));
 								onAttributionUpdateWithValidation({
 									id,
-									orcid: input.trim(),
+									orcid: evt.target.value.trim(),
 								});
-							}
-						}}
-						onBlur={(evt) => {
-							setInvalidOrcid(isOrcidInvalid(evt.target.value));
-							onAttributionUpdateWithValidation({
-								id,
-								orcid: evt.target.value.trim(),
-							});
-						}}
-						error={
-							invalidOrcid
-								? 'Invalid ORCID. Please enter a valid ORCID or leave the field blank.'
-								: undefined
-						}
-					/>
+							}}
+						/>
+						{invalidOrcid && (
+							<div className={`${Classes.FORM_HELPER_TEXT}`}>
+								Invalid ORCID. Please enter a valid ORCID or leave the field blank.
+							</div>
+						)}
+					</div>
 				)}
 			</div>
 		</div>

--- a/types/use-analytics.d.ts
+++ b/types/use-analytics.d.ts
@@ -5,7 +5,7 @@
 
 declare module 'use-analytics' {
 	import type { ComponentType, Context, FC, ReactNode } from 'react';
-	import type { AnalyticsInstance } from 'analytics';
+	import type { AnalyticsInstance, AnalyticsPlugin } from 'analytics';
 
 	export function withAnalytics<P extends object>(Component: ComponentType<P>): FC<P>;
 
@@ -22,4 +22,6 @@ declare module 'use-analytics' {
 		children: ReactNode;
 		// eslint-disable-next-line no-undef
 	}): JSX.Element;
+
+	export type { AnalyticsInstance, AnalyticsPlugin };
 }

--- a/utils/analytics/plugin.ts
+++ b/utils/analytics/plugin.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-undef, import/no-unresolved */
-import { AnalyticsInstance, type AnalyticsPlugin } from 'analytics';
+import { type AnalyticsInstance, type AnalyticsPlugin } from 'use-analytics';
 import type { AnalyticsEvent } from 'utils/api/schemas/analytics';
 
 // this gets rewritten to the AWS lambda on fastly

--- a/utils/analytics/useAnalytics.ts
+++ b/utils/analytics/useAnalytics.ts
@@ -1,7 +1,6 @@
 import type { AnalyticsType } from 'types';
 import type { PageViewPayload, TrackPayload, TrackEvent } from 'utils/api/schemas/analytics';
-import { useAnalytics as useOldAnalytics } from 'use-analytics';
-import type { AnalyticsInstance } from 'analytics';
+import { AnalyticsInstance, useAnalytics as useOldAnalytics } from 'use-analytics';
 import { stubPlugin } from './plugin';
 
 type Analytics = {


### PR DESCRIPTION
## Issue(s) Resolved
Just shifts arounds some types in order to make `@pubpub/sdk` pass `tsc` checks again. Very annoying, would liked to have been able to solve it a different way, but this is the quickest.


## Test Plan
No change, is only a type change.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
