### PR TITLE
fix: handle some 500s more gracefully

### DIFF
--- a/client/containers/CommunityCreate/CommunityCreate.tsx
+++ b/client/containers/CommunityCreate/CommunityCreate.tsx
@@ -18,13 +18,11 @@ const CommunityCreate = () => {
 	const [accentColorLight, setAccentColorLight] = useState('#FFFFFF');
 	const [acceptTerms, setAcceptTerms] = useState(false);
 	const [createIsLoading, setCreateIsLoading] = useState(false);
-	const [createError, setCreateError] = useState(undefined);
+	const [createError, setCreateError] = useState<string | undefined>(undefined);
 
 	const onCreateSubmit = (evt) => {
 		evt.preventDefault();
 		setCreateIsLoading(true);
-		// @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'true' is not assignable to param... Remove this comment to see the full error message
-		setCreateError(true);
 		if (!acceptTerms) return false;
 		return apiFetch('/api/communities', {
 			method: 'POST',
@@ -160,7 +158,15 @@ const CommunityCreate = () => {
 									.
 								</Checkbox>
 							</InputField>
-							<InputField error={createError && 'Error Creating Community'}>
+							<InputField
+								error={
+									createError
+										? createError === 'URL already used'
+											? 'URL already in use by another community'
+											: 'Error Creating Community'
+										: undefined
+								}
+							>
 								<Button
 									name="create"
 									type="submit"

--- a/client/containers/PasswordReset/PasswordReset.tsx
+++ b/client/containers/PasswordReset/PasswordReset.tsx
@@ -113,7 +113,7 @@ const PasswordReset = (props: Props) => {
 				{/* Show password reset request confirmation, with directions to check email  */}
 				{!resetHash && showConfirmation && (
 					<NonIdealState
-						description="Check your inbox for an email with a reset link"
+						description="If your email is known to us, we have sent you an email with a reset link"
 						title="Reset Password Email Sent"
 						// @ts-expect-error ts-migrate(2322) FIXME: Type '{ description: string; title: string; visual... Remove this comment to see the full error message
 						visual="envelope"

--- a/server/community/queries.ts
+++ b/server/community/queries.ts
@@ -21,6 +21,8 @@ import { defer } from 'server/utils/deferred';
 import { getSpamTagForCommunity } from 'server/spamTag/queries';
 import * as types from 'types';
 
+export class CommunityURLAlreadyExistsError extends Error {}
+
 export const getCommunity = (communityId: string) => {
 	return Community.findOne({
 		where: { id: communityId },
@@ -51,7 +53,7 @@ export const createCommunity = (inputValues, userData, alertAndSubscribe = true)
 		'test',
 	];
 	if (forbiddenSubdomains.indexOf(subdomain) > -1) {
-		throw new Error('URL already used');
+		throw new CommunityURLAlreadyExistsError('URL already used');
 	}
 	return Community.findOne({
 		where: { subdomain },
@@ -59,7 +61,7 @@ export const createCommunity = (inputValues, userData, alertAndSubscribe = true)
 	})
 		.then((existingCommunity) => {
 			if (existingCommunity) {
-				throw new Error('URL already used');
+				throw new CommunityURLAlreadyExistsError('URL already used');
 			}
 			const description = inputValues.description.substring(0, 280).replace(/\n/g, ' ') || '';
 			return Community.create(

--- a/server/passwordReset/api.ts
+++ b/server/passwordReset/api.ts
@@ -1,28 +1,39 @@
-import app from 'server/server';
+import app, { wrap } from 'server/server';
 import { User } from 'types';
 
+import { sleep } from 'utils/promises';
 import { createPasswordReset, updatePasswordReset } from './queries';
 
-app.post('/api/password-reset', (req, res) => {
-	const user = req.user || {};
-	return createPasswordReset(req.body, user as User, req.hostname)
-		.then(() => {
+app.post(
+	'/api/password-reset',
+	wrap(async (req, res) => {
+		const user = req.user || {};
+		try {
+			await createPasswordReset(req.body, user as User, req.hostname);
 			return res.status(200).json('success');
-		})
-		.catch((err) => {
+		} catch (err: any) {
+			// do not leak user information
+			if (err.message === "User doesn't exist") {
+				// fake sleep to simulate delay
+				await sleep(1000 + Math.random() * 1000);
+				return res.status(200).json('success');
+			}
 			console.error('Error in postPasswordReset: ', err);
 			return res.status(500).json(err.message);
-		});
-});
+		}
+	}),
+);
 
-app.put('/api/password-reset', (req, res) => {
-	const user = req.user || {};
-	return updatePasswordReset(req.body, user as User)
-		.then(() => {
+app.put(
+	'/api/password-reset',
+	wrap(async (req, res) => {
+		const user = req.user || {};
+		try {
+			await updatePasswordReset(req.body, user as User);
 			return res.status(200).json('success');
-		})
-		.catch((err) => {
+		} catch (err: any) {
 			console.error('Error in putPasswordReset: ', err);
 			return res.status(500).json(err.message);
-		});
-});
+		}
+	}),
+);

--- a/utils/api/contracts/community.ts
+++ b/utils/api/contracts/community.ts
@@ -69,6 +69,7 @@ export const communityRouter = {
 		body: communityCreateSchema,
 		responses: {
 			201: z.string().url(),
+			409: z.string(),
 		},
 	},
 	/**


### PR DESCRIPTION
## Issue(s) Resolved

This PR removes some uncaught errors that were introducing noise in Heroku alerts, making it seems like there was something wrong when either

1. A user was trying to reset a password of an email not belonging to any account
2. A user was trying to create a community with an already existing url

I solved these like so

### Reset password

We now return a `200 'success'` whether the email exists or not. This way, you cannot brute force guess user emails using this path. I guess you can still do this on the account creation screen, but that is a separate issue that could/should be fixed.


### Community creation

We now return a `409 "URL already used"` error in case the url is already in use. 
It also shows this to the user, so it's more clear why they cannot create a certain community.

## Test Plan

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
