### PR TITLE
Hotfiix: handle crossref api errors better

### DIFF
--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -72,8 +72,8 @@ const getSingleStructuredCitation = async (
 	citationStyle: CitationStyleKind,
 	inlineStyle: CitationInlineStyleKind,
 ) => {
+	const fallbackValue = generateFallbackHash(structuredInput);
 	try {
-		const fallbackValue = generateFallbackHash(structuredInput);
 		const citationData = await getSingleCitationAsync(structuredInput);
 		if (citationData) {
 			const citationJson = citationData.format('data', { format: 'object' });
@@ -102,7 +102,7 @@ const getSingleStructuredCitation = async (
 		return {
 			html: '<div>' + structuredInput + '</div>',
 			json: 'Error',
-			inline: null,
+			inline: inlineStyle === 'label' ? `(${fallbackValue})` : null,
 		};
 	}
 };

--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -64,7 +64,7 @@ const getSingleCitationAsync = expiringPromise(
 	async (structuredValue: string) => {
 		return Cite.async(structuredValue);
 	},
-	{ timeout: 1500, throws: () => new Error('Citation data failed to load') },
+	{ timeout: 1000, throws: () => new Error('Citation data failed to load') },
 );
 
 const getSingleStructuredCitation = async (
@@ -103,7 +103,6 @@ const getSingleStructuredCitation = async (
 			html: '<div>' + structuredInput + '</div>',
 			json: 'Error',
 			inline: null,
-			error: true,
 		};
 	}
 };

--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -64,7 +64,7 @@ const getSingleCitationAsync = expiringPromise(
 	async (structuredValue: string) => {
 		return Cite.async(structuredValue);
 	},
-	{ timeout: 8000, throws: () => new Error('Citation data failed to load') },
+	{ timeout: 1500, throws: () => new Error('Citation data failed to load') },
 );
 
 const getSingleStructuredCitation = async (
@@ -100,9 +100,9 @@ const getSingleStructuredCitation = async (
 		};
 	} catch (err) {
 		return {
-			html: 'Error',
+			html: '<div>' + structuredInput + '</div>',
 			json: 'Error',
-			inline: '(Error)',
+			inline: null,
 			error: true,
 		};
 	}


### PR DESCRIPTION
## Issue(s) Resolved
Some pubs with lots of cites are timing out at Heroku because the crossref API is unstable at the moment (https://status.crossref.org/incidents/d7k4ml9vvswv)

This reduces the timeout per cite down to 1 second from 8, and if there's an error, returns the raw doi instead of an error message, so that pages can still be understood by readers.

Longer term, we should probably implement a strategy for now relying on the Crossref API to render cites every time a page is re-rendered out of cache — either storing the results of the API request directly after the first time it's called, or, alternately, creating our own cache of the crossref API.

Additionally, we should try to find a way to send requests through the "polite" API, for better handling, per this blog post: https://status.crossref.org/incidents/d7k4ml9vvswv. I posted an initial request for help in the Cite repo, here: https://github.com/citation-js/citation-js/issues/228
 
## Test Plan
1. Visit a pub with lots of cites in prod locally (e.g. https://research.arcadiascience.com/pub/pub/idea-how-to-validate-proteincartography/release/2). 
2. Make sure it loads relatively quickly.
3. Make sure that in lieu of (error) showing where cites won't load, it shows numbers and, when hovered, raw DOI URLs.
4. Switch pub to author or author-year citation style and make sure it still shows numbers.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
