### PR TITLE
Hotfix: Customize Cite.js user agent for Crossref polite pool

### DIFF
--- a/server/utils/citations/generateCitationHtml.ts
+++ b/server/utils/citations/generateCitationHtml.ts
@@ -97,6 +97,13 @@ export const generateCitationHtml = async (
 		...getCollectionLevelData(primaryCollection),
 		publisher: communityData.publishAs || '',
 	};
+
+	/* Set the user agent with a mailto to use Crossref's "polite" pool. */
+	/* https://www.crossref.org/blog/rebalancing-our-rest-api-traffic/ */
+	Cite.util.setUserAgent(
+		'PubPub/6.0 (https://pubpub.org; mailto:dev@pubpub.org) Citation.js/0.7.11 Node.js/18.7.0',
+	);
+
 	const pubCiteObject = await Cite.async({
 		...commonData,
 		// @ts-expect-error ts-migrate(2339) FIXME: Property 'containerDoi' does not exist on type '{ ... Remove this comment to see the full error message

--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -72,8 +72,8 @@ const getSingleStructuredCitation = async (
 	citationStyle: CitationStyleKind,
 	inlineStyle: CitationInlineStyleKind,
 ) => {
+	const fallbackValue = generateFallbackHash(structuredInput);
 	try {
-		const fallbackValue = generateFallbackHash(structuredInput);
 		const citationData = await getSingleCitationAsync(structuredInput);
 		if (citationData) {
 			const citationJson = citationData.format('data', { format: 'object' });
@@ -102,7 +102,7 @@ const getSingleStructuredCitation = async (
 		return {
 			html: '<div>' + structuredInput + '</div>',
 			json: 'Error',
-			inline: null,
+			inline: inlineStyle === 'label' ? `(${fallbackValue})` : null,
 		};
 	}
 };

--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -64,7 +64,7 @@ const getSingleCitationAsync = expiringPromise(
 	async (structuredValue: string) => {
 		return Cite.async(structuredValue);
 	},
-	{ timeout: 1500, throws: () => new Error('Citation data failed to load') },
+	{ timeout: 1000, throws: () => new Error('Citation data failed to load') },
 );
 
 const getSingleStructuredCitation = async (
@@ -103,7 +103,6 @@ const getSingleStructuredCitation = async (
 			html: '<div>' + structuredInput + '</div>',
 			json: 'Error',
 			inline: null,
-			error: true,
 		};
 	}
 };

--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -4,7 +4,6 @@ import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import Cite from 'citation-js';
-
 import { DocJson } from 'types';
 import { getNotesByKindFromDoc, jsonToNode } from 'components/Editor';
 import { citationStyles, CitationStyleKind, CitationInlineStyleKind } from 'utils/citations';
@@ -27,6 +26,12 @@ citationStyles.forEach((style) => {
 /* https://github.com/citation-js/citation-js/blob/master/packages/core/src/plugins/input/data.js#L90-L97 */
 Cite.plugins.input.removeDataParser('@else/url', false);
 Cite.plugins.input.removeDataParser('@else/url', true);
+
+/* Set the user agent with a mailto to use Crossref's "polite" pool. */
+/* https://www.crossref.org/blog/rebalancing-our-rest-api-traffic/ */
+Cite.util.setUserAgent(
+	'PubPub/6.0 (https://pubpub.org; mailto:dev@pubpub.org) Citation.js/0.7.11 Node.js/18.7.0',
+);
 
 const generateFallbackHash = (structuredValue: string) =>
 	crypto.createHash('md5').update(structuredValue).digest('base64').substring(0, 10);
@@ -64,7 +69,7 @@ const getSingleCitationAsync = expiringPromise(
 	async (structuredValue: string) => {
 		return Cite.async(structuredValue);
 	},
-	{ timeout: 1000, throws: () => new Error('Citation data failed to load') },
+	{ timeout: 2000, throws: () => new Error('Citation data failed to load') },
 );
 
 const getSingleStructuredCitation = async (

--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -69,7 +69,7 @@ const getSingleCitationAsync = expiringPromise(
 	async (structuredValue: string) => {
 		return Cite.async(structuredValue);
 	},
-	{ timeout: 2000, throws: () => new Error('Citation data failed to load') },
+	{ timeout: 1000, throws: () => new Error('Citation data failed to load') },
 );
 
 const getSingleStructuredCitation = async (

--- a/server/utils/citations/structuredCitations.ts
+++ b/server/utils/citations/structuredCitations.ts
@@ -64,7 +64,7 @@ const getSingleCitationAsync = expiringPromise(
 	async (structuredValue: string) => {
 		return Cite.async(structuredValue);
 	},
-	{ timeout: 8000, throws: () => new Error('Citation data failed to load') },
+	{ timeout: 1500, throws: () => new Error('Citation data failed to load') },
 );
 
 const getSingleStructuredCitation = async (
@@ -100,9 +100,9 @@ const getSingleStructuredCitation = async (
 		};
 	} catch (err) {
 		return {
-			html: 'Error',
+			html: '<div>' + structuredInput + '</div>',
 			json: 'Error',
-			inline: '(Error)',
+			inline: null,
 			error: true,
 		};
 	}


### PR DESCRIPTION
## Issue(s) Resolved
Appends a mailto to our user agent string to move to Crossref's "polite" pool, per https://api.crossref.org/swagger-ui/index.html and thanks to @larsgw: https://github.com/citation-js/citation-js/issues/228

## Test Plan
I need help figuring out how to test this to make sure it's working.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
