### PR TITLE
fix(#3082): fix linkedin and bluesky handles

### DIFF
--- a/client/containers/DashboardSettings/CommunitySettings/SocialSettings.tsx
+++ b/client/containers/DashboardSettings/CommunitySettings/SocialSettings.tsx
@@ -111,7 +111,9 @@ const SocialSettings = (props: Props) => {
 				label="LinkedIn"
 				type="text"
 				value={linkedin}
-				helperText={`https://linkedin.com/in/${linkedin || '<your linkedin handle>'}`}
+				helperText={`https://linkedin.com/${
+					linkedin || '<in|company|school>/<your linkedin handle>'
+				}`}
 				onChange={(evt) => {
 					updateCommunityData({ linkedin: evt.target.value });
 				}}

--- a/client/containers/DashboardSettings/CommunitySettings/SocialSettings.tsx
+++ b/client/containers/DashboardSettings/CommunitySettings/SocialSettings.tsx
@@ -120,7 +120,7 @@ const SocialSettings = (props: Props) => {
 				label="Bluesky"
 				type="text"
 				value={bluesky}
-				helperText={`https://bsky.app/profile/@${
+				helperText={`https://bsky.app/profile/${
 					bluesky || '<your bluesky handle>.<your-server.social>'
 				}`}
 				onChange={(evt) => {

--- a/client/containers/User/UserEdit.tsx
+++ b/client/containers/User/UserEdit.tsx
@@ -208,7 +208,7 @@ const UserEdit = (props: Props) => {
 		{
 			label: 'Bluesky',
 			// icon: `${Classes.ICON}-bluesky`,
-			helperText: `https://bsky.app/profile/@${
+			helperText: `https://bsky.app/profile/${
 				bluesky || '<your bluesky handle>.<your-server.social>'
 			}`,
 			value: bluesky,

--- a/client/containers/User/UserEdit.tsx
+++ b/client/containers/User/UserEdit.tsx
@@ -181,7 +181,9 @@ const UserEdit = (props: Props) => {
 		},
 		{
 			label: 'LinkedIn',
-			helperText: `https://linkedin.com/in/${linkedin || '<your linkedin handle>'}`,
+			helperText: `https://linkedin.com/${
+				linkedin || '<in|company|school>/<your linkedin handle>'
+			}`,
 			value: linkedin,
 			onChange: (evt) => {
 				setLinkedin(evt.target.value);

--- a/client/containers/User/UserHeader.tsx
+++ b/client/containers/User/UserHeader.tsx
@@ -60,7 +60,7 @@ const UserHeader = function (props) {
 		{
 			icon: 'linkedin' as const,
 			value: props.userData.linkedin,
-			url: `https://linkedin.com/in/${props.userData.linkedin}`,
+			url: `https://linkedin.com/${props.userData.linkedin}`,
 		},
 		{
 			icon: 'bluesky' as const,

--- a/client/containers/User/UserHeader.tsx
+++ b/client/containers/User/UserHeader.tsx
@@ -65,7 +65,7 @@ const UserHeader = function (props) {
 		{
 			icon: 'bluesky' as const,
 			value: props.userData.bluesky,
-			url: `https://bsky.app/profile/@${props.userData.bluesky}`,
+			url: `https://bsky.app/profile/${props.userData.bluesky}`,
 		},
 		{
 			value: props.userData.googleScholar,

--- a/client/utils/navigation/communityNavigation.ts
+++ b/client/utils/navigation/communityNavigation.ts
@@ -101,7 +101,7 @@ export const createSocialNavItems = (
 			icon: 'bluesky' as const,
 			title: 'Bluesky',
 			value: communityData.bluesky,
-			url: `https://bsky.app/profile/@${communityData.bluesky}`,
+			url: `https://bsky.app/profile/${communityData.bluesky}`,
 		},
 		{
 			id: 'si-7',

--- a/client/utils/navigation/communityNavigation.ts
+++ b/client/utils/navigation/communityNavigation.ts
@@ -94,7 +94,7 @@ export const createSocialNavItems = (
 			icon: 'linkedin' as const,
 			title: 'LinkedIn',
 			value: communityData.linkedin,
-			url: `https://linkedin.com/in/${communityData.linkedin}`,
+			url: `https://linkedin.com/${communityData.linkedin}`,
 		},
 		{
 			id: 'si-6',

--- a/tools/migrations/2024_06_12_replaceLinkedinHandles.js
+++ b/tools/migrations/2024_06_12_replaceLinkedinHandles.js
@@ -1,0 +1,100 @@
+// @ts-check
+
+const { asyncMap } = require('utils/async');
+const { Op } = require('sequelize');
+
+/**
+ * @param {object} options
+ * @param {import('sequelize').Sequelize} options.Sequelize
+ * @param {import('server/sequelize').sequelize} options.sequelize
+ */
+export const up = async ({ Sequelize, sequelize }) => {
+	const communitiesWithLinkedin = await sequelize.models.Community.findAll({
+		where: {
+			linkedin: {
+				[Op.not]: null,
+			},
+		},
+	});
+	console.log(communitiesWithLinkedin);
+	console.log(`Found ${communitiesWithLinkedin.length} communities with linkedin defined`);
+
+	const updatedCommunities = await asyncMap(
+		communitiesWithLinkedin,
+		async (community) =>
+			community.update({
+				linkedin: `in/${community.linkedin}`,
+			}),
+		{ concurrency: 20 },
+	);
+
+	console.log(`Updated ${updatedCommunities.length} communities!`);
+
+	const usersWithLinkedin = await sequelize.models.User.findAll({
+		where: {
+			linkedin: {
+				[Op.not]: null,
+			},
+		},
+	});
+	console.log(`Found ${usersWithLinkedin.length} users with linkedin defined`);
+
+	const updatedUsers = await asyncMap(
+		usersWithLinkedin,
+		async (user) =>
+			user.update({
+				linkedin: `https://www.linkedin.com/in/${user.linkedin}`,
+			}),
+		{ concurrency: 20 },
+	);
+	console.log(`Updated ${updatedUsers.length} users!`);
+
+	console.log('Migration has been completed');
+};
+
+/**
+ * @param {object} options
+ * @param {import('server/sequelize').sequelize} options.sequelize
+ */
+export const down = async ({ sequelize }) => {
+	const communitiesWithLinkedin = await sequelize.models.Community.findAll({
+		where: {
+			linkedin: {
+				[Op.not]: null,
+			},
+		},
+	});
+	console.log(`Found ${communitiesWithLinkedin.length} communities with linkedin defined`);
+
+	const updatedCommunities = await asyncMap(
+		communitiesWithLinkedin,
+		async (community) =>
+			community.update({
+				linkedin: community.linkedin.replace('in/', ''),
+			}),
+		{ concurrency: 20 },
+	);
+
+	console.log(`Reverted ${updatedCommunities.length} communities!`);
+
+	const usersWithLinkedin = await sequelize.models.User.findAll({
+		where: {
+			linkedin: {
+				[Op.not]: null,
+			},
+		},
+	});
+	console.log(`Found ${usersWithLinkedin.length} users with linkedin defined`);
+
+	const updatedUsers = await asyncMap(
+		usersWithLinkedin,
+		async (user) =>
+			user.update({
+				linkedin: user.linkedin.replace('https://www.linkedin.com/in/', ''),
+			}),
+		{ concurrency: 20 },
+	);
+	console.log(`Reverted ${updatedUsers.length} users!`);
+
+	console.log('Migration reversion has been completed');
+};


### PR DESCRIPTION
Resolves #3082

Note: this requires a small migration (more of a fix) to be run to retroactively add `in/` to the existing linkedin handles.


# Test plan

## Bluesky 

1. Go to a communities settings
2. Add a bluesky handle
3. Save
4. Observe that no @ is present, as it should (oversight from me that this snuck in, was thinking of mastodon too much)

Do the same for your user account.

## Linkedin

1. Go to a communities settings
2. Add a linkedin handle
3. Save
4. Observe that the handle you added becomes a link of the form `https://linkedin.com/<handle>` rather than `https://linkedin.com/in/<handle>` as it is on prod.

Do the same for your user account (in theory we could have limited the users to `in/`, which, as i've learned, stands for "individual", rather than for the "in" in linkedin 🤯. Seems weird to limit this though)