### PR TITLE
dev: Debounce collection search

### DIFF
--- a/client/containers/DashboardOverview/CollectionOverview/PubSelect.tsx
+++ b/client/containers/DashboardOverview/CollectionOverview/PubSelect.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useDebounce } from 'use-debounce';
 
 import { PubMenuItem, QueryListDropdown } from 'components';
 import { PubWithCollections } from 'types';
@@ -16,6 +17,7 @@ type Props = {
 const PubSelect = (props: Props) => {
 	const { children, onSelectPub, collectionId, usedPubIds } = props;
 	const [searchTerm, setSearchTerm] = useState('');
+	const [debouncedSearchTerm] = useDebounce(searchTerm, 200);
 
 	const {
 		allQueries: { isLoading },
@@ -23,7 +25,7 @@ const PubSelect = (props: Props) => {
 	} = useManyPubs<PubWithCollections>({
 		batchSize: 50,
 		query: {
-			term: searchTerm,
+			term: debouncedSearchTerm,
 			excludeCollectionIds: [collectionId],
 			ordering: { field: 'updatedDate', direction: 'DESC' },
 		},


### PR DESCRIPTION
## Issue(s) Resolved
Reduces number of manyPubs queries from collection add button, which relieves server load and makes it less likely communities hit rate limiting. Used same strategy as in [PinnedPubs.tsx](https://github.com/pubpub/pubpub/blob/284359e95afe039d7544c55451a7018e17f74684/client/components/LayoutEditor/LayoutEditorPubs/PinnedPubs.tsx)

## Test Plan
- Visit a Collection overview
- With the network console open, click `add pub` button and search for a term
- See that the /api/user/search?q=text query is sent only once every ~200ms at maximum (this is what `PinnedPubs` was set to).
- Delete the text, wait 200ms, and make sure no empty query (api/user/search?q=) is sent.
- Search a common term ("ok" works on demo) and make sure pubs show up and you can add them.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
