### PR TITLE
fix: Crossref deposit error

### DIFF
--- a/deposit/transform/pub.ts
+++ b/deposit/transform/pub.ts
@@ -247,7 +247,8 @@ export async function transformPubToResource(
 		pubResource.meta['created-date'] = expect(pub.releases?.[0]).createdAt.toString();
 		if (depositJson) {
 			// @ts-expect-error FIXME: Property 'deposit' does not exist on type 'object'.
-			const dateOfLastDeposit = new Date(depositJson.data.attributes.updated);
+			const updatedDate = depositJson.data?.attributes?.updated || depositJson.timestamp;
+			const dateOfLastDeposit = new Date(updatedDate);
 			const dateOfLatestRelease = new Date(release.createdAt);
 			if (dateOfLastDeposit.getTime() !== dateOfLatestRelease.getTime()) {
 				pubResource.meta['updated-date'] = dateOfLatestRelease.toString();


### PR DESCRIPTION
## Issue(s) Resolved
Previously, depositing to Crossref (or even, I think, loading a DOI settings page that had been previously deposited) was throwing a date error because it assumed a Datacite deposit record JSON structure. I think that was causing a lot of dyno crashes, and in some cases was also preventing depositing.

```
/app/deposit/transform/pub.ts:250
const dateOfLastDeposit = new Date(depositJson.data.attributes.updated);
TypeError: Cannot read properties of undefined (reading 'attributes')
    at <anonymous> (/app/deposit/transform/pub.ts:250:56)
    at Generator.next (<anonymous>)
    at fulfilled (/app/deposit/transform/pub.ts:2:61)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This fixes that by checking to make sure the timestamp exists, and if not, defaulting to the crossref format.

## Test Plan
### Crossref
1. Visit the pubpub demo community
2. Deposit a pub for the first time
3. Make sure there are no type errors matching the above
4. Visit test.crossref.org and make sure the deposit made it (it will error out due to a change of title error, but as long as there is a timestamp in the submission, it's fine.
5. Refresh the page. Make sure there are no type errors matching the above
6. Redeposit
7. Visit test.crossref.org and make sure the submission makes it.

### Datacite
1. Visit the `eric` community
2. Deposit a pub and make sure the response from datacite is successful.
3. Make sure there are no console errors.
4. Refresh the page.
5. Make sure there are no console errors.
6. Redeposit the pub and make sure the response from datacite is successful.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
