### PR TITLE
feat: add code attrs such as lang to statically rendered html code blocks

### DIFF
--- a/client/components/Editor/schemas/code.ts
+++ b/client/components/Editor/schemas/code.ts
@@ -27,9 +27,17 @@ const renderStaticCode = (node: Node): DOMOutputSpec => {
 	if (parser) {
 		const tree = parser.parse(node.textContent);
 		const children = fromLezer(node.textContent, tree as unknown as Tree);
-		return ['pre', node.attrs, ['code', ...children]] as DOMOutputSpec;
+		return [
+			'pre',
+			{ id: node.attrs.id, 'data-lang': node.attrs.lang },
+			['code', ...children],
+		] as DOMOutputSpec;
 	}
-	return ['pre', node.attrs, ['code', node.textContent]] as DOMOutputSpec;
+	return [
+		'pre',
+		{ id: node.attrs.id, ...(node.attrs.lang && { 'data-lang': node.attrs.lang }) },
+		['code', node.textContent],
+	] as DOMOutputSpec;
 };
 
 const codeSchema: { [key: string]: NodeSpec } = {

--- a/client/components/Editor/schemas/code.ts
+++ b/client/components/Editor/schemas/code.ts
@@ -27,9 +27,9 @@ const renderStaticCode = (node: Node): DOMOutputSpec => {
 	if (parser) {
 		const tree = parser.parse(node.textContent);
 		const children = fromLezer(node.textContent, tree as unknown as Tree);
-		return ['pre', ['code', ...children]] as DOMOutputSpec;
+		return ['pre', node.attrs, ['code', ...children]] as DOMOutputSpec;
 	}
-	return ['pre', ['code', node.textContent]] as DOMOutputSpec;
+	return ['pre', node.attrs, ['code', node.textContent]] as DOMOutputSpec;
 };
 
 const codeSchema: { [key: string]: NodeSpec } = {


### PR DESCRIPTION
## Issue(s) Resolved
HTML exports with code blocks now have the language in the lang attribute of the `pre` tag.

## Test Plan
1. Create a pub
2. Add three code blocks, with js, python, and none language set
3. HTML export
4. Check that the pre tags have `lang=javascript`, `lang=python`, and nothing set as the attributes


## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
