### PR TITLE
enhancement: Don't strip iframe url if target is html

### DIFF
--- a/workers/tasks/export/export.ts
+++ b/workers/tasks/export/export.ts
@@ -35,11 +35,13 @@ export const exportTask = async ({ exportId }: { exportId: string }) => {
 			notesData,
 		});
 	} else {
-		const staticHtml = await renderStaticHtml({
+		const staticHtmlOptions = {
 			pubDoc,
 			notesData,
 			pubMetadata,
-		});
+			pagedTarget,
+		};
+		const staticHtml = await renderStaticHtml(staticHtmlOptions);
 		if (pagedTarget) {
 			url = (await exportWithPaged(staticHtml)).url;
 		} else {

--- a/workers/tasks/export/html.tsx
+++ b/workers/tasks/export/html.tsx
@@ -273,10 +273,11 @@ type RenderStaticHtmlOptions = {
 	pubDoc: DocJson;
 	pubMetadata: PubMetadata;
 	notesData: NotesData;
+	pagedTarget: boolean;
 };
 
 export const renderStaticHtml = async (options: RenderStaticHtmlOptions) => {
-	const { pubDoc, pubMetadata, notesData } = options;
+	const { pubDoc, pubMetadata, notesData, pagedTarget } = options;
 	const { title, nodeLabels, citationInlineStyle } = pubMetadata;
 	const { footnotes, citations, noteManager, renderedStructuredValues } = notesData;
 
@@ -287,9 +288,13 @@ export const renderStaticHtml = async (options: RenderStaticHtmlOptions) => {
 		renderedStructuredValues,
 	});
 
-	const renderableNodes = [filterNonExportableNodes, addHrefsToNotes, blankIframes]
-		.filter((x): x is (nodes: any) => any => !!x)
-		.reduce((nodes, fn) => fn(nodes), pubDoc.content);
+	const renderableNodes = pagedTarget
+		? [filterNonExportableNodes, addHrefsToNotes, blankIframes]
+				.filter((x): x is (nodes: any) => any => !!x)
+				.reduce((nodes, fn) => fn(nodes), pubDoc.content)
+		: [filterNonExportableNodes, addHrefsToNotes]
+				.filter((x): x is (nodes: any) => any => !!x)
+				.reduce((nodes, fn) => fn(nodes), pubDoc.content);
 
 	const docContent = renderStatic({
 		schema: editorSchema,


### PR DESCRIPTION
## Issue(s) Resolved
Because we go from HTML to PDF, where iFrames are not supported, exporting to HTML previously stripped the iFrame url and replaced it with instructions to visit the main document to see interactive content. 

This allows HTML exports to maintain the original URL by passing the target into the `renderStaticHtml` function such that if we target pagedJS outputs, we strip the url, but if we target an html download, we don't strip it.

## Test Plan
1. Visit a Pub with an iframe, e.g. `pub/jpfkepm9/draft`
2. Make a small change to regenerate cache
3. Export HTML
4. Open the HTML in a browser and make sure the iframe appears and the src is properly set
5. Export PDF
6. Scroll to where the iframe would be and make sure it has been stripped and replaced with language about how to view the original.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas
There was only one call-site for `renderStaticHtml`, so I feel pretty good about this being a very limited change for the better.

### Supporting Docs
