### PR TITLE
fix: make querymany return public discussions when pub has release

### DIFF
--- a/server/pub/queryMany.ts
+++ b/server/pub/queryMany.ts
@@ -217,7 +217,13 @@ export const getPubsById = (pubIds: string[], options: PubGetOptions = {}) => {
 		sanitize: async (initialData: InitialData) => {
 			const pubs = await pubsPromise;
 			return pubs
-				.map((pub) => sanitizePub(pub.toJSON(), initialData))
+				.map((pub) =>
+					sanitizePub(
+						pub.toJSON(),
+						initialData,
+						pub.releases && pub.releases.length > 0 ? pub.releases.length : null,
+					),
+				)
 				.filter((pub): pub is SanitizedPubData => !!pub);
 		},
 	};

--- a/server/utils/queryHelpers/pubSanitize.ts
+++ b/server/utils/queryHelpers/pubSanitize.ts
@@ -25,7 +25,7 @@ const filterDiscussionsByDraftOrRelease = (discussions: Discussion[], isRelease:
 
 const getFilteredExports = (pubData, isRelease) => {
 	const { exports, releases } = pubData;
-	if (!isRelease) {
+	if (!isRelease || !exports) {
 		return exports;
 	}
 	const releaseHistoryKeys = new Set(releases.map((release) => release.historyKey));


### PR DESCRIPTION
## Issue(s) Resolved
Makes it possible to get public discussions from the getMany query. Essentially, if the pub has a release, this will change the output of the query to:

- If `getDiscussions: true` is set, return public comments instead of private ones
- Not return the draft of the pub (will still return the draftId, which seems to be more used)
- Not return submissions on the pub
- Return only public exports (if `getExports: true` is also set)

The side effects of this PR should be fairly limited, as this only impacts `getPubsById`, which has limited call sites, mostly dashboards that do not make use of drafts or discussions. There is no other place in the app that sets a `releaseNumber` on `sanitizePub`, so that change will have no additional effect.

Part of the problem is it's unclear what the effect of isRelease was supposed to be, but this seems fine.

## Test Plan
Did a bunch of querying and smoke testing on all the routes this appears to touch:
- Community overview
- Collection overview
- Pub overview
- Submissions

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
