### PR TITLE
add id to unresolved cites when processing for pandoc

### DIFF
--- a/workers/tasks/export/pandoc.ts
+++ b/workers/tasks/export/pandoc.ts
@@ -55,7 +55,12 @@ const createPandocArgs = (
 };
 
 const createCslJsonBibliographyFile = async (notes: PandocNotes) => {
-	const cslJson = Object.values(notes).map((note) => note.cslJson);
+	const cslJson = Object.values(notes).map((note) => {
+		if (!note.id && note.structuredHtml) {
+			note.id = note.structuredHtml;
+		}
+		return note.cslJson;
+	});
 	const file = await getTmpFileForExtension('json');
 	fs.writeFileSync(file.path, JSON.stringify(cslJson));
 	return file.path;


### PR DESCRIPTION
## Issue(s) Resolved
Bit of a hack, but previously JATS export via Pandoc would fail whenever a citation couldn't be resolved via citation.js on the server (which happens frequently these days due to crossref rate limiting), with the following error: `JSON parse error: Error in $.blocks[38][221][0]: When parsing the record Citation of type Text.Pandoc.Definition.Citation the key citationId was not present`.

This "fixes" that at the point of export by checking to see if a citation has an ID and, if not, replacing it with the "structured" text (which is a URI and thus, if the cite can't be resolved, the de facto id). 

Amazingly, this seems to not only allow JATS to export, but actually allows cites to resolve in most cases, because it gives us another bite at the apple but one at a time rather than all at once, which causes the rate limiting.

## Test Plan
1. Test exporting a pub ot JATS that could not load all the cites on the server (e.g., copy the daft of this one locally to your machine, create a release, and see that not all the references render): https://baas.aas.org/pub/2024i009
2. Verify that the unrendered cites do in fact show up in jats.

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
