### PR TITLE
update: Add hideLabel value to output HTML

### DIFF
--- a/client/components/Editor/schemas/audio.ts
+++ b/client/components/Editor/schemas/audio.ts
@@ -36,6 +36,7 @@ export default {
 						size: Number(node.getAttribute('data-size')) || 50,
 						align: node.getAttribute('data-align') || 'center',
 						caption: node.firstChild.getAttribute('alt') || '',
+						hideLabel: node.getAttribute('data-hide-label') || '',
 					};
 				},
 			},
@@ -49,6 +50,7 @@ export default {
 					'data-node-type': 'audio',
 					'data-size': node.attrs.size,
 					'data-align': node.attrs.align,
+					'data-hide-label': node.attrs.hideLabel,
 				},
 				[
 					'audio',

--- a/client/components/Editor/schemas/iframe.ts
+++ b/client/components/Editor/schemas/iframe.ts
@@ -38,6 +38,7 @@ export default {
 						height: Number(node.firstChild.getAttribute('height')) || 419,
 						align: node.getAttribute('data-align') || 'center',
 						caption: node.firstChild.getAttribute('alt') || '',
+						hideLabel: node.getAttribute('data-hide-label') || '',
 					};
 				},
 			},
@@ -51,6 +52,7 @@ export default {
 					'data-node-type': 'iframe',
 					'data-size': node.attrs.size,
 					'data-align': node.attrs.align,
+					'data-hide-label': node.attrs.hideLabel,
 				},
 				[
 					'iframe',

--- a/client/components/Editor/schemas/image.ts
+++ b/client/components/Editor/schemas/image.ts
@@ -58,13 +58,14 @@ export default {
 						size: Number(node.getAttribute('data-size')) || 50,
 						align: node.getAttribute('data-align') || 'center',
 						altText: node.getAttribute('data-alt-text') || '',
+						hideLabel: node.getAttribute('data-hide-label') || '',
 						href: node.getAttribute('data-href') || null,
 					};
 				},
 			},
 		],
 		toDOM: (node, { isStaticallyRendered } = { isStaticallyRendered: false }) => {
-			const { url, align, id, altText, caption, fullResolution, size, href } = node.attrs;
+			const { url, align, id, altText, caption, fullResolution, size, hideLabel, href } = node.attrs;
 
 			const width = align === 'breakout' ? 1920 : 800;
 			const isResizeable = isResizeableFormat(url) && !fullResolution;
@@ -92,6 +93,7 @@ export default {
 					'data-caption': caption,
 					'data-href': href,
 					'data-alt-text': altText,
+					'data-hide-label': hideLabel,
 				},
 				href
 					? [

--- a/client/components/Editor/schemas/image.ts
+++ b/client/components/Editor/schemas/image.ts
@@ -65,7 +65,8 @@ export default {
 			},
 		],
 		toDOM: (node, { isStaticallyRendered } = { isStaticallyRendered: false }) => {
-			const { url, align, id, altText, caption, fullResolution, size, hideLabel, href } = node.attrs;
+			const { url, align, id, altText, caption, fullResolution, size, hideLabel, href } =
+				node.attrs;
 
 			const width = align === 'breakout' ? 1920 : 800;
 			const isResizeable = isResizeableFormat(url) && !fullResolution;

--- a/client/components/Editor/schemas/video.ts
+++ b/client/components/Editor/schemas/video.ts
@@ -39,6 +39,7 @@ export default {
 						align: node.getAttribute('data-align') || 'center',
 						caption: node.firstChild.getAttribute('alt') || '',
 						loop: !!node.firstChild.getAttribute('loop'),
+						hideLabel: node.getAttribute('data-hide-label') || '',
 					};
 				},
 			},
@@ -52,6 +53,7 @@ export default {
 					'data-node-type': 'video',
 					'data-size': node.attrs.size,
 					'data-align': node.attrs.align,
+					'data-hide-label': node.attrs.hideLabel,
 				},
 				[
 					'video',


### PR DESCRIPTION
This adds the hideLabel value onto a `data-hide-label` attribute in the toDom function for images, videos, iframes, and audio.