### PR TITLE
fix: fix many read replica issues

### DIFF
--- a/server/pubAttribution/queries.ts
+++ b/server/pubAttribution/queries.ts
@@ -37,6 +37,7 @@ export const createPubAttribution = async ({
 			where: { id: newAttribution.id },
 			attributes: { exclude: ['updatedAt'] },
 			include: [includeUserModel({ as: 'user', required: false })],
+			useMaster: true,
 		}),
 	);
 

--- a/server/signup/queries.ts
+++ b/server/signup/queries.ts
@@ -39,7 +39,7 @@ export const createSignup = (inputValues, hostname) => {
 			});
 		})
 		.then(() => {
-			return Signup.findOne({ where: { email } });
+			return Signup.findOne({ where: { email }, useMaster: true });
 		})
 		.then((signUpData) => {
 			return sendSignupEmail({

--- a/server/threadComment/queries.ts
+++ b/server/threadComment/queries.ts
@@ -8,6 +8,7 @@ const findThreadCommentWithUser = async (id: string) => {
 		await ThreadComment.findOne({
 			where: { id },
 			include: [includeUserModel({ as: 'author' }), { model: Commenter, as: 'commenter' }],
+			useMaster: true,
 		}),
 	);
 	return threadComment as types.DefinitelyHas<ThreadComment, 'author' | 'commenter'>;

--- a/workers/queue.ts
+++ b/workers/queue.ts
@@ -35,7 +35,9 @@ const { schedulePurge: schedulePurgeWorker } = createCachePurgeDebouncer({
 // to account for cases where a task is interrupted, never acked, and then resent from the queue.
 // This could happen if a task causes the worker dyno to crash, for instance.
 const incrementAttemptCount = async (taskId, maxAttemptCount = 2) => {
-	const workerTaskData = expect(await WorkerTask.findOne({ where: { id: taskId } }));
+	const workerTaskData = expect(
+		await WorkerTask.findOne({ where: { id: taskId }, useMaster: true }),
+	);
 	if (workerTaskData.attemptCount && workerTaskData.attemptCount >= maxAttemptCount) {
 		throw new Error('Too many attempts');
 	}


### PR DESCRIPTION
## Issue(s) Resolved

There is a similar issue with signups as was happening for #3245 , see 
- for signups: https://kfg.sentry.io/issues/6331780888/?project=1505439&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=0
- for activity items: https://kfg.sentry.io/issues/6331759214/?project=1505439&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=1
- pubAttributions: https://kfg.sentry.io/issues/6334216570/?project=1505439&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=7
- createThreadComment: https://kfg.sentry.io/issues/6331844517/?project=1505439&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=9
- workers: https://kfg.sentry.io/issues/6330850394/?project=1505439&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=5

These issues highlight that almost all of these queries should have been in transactions to begin with, but the errors are still annoying. I have a newfound appreciation for `expect`, helps a ton in localizing these errors.

## High level explanation

For all of these issues, we are creating things and then reading them from the DB immediately. The read replication is slow enough sometimes to have the time between reading and writing be shorter than the time the read replication takes.
All are fixed by reading from the master db (the write db)





## Test Plan

1. 🤷‍♂️

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
