### PR TITLE
Attempt to add the browse page link to eLife navigation

### DIFF
--- a/client/layouts/CollapsibleHeader/collapsibleHeaderData.ts
+++ b/client/layouts/CollapsibleHeader/collapsibleHeaderData.ts
@@ -15,6 +15,7 @@ export default {
 	},
 	headerNavLeft: [
 		{ url: '/', title: 'Home' },
+		{ url: '/browse', title: 'Browse' },
 		{ url: '/magazine', title: 'Magazine' },
 		{ url: '/community', title: 'Community' },
 		{ url: '/about', title: 'About' },
@@ -27,6 +28,7 @@ export default {
 	menuNav: [
 		[
 			{ isMobileOnly: true, url: '/', title: 'Home' },
+			{ isMobileOnly: true, url: '/browse', title: 'Browse' },
 			{ isMobileOnly: true, url: '/magazine', title: 'Magazine' },
 			{ isMobileOnly: true, url: '/community', title: 'Community' },
 			{ isMobileOnly: true, url: '/about', title: 'About' },


### PR DESCRIPTION
## Issue(s) Resolved

We are currently rolling out a new URL link in the elifesciences.org site header.
https://github.com/elifesciences/issues/issues/9146

## Concerns

We have not been able to test the change locally, as no-one of our team of four was able to to run an instance of PubPub or Storybook locally. https://github.com/pubpub/pubpub/issues/3257