### PR TITLE
Allow alt and role attributes

### DIFF
--- a/server/page/sanitizePageHtml.ts
+++ b/server/page/sanitizePageHtml.ts
@@ -57,6 +57,7 @@ export const sanitizePageHtml = (html: string) => {
 				'viewBox',
 				'd',
 				'fill-rule',
+				'role',
 			],
 			a: ['href', 'target', 'rel'],
 		},

--- a/server/page/sanitizePageHtml.ts
+++ b/server/page/sanitizePageHtml.ts
@@ -60,6 +60,7 @@ export const sanitizePageHtml = (html: string) => {
 				'role',
 			],
 			a: ['href', 'target', 'rel'],
+			img: ['alt'],
 		},
 		allowedSchemes: ['https', 'mailto'],
 		transformTags: {


### PR DESCRIPTION
## Issue(s) Resolved

- Fix an accessibility bug by allowing `<img>` elements to have an `alt` attribute.
- Make it easier to write accessible `html` by allowing the `role` attribute on all elements.

## Test Plan

We are unable to build and test locally.

## Screenshots (if applicable)

N/A

## Optional

### Notes/Context/Gotchas

We noticed when editing an `html` block that `alt` attributes and `role` attributes are stripped. This change attempts to fix these accessibility bugs.
