### PR TITLE
feat(archive): fix static url rewrites on pages other than home

### DIFF
--- a/client/utils/collections.ts
+++ b/client/utils/collections.ts
@@ -1,7 +1,7 @@
-import { useState } from 'react';
 import { apiFetch } from 'client/utils/apiFetch';
-import { usePageContext } from 'utils/hooks';
+import { useState } from 'react';
 import { getPrimaryCollection } from 'utils/collections/primary';
+import { usePageContext } from 'utils/hooks';
 
 const readingCollectionParam = 'readingCollection';
 

--- a/utils/canonicalUrls.js
+++ b/utils/canonicalUrls.js
@@ -3,19 +3,14 @@ import queryString from 'query-string';
 
 import { isDuqDuq, isQubQub } from 'utils/environment';
 
-let isArchiving = false;
-
-if ('window' in globalThis) {
-	const url = new URL(window.location.href);
-	if (url.searchParams.has('pubpubArchiveBot')) {
-		isArchiving = true;
-	}
-}
-
 export const profileUrl = (userSlug) => `/user/${userSlug}`;
 
+const isArchiving = () =>
+	'window' in globalThis &&
+	window.__pubpub_pageContextProps__.locationData.queryString.includes('pubpubArchiveBot');
+
 export const communityUrl = (community) => {
-	if (isArchiving) {
+	if (isArchiving()) {
 		return '/';
 	}
 	if (isDuqDuq()) {
@@ -30,11 +25,15 @@ export const communityUrl = (community) => {
 	return `https://${community.subdomain}.pubpub.org`;
 };
 
-export const collectionUrl = (community, collection) =>
-	`${communityUrl(community)}/${collection.slug}`;
+export const collectionUrl = (community, collection) => {
+	if (isArchiving()) {
+		return `/${collection.slug}`;
+	}
+	return `${communityUrl(community)}/${collection.slug}`;
+};
 
 export const pubShortUrl = (pub) => {
-	return isArchiving ? `/pub/{pub.slug}` : `https://pubpub.org/pub/${pub.slug}`;
+	return isArchiving() ? `/pub/{pub.slug}` : `https://pubpub.org/pub/${pub.slug}`;
 };
 
 export const pubUrl = (community, pub, options = {}) => {
@@ -52,7 +51,7 @@ export const pubUrl = (community, pub, options = {}) => {
 	} = options;
 
 	// Include the community in the URL if the absolute flag is set to true.
-	const skipCommunity = isArchiving || (absolute ? false : community === null || isQubQub());
+	const skipCommunity = isArchiving() || (absolute ? false : community === null || isQubQub());
 	const baseCommunityUrl = skipCommunity ? '' : communityUrl(community);
 
 	let baseUrl = `${baseCommunityUrl}/pub/${pub.slug}`;
@@ -89,4 +88,6 @@ export const bestPubUrl = ({ pubData, communityData }, options = {}) => {
 
 export const doiUrl = (doi) => `https://doi.org/${doi}`;
 
-export const pageUrl = (community, page) => `${communityUrl(community)}/${page.slug}`;
+export const pageUrl = (community, page) => {
+	return isArchiving() ? `/${page.slug}` : `${communityUrl(community)}/${page.slug}`;
+};

--- a/workers/tasks/archive.tsx
+++ b/workers/tasks/archive.tsx
@@ -436,7 +436,6 @@ const createUrlStreams = (communityData: any, pubs: Pub[], numStreams: number) =
 				urls.push(`${baseUrl}/`);
 				return;
 			}
-
 			urls.push(`${baseUrl}/${page.slug}${param}`);
 		});
 

--- a/workers/tasks/archive/siteDownloaderTransform.ts
+++ b/workers/tasks/archive/siteDownloaderTransform.ts
@@ -30,8 +30,8 @@ const transformAnchorTag = (tag: any, pageUrl: URL) => {
 	if (href?.value === undefined) {
 		return;
 	}
-	if (href.value.startsWith(pageUrl.href)) {
-		href.value = href.value.replace(pageUrl.href, '/');
+	if (href.value.startsWith(pageUrl.origin)) {
+		href.value = href.value.replace(pageUrl.origin, '');
 	}
 };
 


### PR DESCRIPTION
## Issue(s) Resolved

N/A

## Test Plan

- Create a community archive.
- `npx serve` it.
- Confirm that links in JS-rendered contexts (collection dropdown, releases dropdown) direct you to the locally served page rather than the production pubpub community.
- Confirm that links in server-rendered (static HTML) contexts (pub links, page links) do the same.