### PR TITLE
fix: handle null scopesummary

### DIFF
--- a/client/containers/DashboardOverview/overviewRows/CollectionOverviewRow.tsx
+++ b/client/containers/DashboardOverview/overviewRows/CollectionOverviewRow.tsx
@@ -44,7 +44,7 @@ const CollectionOverviewRow = React.forwardRef((props: Props, ref: any) => {
 		[onToggleOpen],
 	);
 	const iconLabelPairs = renderLabelPairs([
-		...getScopeSummaryLabels(collection.scopeSummary!, true),
+		...getScopeSummaryLabels(collection.scopeSummary ?? null, true),
 		getCollectionPublicStateLabel(collection),
 		getCollectionKindLabel(collection),
 	]);

--- a/client/containers/DashboardOverview/overviewRows/labels.tsx
+++ b/client/containers/DashboardOverview/overviewRows/labels.tsx
@@ -16,7 +16,10 @@ export type IconLabelPair = {
 	iconClass?: string;
 };
 
-export const getScopeSummaryLabels = (summary: ScopeSummary, showPubs = false) => {
+export const getScopeSummaryLabels = (summary: ScopeSummary | null, showPubs = false) => {
+	if (!summary) {
+		return [];
+	}
 	const { discussions, reviews, pubs } = summary;
 	const labels: IconLabelPair[] = [];
 	if (showPubs) {


### PR DESCRIPTION
## Issue(s) Resolved

If a collection has a null scopesummary, the Community overview page will error with the following

```
2026-02-23 06:45:28	TypeError: Cannot destructure property 'discussions' of 'summary' as it is null.
2026-02-23 06:45:28	    at getScopeSummaryLabels (/app/client/containers/DashboardOverview/overviewRows/labels.tsx:20:10)
2026-02-23 06:45:28	    at Object.render (/app/client/containers/DashboardOverview/overviewRows/CollectionOverviewRow.tsx:47:27)
2026-02-23 06:45:28	    at b.render (/app/node_modules/.pnpm/react-dom@16.14.0_react@16.14.0/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:46:105)
2026-02-23 06:45:28	    at b.read (/app/node_modules/.pnpm/react-dom@16.14.0_react@16.14.0/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:44:18)
2026-02-23 06:45:28	    at c._read (/app/node_modules/.pnpm/react-dom@16.14.0_react@16.14.0/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:54:246)
2026-02-23 06:45:28	    at Readable.read (node:internal/streams/readable:737:12)
2026-02-23 06:45:28	    at resume_ (node:internal/streams/readable:1260:12)
2026-02-23 06:45:28	    at process.processTicksAndRejections (node:internal/process/task_queues:89:21)
2026-02-23 06:45:28	Emitted 'error' event on b instance at:
2026-02-23 06:45:28	    at emitErrorNT (node:internal/streams/destroy:170:8)
2026-02-23 06:45:28	    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
2026-02-23 06:45:28	    at process.processTicksAndRejections (node:internal/process/task_queues:89:21)
```

## Test Plan

Send it

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas


