### PR TITLE
fix: fix undefined titles

### DIFF
--- a/server/routes/dashboardActivity.tsx
+++ b/server/routes/dashboardActivity.tsx
@@ -45,7 +45,7 @@ router.get(
 					viewData={{ activityData }}
 					headerComponents={generateMetaComponents({
 						initialData,
-						title: `Activity · ${initialData.scopeData.elements.activeTarget.title}`,
+						title: `Activity · ${initialData.scopeData.elements.activeTarget.title ?? initialData.communityData.title}`,
 						unlisted: true,
 					})}
 				/>,

--- a/server/routes/dashboardDiscussions.tsx
+++ b/server/routes/dashboardDiscussions.tsx
@@ -36,7 +36,7 @@ router.get(
 					viewData={{ discussionsData }}
 					headerComponents={generateMetaComponents({
 						initialData,
-						title: `Discussions · ${initialData.scopeData.elements.activeTarget.title}`,
+						title: `Discussions · ${initialData.scopeData.elements.activeTarget.title ?? initialData.communityData.title}`,
 						unlisted: true,
 					})}
 				/>,

--- a/server/routes/dashboardFacets.tsx
+++ b/server/routes/dashboardFacets.tsx
@@ -40,7 +40,7 @@ router.get(
 					viewData={{ facets, scopeId: scope }}
 					headerComponents={generateMetaComponents({
 						initialData,
-						title: `Facets · ${initialData.scopeData.elements.activeTarget.title}`,
+						title: `Facets · ${initialData.scopeData.elements.activeTarget.title ?? initialData.communityData.title}`,
 						unlisted: true,
 					})}
 				/>,

--- a/server/routes/dashboardImpact.tsx
+++ b/server/routes/dashboardImpact.tsx
@@ -45,7 +45,7 @@ router.get(
 					viewData={{ impactData }}
 					headerComponents={generateMetaComponents({
 						initialData,
-						title: `Impact · ${initialData.scopeData.elements.activeTarget.title}`,
+						title: `Impact · ${initialData.scopeData.elements.activeTarget.title ?? initialData.communityData.title}`,
 						unlisted: true,
 					})}
 				/>,

--- a/server/routes/dashboardMembers.tsx
+++ b/server/routes/dashboardMembers.tsx
@@ -37,7 +37,7 @@ router.get(
 					viewData={{ membersData }}
 					headerComponents={generateMetaComponents({
 						initialData,
-						title: `Members · ${initialData.scopeData.elements.activeTarget.title}`,
+						title: `Members · ${initialData.scopeData.elements.activeTarget.title ?? initialData.communityData.title}`,
 						unlisted: true,
 					})}
 				/>,

--- a/server/routes/dashboardPages.tsx
+++ b/server/routes/dashboardPages.tsx
@@ -32,7 +32,7 @@ router.get(['/dash/pages'], async (req, res, next) => {
 				viewData={{}}
 				headerComponents={generateMetaComponents({
 					initialData,
-					title: `Pages · ${activeTarget.title}`,
+					title: `Pages · ${activeTarget.title ?? initialData.communityData.title}`,
 					unlisted: true,
 				})}
 			/>,

--- a/server/routes/dashboardReview.tsx
+++ b/server/routes/dashboardReview.tsx
@@ -43,7 +43,7 @@ router.get(['/dash/pub/:pubSlug/reviews/:reviewNumber'], async (req, res, next) 
 				viewData={{ reviewData: sanitizedReviewData }}
 				headerComponents={generateMetaComponents({
 					initialData,
-					title: `Review ${req.params.reviewNumber} · ${initialData.scopeData.elements.activeTarget?.title}`,
+					title: `Review ${req.params.reviewNumber} · ${initialData.scopeData.elements.activeTarget?.title ?? initialData.communityData.title}`,
 					unlisted: true,
 				})}
 			/>,

--- a/server/routes/dashboardReviews.tsx
+++ b/server/routes/dashboardReviews.tsx
@@ -53,7 +53,7 @@ router.get(
 					viewData={{ pubsWithReviews }}
 					headerComponents={generateMetaComponents({
 						initialData,
-						title: `Reviews · ${initialData.scopeData.elements.activeTarget.title}`,
+						title: `Reviews · ${initialData.scopeData.elements.activeTarget.title ?? initialData.communityData.title}`,
 						unlisted: true,
 					})}
 				/>,

--- a/server/routes/dashboardSettings.tsx
+++ b/server/routes/dashboardSettings.tsx
@@ -77,7 +77,7 @@ router.get(
 					viewData={{ settingsData, subMode: req.params.subMode }}
 					headerComponents={generateMetaComponents({
 						initialData,
-						title: `Settings · ${initialData.scopeData.elements.activeTarget.title}`,
+						title: `Settings · ${initialData.scopeData.elements.activeTarget.title ?? initialData.communityData.title}`,
 						unlisted: true,
 					})}
 				/>,

--- a/server/routes/dashboardSubmissions.tsx
+++ b/server/routes/dashboardSubmissions.tsx
@@ -92,7 +92,7 @@ router.get(
 						viewData={{ initialSubmissionWorkflow }}
 						headerComponents={generateMetaComponents({
 							initialData,
-							title: `Submission Workflow · ${initialData.scopeData.elements.activeTarget.title}`,
+							title: `Submission Workflow · ${initialData.scopeData.elements.activeTarget.title ?? initialData.communityData.title}`,
 							unlisted: true,
 						})}
 					/>,
@@ -112,7 +112,7 @@ router.get(
 						}}
 						headerComponents={generateMetaComponents({
 							initialData,
-							title: `Submissions · ${initialData.scopeData.elements.activeTarget.title}`,
+							title: `Submissions · ${initialData.scopeData.elements.activeTarget.title ?? initialData.communityData.title}`,
 							unlisted: true,
 						})}
 					/>,


### PR DESCRIPTION
## Issue(s) Resolved

Some metadata titles ended up looking like `Members - undefined` bc `activeTarget.title` isnt defined for communities

Rather than figuring out why that happens i just added this fallback

## Test Plan

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
