### PR TITLE
fix: actually sort layouts by collection order

### DIFF
--- a/server/utils/layouts/layoutPubs.ts
+++ b/server/utils/layouts/layoutPubs.ts
@@ -43,7 +43,6 @@ const getAllPubIdsRaw = async (communityId: string): Promise<PubWithMetadata[]> 
 	const query = sql`SELECT 
 "Pub"."id", 
 "Pub"."createdAt",
-"Pub"."title",
 "Pub"."customPublishedAt",
 MIN("releases"."createdAt") AS "firstReleaseDate",
 COALESCE(


### PR DESCRIPTION
## Issue(s) Resolved

Pages with more than one pub block, with pubs sorted by collection order, were not actually sorted by collection order.

That's bc the code was somehow assuming (who could it have been 🤔) that `CollectionPub.rank` was a stringified float, when it was ofc a mudder rank like `"aa"`.

Using `localeCompare` instead fixed it.

## Test Plan

Just send it and see if https://oecs.mit.edu/open-encyclopedia-of-cognitive-science is sorted alphabetically now

## Screenshots (if applicable)

## Optional

### Notes/Context/Gotchas

### Supporting Docs
